### PR TITLE
Respect reduced motion preference in testimonials carousel

### DIFF
--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -123,18 +123,43 @@ export default function LandingPage() {
   const isSignedIn = Boolean(userId);
   const [activeSlide, setActiveSlide] = useState(0);
   const [paused, setPaused] = useState(false);
+  const [allowAutoplay, setAllowAutoplay] = useState(true);
 
   const testimonialCount = TESTIMONIALS.length;
 
   useEffect(() => {
-    if (paused || testimonialCount <= 1) {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    const updatePreference = (event: MediaQueryListEvent | MediaQueryList) => {
+      setAllowAutoplay(!event.matches);
+    };
+
+    updatePreference(mediaQuery);
+
+    const handleChange = (event: MediaQueryListEvent) => updatePreference(event);
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  useEffect(() => {
+    if (paused || testimonialCount <= 1 || !allowAutoplay) {
       return;
     }
     const timer = window.setInterval(() => {
       setActiveSlide((current) => (current + 1) % testimonialCount);
     }, 4000);
     return () => window.clearInterval(timer);
-  }, [paused, testimonialCount]);
+  }, [allowAutoplay, paused, testimonialCount]);
 
   const goToSlide = (index: number) => {
     setActiveSlide((index + testimonialCount) % testimonialCount);


### PR DESCRIPTION
## Summary
- add a motion-preference watcher so the landing page testimonial carousel avoids auto-advancing when reduced motion is requested
- ensure the auto-advance interval only runs when autoplay is allowed

## Testing
- npm run typecheck:web *(fails: missing dependencies such as @clerk/clerk-react and react-router-dom in the workspace setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e284e6b4b4832285e0cfb30d984cd6