### PR TITLE
feat(web): display pillars from API

### DIFF
--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- fetch pillars from the backend API on app load and render mission cards dynamically
- add Vite env typings so the web client can read the API base URL safely

## Testing
- npm run typecheck:web

------
https://chatgpt.com/codex/tasks/task_e_68e1d6189d7483229fa33de46a0d6a3c