### PR TITLE
Add service-local SQL runner for web Railway deploy

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -22,6 +22,17 @@ export VITE_API_URL="https://your-api.example.com"
 
 The URL is read at runtime via `import.meta.env.VITE_API_URL`. Do not include trailing slashes.
 
+## Database utilities
+
+To apply the service-local SQL bundle, provide `DATABASE_URL` and run:
+
+```bash
+export DATABASE_URL="postgres://..."
+npm run db:all
+```
+
+Railway pre-deploy runs the same command, so successful execution locally mirrors the deploy step. Use `npm run dbg:env` to verify SQL path resolution when debugging.
+
 ## Routes
 - `/login` – Paste a user ID or continue with the shared demo account.
 - `/dashboard` – Authenticated dashboard with XP, streaks, pillars, activity, and insights.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview --host 0.0.0.0 --port ${PORT:-3000}",
     "typecheck": "tsc --noEmit",
-    "db:all": "node ./scripts/run-sql.js"
+    "db:all": "node ./scripts/run-sql.cjs",
+    "dbg:env": "node ./scripts/print-env.cjs"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.9.5",

--- a/apps/web/scripts/print-env.cjs
+++ b/apps/web/scripts/print-env.cjs
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const baseDir = __dirname;
+const resolvedSqlDir = process.env.SQL_DIR
+  ? path.resolve(process.cwd(), process.env.SQL_DIR)
+  : path.resolve(baseDir, '../sql');
+
+console.log('process.cwd():', process.cwd());
+console.log('__dirname:', __dirname);
+console.log('Resolved SQL_DIR:', resolvedSqlDir);
+
+try {
+  const files = fs
+    .readdirSync(resolvedSqlDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort((a, b) => a.localeCompare(b));
+
+  console.log('SQL files:');
+  for (const file of files) {
+    console.log(`  - ${file}`);
+  }
+
+  if (files.length === 0) {
+    console.log('  (none found)');
+  }
+} catch (error) {
+  console.warn(`Could not read SQL directory: ${error.message}`);
+}

--- a/apps/web/scripts/run-sql.cjs
+++ b/apps/web/scripts/run-sql.cjs
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+const { Pool } = require('@neondatabase/serverless');
+
+function ensureSslModeRequire(url) {
+  if (!url) {
+    throw new Error('DATABASE_URL is required');
+  }
+
+  if (url.includes('sslmode=')) {
+    return url.replace(/sslmode=[^&]+/i, 'sslmode=require');
+  }
+
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}sslmode=require`;
+}
+
+function resolveSqlDir() {
+  const baseDir = __dirname;
+  return process.env.SQL_DIR
+    ? path.resolve(process.cwd(), process.env.SQL_DIR)
+    : path.resolve(baseDir, '../sql');
+}
+
+async function main() {
+  const rawDatabaseUrl = process.env.DATABASE_URL;
+  const connectionString = ensureSslModeRequire(rawDatabaseUrl);
+  const sqlDir = resolveSqlDir();
+
+  if (!fs.existsSync(sqlDir)) {
+    throw new Error(`SQL directory not found: ${sqlDir}`);
+  }
+
+  const sqlFiles = fs
+    .readdirSync(sqlDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort((a, b) => a.localeCompare(b));
+
+  if (sqlFiles.length === 0) {
+    console.warn(`⚠️  No SQL files found in ${sqlDir}`);
+    return;
+  }
+
+  console.log(`Using SQL directory: ${sqlDir}`);
+
+  const pool = new Pool({ connectionString });
+
+  try {
+    for (const file of sqlFiles) {
+      const fullPath = path.join(sqlDir, file);
+      const sql = fs.readFileSync(fullPath, 'utf8');
+
+      console.log(`→ Running ${file}`);
+
+      try {
+        await pool.query(sql);
+        console.log(`  ✓ Applied ${file}`);
+      } catch (error) {
+        const message = error?.message || '';
+        if (/already exists/i.test(message) || /duplicate/i.test(message)) {
+          console.warn(`  ⚠️  Skipped ${file}: ${message}`);
+          continue;
+        }
+
+        console.error(`  ✖ Failed ${file}: ${message}`);
+        throw error;
+      }
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/web/sql/001_extensions.sql
+++ b/apps/web/sql/001_extensions.sql
@@ -1,0 +1,5 @@
+BEGIN;
+-- Core extensions for UUID + case-insensitive text
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS citext;
+COMMIT;

--- a/apps/web/sql/010_tables_core.sql
+++ b/apps/web/sql/010_tables_core.sql
@@ -1,0 +1,131 @@
+BEGIN;
+-- Pillars → Traits → Stats scaffolding
+CREATE TABLE IF NOT EXISTS pillars (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS pillars_name_idx ON pillars (name);
+
+CREATE TABLE IF NOT EXISTS traits (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    pillar_id UUID NOT NULL REFERENCES pillars(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS traits_pillar_id_idx ON traits (pillar_id);
+
+CREATE TABLE IF NOT EXISTS stats (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    trait_id UUID NOT NULL REFERENCES traits(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    unit TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS stats_trait_id_idx ON stats (trait_id);
+
+-- Users & profile metadata
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email CITEXT NOT NULL UNIQUE,
+    display_name TEXT,
+    avatar_url TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS users_email_idx ON users (email);
+
+-- Ensure optional avatar column exists when table predates migration
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS avatar_url TEXT;
+
+-- Tasks owned by users
+CREATE TABLE IF NOT EXISTS tasks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    weekly_target INTEGER NOT NULL DEFAULT 1,
+    xp SMALLINT NOT NULL DEFAULT 10,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Backfill legacy schemas with new columns
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS name TEXT,
+    ADD COLUMN IF NOT EXISTS weekly_target INTEGER,
+    ADD COLUMN IF NOT EXISTS xp SMALLINT,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT now();
+
+UPDATE tasks SET name = COALESCE(name, title) WHERE name IS NULL;
+UPDATE tasks SET weekly_target = 1 WHERE weekly_target IS NULL;
+UPDATE tasks SET xp = 10 WHERE xp IS NULL;
+
+ALTER TABLE tasks
+    ALTER COLUMN name SET NOT NULL,
+    ALTER COLUMN weekly_target SET NOT NULL,
+    ALTER COLUMN weekly_target SET DEFAULT 1,
+    ALTER COLUMN xp SET NOT NULL,
+    ALTER COLUMN xp SET DEFAULT 10,
+    ALTER COLUMN created_at SET DEFAULT now();
+
+-- Preserve optional relations if legacy columns exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.constraint_column_usage
+        WHERE table_name = 'tasks' AND constraint_name = 'tasks_user_id_fkey'
+    ) THEN
+        ALTER TABLE tasks
+            ADD COLUMN IF NOT EXISTS user_id UUID,
+            ALTER COLUMN user_id SET NOT NULL,
+            ADD CONSTRAINT tasks_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+    END IF;
+END
+$$;
+
+-- Attach pillar/trait/stat references when tables exist
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS pillar_id UUID REFERENCES pillars(id) ON DELETE SET NULL;
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS trait_id UUID REFERENCES traits(id) ON DELETE SET NULL;
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS stat_id UUID REFERENCES stats(id) ON DELETE SET NULL;
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS description TEXT;
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+
+CREATE INDEX IF NOT EXISTS tasks_user_id_idx ON tasks (user_id);
+CREATE INDEX IF NOT EXISTS tasks_pillar_id_idx ON tasks (pillar_id);
+CREATE INDEX IF NOT EXISTS tasks_trait_id_idx ON tasks (trait_id);
+CREATE INDEX IF NOT EXISTS tasks_user_id_weekly_target_idx ON tasks (user_id, weekly_target);
+
+-- Task logs for completions
+CREATE TABLE IF NOT EXISTS task_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    task_id UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    done_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE task_logs
+    ADD COLUMN IF NOT EXISTS notes TEXT,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT now();
+
+ALTER TABLE task_logs
+    ALTER COLUMN done_at SET NOT NULL,
+    ALTER COLUMN done_at SET DEFAULT now();
+
+CREATE INDEX IF NOT EXISTS task_logs_user_task_done_at_idx ON task_logs (user_id, task_id, done_at);
+CREATE INDEX IF NOT EXISTS task_logs_task_id_idx ON task_logs (task_id);
+CREATE INDEX IF NOT EXISTS task_logs_user_id_idx ON task_logs (user_id);
+
+COMMIT;

--- a/apps/web/sql/015_game_config.sql
+++ b/apps/web/sql/015_game_config.sql
@@ -1,0 +1,49 @@
+BEGIN;
+-- Enumerations and progression scaffolding
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'pillar_type') THEN
+        CREATE TYPE pillar_type AS ENUM ('BODY', 'MIND', 'SOUL');
+    END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS level_rules (
+    level INTEGER PRIMARY KEY,
+    xp_required INTEGER NOT NULL UNIQUE
+);
+
+INSERT INTO level_rules (level, xp_required)
+VALUES
+    (1, 0),
+    (2, 100),
+    (3, 250),
+    (4, 450),
+    (5, 700),
+    (6, 1000),
+    (7, 1350),
+    (8, 1750),
+    (9, 2200),
+    (10, 2800)
+ON CONFLICT (level) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS achievements (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code TEXT NOT NULL UNIQUE,
+    title TEXT NOT NULL,
+    description TEXT,
+    points INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS achievements_code_idx ON achievements (code);
+
+CREATE TABLE IF NOT EXISTS user_achievements (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    achievement_code TEXT NOT NULL REFERENCES achievements(code),
+    earned_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (user_id, achievement_code)
+);
+
+COMMIT;

--- a/apps/web/sql/020_mv_task_weeks.sql
+++ b/apps/web/sql/020_mv_task_weeks.sql
@@ -1,0 +1,21 @@
+BEGIN;
+-- Weekly aggregation of task completions
+
+DROP MATERIALIZED VIEW IF EXISTS public.mv_task_weeks;
+
+CREATE MATERIALIZED VIEW public.mv_task_weeks AS
+SELECT
+    tl.user_id,
+    tl.task_id,
+    date_trunc('week', tl.done_at)::date AS week_start,
+    COUNT(*)::INT AS times_in_week
+FROM task_logs tl
+GROUP BY tl.user_id, tl.task_id, date_trunc('week', tl.done_at)::date
+WITH NO DATA;
+
+CREATE INDEX IF NOT EXISTS mv_task_weeks_user_task_week_idx
+    ON public.mv_task_weeks (user_id, task_id, week_start);
+
+COMMENT ON MATERIALIZED VIEW public.mv_task_weeks IS 'Refresh after task_logs inserts; use REFRESH CONCURRENTLY in production.';
+
+COMMIT;

--- a/apps/web/sql/030_views_streak_flags.sql
+++ b/apps/web/sql/030_views_streak_flags.sql
@@ -1,0 +1,19 @@
+BEGIN;
+-- Flags for consistency tiers (1-4 completions per week)
+
+DROP VIEW IF EXISTS public.v_task_weeks_flags CASCADE;
+
+CREATE VIEW public.v_task_weeks_flags AS
+SELECT
+    user_id,
+    task_id,
+    week_start,
+    (times_in_week >= 1) AS c1s_ok,
+    (times_in_week >= 2) AS c2s_ok,
+    (times_in_week >= 3) AS c3s_ok,
+    (times_in_week >= 4) AS c4s_ok
+FROM public.mv_task_weeks;
+
+COMMENT ON VIEW public.v_task_weeks_flags IS 'Boolean thresholds derived from mv_task_weeks (true when weekly count ≥ tier).';
+
+COMMIT;

--- a/apps/web/sql/040_views_streaks.sql
+++ b/apps/web/sql/040_views_streaks.sql
@@ -1,0 +1,92 @@
+BEGIN;
+-- Consecutive-week streak calculations (current + max)
+
+DROP VIEW IF EXISTS public.v_task_streaks_actual CASCADE;
+
+CREATE VIEW public.v_task_streaks_actual AS
+WITH task_base AS (
+    SELECT id AS task_id, user_id FROM tasks
+),
+flags AS (
+    SELECT * FROM public.v_task_weeks_flags
+),
+latest AS (
+    SELECT user_id, task_id, MAX(week_start) AS last_week
+    FROM flags
+    GROUP BY user_id, task_id
+),
+tier_weeks AS (
+    SELECT 'c1s'::TEXT AS tier, user_id, task_id, week_start FROM flags WHERE c1s_ok
+    UNION ALL
+    SELECT 'c2s', user_id, task_id, week_start FROM flags WHERE c2s_ok
+    UNION ALL
+    SELECT 'c3s', user_id, task_id, week_start FROM flags WHERE c3s_ok
+    UNION ALL
+    SELECT 'c4s', user_id, task_id, week_start FROM flags WHERE c4s_ok
+),
+islands AS (
+    SELECT tier, user_id, task_id, MIN(week_start) AS start_week, MAX(week_start) AS end_week, COUNT(*) AS streak_length
+    FROM (
+        SELECT tier,
+               user_id,
+               task_id,
+               week_start,
+               week_start - (ROW_NUMBER() OVER (PARTITION BY tier, user_id, task_id ORDER BY week_start)) * INTERVAL '1 week' AS grp
+        FROM tier_weeks
+    ) sub
+    GROUP BY tier, user_id, task_id, grp
+)
+SELECT
+    tb.user_id,
+    tb.task_id,
+    COALESCE(MAX(i.streak_length) FILTER (WHERE i.tier = 'c1s' AND i.end_week = latest.last_week), 0) AS c1s_actual,
+    COALESCE(MAX(i.streak_length) FILTER (WHERE i.tier = 'c2s' AND i.end_week = latest.last_week), 0) AS c2s_actual,
+    COALESCE(MAX(i.streak_length) FILTER (WHERE i.tier = 'c3s' AND i.end_week = latest.last_week), 0) AS c3s_actual,
+    COALESCE(MAX(i.streak_length) FILTER (WHERE i.tier = 'c4s' AND i.end_week = latest.last_week), 0) AS c4s_actual
+FROM task_base tb
+LEFT JOIN latest ON latest.user_id = tb.user_id AND latest.task_id = tb.task_id
+LEFT JOIN islands i ON i.user_id = tb.user_id AND i.task_id = tb.task_id
+GROUP BY tb.user_id, tb.task_id;
+
+DROP VIEW IF EXISTS public.v_task_streaks_max CASCADE;
+
+CREATE VIEW public.v_task_streaks_max AS
+WITH task_base AS (
+    SELECT id AS task_id, user_id FROM tasks
+),
+flags AS (
+    SELECT * FROM public.v_task_weeks_flags
+),
+tier_weeks AS (
+    SELECT 'c1s'::TEXT AS tier, user_id, task_id, week_start FROM flags WHERE c1s_ok
+    UNION ALL
+    SELECT 'c2s', user_id, task_id, week_start FROM flags WHERE c2s_ok
+    UNION ALL
+    SELECT 'c3s', user_id, task_id, week_start FROM flags WHERE c3s_ok
+    UNION ALL
+    SELECT 'c4s', user_id, task_id, week_start FROM flags WHERE c4s_ok
+),
+islands AS (
+    SELECT tier, user_id, task_id, MIN(week_start) AS start_week, MAX(week_start) AS end_week, COUNT(*) AS streak_length
+    FROM (
+        SELECT tier,
+               user_id,
+               task_id,
+               week_start,
+               week_start - (ROW_NUMBER() OVER (PARTITION BY tier, user_id, task_id ORDER BY week_start)) * INTERVAL '1 week' AS grp
+        FROM tier_weeks
+    ) sub
+    GROUP BY tier, user_id, task_id, grp
+)
+SELECT
+    tb.user_id,
+    tb.task_id,
+    COALESCE(MAX(i.streak_length) FILTER (WHERE i.tier = 'c1s'), 0) AS c1s_max,
+    COALESCE(MAX(i.streak_length) FILTER (WHERE i.tier = 'c2s'), 0) AS c2s_max,
+    COALESCE(MAX(i.streak_length) FILTER (WHERE i.tier = 'c3s'), 0) AS c3s_max,
+    COALESCE(MAX(i.streak_length) FILTER (WHERE i.tier = 'c4s'), 0) AS c4s_max
+FROM task_base tb
+LEFT JOIN islands i ON i.user_id = tb.user_id AND i.task_id = tb.task_id
+GROUP BY tb.user_id, tb.task_id;
+
+COMMIT;

--- a/apps/web/sql/050_progress_views.sql
+++ b/apps/web/sql/050_progress_views.sql
@@ -1,0 +1,45 @@
+BEGIN;
+-- User XP totals + level progress
+
+DROP MATERIALIZED VIEW IF EXISTS public.mv_user_progress;
+
+CREATE MATERIALIZED VIEW public.mv_user_progress AS
+WITH xp_base AS (
+    SELECT
+        u.id AS user_id,
+        COALESCE(SUM(t.xp), 0)::BIGINT AS total_xp
+    FROM users u
+    LEFT JOIN task_logs tl ON tl.user_id = u.id
+    LEFT JOIN tasks t ON t.id = tl.task_id
+    GROUP BY u.id
+),
+lvl AS (
+    SELECT
+        xb.user_id,
+        xb.total_xp,
+        COALESCE((
+            SELECT MAX(lr.level)
+            FROM level_rules lr
+            WHERE lr.xp_required <= xb.total_xp
+        ), 1) AS level,
+        COALESCE((
+            SELECT MIN(lr.xp_required)
+            FROM level_rules lr
+            WHERE lr.xp_required > xb.total_xp
+        ), xb.total_xp) AS next_level_xp
+    FROM xp_base xb
+)
+SELECT
+    lvl.user_id,
+    lvl.total_xp,
+    lvl.level,
+    lvl.next_level_xp,
+    GREATEST(lvl.next_level_xp - lvl.total_xp, 0) AS progress_to_next
+FROM lvl
+WITH NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mv_user_progress_user_id_idx ON public.mv_user_progress (user_id);
+
+COMMENT ON MATERIALIZED VIEW public.mv_user_progress IS 'Refresh to sync XP/levels after task logs; consider REFRESH CONCURRENTLY in prod.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a CommonJS SQL runner and env diagnostics script for the web service
- bundle the required SQL files alongside the service with drop/create idempotent statements
- document how to run the database prep command locally and update npm scripts to use the new runner

## Testing
- npm run dbg:env

------
https://chatgpt.com/codex/tasks/task_e_68e28b3933ec832285ca5ff5c49941ed