### PR TITLE
Ensure weekly constancy MV recreates with expected schema

### DIFF
--- a/apps/api/sql/011_mv_and_views_weekly_constancy.sql
+++ b/apps/api/sql/011_mv_and_views_weekly_constancy.sql
@@ -32,6 +32,15 @@
 BEGIN;
 
 -- --------------------------------------------------------------------------
+-- Asegurar que la vista materializada y sus dependencias se puedan recrear con
+-- el esquema correcto, incluso si versiones previas existían sin days_in_week.
+-- --------------------------------------------------------------------------
+DROP VIEW IF EXISTS public.v_task_week_goal;
+DROP VIEW IF EXISTS public.v_task_week_max_days;
+DROP VIEW IF EXISTS public.v_task_week_constancy;
+DROP MATERIALIZED VIEW IF EXISTS public.mv_task_weeks;
+
+-- --------------------------------------------------------------------------
 -- Materialized view semanal basada en mv_task_days.
 -- Cada fila representa una tarea con actividad en la semana (lunes-domingo ISO).
 -- --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- drop dependent weekly constancy views and materialized view before recreation
- guarantee the mv_task_weeks schema includes the days_in_week column for downstream views

## Testing
- `npm run db:all` *(fails: DATABASE_URL is required to run SQL files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a754f3f4832291cb8dc90b1ad740