### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,17 +9,18 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "express": "^4.19.2",
-    "zod": "^3.23.8",
+    "@prisma/client": "^5.18.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "@prisma/client": "^5.18.0"
+    "express": "^4.19.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
-    "typescript": "^5.6.0",
-    "ts-node-dev": "^2.0.0",
-    "prisma": "^5.18.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
-    "@types/node": "^20.11.30"
+    "@types/node": "^20.11.30",
+    "prisma": "^5.18.0",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.6.0"
   }
 }

--- a/apps/api/src/controllers/checkInController.ts
+++ b/apps/api/src/controllers/checkInController.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
-import { createCheckIn } from '../services/wellnessService.js';
+import { createCheckIn, type CheckInPayload } from '../services/wellnessService.js';
 
-const checkInSchema = z.object({
+const checkInSchema: z.ZodType<CheckInPayload> = z.object({
   mood: z.string().min(1),
   notes: z.string().optional()
 });

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,9 +1,15 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App.tsx';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
     <App />
-  </React.StrictMode>
+  </StrictMode>
 );

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "node",
     "jsx": "react-jsx",
+    "noEmit": true,
     "types": ["vite/client"]
   },
   "include": ["src", "vite.config.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^4.17.21",
         "@types/node": "^20.11.30",
         "prisma": "^5.18.0",
@@ -1270,6 +1271,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- align the API check-in controller schema with the service payload type
- add the missing cors type definitions and prevent web builds from emitting JS side-effects
- update the web entrypoint imports to work without synthetic default imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1acae6f5083229a43ddd31aa6b641