### PR TITLE
Configure web API base URL

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -224,7 +224,10 @@ type Task = {
 };
 
 const API_BASE_URL = (() => {
-  const configuredBaseUrl = import.meta.env.VITE_API_BASE_URL;
+  const configuredBaseUrlRaw = import.meta.env.VITE_API_BASE_URL;
+  const configuredBaseUrl = configuredBaseUrlRaw
+    ? configuredBaseUrlRaw.trim().replace(/\/+$/, '')
+    : undefined;
   if (configuredBaseUrl) {
     return configuredBaseUrl;
   }
@@ -233,17 +236,17 @@ const API_BASE_URL = (() => {
     return 'http://localhost:3000';
   }
 
-  const { protocol, hostname, origin } = window.location;
+  const { hostname, origin } = window.location;
 
   if (hostname === 'localhost' || hostname === '127.0.0.1') {
     return 'http://localhost:3000';
   }
 
-  if (hostname.endsWith('.up.railway.app')) {
-    const apiHostname = hostname.replace(/^web-/, 'api-');
-    if (apiHostname !== hostname) {
-      return `${protocol}//${apiHostname}`;
-    }
+  if (import.meta.env.PROD) {
+    console.warn(
+      'VITE_API_BASE_URL is not configured; falling back to the current origin. ' +
+        'Configure the variable in production to avoid cross-origin issues.'
+    );
   }
 
   return origin;

--- a/railway.toml
+++ b/railway.toml
@@ -9,3 +9,4 @@ command = "npm --workspace apps/web run preview"
 
   [service.web.env]
   PORT = "5173"
+  VITE_API_BASE_URL = "https://innerbloom-api.up.railway.app"


### PR DESCRIPTION
## Summary
- normalize API base URL resolution in the web app to rely on the configured environment variable
- configure the Railway web service to export the live API base URL

## Testing
- pnpm --filter @innerbloom/web build

------
https://chatgpt.com/codex/tasks/task_e_68e1e0719a8c8322aaa3c54e7b81908a