### PR TITLE
Fix mv_task_weeks recreation by dropping legacy views first

### DIFF
--- a/apps/api/sql/011_mv_and_views_weekly_constancy.sql
+++ b/apps/api/sql/011_mv_and_views_weekly_constancy.sql
@@ -31,10 +31,13 @@
 
 BEGIN;
 
--- --------------------------------------------------------------------------
 -- Asegurar que la vista materializada y sus dependencias se puedan recrear con
--- el esquema correcto, incluso si versiones previas existían sin days_in_week.
+-- el esquema correcto, incluso si versiones previas existían sin days_in_week
+-- o con vistas auxiliares antiguas (p.ej. las usadas por el frontend histórico).
 -- --------------------------------------------------------------------------
+DROP VIEW IF EXISTS public.v_task_streaks_actual;
+DROP VIEW IF EXISTS public.v_task_streaks_max;
+DROP VIEW IF EXISTS public.v_task_weeks_flags;
 DROP VIEW IF EXISTS public.v_task_week_goal;
 DROP VIEW IF EXISTS public.v_task_week_max_days;
 DROP VIEW IF EXISTS public.v_task_week_constancy;


### PR DESCRIPTION
## Summary
- drop legacy weekly streak views before recreating mv_task_weeks so older schemas no longer block migrations
- document why the extra drops are required for historical frontend helpers

## Testing
- npm run db:all *(fails: DATABASE_URL is required to run SQL files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d6e00f1c8322b5e668c49c4b4d92