### PR TITLE
Update API base URL for web deployment

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -9,4 +9,4 @@ command = "npm --workspace apps/web run preview"
 
   [service.web.env]
   PORT = "5173"
-  VITE_API_BASE_URL = "https://innerbloom-api.up.railway.app"
+  VITE_API_BASE_URL = "https://web-dev-dfa2.up.railway.app"


### PR DESCRIPTION
## Summary
- update the Railway web service configuration to point VITE_API_BASE_URL at https://web-dev-dfa2.up.railway.app so the frontend calls the correct API endpoint

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e1e652a4008322bd08fd8e33d3d8ef