### PR TITLE
Allow configuring API CORS origins

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -8,6 +8,7 @@
 | `CLERK_WEBHOOK_SECRET` | ✅ | Svix signing secret provided by Clerk for the `user.*` webhook. |
 | `CLERK_API_KEY` | ➖ | Clerk Backend API key. Required only for the backfill script. |
 | `PORT` | ➖ | Port for the Fastify server (defaults to `3000`). |
+| `CORS_ALLOWED_ORIGINS` | ➖ | Comma-separated list of additional origins allowed to call the API. |
 
 ## Database migrations
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,13 +1,22 @@
+import process from 'node:process';
 import cors, { type CorsOptions } from 'cors';
 import express, { NextFunction, Request, Response } from 'express';
 import { z } from 'zod';
 import routes from './routes/index.js';
 import { HttpError, isHttpError } from './lib/http-error.js';
 
-const allowedOrigins = [
+const defaultAllowedOrigins = [
   'https://web-dev-dfa2.up.railway.app',
+  'https://web-production-734a.up.railway.app',
   'http://localhost:5173',
 ];
+
+const envAllowedOrigins = (process.env.CORS_ALLOWED_ORIGINS ?? '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter((origin) => origin.length > 0);
+
+const allowedOrigins = Array.from(new Set([...defaultAllowedOrigins, ...envAllowedOrigins]));
 
 const corsOptions: CorsOptions = {
   origin: (origin, callback) => {


### PR DESCRIPTION
## Summary
- allow the API CORS middleware to accept a configurable set of origins and include the production web app by default
- document the new `CORS_ALLOWED_ORIGINS` environment variable for deployments

## Testing
- npm run typecheck:api *(fails: existing TypeScript errors about missing Fastify/Svix type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68e362e7c5b48322a27e920870281254