### PR TITLE
Fix API base URL fallback for deployed web app

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -223,7 +223,31 @@ type Task = {
   lastCompletedAt: string | null;
 };
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000';
+const API_BASE_URL = (() => {
+  const configuredBaseUrl = import.meta.env.VITE_API_BASE_URL;
+  if (configuredBaseUrl) {
+    return configuredBaseUrl;
+  }
+
+  if (typeof window === 'undefined') {
+    return 'http://localhost:3000';
+  }
+
+  const { protocol, hostname, origin } = window.location;
+
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    return 'http://localhost:3000';
+  }
+
+  if (hostname.endsWith('.up.railway.app')) {
+    const apiHostname = hostname.replace(/^web-/, 'api-');
+    if (apiHostname !== hostname) {
+      return `${protocol}//${apiHostname}`;
+    }
+  }
+
+  return origin;
+})();
 const DEMO_USER_ID =
   import.meta.env.VITE_DEMO_USER_ID ?? '00000000-0000-0000-0000-000000000001';
 


### PR DESCRIPTION
## Summary
- add a runtime helper to resolve the API base URL when the env var is not set
- default to localhost during local development and derive the API service domain on Railway

## Testing
- npm --workspace apps/web run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1de016c0083228495c04375386895