### PR TITLE
Add Railway allowed host configuration to Vite preview

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,6 +4,12 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: '0.0.0.0',
     port: 5173
+  },
+  preview: {
+    host: '0.0.0.0',
+    port: 5173,
+    allowedHosts: ['.railway.app']
   }
 });


### PR DESCRIPTION
## Summary
- set Vite dev server to bind to 0.0.0.0 for local and hosted usage
- configure Vite preview to allow Railway domains via allowedHosts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d41a87b883229283b5bdfa6ac0d8