### PR TITLE
Fix web preview server binding

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "prestart": "npm run build",
-    "start": "vite preview",
+    "start": "node ./scripts/start-preview.js",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "db:all": "node ./scripts/run-sql.cjs",

--- a/apps/web/scripts/start-preview.js
+++ b/apps/web/scripts/start-preview.js
@@ -1,0 +1,32 @@
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const DEFAULT_PORT = '4173';
+const DEFAULT_HOST = '0.0.0.0';
+
+const port = process.env.PORT && process.env.PORT.trim() !== '' ? process.env.PORT : DEFAULT_PORT;
+const host = process.env.HOST && process.env.HOST.trim() !== '' ? process.env.HOST : DEFAULT_HOST;
+
+const filename = fileURLToPath(import.meta.url);
+const viteBin = join(dirname(filename), '..', 'node_modules', 'vite', 'bin', 'vite.js');
+
+const preview = spawn(process.execPath, [viteBin, 'preview', '--host', host, '--port', port], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+preview.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});
+
+preview.on('error', (error) => {
+  console.error('Failed to start Vite preview server', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a dedicated preview launcher that binds Vite to the requested host and port
- update the web package start script to use the launcher so Railway receives traffic

## Testing
- PORT=5173 npm --workspace apps/web run start

------
https://chatgpt.com/codex/tasks/task_e_68e29f5217cc8322a5515af96c5560a9