### PR TITLE
feat: add Clerk user mirroring

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,99 +1,49 @@
 # Innerbloom API
 
-## Database SQL runner
+## Environment variables
 
-Run the idempotent SQL migrations locally (requires `DATABASE_URL` pointing to Postgres 14+):
+| Name | Required | Description |
+| --- | --- | --- |
+| `DATABASE_URL` | ✅ | PostgreSQL connection string used by the API and scripts. SSL is automatically enabled when `sslmode=require` is present. |
+| `CLERK_WEBHOOK_SECRET` | ✅ | Svix signing secret provided by Clerk for the `user.*` webhook. |
+| `CLERK_API_KEY` | ➖ | Clerk Backend API key. Required only for the backfill script. |
+| `PORT` | ➖ | Port for the Fastify server (defaults to `3000`). |
 
-```bash
-export DATABASE_URL="postgres://..."
-npm run db:all
-```
+## Database migrations
 
-For Railway/Neon consoles you can also execute them directly with `psql`:
-
-```bash
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f apps/api/sql/001_extensions.sql
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f apps/api/sql/010_tables_core.sql
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f apps/api/sql/015_game_config.sql
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f apps/api/sql/020_mv_task_weeks.sql
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f apps/api/sql/030_views_streak_flags.sql
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f apps/api/sql/040_views_streaks.sql
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f apps/api/sql/050_progress_views.sql
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f apps/api/sql/060_daily_streaks.sql
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f apps/api/sql/090_seeds_dev.sql
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f apps/api/sql/999_refresh_helpers.sql
-```
-
-Materialized views ship `WITH NO DATA`; refresh them after seeding:
+Run the idempotent SQL bundle locally (requires `DATABASE_URL`):
 
 ```bash
-psql "$DATABASE_URL" -c "REFRESH MATERIALIZED VIEW mv_task_weeks;"
-psql "$DATABASE_URL" -c "REFRESH MATERIALIZED VIEW mv_user_progress;"
+npm run db:apply
 ```
 
-## REST endpoints
+## Development server
 
-Base URL: keep the existing prefix (default `/`). All responses are JSON.
+Start the API locally:
 
-### Health
 ```bash
-curl -s http://localhost:3000/health/db
+npm run dev
 ```
 
-### Pillars catalog
+The server exposes `GET /healthz` for health checks and mounts the existing Express routes alongside the new Fastify handlers.
+
+## Clerk integration
+
+### Webhook
+
+* Endpoint: `POST /api/webhooks/clerk`
+* Headers: `svix-id`, `svix-timestamp`, `svix-signature`
+* Signature verification: performed with the official Svix verifier using `CLERK_WEBHOOK_SECRET`
+* Supported events: `user.created`, `user.updated`, `user.deleted`
+
+A valid request upserts the mirrored user record in Postgres (or soft-deletes on `user.deleted`). The handler responds with HTTP `204` on success and `400/422` for invalid requests.
+
+### Backfill
+
+Populate or refresh the mirrored users using the Clerk Backend API:
+
 ```bash
-curl -s http://localhost:3000/pillars
+npm run backfill:users
 ```
 
-### Legacy task utilities (MVP compatibility)
-```bash
-curl -s "http://localhost:3000/tasks?userId=<USER_ID>"
-curl -s "http://localhost:3000/task-logs?userId=<USER_ID>"
-curl -s -X POST http://localhost:3000/task-logs \
-  -H "Content-Type: application/json" \
-  -d '{"userId":"<USER_ID>","taskId":"<TASK_ID>","doneAt":"2024-01-01T10:00:00Z"}'
-```
-
-### Progress overview
-`GET /users/:userId/progress`
-```bash
-curl -s http://localhost:3000/users/<USER_ID>/progress
-```
-
-### User tasks
-`GET /users/:userId/tasks`
-```bash
-curl -s http://localhost:3000/users/<USER_ID>/tasks
-```
-
-### Recent task logs
-`GET /users/:userId/task-logs?limit=20`
-```bash
-curl -s "http://localhost:3000/users/<USER_ID>/task-logs?limit=10"
-```
-
-### Task streaks
-`GET /users/:userId/streaks`
-```bash
-curl -s http://localhost:3000/users/<USER_ID>/streaks
-```
-
-### Emotion heatmap (stub)
-`GET /users/:userId/emotions?days=30`
-```bash
-curl -s http://localhost:3000/users/<USER_ID>/emotions
-```
-
-### Leaderboard
-`GET /leaderboard?limit=10&offset=0`
-```bash
-curl -s "http://localhost:3000/leaderboard?limit=5"
-```
-
-### Complete a task (creates a log)
-`POST /tasks/complete`
-```bash
-curl -s -X POST http://localhost:3000/tasks/complete \
-  -H "Content-Type: application/json" \
-  -d '{"userId":"<USER_ID>","taskId":"<TASK_ID>","doneAt":"2024-01-01T18:00:00Z"}'
-```
+This script paginates Clerk users, performs upserts, and logs totals for inserted vs. updated rows.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "prestart": "npm run build",
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx apps/api/src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
@@ -12,14 +12,22 @@
     "db:migrate": "drizzle-kit migrate --config ./drizzle.config.ts",
     "db:push": "node ./scripts/run-sql.js",
     "db:seed": "node ./scripts/run-sql.js",
-    "db:all": "node ./scripts/run-sql.js"
+    "db:all": "node ./scripts/run-sql.js",
+    "db:apply": "tsx apps/api/scripts/apply-sql.ts",
+    "predeploy": "npm run db:apply",
+    "backfill:users": "tsx apps/api/scripts/clerk-backfill.ts"
   },
   "dependencies": {
+    "@fastify/express": "^4.0.2",
     "@neondatabase/serverless": "^0.9.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.32.2",
     "express": "^4.19.2",
+    "fastify": "^5.6.1",
+    "fastify-raw-body": "^5.0.0",
+    "pg": "^8.16.3",
+    "svix": "^1.76.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/apps/api/scripts/apply-sql.ts
+++ b/apps/api/scripts/apply-sql.ts
@@ -1,0 +1,60 @@
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { pool } from '../src/db/pool.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const sqlDirectory = path.resolve(__dirname, '..', 'sql');
+
+async function applyFile(fileName: string): Promise<void> {
+  const fullPath = path.join(sqlDirectory, fileName);
+  const sql = await readFile(fullPath, 'utf8');
+  const trimmed = sql.trim();
+
+  if (!trimmed) {
+    console.log(`⚠ Skipped ${fileName} (empty file)`);
+    return;
+  }
+
+  const client = await pool.connect();
+
+  try {
+    console.log(`→ Running ${fileName}`);
+    await client.query('BEGIN');
+    await client.query(sql);
+    await client.query('COMMIT');
+    console.log(`✓ Applied ${fileName}`);
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {
+      // ignore rollback errors
+    });
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`✖ ${fileName} → ${message}`);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function main(): Promise<void> {
+  const entries = await readdir(sqlDirectory);
+  const files = entries.filter((file) => file.endsWith('.sql')).sort((a, b) => a.localeCompare(b));
+
+  for (const file of files) {
+    await applyFile(file);
+  }
+}
+
+main()
+  .then(async () => {
+    await pool.end();
+  })
+  .catch(async (error) => {
+    await pool.end();
+    process.exitCode = 1;
+    if (error instanceof Error) {
+      console.error(error.stack);
+    }
+  });

--- a/apps/api/scripts/clerk-backfill.ts
+++ b/apps/api/scripts/clerk-backfill.ts
@@ -1,0 +1,170 @@
+import process from 'node:process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { pool } from '../src/db/pool.js';
+
+const apiKey = process.env.CLERK_API_KEY;
+
+if (!apiKey) {
+  throw new Error('CLERK_API_KEY must be provided to run the backfill');
+}
+
+const UPSERT_SQL = `
+INSERT INTO users (clerk_user_id, email_primary, full_name, image_url, timezone, locale)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (clerk_user_id) DO UPDATE SET
+  email_primary = EXCLUDED.email_primary,
+  full_name = EXCLUDED.full_name,
+  image_url = EXCLUDED.image_url,
+  timezone = EXCLUDED.timezone,
+  locale = EXCLUDED.locale
+RETURNING (xmax = 0) AS inserted;
+`;
+
+type ClerkEmailAddress = {
+  id?: string | null;
+  email_address?: string | null;
+};
+
+type ClerkUser = {
+  id?: string;
+  email_addresses?: ClerkEmailAddress[] | null;
+  primary_email_address_id?: string | null;
+  primary_email_address?: ClerkEmailAddress | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  username?: string | null;
+  image_url?: string | null;
+  profile_image_url?: string | null;
+  timezone?: string | null;
+  locale?: string | null;
+};
+
+function extractPrimaryEmail(user: ClerkUser): string | null {
+  const fromPrimaryObject = user.primary_email_address?.email_address;
+  if (typeof fromPrimaryObject === 'string' && fromPrimaryObject.length > 0) {
+    return fromPrimaryObject;
+  }
+
+  const emailAddresses = user.email_addresses ?? [];
+  const primaryId = user.primary_email_address_id;
+
+  if (primaryId) {
+    const match = emailAddresses.find((entry) => entry?.id === primaryId);
+    if (match?.email_address) {
+      return match.email_address;
+    }
+  }
+
+  for (const entry of emailAddresses) {
+    if (entry?.email_address) {
+      return entry.email_address;
+    }
+  }
+
+  return null;
+}
+
+function extractFullName(user: ClerkUser): string | null {
+  const parts = [user.first_name, user.last_name]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .filter((value) => value.length > 0);
+
+  if (parts.length > 0) {
+    return parts.join(' ');
+  }
+
+  const username = typeof user.username === 'string' ? user.username.trim() : '';
+  return username.length > 0 ? username : null;
+}
+
+function buildUpsertParams(user: ClerkUser): [string, string | null, string | null, string | null, string | null, string | null] {
+  if (!user.id) {
+    throw new Error('Clerk user is missing an id');
+  }
+
+  const email = extractPrimaryEmail(user);
+  const fullName = extractFullName(user);
+  const imageUrl = user.image_url ?? user.profile_image_url ?? null;
+  const timezone = user.timezone ?? null;
+  const locale = user.locale ?? null;
+
+  return [user.id, email, fullName, imageUrl, timezone, locale];
+}
+
+async function fetchUsers(offset: number, limit: number): Promise<ClerkUser[]> {
+  const url = new URL('https://api.clerk.com/v1/users');
+  url.searchParams.set('limit', String(limit));
+  url.searchParams.set('offset', String(offset));
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Clerk API request failed with status ${response.status}: ${body}`);
+  }
+
+  const payload = (await response.json()) as unknown;
+
+  if (!Array.isArray(payload)) {
+    throw new Error('Unexpected Clerk API response shape');
+  }
+
+  return payload as ClerkUser[];
+}
+
+async function main(): Promise<void> {
+  const limit = 100;
+  let offset = 0;
+  let processed = 0;
+  let inserted = 0;
+  let updated = 0;
+
+  while (true) {
+    const users = await fetchUsers(offset, limit);
+
+    if (users.length === 0) {
+      break;
+    }
+
+    for (const user of users) {
+      const params = buildUpsertParams(user);
+      const result = await pool.query<{ inserted: boolean }>(UPSERT_SQL, params);
+      processed += 1;
+
+      if (result.rows[0]?.inserted) {
+        inserted += 1;
+      } else {
+        updated += 1;
+      }
+    }
+
+    offset += users.length;
+
+    if (users.length < limit) {
+      break;
+    }
+
+    await delay(200);
+  }
+
+  console.log(`Processed ${processed} users (${inserted} inserted, ${updated} updated).`);
+}
+
+main()
+  .then(async () => {
+    await pool.end();
+  })
+  .catch(async (error) => {
+    await pool.end();
+    process.exitCode = 1;
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error(error);
+    }
+  });

--- a/apps/api/sql/001_users.sql
+++ b/apps/api/sql/001_users.sql
@@ -1,0 +1,142 @@
+-- Ensure required extensions exist (idempotent)
+CREATE EXTENSION IF NOT EXISTS citext;
+
+DO $$
+BEGIN
+  BEGIN
+    EXECUTE 'CREATE EXTENSION IF NOT EXISTS pgcrypto';
+  EXCEPTION
+    WHEN undefined_file THEN
+      BEGIN
+        EXECUTE 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"';
+      EXCEPTION
+        WHEN undefined_file THEN
+          RAISE NOTICE 'Neither pgcrypto nor uuid-ossp extension could be created.';
+      END;
+  END;
+END;
+$$;
+
+-- Canonical enum for game modes
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'game_mode'
+  ) THEN
+    EXECUTE $$CREATE TYPE game_mode AS ENUM ('LOW','CHILL','FLOW','EVOLVE')$$;
+  END IF;
+END;
+$$;
+
+ALTER TYPE game_mode ADD VALUE IF NOT EXISTS 'LOW';
+ALTER TYPE game_mode ADD VALUE IF NOT EXISTS 'CHILL';
+ALTER TYPE game_mode ADD VALUE IF NOT EXISTS 'FLOW';
+ALTER TYPE game_mode ADD VALUE IF NOT EXISTS 'EVOLVE';
+
+-- Users table (first table in the database)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+  ) THEN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_proc
+      WHERE proname = 'gen_random_uuid'
+        AND pg_function_is_visible(oid)
+    ) THEN
+      EXECUTE $$
+        CREATE TABLE public.users (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          clerk_user_id TEXT UNIQUE NOT NULL,
+          email_primary CITEXT NULL,
+          full_name TEXT NULL,
+          image_url TEXT NULL,
+          game_mode game_mode NULL DEFAULT NULL,
+          weekly_target SMALLINT GENERATED ALWAYS AS (
+            CASE game_mode
+              WHEN 'LOW' THEN 1
+              WHEN 'CHILL' THEN 2
+              WHEN 'FLOW' THEN 3
+              WHEN 'EVOLVE' THEN 4
+              ELSE NULL
+            END
+          ) STORED,
+          timezone TEXT NULL,
+          locale TEXT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          deleted_at TIMESTAMPTZ NULL
+        )
+      $$;
+    ELSE
+      EXECUTE $$
+        CREATE TABLE public.users (
+          id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+          clerk_user_id TEXT UNIQUE NOT NULL,
+          email_primary CITEXT NULL,
+          full_name TEXT NULL,
+          image_url TEXT NULL,
+          game_mode game_mode NULL DEFAULT NULL,
+          weekly_target SMALLINT GENERATED ALWAYS AS (
+            CASE game_mode
+              WHEN 'LOW' THEN 1
+              WHEN 'CHILL' THEN 2
+              WHEN 'FLOW' THEN 3
+              WHEN 'EVOLVE' THEN 4
+              ELSE NULL
+            END
+          ) STORED,
+          timezone TEXT NULL,
+          locale TEXT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          deleted_at TIMESTAMPTZ NULL
+        )
+      $$;
+    END IF;
+  END IF;
+END;
+$$;
+
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS email_primary CITEXT NULL,
+  ADD COLUMN IF NOT EXISTS full_name TEXT NULL,
+  ADD COLUMN IF NOT EXISTS image_url TEXT NULL,
+  ADD COLUMN IF NOT EXISTS game_mode game_mode NULL,
+  ADD COLUMN IF NOT EXISTS weekly_target SMALLINT GENERATED ALWAYS AS (
+    CASE game_mode
+      WHEN 'LOW' THEN 1
+      WHEN 'CHILL' THEN 2
+      WHEN 'FLOW' THEN 3
+      WHEN 'EVOLVE' THEN 4
+      ELSE NULL
+    END
+  ) STORED,
+  ADD COLUMN IF NOT EXISTS timezone TEXT NULL,
+  ADD COLUMN IF NOT EXISTS locale TEXT NULL,
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ NULL;
+
+CREATE INDEX IF NOT EXISTS idx_users_email_primary ON public.users (email_primary);
+
+-- Updated at trigger
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_users_updated_at ON public.users;
+CREATE TRIGGER trg_users_updated_at
+BEFORE UPDATE ON public.users
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();

--- a/apps/api/src/db/pool.ts
+++ b/apps/api/src/db/pool.ts
@@ -1,0 +1,23 @@
+import process from 'node:process';
+import { Pool, type PoolClient } from 'pg';
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is required to create a database pool');
+}
+
+const shouldUseSsl = databaseUrl.includes('sslmode=require');
+
+export const pool = new Pool({
+  connectionString: databaseUrl,
+  ssl: shouldUseSsl
+    ? {
+        rejectUnauthorized: false,
+      }
+    : undefined,
+});
+
+export async function getClient(): Promise<PoolClient> {
+  return pool.connect();
+}

--- a/apps/api/src/routes/users.me.ts
+++ b/apps/api/src/routes/users.me.ts
@@ -1,0 +1,35 @@
+import type { FastifyInstance } from 'fastify';
+import { pool } from '../db/pool.js';
+
+type UsersMeRow = {
+  id: string;
+  clerk_user_id: string;
+  email_primary: string | null;
+  full_name: string | null;
+  image_url: string | null;
+  game_mode: string | null;
+  weekly_target: number | null;
+  timezone: string | null;
+  locale: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export default async function usersMeRoutes(fastify: FastifyInstance): Promise<void> {
+  fastify.get('/api/users/me', async (request, reply) => {
+    const header = request.headers['x-user-id'];
+
+    if (typeof header !== 'string' || header.length === 0) {
+      return reply.status(400).send({ error: 'X-User-Id header is required' });
+    }
+
+    const result = await pool.query<UsersMeRow>('SELECT * FROM users WHERE clerk_user_id = $1', [header]);
+
+    if (result.rows.length === 0) {
+      return reply.status(404).send({ error: 'User not found' });
+    }
+
+    return reply.status(200).send(result.rows[0]);
+  });
+}

--- a/apps/api/src/routes/webhooks/clerk.ts
+++ b/apps/api/src/routes/webhooks/clerk.ts
@@ -1,0 +1,184 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { Webhook, type WebhookRequiredHeaders } from 'svix';
+import { pool } from '../../db/pool.js';
+
+const webhookSecret = process.env.CLERK_WEBHOOK_SECRET;
+
+if (!webhookSecret) {
+  throw new Error('CLERK_WEBHOOK_SECRET must be configured for Clerk webhooks');
+}
+
+const webhookVerifier = new Webhook(webhookSecret);
+
+const UPSERT_SQL = `
+INSERT INTO users (clerk_user_id, email_primary, full_name, image_url, timezone, locale)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (clerk_user_id) DO UPDATE SET
+  email_primary = EXCLUDED.email_primary,
+  full_name = EXCLUDED.full_name,
+  image_url = EXCLUDED.image_url,
+  timezone = EXCLUDED.timezone,
+  locale = EXCLUDED.locale;
+`;
+
+type SvixHeaders = Pick<WebhookRequiredHeaders, 'svix-id' | 'svix-timestamp' | 'svix-signature'>;
+
+type ClerkEmailAddress = {
+  id?: string | null;
+  email_address?: string | null;
+};
+
+type ClerkUser = {
+  id?: string;
+  email_addresses?: ClerkEmailAddress[] | null;
+  primary_email_address_id?: string | null;
+  primary_email_address?: ClerkEmailAddress | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  username?: string | null;
+  image_url?: string | null;
+  profile_image_url?: string | null;
+  timezone?: string | null;
+  locale?: string | null;
+};
+
+type ClerkWebhookEvent = {
+  data: ClerkUser;
+  type: string;
+};
+
+type WebhookRequest = FastifyRequest & { rawBody?: string | Buffer };
+
+function extractPrimaryEmail(user: ClerkUser): string | null {
+  const fromPrimaryObject = user.primary_email_address?.email_address;
+  if (typeof fromPrimaryObject === 'string' && fromPrimaryObject.length > 0) {
+    return fromPrimaryObject;
+  }
+
+  const emailAddresses = user.email_addresses ?? [];
+  const primaryId = user.primary_email_address_id;
+
+  if (primaryId) {
+    const match = emailAddresses.find((entry) => entry?.id === primaryId);
+    if (match?.email_address) {
+      return match.email_address;
+    }
+  }
+
+  for (const entry of emailAddresses) {
+    if (entry?.email_address) {
+      return entry.email_address;
+    }
+  }
+
+  return null;
+}
+
+function extractFullName(user: ClerkUser): string | null {
+  const parts = [user.first_name, user.last_name]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .filter((value) => value.length > 0);
+
+  if (parts.length > 0) {
+    return parts.join(' ');
+  }
+
+  const username = typeof user.username === 'string' ? user.username.trim() : '';
+  return username.length > 0 ? username : null;
+}
+
+function buildUpsertParams(user: ClerkUser): [string, string | null, string | null, string | null, string | null, string | null] {
+  if (!user.id) {
+    throw new Error('Clerk user is missing an id');
+  }
+
+  const email = extractPrimaryEmail(user);
+  const fullName = extractFullName(user);
+  const imageUrl = user.image_url ?? user.profile_image_url ?? null;
+  const timezone = user.timezone ?? null;
+  const locale = user.locale ?? null;
+
+  return [user.id, email, fullName, imageUrl, timezone, locale];
+}
+
+async function handleUserUpsert(reply: FastifyReply, user: ClerkUser): Promise<void> {
+  const params = buildUpsertParams(user);
+  await pool.query(UPSERT_SQL, params);
+  await reply.status(204).send();
+}
+
+async function handleUserDeleted(reply: FastifyReply, user: ClerkUser): Promise<void> {
+  if (!user.id) {
+    throw new Error('Clerk user is missing an id');
+  }
+
+  await pool.query('UPDATE users SET deleted_at = now() WHERE clerk_user_id = $1', [user.id]);
+  await reply.status(204).send();
+}
+
+export default async function clerkWebhookRoutes(fastify: FastifyInstance): Promise<void> {
+  fastify.post(
+    '/api/webhooks/clerk',
+    async (request: WebhookRequest, reply) => {
+      const headers = extractSvixHeaders(request.headers);
+      if (!headers) {
+        return reply.status(400).send({ error: 'Missing Svix signature headers' });
+      }
+
+      const payload = request.rawBody;
+      if (payload === undefined) {
+        return reply.status(400).send({ error: 'Request body is required for signature verification' });
+      }
+
+      const payloadString = typeof payload === 'string' ? payload : payload.toString('utf8');
+
+      let event: ClerkWebhookEvent;
+      try {
+        event = webhookVerifier.verify(payloadString, headers) as ClerkWebhookEvent;
+      } catch (error) {
+        request.log.error({ err: error }, 'Invalid Clerk webhook signature');
+        return reply.status(400).send({ error: 'Invalid signature' });
+      }
+
+      const { type, data } = event;
+
+      try {
+        if (type === 'user.created' || type === 'user.updated') {
+          await handleUserUpsert(reply, data);
+          return;
+        }
+
+        if (type === 'user.deleted') {
+          await handleUserDeleted(reply, data);
+          return;
+        }
+
+        request.log.warn({ eventType: type }, 'Unhandled Clerk webhook event');
+        return reply.status(422).send({ error: 'Unhandled event type' });
+      } catch (error) {
+        request.log.error({ err: error }, 'Failed processing Clerk webhook');
+        return reply.status(500).send({ error: 'Failed to process webhook' });
+      }
+    },
+  );
+}
+
+function extractSvixHeaders(headers: WebhookRequest['headers']): SvixHeaders | null {
+  const id = headers['svix-id'];
+  const timestamp = headers['svix-timestamp'];
+  const signature = headers['svix-signature'];
+
+  if (!isSingleHeader(id) || !isSingleHeader(timestamp) || !isSingleHeader(signature)) {
+    return null;
+  }
+
+  return {
+    'svix-id': id,
+    'svix-timestamp': timestamp,
+    'svix-signature': signature,
+  };
+}
+
+function isSingleHeader(value: string | string[] | undefined): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,36 @@
 {
-  "name": "innerbloom-monorepo",
+  "name": "innerbloom",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "innerbloom-monorepo",
+      "name": "innerbloom",
       "workspaces": [
-        "apps/api",
-        "apps/web"
+        "apps/*"
       ],
       "devDependencies": {
         "@types/node": "^24.6.2",
         "concurrently": "^9.2.1",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": "20.x"
       }
     },
     "apps/api": {
       "name": "@innerbloom/api",
       "dependencies": {
+        "@fastify/express": "^4.0.2",
         "@neondatabase/serverless": "^0.9.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "drizzle-orm": "^0.32.2",
         "express": "^4.19.2",
+        "fastify": "^5.6.1",
+        "fastify-raw-body": "^5.0.0",
+        "pg": "^8.16.3",
+        "svix": "^1.76.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -1038,6 +1045,146 @@
         "node": ">=12"
       }
     },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.2.tgz",
+      "integrity": "sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/express": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/express/-/express-4.0.2.tgz",
+      "integrity": "sha512-lzu9MLdjlsK4Q2RiqEAwTgwQPrWQVP0kmbgAi/w9rIUqtnacjKvj3EHVTR6PIvXDs6Ut1jnTHiGbuNxHTsZwHQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "express": "^4.18.3",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
+      "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/proxy-addr/node_modules/ipaddr.js": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@innerbloom/api": {
       "resolved": "apps/api",
       "link": true
@@ -1339,6 +1486,12 @@
         "linux"
       ]
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "dev": true,
@@ -1539,6 +1692,12 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "license": "MIT",
@@ -1548,6 +1707,39 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -1608,6 +1800,15 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1644,6 +1845,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.1.0.tgz",
+      "integrity": "sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
       }
     },
     "node_modules/balanced-match": {
@@ -2618,6 +2829,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "dev": true,
@@ -3099,6 +3316,18 @@
       "version": "2.0.0",
       "license": "MIT"
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -3129,11 +3358,180 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-stringify": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.1.1.tgz",
+      "integrity": "sha512-DbgptncYEXZqDUOEl4krff4mUiVrTZZVI7BBrQR/T3BqMj/eM1flTC1Uk2uUoLcWCxjT95xKulV/Lc6hhOZsBQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.6.1.tgz",
+      "integrity": "sha512-WjjlOciBF0K8pDUPZoGPhqhKrQJ02I8DKaDIfO51EL0kbSMwQFl85cRwhOvmSDWoukNOdTo27gLN549pLCcH7Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.0",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.0.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fastify-raw-body": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-raw-body/-/fastify-raw-body-5.0.0.tgz",
+      "integrity": "sha512-2qfoaQ3BQDhZ1gtbkKZd6n0kKxJISJGM6u/skD9ljdWItAscjXrtZ1lnjr7PavmXX9j4EyCPmBDiIsLn07d5vA==",
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "secure-json-parse": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "url": "https://github.com/Eomm/fastify-raw-body?sponsor=1"
+      }
+    },
+    "node_modules/fastify-raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fastify-raw-body/node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/fastify-raw-body/node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3178,6 +3576,20 @@
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
+    },
+    "node_modules/find-my-way": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.3.0.tgz",
+      "integrity": "sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -3553,6 +3965,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "dev": true,
@@ -3563,6 +4000,52 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -3805,6 +4288,15 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
@@ -3874,6 +4366,46 @@
       "version": "0.1.12",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -3890,6 +4422,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
@@ -3914,6 +4455,70 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -3943,6 +4548,43 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/pino": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.13.1.tgz",
+      "integrity": "sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.7",
@@ -4179,6 +4821,22 @@
         "fsevents": "2.3.3"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "license": "MIT",
@@ -4203,6 +4861,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4222,6 +4886,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/range-parser": {
@@ -4343,6 +5013,15 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4352,6 +5031,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -4384,16 +5078,30 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.52.4",
@@ -4487,6 +5195,34 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex2": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
+      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -4497,6 +5233,22 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -4682,6 +5434,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slow-redact": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.1.tgz",
+      "integrity": "sha512-NvFvl1GuLZNW4U046Tfi8b26zXo8aBzgCAS2f7yVJR/fArN93mOqSA99cB9uITm92ajSz01bsu1K7SCVVjIMpQ==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "dev": true,
@@ -4705,6 +5472,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/statuses": {
@@ -4830,6 +5606,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svix": {
+      "version": "1.76.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.76.1.tgz",
+      "integrity": "sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "@types/node": "^22.7.5",
+        "es6-promise": "^4.2.8",
+        "fast-sha256": "^1.3.0",
+        "url-parse": "^1.5.10",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/@types/node": {
+      "version": "22.18.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
+      "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/swr": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
@@ -4904,6 +5703,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4915,6 +5723,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/toidentifier": {
@@ -5467,6 +6284,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -5488,6 +6315,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -5606,6 +6446,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {


### PR DESCRIPTION
## Summary
- add idempotent SQL to create the users table, enum, and triggers required for Clerk mirroring
- implement pg pool utilities, SQL runner, Clerk webhook handler, and backfill script
- migrate the API entrypoint to Fastify, expose helper routes, and document new workflows

## Testing
- npm --workspace apps/api run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e2ec91731483228cdaef497d89d2cc