### PR TITLE
Fix API TypeScript config resolution

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,6 +1,14 @@
 {
-  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
## Summary
- inline the API workspace TypeScript compiler options instead of extending the repository base config so builds do not look for `/tsconfig.base.json`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1ccb5f500832294a98cfa744ea0eb