### PR TITLE
feat: add user progress and leaderboard endpoints

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -30,3 +30,70 @@ Materialized views ship `WITH NO DATA`; refresh them after seeding:
 psql "$DATABASE_URL" -c "REFRESH MATERIALIZED VIEW mv_task_weeks;"
 psql "$DATABASE_URL" -c "REFRESH MATERIALIZED VIEW mv_user_progress;"
 ```
+
+## REST endpoints
+
+Base URL: keep the existing prefix (default `/`). All responses are JSON.
+
+### Health
+```bash
+curl -s http://localhost:3000/health/db
+```
+
+### Pillars catalog
+```bash
+curl -s http://localhost:3000/pillars
+```
+
+### Legacy task utilities (MVP compatibility)
+```bash
+curl -s "http://localhost:3000/tasks?userId=<USER_ID>"
+curl -s "http://localhost:3000/task-logs?userId=<USER_ID>"
+curl -s -X POST http://localhost:3000/task-logs \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"<USER_ID>","taskId":"<TASK_ID>","doneAt":"2024-01-01T10:00:00Z"}'
+```
+
+### Progress overview
+`GET /users/:userId/progress`
+```bash
+curl -s http://localhost:3000/users/<USER_ID>/progress
+```
+
+### User tasks
+`GET /users/:userId/tasks`
+```bash
+curl -s http://localhost:3000/users/<USER_ID>/tasks
+```
+
+### Recent task logs
+`GET /users/:userId/task-logs?limit=20`
+```bash
+curl -s "http://localhost:3000/users/<USER_ID>/task-logs?limit=10"
+```
+
+### Task streaks
+`GET /users/:userId/streaks`
+```bash
+curl -s http://localhost:3000/users/<USER_ID>/streaks
+```
+
+### Emotion heatmap (stub)
+`GET /users/:userId/emotions?days=30`
+```bash
+curl -s http://localhost:3000/users/<USER_ID>/emotions
+```
+
+### Leaderboard
+`GET /leaderboard?limit=10&offset=0`
+```bash
+curl -s "http://localhost:3000/leaderboard?limit=5"
+```
+
+### Complete a task (creates a log)
+`POST /tasks/complete`
+```bash
+curl -s -X POST http://localhost:3000/tasks/complete \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"<USER_ID>","taskId":"<TASK_ID>","doneAt":"2024-01-01T18:00:00Z"}'
+```

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,27 +1,8 @@
 import cors, { type CorsOptions } from 'cors';
 import express, { NextFunction, Request, Response } from 'express';
-import { desc, eq, sql as drizzleSql } from 'drizzle-orm';
 import { z } from 'zod';
-import { db } from './db/client.js';
-import { pillars, stats, taskLogs, tasks, traits, users } from './db/schema.js';
-
-class HttpError extends Error {
-  constructor(
-    public status: number,
-    message: string,
-    public details?: unknown,
-  ) {
-    super(message);
-    this.name = 'HttpError';
-  }
-}
-
-type AsyncHandler = (req: Request, res: Response) => Promise<void>;
-
-const asyncHandler = (handler: AsyncHandler) =>
-  (req: Request, res: Response, next: NextFunction) => {
-    handler(req, res).catch(next);
-  };
+import routes from './routes/index.js';
+import { HttpError, isHttpError } from './lib/http-error.js';
 
 const allowedOrigins = [
   'https://web-dev-dfa2.up.railway.app',
@@ -39,217 +20,19 @@ const corsOptions: CorsOptions = {
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
 };
 
-const tasksQuerySchema = z.object({
-  userId: z.string().uuid({ message: 'userId must be a valid UUID' }),
-});
-
-const taskLogsQuerySchema = z.object({
-  userId: z.string().uuid({ message: 'userId must be a valid UUID' }),
-});
-
-const createTaskLogSchema = z.object({
-  userId: z.string().uuid({ message: 'userId must be a valid UUID' }),
-  taskId: z.string().uuid({ message: 'taskId must be a valid UUID' }),
-  doneAt: z.coerce.date({ message: 'doneAt must be a date or ISO string' }),
-});
-
-const LOG_LIMIT = 20;
-
 const app = express();
 
 app.use(cors(corsOptions));
 app.options('*', cors(corsOptions));
 app.use(express.json());
-
-const api = express.Router();
-
-api.get(
-  '/health/db',
-  asyncHandler(async (_req, res) => {
-    try {
-      await db.execute(drizzleSql`select 1`);
-      res.json({ ok: true });
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Unable to reach the database';
-      res.status(500).json({ ok: false, error: message });
-    }
-  }),
-);
-
-api.get(
-  '/pillars',
-  asyncHandler(async (_req, res) => {
-    const rows = await db
-      .select({
-        id: pillars.id,
-        name: pillars.name,
-        description: pillars.description,
-      })
-      .from(pillars)
-      .orderBy(pillars.name);
-
-    res.json(
-      rows.map((row) => ({
-        ...row,
-        description: row.description ?? '',
-      })),
-    );
-  }),
-);
-
-api.get(
-  '/tasks',
-  asyncHandler(async (req, res) => {
-    const parsed = tasksQuerySchema.safeParse(req.query);
-
-    if (!parsed.success) {
-      throw new HttpError(400, 'Invalid query parameters', parsed.error.flatten());
-    }
-
-    const { userId } = parsed.data;
-
-    const [existingUser] = await db
-      .select({ id: users.id })
-      .from(users)
-      .where(eq(users.id, userId))
-      .limit(1);
-
-    if (!existingUser) {
-      throw new HttpError(404, 'User not found');
-    }
-
-    const taskRows = await db
-      .select({
-        id: tasks.id,
-        title: tasks.title,
-        description: tasks.description,
-        pillarId: tasks.pillarId,
-        pillarName: pillars.name,
-        traitId: tasks.traitId,
-        traitName: traits.name,
-        statId: tasks.statId,
-        statName: stats.name,
-        createdAt: tasks.createdAt,
-        updatedAt: tasks.updatedAt,
-      })
-      .from(tasks)
-      .innerJoin(pillars, eq(tasks.pillarId, pillars.id))
-      .leftJoin(traits, eq(tasks.traitId, traits.id))
-      .leftJoin(stats, eq(tasks.statId, stats.id))
-      .where(eq(tasks.userId, userId))
-      .orderBy(tasks.createdAt);
-
-    const taskLogRows = await db
-      .select({
-        taskId: taskLogs.taskId,
-        lastCompletedAt: drizzleSql<Date | null>`MAX(${taskLogs.doneAt})`,
-      })
-      .from(taskLogs)
-      .where(eq(taskLogs.userId, userId))
-      .groupBy(taskLogs.taskId);
-
-    const lastCompletedMap = new Map<string, Date | null>();
-    for (const row of taskLogRows) {
-      lastCompletedMap.set(
-        row.taskId,
-        row.lastCompletedAt ? new Date(row.lastCompletedAt) : null,
-      );
-    }
-
-    const payload = taskRows.map((task) => ({
-      ...task,
-      lastCompletedAt: lastCompletedMap.get(task.id)?.toISOString() ?? null,
-      pillar_id: task.pillarId,
-      trait_id: task.traitId,
-      stat_id: task.statId,
-    }));
-
-    res.json(payload);
-  }),
-);
-
-api.get(
-  '/task-logs',
-  asyncHandler(async (req, res) => {
-    const parsed = taskLogsQuerySchema.safeParse(req.query);
-
-    if (!parsed.success) {
-      throw new HttpError(400, 'Invalid query parameters', parsed.error.flatten());
-    }
-
-    const { userId } = parsed.data;
-
-    const rows = await db
-      .select({
-        id: taskLogs.id,
-        taskId: taskLogs.taskId,
-        taskTitle: tasks.title,
-        doneAt: taskLogs.doneAt,
-      })
-      .from(taskLogs)
-      .innerJoin(tasks, eq(taskLogs.taskId, tasks.id))
-      .where(eq(taskLogs.userId, userId))
-      .orderBy(desc(taskLogs.doneAt))
-      .limit(LOG_LIMIT);
-
-    const payload = rows.map((row) => ({
-      id: row.id,
-      taskId: row.taskId,
-      taskTitle: row.taskTitle,
-      doneAt: row.doneAt.toISOString(),
-    }));
-
-    res.json(payload);
-  }),
-);
-
-api.post(
-  '/task-logs',
-  asyncHandler(async (req, res) => {
-    const parsed = createTaskLogSchema.safeParse(req.body);
-
-    if (!parsed.success) {
-      throw new HttpError(400, 'Invalid request body', parsed.error.flatten());
-    }
-
-    const { userId, taskId, doneAt } = parsed.data;
-
-    const [task] = await db
-      .select({ id: tasks.id, ownerId: tasks.userId })
-      .from(tasks)
-      .where(eq(tasks.id, taskId))
-      .limit(1);
-
-    if (!task) {
-      throw new HttpError(404, 'Task not found');
-    }
-
-    if (task.ownerId !== userId) {
-      throw new HttpError(403, 'Task does not belong to this user');
-    }
-
-    const inserted = await db
-      .insert(taskLogs)
-      .values({
-        taskId,
-        userId,
-        doneAt,
-      })
-      .returning();
-
-    res.status(201).json({ taskLog: inserted[0] });
-  }),
-);
-
-app.use(api);
+app.use(routes);
 
 app.use((_req, _res, next) => {
   next(new HttpError(404, 'Route not found'));
 });
 
 app.use((error: unknown, _req: Request, res: Response, _next: NextFunction) => {
-  if (error instanceof HttpError) {
+  if (isHttpError(error)) {
     return res.status(error.status).json({
       error: {
         message: error.message,

--- a/apps/api/src/lib/async-handler.ts
+++ b/apps/api/src/lib/async-handler.ts
@@ -1,0 +1,10 @@
+import { NextFunction, Request, Response } from 'express';
+
+type AsyncHandler = (req: Request, res: Response, next: NextFunction) => Promise<void>;
+
+export const asyncHandler = (handler: AsyncHandler) =>
+  (req: Request, res: Response, next: NextFunction) => {
+    handler(req, res, next).catch(next);
+  };
+
+export type { AsyncHandler };

--- a/apps/api/src/lib/http-error.ts
+++ b/apps/api/src/lib/http-error.ts
@@ -1,0 +1,14 @@
+export class HttpError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+    public details?: unknown,
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
+export function isHttpError(error: unknown): error is HttpError {
+  return error instanceof HttpError;
+}

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import { sql } from 'drizzle-orm';
+import { db } from '../db/client.js';
+import { asyncHandler } from '../lib/async-handler.js';
+
+const router = Router();
+
+router.get(
+  '/health/db',
+  asyncHandler(async (_req, res) => {
+    try {
+      await db.execute(sql`select 1`);
+      res.json({ ok: true });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unable to reach the database';
+      res.status(500).json({ ok: false, error: message });
+    }
+  }),
+);
+
+export default router;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import healthRoutes from './health.js';
+import leaderboardRoutes from './leaderboard.js';
+import legacyRoutes from './legacy.js';
+import pillarsRoutes from './pillars.js';
+import tasksRoutes from './tasks.js';
+import usersRoutes from './users.js';
+
+const router = Router();
+
+router.use(healthRoutes);
+router.use(pillarsRoutes);
+router.use(legacyRoutes);
+router.use(tasksRoutes);
+router.use(usersRoutes);
+router.use(leaderboardRoutes);
+
+export default router;

--- a/apps/api/src/routes/leaderboard.ts
+++ b/apps/api/src/routes/leaderboard.ts
@@ -1,0 +1,58 @@
+import { Router } from 'express';
+import { sql } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../db/client.js';
+import { asyncHandler } from '../lib/async-handler.js';
+import { HttpError } from '../lib/http-error.js';
+
+const router = Router();
+
+const leaderboardQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(50).optional(),
+  offset: z.coerce.number().int().nonnegative().optional(),
+});
+
+router.get(
+  '/leaderboard',
+  asyncHandler(async (req, res) => {
+    const { limit, offset } = leaderboardQuerySchema.parse(req.query);
+
+    const finalLimit = limit ?? 10;
+    const finalOffset = offset ?? 0;
+
+    if (finalLimit > 50) {
+      throw new HttpError(400, 'limit must be 50 or less');
+    }
+
+    const result = await db.execute<{
+      user_id: string;
+      total_xp: string | number | null;
+      level: string | number | null;
+      display_name: string | null;
+    }>(sql`
+      SELECT
+        mup.user_id,
+        mup.total_xp,
+        mup.level,
+        u.display_name
+      FROM mv_user_progress mup
+      LEFT JOIN users u ON u.id = mup.user_id
+      ORDER BY mup.total_xp DESC, mup.user_id ASC
+      LIMIT ${finalLimit}
+      OFFSET ${finalOffset}
+    `);
+
+    res.json({
+      limit: finalLimit,
+      offset: finalOffset,
+      users: result.rows.map((row) => ({
+        userId: row.user_id,
+        totalXp: Number(row.total_xp ?? 0),
+        level: Number(row.level ?? 1),
+        displayName: row.display_name ?? null,
+      })),
+    });
+  }),
+);
+
+export default router;

--- a/apps/api/src/routes/legacy.ts
+++ b/apps/api/src/routes/legacy.ts
@@ -1,0 +1,178 @@
+import { Router } from 'express';
+import { desc, eq, sql } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../db/client.js';
+import {
+  pillars,
+  stats,
+  taskLogs,
+  tasks,
+  traits,
+  users,
+} from '../db/schema.js';
+import { asyncHandler } from '../lib/async-handler.js';
+import { HttpError } from '../lib/http-error.js';
+
+const router = Router();
+
+const tasksQuerySchema = z.object({
+  userId: z.string().uuid({ message: 'userId must be a valid UUID' }),
+});
+
+const taskLogsQuerySchema = z.object({
+  userId: z.string().uuid({ message: 'userId must be a valid UUID' }),
+});
+
+const createTaskLogSchema = z.object({
+  userId: z.string().uuid({ message: 'userId must be a valid UUID' }),
+  taskId: z.string().uuid({ message: 'taskId must be a valid UUID' }),
+  doneAt: z.coerce.date({ message: 'doneAt must be a date or ISO string' }),
+});
+
+const LEGACY_LOG_LIMIT = 20;
+
+router.get(
+  '/tasks',
+  asyncHandler(async (req, res) => {
+    const parsed = tasksQuerySchema.safeParse(req.query);
+
+    if (!parsed.success) {
+      throw new HttpError(400, 'Invalid query parameters', parsed.error.flatten());
+    }
+
+    const { userId } = parsed.data;
+
+    const [existingUser] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    if (!existingUser) {
+      throw new HttpError(404, 'User not found');
+    }
+
+    const taskRows = await db
+      .select({
+        id: tasks.id,
+        title: tasks.title,
+        description: tasks.description,
+        pillarId: tasks.pillarId,
+        pillarName: pillars.name,
+        traitId: tasks.traitId,
+        traitName: traits.name,
+        statId: tasks.statId,
+        statName: stats.name,
+        createdAt: tasks.createdAt,
+        updatedAt: tasks.updatedAt,
+      })
+      .from(tasks)
+      .innerJoin(pillars, eq(tasks.pillarId, pillars.id))
+      .leftJoin(traits, eq(tasks.traitId, traits.id))
+      .leftJoin(stats, eq(tasks.statId, stats.id))
+      .where(eq(tasks.userId, userId))
+      .orderBy(tasks.createdAt);
+
+    const taskLogRows = await db
+      .select({
+        taskId: taskLogs.taskId,
+        lastCompletedAt: sql<Date | null>`MAX(${taskLogs.doneAt})`,
+      })
+      .from(taskLogs)
+      .where(eq(taskLogs.userId, userId))
+      .groupBy(taskLogs.taskId);
+
+    const lastCompletedMap = new Map<string, Date | null>();
+    for (const row of taskLogRows) {
+      lastCompletedMap.set(
+        row.taskId,
+        row.lastCompletedAt ? new Date(row.lastCompletedAt) : null,
+      );
+    }
+
+    const payload = taskRows.map((task) => ({
+      ...task,
+      lastCompletedAt: lastCompletedMap.get(task.id)?.toISOString() ?? null,
+      pillar_id: task.pillarId,
+      trait_id: task.traitId,
+      stat_id: task.statId,
+    }));
+
+    res.json(payload);
+  }),
+);
+
+router.get(
+  '/task-logs',
+  asyncHandler(async (req, res) => {
+    const parsed = taskLogsQuerySchema.safeParse(req.query);
+
+    if (!parsed.success) {
+      throw new HttpError(400, 'Invalid query parameters', parsed.error.flatten());
+    }
+
+    const { userId } = parsed.data;
+
+    const rows = await db
+      .select({
+        id: taskLogs.id,
+        taskId: taskLogs.taskId,
+        taskTitle: tasks.title,
+        doneAt: taskLogs.doneAt,
+      })
+      .from(taskLogs)
+      .innerJoin(tasks, eq(taskLogs.taskId, tasks.id))
+      .where(eq(taskLogs.userId, userId))
+      .orderBy(desc(taskLogs.doneAt))
+      .limit(LEGACY_LOG_LIMIT);
+
+    const payload = rows.map((row) => ({
+      id: row.id,
+      taskId: row.taskId,
+      taskTitle: row.taskTitle,
+      doneAt: row.doneAt.toISOString(),
+    }));
+
+    res.json(payload);
+  }),
+);
+
+router.post(
+  '/task-logs',
+  asyncHandler(async (req, res) => {
+    const parsed = createTaskLogSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      throw new HttpError(400, 'Invalid request body', parsed.error.flatten());
+    }
+
+    const { userId, taskId, doneAt } = parsed.data;
+
+    const [task] = await db
+      .select({ id: tasks.id, ownerId: tasks.userId })
+      .from(tasks)
+      .where(eq(tasks.id, taskId))
+      .limit(1);
+
+    if (!task) {
+      throw new HttpError(404, 'Task not found');
+    }
+
+    if (task.ownerId !== userId) {
+      throw new HttpError(403, 'Task does not belong to this user');
+    }
+
+    const inserted = await db
+      .insert(taskLogs)
+      .values({
+        taskId,
+        userId,
+        doneAt,
+      })
+      .returning();
+
+    res.status(201).json({ taskLog: inserted[0] });
+  }),
+);
+
+export default router;

--- a/apps/api/src/routes/pillars.ts
+++ b/apps/api/src/routes/pillars.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import { asc } from 'drizzle-orm';
+import { db } from '../db/client.js';
+import { pillars } from '../db/schema.js';
+import { asyncHandler } from '../lib/async-handler.js';
+
+const router = Router();
+
+router.get(
+  '/pillars',
+  asyncHandler(async (_req, res) => {
+    const rows = await db
+      .select({
+        id: pillars.id,
+        name: pillars.name,
+        description: pillars.description,
+      })
+      .from(pillars)
+      .orderBy(asc(pillars.name));
+
+    res.json(
+      rows.map((row) => ({
+        ...row,
+        description: row.description ?? '',
+      })),
+    );
+  }),
+);
+
+export default router;

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,0 +1,56 @@
+import { Router } from 'express';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../db/client.js';
+import { taskLogs, tasks } from '../db/schema.js';
+import { asyncHandler } from '../lib/async-handler.js';
+import { HttpError } from '../lib/http-error.js';
+
+const router = Router();
+
+const completeTaskSchema = z.object({
+  userId: z.string().uuid({ message: 'userId must be a valid UUID' }),
+  taskId: z.string().uuid({ message: 'taskId must be a valid UUID' }),
+  doneAt: z.coerce.date().optional(),
+});
+
+router.post(
+  '/tasks/complete',
+  asyncHandler(async (req, res) => {
+    const parsed = completeTaskSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      throw new HttpError(400, 'Invalid request body', parsed.error.flatten());
+    }
+
+    const { userId, taskId } = parsed.data;
+    const doneAt = parsed.data.doneAt ?? new Date();
+
+    const [task] = await db
+      .select({ id: tasks.id, ownerId: tasks.userId })
+      .from(tasks)
+      .where(eq(tasks.id, taskId))
+      .limit(1);
+
+    if (!task) {
+      throw new HttpError(404, 'Task not found');
+    }
+
+    if (task.ownerId !== userId) {
+      throw new HttpError(403, 'Task does not belong to this user');
+    }
+
+    const [inserted] = await db
+      .insert(taskLogs)
+      .values({
+        taskId,
+        userId,
+        doneAt,
+      })
+      .returning({ id: taskLogs.id });
+
+    res.status(201).json({ ok: true, id: inserted.id });
+  }),
+);
+
+export default router;

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,0 +1,242 @@
+import { Router } from 'express';
+import { asc, desc, eq, sql } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '../db/client.js';
+import {
+  dailyStreaks,
+  pillars,
+  taskLogs,
+  tasks,
+  traits,
+  users,
+} from '../db/schema.js';
+import { asyncHandler } from '../lib/async-handler.js';
+import { HttpError } from '../lib/http-error.js';
+
+const router = Router();
+
+const userParamSchema = z.object({
+  userId: z.string().uuid({ message: 'userId must be a valid UUID' }),
+});
+
+const taskLogsQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(100).optional(),
+});
+
+const emotionsQuerySchema = z.object({
+  days: z.coerce.number().int().positive().max(365).optional(),
+});
+
+async function requireUser(userId: string) {
+  const [existing] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!existing) {
+    throw new HttpError(404, 'User not found');
+  }
+}
+
+router.get(
+  '/:userId/progress',
+  asyncHandler(async (req, res) => {
+    const { userId } = userParamSchema.parse(req.params);
+
+    await requireUser(userId);
+
+    const progressResult = await db.execute<{
+      total_xp: string | number | null;
+      level: string | number | null;
+      next_level_xp: string | number | null;
+      progress_to_next: string | number | null;
+    }>(sql`
+      SELECT total_xp, level, next_level_xp, progress_to_next
+      FROM mv_user_progress
+      WHERE user_id = ${userId}
+      LIMIT 1
+    `);
+
+    const progressRow = progressResult.rows[0];
+
+    const streakRow = await db.query.dailyStreaks.findFirst({
+      where: eq(dailyStreaks.userId, userId),
+    });
+
+    const totalXp = Number(progressRow?.total_xp ?? 0);
+    const level = Number(progressRow?.level ?? 1);
+    const nextLevelXp = Number(progressRow?.next_level_xp ?? 0);
+    const progressToNext = Number(progressRow?.progress_to_next ?? 0);
+
+    res.json({
+      userId,
+      totalXp,
+      level,
+      nextLevelXp,
+      progressToNext,
+      currentStreak: streakRow?.currentStreak ?? 0,
+      longestStreak: streakRow?.longestStreak ?? 0,
+    });
+  }),
+);
+
+router.get(
+  '/:userId/tasks',
+  asyncHandler(async (req, res) => {
+    const { userId } = userParamSchema.parse(req.params);
+
+    await requireUser(userId);
+
+    const rows = await db
+      .select({
+        id: tasks.id,
+        name: tasks.name,
+        weeklyTarget: tasks.weeklyTarget,
+        xp: tasks.xp,
+        pillarId: tasks.pillarId,
+        pillarName: pillars.name,
+        traitId: tasks.traitId,
+        traitName: traits.name,
+      })
+      .from(tasks)
+      .innerJoin(pillars, eq(tasks.pillarId, pillars.id))
+      .leftJoin(traits, eq(tasks.traitId, traits.id))
+      .where(eq(tasks.userId, userId))
+      .orderBy(asc(tasks.createdAt));
+
+    res.json(
+      rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        weeklyTarget: row.weeklyTarget,
+        xp: row.xp,
+        pillar: {
+          id: row.pillarId,
+          name: row.pillarName,
+        },
+        trait: row.traitId
+          ? {
+              id: row.traitId,
+              name: row.traitName ?? '',
+            }
+          : null,
+      })),
+    );
+  }),
+);
+
+router.get(
+  '/:userId/task-logs',
+  asyncHandler(async (req, res) => {
+    const { userId } = userParamSchema.parse(req.params);
+    const { limit } = taskLogsQuerySchema.parse(req.query);
+
+    await requireUser(userId);
+
+    const finalLimit = limit ?? 20;
+
+    const rows = await db
+      .select({
+        id: taskLogs.id,
+        taskId: taskLogs.taskId,
+        taskName: tasks.name,
+        doneAt: taskLogs.doneAt,
+      })
+      .from(taskLogs)
+      .innerJoin(tasks, eq(taskLogs.taskId, tasks.id))
+      .where(eq(taskLogs.userId, userId))
+      .orderBy(desc(taskLogs.doneAt))
+      .limit(finalLimit);
+
+    res.json(
+      rows.map((row) => ({
+        id: row.id,
+        taskId: row.taskId,
+        taskName: row.taskName,
+        doneAt: row.doneAt.toISOString(),
+      })),
+    );
+  }),
+);
+
+router.get(
+  '/:userId/streaks',
+  asyncHandler(async (req, res) => {
+    const { userId } = userParamSchema.parse(req.params);
+
+    await requireUser(userId);
+
+    const streakResult = await db.execute<{
+      task_id: string;
+      task_name: string | null;
+      c1s_current: string | number | null;
+      c2s_current: string | number | null;
+      c3s_current: string | number | null;
+      c4s_current: string | number | null;
+      c1s_max: string | number | null;
+      c2s_max: string | number | null;
+      c3s_max: string | number | null;
+      c4s_max: string | number | null;
+    }>(sql`
+      SELECT
+        t.id AS task_id,
+        t.name AS task_name,
+        COALESCE(actual.c1s_actual, 0) AS c1s_current,
+        COALESCE(actual.c2s_actual, 0) AS c2s_current,
+        COALESCE(actual.c3s_actual, 0) AS c3s_current,
+        COALESCE(actual.c4s_actual, 0) AS c4s_current,
+        COALESCE(max.c1s_max, 0) AS c1s_max,
+        COALESCE(max.c2s_max, 0) AS c2s_max,
+        COALESCE(max.c3s_max, 0) AS c3s_max,
+        COALESCE(max.c4s_max, 0) AS c4s_max
+      FROM tasks t
+      LEFT JOIN v_task_streaks_actual actual
+        ON actual.user_id = t.user_id AND actual.task_id = t.id
+      LEFT JOIN v_task_streaks_max max
+        ON max.user_id = t.user_id AND max.task_id = t.id
+      WHERE t.user_id = ${userId}
+      ORDER BY t.name
+    `);
+
+    res.json(
+      streakResult.rows.map((row) => ({
+        taskId: row.task_id,
+        taskName: row.task_name ?? '',
+        current: {
+          c1s: Number(row.c1s_current ?? 0),
+          c2s: Number(row.c2s_current ?? 0),
+          c3s: Number(row.c3s_current ?? 0),
+          c4s: Number(row.c4s_current ?? 0),
+        },
+        longest: {
+          c1s: Number(row.c1s_max ?? 0),
+          c2s: Number(row.c2s_max ?? 0),
+          c3s: Number(row.c3s_max ?? 0),
+          c4s: Number(row.c4s_max ?? 0),
+        },
+      })),
+    );
+  }),
+);
+
+router.get(
+  '/:userId/emotions',
+  asyncHandler(async (req, res) => {
+    const { userId } = userParamSchema.parse(req.params);
+    const { days } = emotionsQuerySchema.parse(req.query);
+
+    await requireUser(userId);
+
+    const range = days ?? 30;
+
+    // TODO: replace stub when emotion tracking schema is available
+    res.json({
+      userId,
+      days: range,
+      entries: [],
+    });
+  }),
+);
+
+export default router;


### PR DESCRIPTION
## Summary
- restructure the API to mount modular routers while preserving health, pillars, and legacy task endpoints
- add user-centric routes for progress, task listings, recent logs, streaks, and an emotions stub sourced from the new SQL views
- expose leaderboard and task completion endpoints and document the REST surface in the README

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e272b03dc08322afb8896afcae1638