### PR TITLE
chore(auth): replace deprecated Clerk afterSign* props with fallbackRedirectUrl and centralize DASHBOARD_PATH

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,4 @@
+# Web app environment variables
+VITE_API_URL=https://your-api.example.com
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_XXXXXXXXXXXXXXXXXXXXXXXXXXXX
+VITE_DASHBOARD_PATH=/dashboard

--- a/apps/web/src/config/auth.ts
+++ b/apps/web/src/config/auth.ts
@@ -1,0 +1,1 @@
+export const DASHBOARD_PATH = import.meta.env.VITE_DASHBOARD_PATH || '/dashboard';

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -19,7 +19,7 @@ if (!publishableKey) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <ClerkProvider publishableKey={publishableKey} afterSignOutUrl="/">
+    <ClerkProvider publishableKey={publishableKey}>
       <BrowserRouter>
         <App />
       </BrowserRouter>

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,4 +1,5 @@
 import { SignIn } from '@clerk/clerk-react';
+import { DASHBOARD_PATH } from '../config/auth';
 
 export default function LoginPage() {
   return (
@@ -14,7 +15,7 @@ export default function LoginPage() {
         routing="path"
         path="/login"
         signUpUrl="/sign-up"
-        afterSignInUrl="/dashboard"
+        fallbackRedirectUrl={DASHBOARD_PATH}
       />
     </div>
   );

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -1,4 +1,5 @@
 import { SignUp } from '@clerk/clerk-react';
+import { DASHBOARD_PATH } from '../config/auth';
 
 export default function SignUpPage() {
   return (
@@ -14,7 +15,7 @@ export default function SignUpPage() {
         routing="path"
         path="/sign-up"
         signInUrl="/login"
-        afterSignUpUrl="/dashboard"
+        fallbackRedirectUrl={DASHBOARD_PATH}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- replace deprecated afterSignInUrl and afterSignUpUrl usages with fallbackRedirectUrl tied to a shared DASHBOARD_PATH config
- remove deprecated afterSignOutUrl from the ClerkProvider while continuing to read the publishable key from env
- add a web .env.example documenting VITE_DASHBOARD_PATH for local setup

## Testing
- npm run build (apps/web)


------
https://chatgpt.com/codex/tasks/task_e_68e2ee9f28d083229266d2f00f59bec0