### PR TITLE
Allow Railway to provide web port

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -8,5 +8,4 @@ command = "npm --workspace apps/api run start"
 command = "npm --workspace apps/web run start"
 
   [service.web.env]
-  PORT = "5173"
   VITE_API_BASE_URL = "https://web-dev-dfa2.up.railway.app"


### PR DESCRIPTION
## Summary
- remove the hard-coded web service PORT from railway.toml so Railway can inject its own value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2c56a5e4c83228b3a49809b27cd26