### PR TITLE
fix(web): self-contained tsconfig and preview script for Railway

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --host 0.0.0.0 --port ${PORT:-3000}",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,12 +1,11 @@
 {
-  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx",
-    "noEmit": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "types": ["vite/client", "node"]
+    "strict": true,
+    "skipLibCheck": true
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- replace the web app tsconfig with a self-contained configuration suitable for Railway
- update the preview script to expose the Vite preview server on Railway-provided host and port

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b5d2b3108322b8339a94b7fc2b68