### PR TITLE
Fix v_energy_today view lateral function alias

### DIFF
--- a/apps/api/sql/021_views_energy.sql
+++ b/apps/api/sql/021_views_energy.sql
@@ -43,6 +43,6 @@ SELECT
   (res).mind,
   public.fn_tz_today() AS computed_for_date
 FROM public.users u
-CROSS JOIN LATERAL public.fn_energy_today(u.id) AS res(body numeric, soul numeric, mind numeric);
+CROSS JOIN LATERAL public.fn_energy_today(u.id) AS res;
 
 COMMIT;


### PR DESCRIPTION
## Summary
- remove redundant column definition from v_energy_today view when calling fn_energy_today

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d86499708322a8839e0d67fdd33e