### PR TITLE
Enable npm workspace build scripts for API

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,14 +3,14 @@
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate --config ./drizzle.config.ts",
     "db:migrate": "drizzle-kit migrate --config ./drizzle.config.ts",
     "db:push": "node ./scripts/run-sql.js",
     "db:seed": "node ./scripts/run-sql.js sql/002_seed.sql",
-    "db:all": "pnpm db:generate && pnpm db:migrate && pnpm db:push && pnpm db:seed"
+    "db:all": "npm run db:generate && npm run db:migrate && npm run db:push && npm run db:seed"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "db:seed": "pnpm --filter @innerbloom/api db:seed",
     "db:all": "pnpm --filter @innerbloom/api db:all",
     "dev:api": "pnpm --filter @innerbloom/api dev",
-    "build:api": "pnpm --filter @innerbloom/api build",
-    "start:api": "pnpm --filter @innerbloom/api start"
+    "build:api": "npm --workspace apps/api run build",
+    "start:api": "npm --workspace apps/api run start",
+    "db:all:api": "npm --workspace apps/api run db:all"
   },
   "devDependencies": {
     "tsx": "^4.19.1",


### PR DESCRIPTION
## Summary
- add npm workspace scripts so the API can be built and started without pnpm
- update the API workspace build and database scripts to avoid pnpm-only commands

## Testing
- npm --workspace apps/api run build

------
https://chatgpt.com/codex/tasks/task_e_68e1c4ee21848322bfa0601fcdc86db2