### PR TITLE
Fix API build typing issues

### DIFF
--- a/apps/api/src/controllers/checkInController.ts
+++ b/apps/api/src/controllers/checkInController.ts
@@ -16,7 +16,8 @@ export async function createCheckInHandler(req: Request, res: Response) {
     return res.status(400).json({ errors: parseResult.error.issues });
   }
 
-  const payload: CheckInPayload = parseResult.data;
+  const { mood, notes } = parseResult.data;
+  const payload: CheckInPayload = { mood, notes };
   const result = await createCheckIn(payload);
   res.status(201).json(result);
 }

--- a/apps/api/src/types/cors.d.ts
+++ b/apps/api/src/types/cors.d.ts
@@ -1,0 +1,22 @@
+declare module 'cors' {
+  import type { RequestHandler } from 'express';
+
+  type StaticOrigin = boolean | string | RegExp | (string | RegExp)[];
+  type OriginCallback = (err: Error | null, allow?: StaticOrigin) => void;
+
+  export interface CorsOptions {
+    origin?: StaticOrigin | ((origin: string | undefined, callback: OriginCallback) => void);
+    methods?: string | string[];
+    allowedHeaders?: string | string[];
+    exposedHeaders?: string | string[];
+    credentials?: boolean;
+    maxAge?: number;
+    preflightContinue?: boolean;
+    optionsSuccessStatus?: number;
+  }
+
+  export type CorsRequestHandler = RequestHandler;
+
+  const cors: (options?: CorsOptions) => CorsRequestHandler;
+  export default cors;
+}


### PR DESCRIPTION
## Summary
- ensure the check-in controller constructs an explicit payload that satisfies the service contract
- provide local TypeScript declarations for the cors package so builds succeed without dev-only type packages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1b1b0a7d48322aabeecf225e3bf57