### PR TITLE
Ensure Railway services build before start

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prestart": "npm run build",
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "prestart": "npm run build",
+    "start": "vite preview",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "db:all": "node ./scripts/run-sql.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@clerk/clerk-react':
         specifier: ^5.8.1
         version: 5.50.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@neondatabase/serverless':
+        specifier: ^0.9.5
+        version: 0.9.5
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.19
@@ -2715,7 +2718,7 @@ snapshots:
 
   '@types/pg@8.11.6':
     dependencies:
-      '@types/node': 20.19.19
+      '@types/node': 24.6.2
       pg-protocol: 1.10.3
       pg-types: 4.1.0
 

--- a/railway.toml
+++ b/railway.toml
@@ -5,8 +5,8 @@ command = "npm --workspace apps/api run start"
   PORT = "8080"
 
 [service.web]
-command = "npm --workspace apps/web run preview"
+command = "npm --workspace apps/web run start"
 
   [service.web.env]
   PORT = "5173"
-  VITE_API_BASE_URL = "https://web-dev-dfa2.up.railway.app"
+  VITE_API_URL = "https://web-dev-dfa2.up.railway.app"


### PR DESCRIPTION
## Summary
- add prestart hooks for the API and web workspaces so TypeScript builds run before the services start
- update the Railway web service command to use the new start script and fix the API base URL env name

## Testing
- npm --workspace apps/web run build

------
https://chatgpt.com/codex/tasks/task_e_68e29c98cb8c83228153ea29d88c306b