### PR TITLE
Fix API routes and wire frontend to Neon data

### DIFF
--- a/apps/web/src/components/TaskHistory.tsx
+++ b/apps/web/src/components/TaskHistory.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { API_BASE, fetchTaskLogs, TaskLogDTO } from '../lib/api';
+import { fetchTaskLogs, TaskLogDTO } from '../lib/api';
 
-const USER_ID = '00000000-0000-0000-0000-000000000001';
+const DEMO_USER = '00000000-0000-0000-0000-000000000001';
 
 export default function TaskHistory() {
   const [data, setData] = useState<TaskLogDTO[]>([]);
@@ -9,13 +9,7 @@ export default function TaskHistory() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!API_BASE) {
-      setError('API base URL is not configured.');
-      setLoading(false);
-      return;
-    }
-
-    fetchTaskLogs(USER_ID)
+    fetchTaskLogs(DEMO_USER)
       .then(setData)
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
@@ -23,6 +17,7 @@ export default function TaskHistory() {
 
   if (loading) return <p>Loading…</p>;
   if (error) return <p style={{ color: 'red' }}>Failed to fetch: {error}</p>;
+  if (!data.length) return <p>No recent activity yet.</p>;
 
   return (
     <div style={{ marginTop: 16 }}>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,17 +1,22 @@
 export const API_BASE = (import.meta.env.VITE_API_URL ?? '').replace(/\/+$/, '');
 
+function base(): string {
+  if (!API_BASE) throw new Error('API base URL is not configured.');
+  return API_BASE;
+}
+
 async function j<T>(url: string) {
   const r = await fetch(url);
   if (!r.ok) throw new Error(`HTTP ${r.status}`);
   return r.json() as Promise<T>;
 }
 
-export type TaskLogDTO = { id: string; taskId: string; taskTitle: string; doneAt: string };
-export async function fetchTaskLogs(userId: string) {
-  return j<TaskLogDTO[]>(`${API_BASE}/api/task-logs?userId=${encodeURIComponent(userId)}`);
+export type Pillar = { id: string; name: string; description: string };
+export async function fetchPillars() {
+  return j<Pillar[]>(`${base()}/pillars`);
 }
 
-export type Pillar = { id: string; name: string; description: string | null };
-export async function fetchPillars() {
-  return j<Pillar[]>(`${API_BASE}/api/pillars`);
+export type TaskLogDTO = { id: string; taskId: string; taskTitle: string; doneAt: string };
+export async function fetchTaskLogs(userId: string) {
+  return j<TaskLogDTO[]>(`${base()}/task-logs?userId=${encodeURIComponent(userId)}`);
 }


### PR DESCRIPTION
## Summary
- move API router to the root path and add database-aware health/pillars/tasks/task-logs handlers
- reuse Drizzle to deliver task metadata and recent logs from Neon while keeping CORS locked down
- update the web client to read VITE_API_URL, show a dev warning when missing, and render live task history data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e256ffa3e08322a02fa347cbbc4150