### PR TITLE
Fix API database scripts to run from any working directory

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,9 +9,9 @@
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate --config ./drizzle.config.ts",
     "db:migrate": "drizzle-kit migrate --config ./drizzle.config.ts",
-    "db:push": "node ../../scripts/run-sql.js",
-    "db:seed": "node ../../scripts/run-sql.js",
-    "db:all": "node ../../scripts/run-sql.js"
+    "db:push": "node ./scripts/run-sql.js",
+    "db:seed": "node ./scripts/run-sql.js",
+    "db:all": "node ./scripts/run-sql.js"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.9.1",

--- a/apps/api/scripts/run-sql.js
+++ b/apps/api/scripts/run-sql.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../../../scripts/run-sql.js';


### PR DESCRIPTION
## Summary
- add an API-local wrapper that imports the shared SQL runner
- update the API npm database commands to use the wrapper so the runner is found regardless of cwd

## Testing
- npm --prefix apps/api run db:all *(fails: DATABASE_URL is required to run SQL files)*

------
https://chatgpt.com/codex/tasks/task_e_68e288da15fc832283e9c55c4f5490d0