### PR TITLE
Fix materialized view creation script

### DIFF
--- a/apps/api/sql/020_mv_task_weeks.sql
+++ b/apps/api/sql/020_mv_task_weeks.sql
@@ -1,26 +1,19 @@
 BEGIN;
 -- Weekly aggregation of task completions
-DO $$
-BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM pg_matviews WHERE matviewname = 'mv_task_weeks'
-    ) THEN
-        EXECUTE $$
-            CREATE MATERIALIZED VIEW mv_task_weeks AS
-            SELECT
-                tl.user_id,
-                tl.task_id,
-                date_trunc('week', tl.done_at)::date AS week_start,
-                COUNT(*)::INT AS times_in_week
-            FROM task_logs tl
-            GROUP BY tl.user_id, tl.task_id, date_trunc('week', tl.done_at)::date
-            WITH NO DATA
-        $$;
-    END IF;
-END
-$$;
 
-CREATE INDEX IF NOT EXISTS mv_task_weeks_user_task_week_idx
+DROP MATERIALIZED VIEW IF EXISTS mv_task_weeks;
+
+CREATE MATERIALIZED VIEW mv_task_weeks AS
+SELECT
+    tl.user_id,
+    tl.task_id,
+    date_trunc('week', tl.done_at)::date AS week_start,
+    COUNT(*)::INT AS times_in_week
+FROM task_logs tl
+GROUP BY tl.user_id, tl.task_id, date_trunc('week', tl.done_at)::date
+WITH NO DATA;
+
+CREATE INDEX mv_task_weeks_user_task_week_idx
     ON mv_task_weeks (user_id, task_id, week_start);
 
 COMMENT ON MATERIALIZED VIEW mv_task_weeks IS 'Refresh after task_logs inserts; use REFRESH CONCURRENTLY in production.';


### PR DESCRIPTION
## Summary
- replace the DO block with an idempotent DROP/CREATE sequence for the mv_task_weeks materialized view
- ensure the supporting index is recreated after the view is rebuilt

## Testing
- npm run db:all *(fails: DATABASE_URL is required to run SQL files)*

------
https://chatgpt.com/codex/tasks/task_e_68e27b5d87988322a775fe000033e476