### PR TITLE
Configure API CORS for frontend origins

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,4 @@
-import cors from 'cors';
+import cors, { CorsOptions } from 'cors';
 import express, { NextFunction, Request, Response } from 'express';
 import { eq, sql as drizzleSql } from 'drizzle-orm';
 import { z } from 'zod';
@@ -43,8 +43,24 @@ const createTaskLogSchema = z.object({
 export function createApp() {
   const app = express();
 
-  // Allow our friends (the frontend) to talk to us.
-  app.use(cors());
+  const allowedOrigins = [
+    'https://web-dev-dfa2.up.railway.app',
+    'http://localhost:5173',
+  ];
+
+  const corsOptions: CorsOptions = {
+    origin: (origin, callback) => {
+      if (!origin) {
+        return callback(null, true);
+      }
+
+      return callback(null, allowedOrigins.includes(origin));
+    },
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  };
+
+  app.use(cors(corsOptions));
+  app.options('*', cors(corsOptions));
   // Teach Express to understand JSON payloads.
   app.use(express.json());
 


### PR DESCRIPTION
## Summary
- configure API CORS to allow the deployed frontend and local dev origins
- handle preflight requests globally while keeping existing route paths at the root

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e249fa4a7083228bc1d7e594c52f3c