### PR TITLE
Configure VITE_API_BASE_URL for production builds

### DIFF
--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://innerbloom-api.up.railway.app


### PR DESCRIPTION
## Summary
- add a production environment file for the Vite web app
- configure the API base URL so deployments can reach the backend

## Testing
- pnpm --filter @innerbloom/web build

------
https://chatgpt.com/codex/tasks/task_e_68e1e5100b5c83228620f58be5072a5a