### PR TITLE
Handle initial materialized view refresh

### DIFF
--- a/apps/api/sql/090_refresh_helpers.sql
+++ b/apps/api/sql/090_refresh_helpers.sql
@@ -37,12 +37,24 @@ BEGIN;
 CREATE OR REPLACE PROCEDURE public.sp_refresh_daily_materialized()
 LANGUAGE plpgsql
 AS $$
+DECLARE
+  is_populated boolean;
 BEGIN
   IF to_regclass('public.mv_task_days') IS NULL THEN
     RAISE NOTICE 'mv_task_days no existe, no se refresca.';
   ELSE
-    RAISE NOTICE 'Refrescando mv_task_days (CONCURRENTLY).';
-    REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_task_days;
+    SELECT relispopulated
+    INTO is_populated
+    FROM pg_class
+    WHERE oid = 'public.mv_task_days'::regclass;
+
+    IF is_populated THEN
+      RAISE NOTICE 'Refrescando mv_task_days (CONCURRENTLY).';
+      REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_task_days;
+    ELSE
+      RAISE NOTICE 'Refrescando mv_task_days (NO CONCURRENTLY, primera carga).';
+      REFRESH MATERIALIZED VIEW public.mv_task_days;
+    END IF;
   END IF;
 END;
 $$;
@@ -53,12 +65,24 @@ $$;
 CREATE OR REPLACE PROCEDURE public.sp_refresh_weekly_materialized()
 LANGUAGE plpgsql
 AS $$
+DECLARE
+  is_populated boolean;
 BEGIN
   IF to_regclass('public.mv_task_weeks') IS NULL THEN
     RAISE NOTICE 'mv_task_weeks no existe, no se refresca.';
   ELSE
-    RAISE NOTICE 'Refrescando mv_task_weeks (CONCURRENTLY).';
-    REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_task_weeks;
+    SELECT relispopulated
+    INTO is_populated
+    FROM pg_class
+    WHERE oid = 'public.mv_task_weeks'::regclass;
+
+    IF is_populated THEN
+      RAISE NOTICE 'Refrescando mv_task_weeks (CONCURRENTLY).';
+      REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_task_weeks;
+    ELSE
+      RAISE NOTICE 'Refrescando mv_task_weeks (NO CONCURRENTLY, primera carga).';
+      REFRESH MATERIALIZED VIEW public.mv_task_weeks;
+    END IF;
   END IF;
 END;
 $$;


### PR DESCRIPTION
## Summary
- avoid concurrent refresh for materialized views that have not been populated yet
- fall back to a standard refresh during the first run and keep concurrent refreshes afterwards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d9af9d3c832293b2a1cd109c6055