### PR TITLE
Fix game_mode type creation syntax

### DIFF
--- a/apps/api/sql/001_users.sql
+++ b/apps/api/sql/001_users.sql
@@ -18,8 +18,6 @@ END;
 $$;
 
 
-CREATE TYPE IF NOT EXISTS game_mode AS ENUM ('LOW','CHILL','FLOW','EVOLVE');
-
 DO $m$
 BEGIN
   IF EXISTS (


### PR DESCRIPTION
## Summary
- remove the unsupported CREATE TYPE IF NOT EXISTS statement from the users seed script to avoid syntax errors on Postgres

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2f3569f2c832282569572096ba79c