### PR TITLE
Normalize frontend env vars for API and Clerk

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,3 @@
+# API service environment variables
+DATABASE_URL=postgres://user:password@host:5432/dbname
+CLERK_SECRET_KEY=sk_test_XXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,3 @@
+# Web client environment variables
+VITE_API_BASE_URL=http://localhost:3000
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_XXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -17,10 +17,25 @@ The dev server runs on <http://localhost:5173> by default.
 Set the API origin before starting the dev server or building:
 
 ```bash
-export VITE_API_URL="https://your-api.example.com"
+export VITE_API_BASE_URL="https://your-api.example.com"
+export VITE_CLERK_PUBLISHABLE_KEY="pk_test_xxx"
 ```
 
-The URL is read at runtime via `import.meta.env.VITE_API_URL`. Do not include trailing slashes.
+The API URL is read at runtime via `import.meta.env.VITE_API_BASE_URL`. Do not include trailing slashes.
+
+### Railway configuration
+
+Configure the Railway services with the following environment variables:
+
+- **Web service** (`apps/web`)
+  - `VITE_API_BASE_URL` &rarr; Public API URL (for example, `https://api-XXXX.up.railway.app`)
+  - `VITE_CLERK_PUBLISHABLE_KEY` &rarr; Clerk publishable key
+  - _Do not_ define `CLERK_SECRET_KEY` here; it must remain server-side only.
+- **API service** (`apps/api`)
+  - `DATABASE_URL`
+  - `CLERK_SECRET_KEY`
+
+After renaming any existing variables (for example `VITE_API_URL` &rarr; `VITE_API_BASE_URL`), redeploy both services so the new configuration is applied.
 
 ## Database utilities
 

--- a/apps/web/src/components/layout/DevBanner.tsx
+++ b/apps/web/src/components/layout/DevBanner.tsx
@@ -14,7 +14,7 @@ export function DevBanner() {
   const handlePing = async () => {
     if (!API_BASE) {
       setStatus('error');
-      setMessage('VITE_API_URL is not set');
+      setMessage('VITE_API_BASE_URL is not set');
       return;
     }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,8 +1,18 @@
-export const API_BASE = (import.meta.env.VITE_API_URL ?? '').replace(/\/+$/, '');
+const rawBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export const API_BASE = rawBaseUrl.replace(/\/+$/, '');
+
+if (import.meta.env.DEV) {
+  // eslint-disable-next-line no-console
+  console.debug('[api] VITE_API_BASE_URL', API_BASE || '(not set)');
+}
 
 function ensureBase(): string {
   if (!API_BASE) {
-    throw new Error('API base URL is not configured. Set VITE_API_URL to continue.');
+    const message = 'API base URL is not configured. Set VITE_API_BASE_URL to continue.';
+    // eslint-disable-next-line no-console
+    console.error(message);
+    throw new Error(message);
   }
   return API_BASE;
 }

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_CLERK_PUBLISHABLE_KEY?: string;
 }
 
 interface ImportMeta {

--- a/railway.toml
+++ b/railway.toml
@@ -9,4 +9,4 @@ command = "npm --workspace apps/web run start"
 
   [service.web.env]
   PORT = "5173"
-  VITE_API_URL = "https://web-dev-dfa2.up.railway.app"
+  VITE_API_BASE_URL = "https://web-dev-dfa2.up.railway.app"


### PR DESCRIPTION
## Summary
- align the web client with the VITE_API_BASE_URL variable and surface clearer console diagnostics
- document correct Railway environment variables and provide example .env files for web and api packages
- ensure the sample Railway config and dev tooling reference the new variable names

## Testing
- npm --workspace apps/web run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a3da08f88322bcda15d971acdb79