### PR TITLE
Fix API tsconfig and Drizzle config for Railway

### DIFF
--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -1,26 +1,8 @@
-import 'dotenv/config';
-import { defineConfig } from 'drizzle-kit';
-
-const databaseUrl = (() => {
-  const rawUrl = process.env.DATABASE_URL;
-
-  if (!rawUrl) {
-    throw new Error('DATABASE_URL is required for drizzle config');
-  }
-
-  const parsed = new URL(rawUrl);
-  if (!parsed.searchParams.has('sslmode')) {
-    parsed.searchParams.set('sslmode', 'require');
-  }
-
-  return parsed.toString();
-})();
+import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
-  schema: './src/db/schema.ts',
-  out: './drizzle',
-  dialect: 'postgresql',
-  dbCredentials: {
-    url: databaseUrl,
-  },
+  dialect: "postgresql",
+  schema: "./src/db/schema.ts",
+  out: "./drizzle",
+  dbCredentials: { url: process.env.DATABASE_URL! }
 });

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
-    "types": ["node"]
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,11 +2,12 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "sourceMap": true
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
## Summary
- switch the shared TypeScript base config to NodeNext/ESM settings for compatibility with Railway's npm build
- trim the API tsconfig overrides to only set the build directories while inheriting the base compiler behavior
- simplify the Drizzle config to the default PostgreSQL/Neon setup and rely on DATABASE_URL at runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1c7b90a1c83228bb5701130b0514b