### PR TITLE
Align API base path and surface task history

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,10 +1,8 @@
 import 'dotenv/config';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
-import { createApp } from './app.js';
+import app from './app.js';
 import { dbReady } from './db/client.js';
-
-export const app = createApp();
 
 const preferredPorts = [process.env.PORT, '3000', '8080'];
 const port = Number(
@@ -42,4 +40,4 @@ if (executedDirectly) {
   void start();
 }
 
-export { start };
+export { start, app };

--- a/apps/web/src/components/TaskHistory.tsx
+++ b/apps/web/src/components/TaskHistory.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { API_BASE, fetchTaskLogs, TaskLogDTO } from '../lib/api';
+
+const USER_ID = '00000000-0000-0000-0000-000000000001';
+
+export default function TaskHistory() {
+  const [data, setData] = useState<TaskLogDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!API_BASE) {
+      setError('API base URL is not configured.');
+      setLoading(false);
+      return;
+    }
+
+    fetchTaskLogs(USER_ID)
+      .then(setData)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p>Loading…</p>;
+  if (error) return <p style={{ color: 'red' }}>Failed to fetch: {error}</p>;
+
+  return (
+    <div style={{ marginTop: 16 }}>
+      <h3>Recent activity</h3>
+      <ul>
+        {data.map((log) => (
+          <li key={log.id}>
+            {new Date(log.doneAt).toLocaleString()} — <strong>{log.taskTitle}</strong>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,17 @@
+export const API_BASE = (import.meta.env.VITE_API_URL ?? '').replace(/\/+$/, '');
+
+async function j<T>(url: string) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return r.json() as Promise<T>;
+}
+
+export type TaskLogDTO = { id: string; taskId: string; taskTitle: string; doneAt: string };
+export async function fetchTaskLogs(userId: string) {
+  return j<TaskLogDTO[]>(`${API_BASE}/api/task-logs?userId=${encodeURIComponent(userId)}`);
+}
+
+export type Pillar = { id: string; name: string; description: string | null };
+export async function fetchPillars() {
+  return j<Pillar[]>(`${API_BASE}/api/pillars`);
+}


### PR DESCRIPTION
## Summary
- configure Express with shared CORS settings and mount routes beneath `/api`
- expose `/api/pillars`, `/api/tasks`, and `/api/task-logs` using Drizzle queries with task metadata
- add frontend API helpers and render a task history list for the seeded demo user

## Testing
- npm run build:api
- npm run build:web

------
https://chatgpt.com/codex/tasks/task_e_68e24d7cd1848322b139dff57f3af25f