### PR TITLE
Handle missing Clerk publishable key more gracefully

### DIFF
--- a/apps/web/src/config/clerk.ts
+++ b/apps/web/src/config/clerk.ts
@@ -1,0 +1,50 @@
+const metaName = 'clerk-publishable-key';
+
+function readMetaTag(): string | undefined {
+  if (typeof document === 'undefined') {
+    return undefined;
+  }
+
+  const meta = document.querySelector(`meta[name="${metaName}"]`);
+  const value = meta?.getAttribute('content')?.trim();
+
+  return value ? value : undefined;
+}
+
+function readGlobalFallback(): string | undefined {
+  if (typeof __NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY__ === 'string' && __NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY__.trim() !== '') {
+    return __NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY__;
+  }
+
+  if (typeof window !== 'undefined') {
+    const maybeWindow = window as typeof window & {
+      CLERK_PUBLISHABLE_KEY?: string;
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?: string;
+    };
+
+    const candidates = [maybeWindow.CLERK_PUBLISHABLE_KEY, maybeWindow.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim() !== '') {
+        return candidate;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function getClerkPublishableKey(): string | undefined {
+  const candidates = [
+    import.meta.env.VITE_CLERK_PUBLISHABLE_KEY,
+    readGlobalFallback(),
+    readMetaTag(),
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim() !== '') {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,25 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
+import { getClerkPublishableKey } from './config/clerk';
+
+function MissingClerkConfiguration() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface px-6 text-center text-text">
+      <h1 className="text-2xl font-semibold text-white">Configuración de Clerk incompleta</h1>
+      <p className="max-w-xl text-sm text-text-subtle">
+        No encontramos una publishable key para Clerk. Define la variable{' '}
+        <code className="rounded bg-white/5 px-1 py-0.5 text-xs text-white">VITE_CLERK_PUBLISHABLE_KEY</code>{' '}
+        (o&nbsp;<code className="rounded bg-white/5 px-1 py-0.5 text-xs text-white">NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY</code>)
+        y vuelve a desplegar la aplicación.
+      </p>
+      <p className="max-w-xl text-xs text-text-muted">
+        También puedes inyectar la clave mediante la etiqueta{' '}
+        <code className="rounded bg-white/5 px-1 py-0.5">&lt;meta name="clerk-publishable-key" /&gt;</code> en <code>index.html</code>.
+      </p>
+    </div>
+  );
+}
 
 const rootElement = document.getElementById('root');
 
@@ -11,18 +30,24 @@ if (!rootElement) {
   throw new Error('Root element not found');
 }
 
-const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+const publishableKey = getClerkPublishableKey();
+
+const root = createRoot(rootElement);
 
 if (!publishableKey) {
-  throw new Error('VITE_CLERK_PUBLISHABLE_KEY is not set');
+  root.render(
+    <StrictMode>
+      <MissingClerkConfiguration />
+    </StrictMode>,
+  );
+} else {
+  root.render(
+    <StrictMode>
+      <ClerkProvider publishableKey={publishableKey} afterSignOutUrl="/">
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ClerkProvider>
+    </StrictMode>,
+  );
 }
-
-createRoot(rootElement).render(
-  <StrictMode>
-    <ClerkProvider publishableKey={publishableKey} afterSignOutUrl="/">
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </ClerkProvider>
-  </StrictMode>,
-);

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -3,8 +3,11 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_CLERK_PUBLISHABLE_KEY?: string;
+  readonly NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?: string;
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+declare const __NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY__: string | undefined;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,15 +1,24 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    host: '0.0.0.0',
-    port: 5173
-  },
-  preview: {
-    host: '0.0.0.0',
-    port: 5173,
-    allowedHosts: ['.railway.app']
-  }
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const fallbackClerkKey =
+    env.VITE_CLERK_PUBLISHABLE_KEY || env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || env.CLERK_PUBLISHABLE_KEY || '';
+
+  return {
+    plugins: [react()],
+    define: {
+      __NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY__: JSON.stringify(fallbackClerkKey)
+    },
+    server: {
+      host: '0.0.0.0',
+      port: 5173
+    },
+    preview: {
+      host: '0.0.0.0',
+      port: 5173,
+      allowedHosts: ['.railway.app']
+    }
+  };
 });


### PR DESCRIPTION
## Summary
- add a Clerk config helper that discovers the publishable key from Vite env, window fallbacks, or a meta tag
- render a friendly configuration warning screen instead of crashing when the key is missing
- inject NEXT_PUBLIC/CLERK fallback env vars via Vite config and update type definitions

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e2d6bc48188322a8812578f83f2358