### PR TITLE
feat(api): add user state dashboard endpoints

### DIFF
--- a/apps/api/src/__tests__/dashboard.test.ts
+++ b/apps/api/src/__tests__/dashboard.test.ts
@@ -93,4 +93,32 @@ describeIfReady('Dashboard endpoints', () => {
     expect(response.body).toHaveProperty('to');
     expect(Array.isArray(response.body.emotions)).toBe(true);
   });
+
+  it('returns user state summary', async () => {
+    const response = await request(app)
+      .get(`/users/${userId}/state`)
+      .expect('Content-Type', /json/);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('date');
+    expect(response.body).toHaveProperty('mode');
+    expect(response.body).toHaveProperty('weekly_target');
+    expect(response.body).toHaveProperty('pillars');
+  });
+
+  it('returns user state timeseries', async () => {
+    const to = new Date();
+    const from = new Date(to);
+    from.setUTCDate(from.getUTCDate() - 6);
+
+    const format = (date: Date) => date.toISOString().slice(0, 10);
+
+    const response = await request(app)
+      .get(`/users/${userId}/state/timeseries`)
+      .query({ from: format(from), to: format(to) })
+      .expect('Content-Type', /json/);
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.body)).toBe(true);
+  });
 });

--- a/apps/api/src/__tests__/user-state-service.test.ts
+++ b/apps/api/src/__tests__/user-state-service.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeDailyTargets,
+  computeHalfLife,
+  enumerateDates,
+  propagateEnergy,
+  type DailyTargetByPillar,
+  type XpByDate,
+} from '../controllers/users/user-state-utils.js';
+
+function createXpSeries(dates: string[], value: number): XpByDate {
+  const map: XpByDate = new Map();
+
+  for (const date of dates) {
+    map.set(date, { Body: value, Mind: value, Soul: value });
+  }
+
+  return map;
+}
+
+describe('propagateEnergy', () => {
+  it('returns 100 for all pillars when grace is forced', () => {
+    const dailyTargets: DailyTargetByPillar = { Body: 10, Mind: 10, Soul: 10 };
+    const halfLife = computeHalfLife('FLOW');
+    const dates = enumerateDates('2024-01-01', '2024-01-06');
+
+    const { series } = propagateEnergy({
+      dates,
+      xpByDate: new Map(),
+      halfLifeByPillar: halfLife,
+      dailyTargets,
+      forceFullGrace: true,
+    });
+
+    for (const row of series) {
+      expect(row).toMatchObject({ Body: 100, Mind: 100, Soul: 100 });
+    }
+  });
+
+  it('decays energy over time without xp after grace period', () => {
+    const dates = enumerateDates('2024-01-01', '2024-01-20');
+    const dailyTargets: DailyTargetByPillar = { Body: 50, Mind: 50, Soul: 50 };
+    const halfLife = computeHalfLife('CHILL');
+
+    const { series } = propagateEnergy({
+      dates,
+      xpByDate: new Map(),
+      halfLifeByPillar: halfLife,
+      dailyTargets,
+      graceUntilDate: '2024-01-02',
+    });
+
+    const last = series.at(-1);
+
+    expect(last?.Body ?? 0).toBeLessThan(60);
+    expect(last?.Mind ?? 0).toBeLessThan(60);
+    expect(last?.Soul ?? 0).toBeLessThan(60);
+  });
+
+  it('maintains energy near 100 when hitting daily targets', () => {
+    const dates = enumerateDates('2024-01-01', '2024-01-10');
+    const xpBase = { Body: 70, Mind: 70, Soul: 70 };
+    const dailyTargets = computeDailyTargets(xpBase, 7);
+    const halfLife = computeHalfLife('FLOW');
+    const xpSeries = createXpSeries(dates, dailyTargets.Body);
+
+    const { series } = propagateEnergy({
+      dates,
+      xpByDate: xpSeries,
+      halfLifeByPillar: halfLife,
+      dailyTargets,
+      graceUntilDate: '2024-01-03',
+    });
+
+    const last = series.at(-1);
+
+    expect(last?.Body).toBeGreaterThan(95);
+    expect(last?.Mind).toBeGreaterThan(95);
+    expect(last?.Soul).toBeGreaterThan(95);
+  });
+
+  it('returns zero energy when there is no target and grace is disabled', () => {
+    const dates = ['2024-01-01', '2024-01-02'];
+    const dailyTargets: DailyTargetByPillar = { Body: 0, Mind: 0, Soul: 0 };
+    const halfLife = computeHalfLife('LOW');
+
+    const { series } = propagateEnergy({
+      dates,
+      xpByDate: new Map(),
+      halfLifeByPillar: halfLife,
+      dailyTargets,
+    });
+
+    for (const row of series) {
+      expect(row.Body).toBe(0);
+      expect(row.Mind).toBe(0);
+      expect(row.Soul).toBe(0);
+    }
+  });
+});

--- a/apps/api/src/controllers/users/get-user-state-timeseries.ts
+++ b/apps/api/src/controllers/users/get-user-state-timeseries.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod';
+import type { AsyncHandler } from '../../lib/async-handler.js';
+import { HttpError } from '../../lib/http-error.js';
+import { SimpleTtlCache } from '../../lib/simple-cache.js';
+import { uuidSchema } from '../../lib/validation.js';
+import {
+  addDays,
+  computeDailyTargets,
+  computeHalfLife,
+  enumerateDates,
+  getDailyXpSeriesByPillar,
+  getUserLogStats,
+  getUserProfile,
+  getXpBaseByPillar,
+  propagateEnergy,
+} from './user-state-service.js';
+
+type TimeseriesResponse = Array<{
+  date: string;
+  Body: number;
+  Mind: number;
+  Soul: number;
+}>;
+
+const paramsSchema = z.object({
+  id: uuidSchema,
+});
+
+const querySchema = z.object({
+  from: z.string().min(1),
+  to: z.string().min(1),
+});
+
+const cache = new SimpleTtlCache<TimeseriesResponse>({ ttlMs: 5 * 60 * 1000, maxEntries: 200 });
+
+function assertValidDate(value: string, field: 'from' | 'to'): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new HttpError(400, 'invalid_date', `${field} must be formatted as YYYY-MM-DD`);
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new HttpError(400, 'invalid_date', `${field} must be a valid date`);
+  }
+
+  return value;
+}
+
+export const getUserStateTimeseries: AsyncHandler = async (req, res) => {
+  const { id } = paramsSchema.parse(req.params);
+  const { from, to } = querySchema.parse(req.query);
+
+  const fromDate = assertValidDate(from, 'from');
+  const toDate = assertValidDate(to, 'to');
+
+  if (fromDate > toDate) {
+    throw new HttpError(400, 'invalid_date_range', 'from must be before or equal to to');
+  }
+
+  const cacheKey = `${id}:${fromDate}:${toDate}`;
+  const cached = cache.get(cacheKey);
+
+  if (cached) {
+    res.json(cached);
+    return;
+  }
+
+  const profile = await getUserProfile(id);
+  const logStats = await getUserLogStats(id);
+  const xpBaseByPillar = await getXpBaseByPillar(id);
+  const halfLifeByPillar = computeHalfLife(profile.modeCode);
+  const dailyTargets = computeDailyTargets(xpBaseByPillar, profile.weeklyTarget);
+  const graceApplied = logStats.uniqueDays < 7;
+  const graceUntilDate = logStats.firstDate ? addDays(logStats.firstDate, 6) : null;
+
+  const propagationStart = logStats.firstDate
+    ? (logStats.firstDate < fromDate ? logStats.firstDate : fromDate)
+    : fromDate;
+
+  const propagationDates = enumerateDates(propagationStart, toDate);
+
+  let xpSeries = new Map<string, Partial<Record<'Body' | 'Mind' | 'Soul', number>>>();
+
+  if (propagationDates.length > 0) {
+    xpSeries = await getDailyXpSeriesByPillar(id, propagationStart, toDate);
+  }
+
+  const { series } = propagateEnergy({
+    dates: propagationDates.length > 0 ? propagationDates : enumerateDates(fromDate, toDate),
+    xpByDate: xpSeries,
+    halfLifeByPillar,
+    dailyTargets,
+    forceFullGrace: graceApplied,
+    graceUntilDate,
+  });
+
+  const filtered = series
+    .filter((row) => row.date >= fromDate && row.date <= toDate)
+    .map((row) => ({
+      date: row.date,
+      Body: row.Body,
+      Mind: row.Mind,
+      Soul: row.Soul,
+    }));
+
+  cache.set(cacheKey, filtered);
+
+  res.json(filtered);
+};

--- a/apps/api/src/controllers/users/get-user-state.ts
+++ b/apps/api/src/controllers/users/get-user-state.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+import type { AsyncHandler } from '../../lib/async-handler.js';
+import { SimpleTtlCache } from '../../lib/simple-cache.js';
+import { uuidSchema } from '../../lib/validation.js';
+import {
+  addDays,
+  computeDailyTargets,
+  computeGainFactors,
+  computeHalfLife,
+  computeDecayRates,
+  enumerateDates,
+  formatDateInTimezone,
+  getDailyXpSeriesByPillar,
+  getUserLogStats,
+  getUserProfile,
+  getXpBaseByPillar,
+  propagateEnergy,
+  type Pillar,
+} from './user-state-service.js';
+
+type PillarStateResponse = {
+  hp?: number;
+  focus?: number;
+  mood?: number;
+  xp_today: number;
+  d: number;
+  k: number;
+  H: number;
+  xp_obj_day: number;
+};
+
+type StateResponse = {
+  date: string;
+  mode: string;
+  weekly_target: number;
+  grace: {
+    applied: boolean;
+    unique_days: number;
+  };
+  pillars: Record<'Body' | 'Mind' | 'Soul', PillarStateResponse>;
+};
+
+const paramsSchema = z.object({
+  id: uuidSchema,
+});
+
+const cache = new SimpleTtlCache<StateResponse>({ ttlMs: 5 * 60 * 1000, maxEntries: 200 });
+
+export const getUserState: AsyncHandler = async (req, res) => {
+  const { id } = paramsSchema.parse(req.params);
+
+  const cached = cache.get(id);
+
+  if (cached) {
+    res.json(cached);
+    return;
+  }
+
+  const profile = await getUserProfile(id);
+  const logStats = await getUserLogStats(id);
+  const xpBaseByPillar = await getXpBaseByPillar(id);
+  const halfLifeByPillar = computeHalfLife(profile.modeCode);
+  const decayRates = computeDecayRates(halfLifeByPillar);
+  const dailyTargets = computeDailyTargets(xpBaseByPillar, profile.weeklyTarget);
+  const gainFactors = computeGainFactors(decayRates, dailyTargets);
+  const today = formatDateInTimezone(new Date(), profile.timezone);
+  const graceApplied = logStats.uniqueDays < 7;
+  const graceUntilDate = logStats.firstDate ? addDays(logStats.firstDate, 6) : null;
+
+  const fromDate = logStats.firstDate ?? today;
+  const dateSeries = enumerateDates(fromDate, today);
+
+  let xpSeries = new Map<string, Partial<Record<Pillar, number>>>();
+
+  if (logStats.firstDate) {
+    xpSeries = await getDailyXpSeriesByPillar(id, fromDate, today);
+  }
+
+  const { lastEnergy } = propagateEnergy({
+    dates: dateSeries.length > 0 ? dateSeries : [today],
+    xpByDate: xpSeries,
+    halfLifeByPillar,
+    dailyTargets,
+    forceFullGrace: graceApplied,
+    graceUntilDate,
+  });
+
+  const xpToday = xpSeries.get(today) ?? {};
+  const pillars: Record<'Body' | 'Mind' | 'Soul', PillarStateResponse> = {
+    Body: {
+      hp: lastEnergy.Body,
+      xp_today: xpToday.Body ?? 0,
+      d: Number(decayRates.Body.toFixed(6)),
+      k: Number(gainFactors.Body.toFixed(6)),
+      H: halfLifeByPillar.Body,
+      xp_obj_day: dailyTargets.Body,
+    },
+    Mind: {
+      focus: lastEnergy.Mind,
+      xp_today: xpToday.Mind ?? 0,
+      d: Number(decayRates.Mind.toFixed(6)),
+      k: Number(gainFactors.Mind.toFixed(6)),
+      H: halfLifeByPillar.Mind,
+      xp_obj_day: dailyTargets.Mind,
+    },
+    Soul: {
+      mood: lastEnergy.Soul,
+      xp_today: xpToday.Soul ?? 0,
+      d: Number(decayRates.Soul.toFixed(6)),
+      k: Number(gainFactors.Soul.toFixed(6)),
+      H: halfLifeByPillar.Soul,
+      xp_obj_day: dailyTargets.Soul,
+    },
+  };
+
+  const response: StateResponse = {
+    date: today,
+    mode: profile.modeCode,
+    weekly_target: profile.weeklyTarget,
+    grace: {
+      applied: graceApplied,
+      unique_days: logStats.uniqueDays,
+    },
+    pillars,
+  };
+
+  cache.set(id, response);
+
+  res.json(response);
+};

--- a/apps/api/src/controllers/users/user-state-service.ts
+++ b/apps/api/src/controllers/users/user-state-service.ts
@@ -1,0 +1,166 @@
+import { pool } from '../../db.js';
+import { HttpError } from '../../lib/http-error.js';
+import { PILLARS, type Pillar, type XpByDate } from './user-state-utils.js';
+
+const PILLAR_ID_TO_NAME: Record<number, Pillar> = {
+  1: 'Body',
+  2: 'Mind',
+  3: 'Soul',
+};
+
+export type UserProfile = {
+  userId: string;
+  modeCode: string;
+  weeklyTarget: number;
+  timezone: string | null;
+};
+
+export type XpBaseByPillar = Record<Pillar, number>;
+
+export type LogStats = {
+  uniqueDays: number;
+  firstDate: string | null;
+};
+
+export async function getUserProfile(userId: string): Promise<UserProfile> {
+  const result = await pool.query<{
+    user_id: string;
+    mode_code: string | null;
+    weekly_target: number | null;
+    timezone: string | null;
+  }>(
+    `SELECT u.user_id,
+            COALESCE(gm.code, u.game_mode) AS mode_code,
+            COALESCE(gm.weekly_target, u.weekly_target) AS weekly_target,
+            u.timezone
+       FROM users u
+  LEFT JOIN cat_game_mode gm
+         ON (gm.game_mode_id = u.game_mode_id)
+         OR (gm.code = u.game_mode)
+      WHERE u.user_id = $1
+      LIMIT 1`,
+    [userId],
+  );
+
+  if (result.rowCount === 0) {
+    throw new HttpError(404, 'user_not_found', 'User not found');
+  }
+
+  const row = result.rows[0];
+
+  return {
+    userId: row.user_id,
+    modeCode: (row.mode_code ?? 'CHILL').toUpperCase(),
+    weeklyTarget: Number(row.weekly_target ?? 0),
+    timezone: row.timezone,
+  };
+}
+
+export async function getXpBaseByPillar(userId: string): Promise<XpBaseByPillar> {
+  const result = await pool.query<{
+    pillar_id: number;
+    xp_base: string | number;
+  }>(
+    `SELECT t.pillar_id, SUM(t.xp_base) AS xp_base
+       FROM tasks t
+       JOIN users u ON u.user_id = t.user_id
+      WHERE t.user_id = $1
+        AND t.tasks_group_id = u.tasks_group_id
+        AND t.active = TRUE
+   GROUP BY t.pillar_id`,
+    [userId],
+  );
+
+  const base: XpBaseByPillar = { Body: 0, Mind: 0, Soul: 0 };
+
+  for (const row of result.rows) {
+    const pillarName = PILLAR_ID_TO_NAME[row.pillar_id];
+
+    if (!pillarName) {
+      continue;
+    }
+
+    base[pillarName] = Number(row.xp_base ?? 0);
+  }
+
+  return base;
+}
+
+export async function getDailyXpSeriesByPillar(
+  userId: string,
+  from: string,
+  to: string,
+): Promise<XpByDate> {
+  const result = await pool.query<{
+    date: string;
+    pillar_id: number;
+    xp_day: string | number;
+  }>(
+    `SELECT dl.date, t.pillar_id, SUM(dl.quantity * t.xp_base) AS xp_day
+       FROM daily_log dl
+       JOIN tasks t ON t.task_id = dl.task_id
+      WHERE dl.user_id = $1
+        AND dl.date BETWEEN $2 AND $3
+   GROUP BY dl.date, t.pillar_id`,
+    [userId, from, to],
+  );
+
+  const series: XpByDate = new Map();
+
+  for (const row of result.rows) {
+    const pillarName = PILLAR_ID_TO_NAME[row.pillar_id];
+
+    if (!pillarName) {
+      continue;
+    }
+
+    const current = series.get(row.date) ?? {};
+    current[pillarName] = Number(row.xp_day ?? 0);
+    series.set(row.date, current);
+  }
+
+  return series;
+}
+
+export async function getUserLogStats(userId: string): Promise<LogStats> {
+  const result = await pool.query<{
+    first_date: string | null;
+    unique_days: string | number | null;
+  }>(
+    `SELECT MIN(date) AS first_date,
+            COUNT(DISTINCT date) AS unique_days
+       FROM daily_log
+      WHERE user_id = $1`,
+    [userId],
+  );
+
+  const row = result.rows[0];
+
+  return {
+    uniqueDays: Number(row?.unique_days ?? 0),
+    firstDate: row?.first_date ?? null,
+  };
+}
+
+export {
+  addDays,
+  computeDailyTargets,
+  computeDecayRates,
+  computeGainFactors,
+  computeHalfLife,
+  enumerateDates,
+  formatDateInTimezone,
+  propagateEnergy,
+} from './user-state-utils.js';
+
+export type {
+  DailyTargetByPillar,
+  DecayRateByPillar,
+  GainFactorByPillar,
+  HalfLifeByPillar,
+  Pillar,
+  PropagateOptions,
+  PropagatedSeriesRow,
+  PropagationResult,
+  XpByDate,
+} from './user-state-utils.js';

--- a/apps/api/src/controllers/users/user-state-utils.ts
+++ b/apps/api/src/controllers/users/user-state-utils.ts
@@ -1,0 +1,176 @@
+export type Pillar = 'Body' | 'Mind' | 'Soul';
+
+export const PILLARS: readonly Pillar[] = ['Body', 'Mind', 'Soul'];
+
+const HALF_LIFE_BY_MODE: Record<string, Record<Pillar, number>> = {
+  LOW: { Body: 7, Mind: 9, Soul: 11 },
+  CHILL: { Body: 6, Mind: 8, Soul: 10 },
+  FLOW: { Body: 5, Mind: 7, Soul: 9 },
+  EVOLVE: { Body: 4, Mind: 6, Soul: 8 },
+};
+
+const DEFAULT_HALF_LIFE = HALF_LIFE_BY_MODE.CHILL;
+
+export type XpByDate = Map<string, Partial<Record<Pillar, number>>>;
+
+export type HalfLifeByPillar = Record<Pillar, number>;
+
+export type DecayRateByPillar = Record<Pillar, number>;
+
+export type GainFactorByPillar = Record<Pillar, number>;
+
+export type DailyTargetByPillar = Record<Pillar, number>;
+
+export type PropagatedSeriesRow = {
+  date: string;
+} & Record<Pillar, number>;
+
+export type PropagationResult = {
+  lastEnergy: Record<Pillar, number>;
+  series: PropagatedSeriesRow[];
+};
+
+export function computeHalfLife(modeCode: string): HalfLifeByPillar {
+  const key = modeCode.toUpperCase();
+  const config = HALF_LIFE_BY_MODE[key] ?? DEFAULT_HALF_LIFE;
+
+  return { ...config };
+}
+
+export function computeDecayRates(halfLifeByPillar: HalfLifeByPillar): DecayRateByPillar {
+  return PILLARS.reduce<DecayRateByPillar>((acc, pillar) => {
+    const halfLife = halfLifeByPillar[pillar];
+
+    acc[pillar] = halfLife > 0 ? 1 - Math.pow(0.5, 1 / halfLife) : 0;
+
+    return acc;
+  }, {} as DecayRateByPillar);
+}
+
+export function computeDailyTargets(
+  xpBaseByPillar: Record<Pillar, number>,
+  weeklyTarget: number,
+): DailyTargetByPillar {
+  return PILLARS.reduce<DailyTargetByPillar>((acc, pillar) => {
+    const base = xpBaseByPillar[pillar] ?? 0;
+    acc[pillar] = base > 0 && weeklyTarget > 0 ? (base * weeklyTarget) / 7 : 0;
+    return acc;
+  }, {} as DailyTargetByPillar);
+}
+
+export function computeGainFactors(
+  decayRates: DecayRateByPillar,
+  dailyTargets: DailyTargetByPillar,
+): GainFactorByPillar {
+  return PILLARS.reduce<GainFactorByPillar>((acc, pillar) => {
+    const target = dailyTargets[pillar];
+    const decay = decayRates[pillar];
+
+    acc[pillar] = target > 0 ? (100 * decay) / target : 0;
+
+    return acc;
+  }, {} as GainFactorByPillar);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function enumerateDates(from: string, to: string): string[] {
+  const dates: string[] = [];
+  const cursor = new Date(from);
+  const target = new Date(to);
+
+  if (Number.isNaN(cursor.getTime()) || Number.isNaN(target.getTime())) {
+    return dates;
+  }
+
+  while (cursor <= target) {
+    dates.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+
+  return dates;
+}
+
+export function addDays(date: string, days: number): string {
+  const d = new Date(date);
+
+  if (Number.isNaN(d.getTime())) {
+    return date;
+  }
+
+  d.setUTCDate(d.getUTCDate() + days);
+
+  return d.toISOString().slice(0, 10);
+}
+
+export type PropagateOptions = {
+  dates: string[];
+  xpByDate: XpByDate;
+  halfLifeByPillar: HalfLifeByPillar;
+  dailyTargets: DailyTargetByPillar;
+  forceFullGrace?: boolean;
+  graceUntilDate?: string | null;
+  initialEnergy?: number;
+};
+
+export function propagateEnergy({
+  dates,
+  xpByDate,
+  halfLifeByPillar,
+  dailyTargets,
+  forceFullGrace = false,
+  graceUntilDate,
+  initialEnergy = 60,
+}: PropagateOptions): PropagationResult {
+  const decayRates = computeDecayRates(halfLifeByPillar);
+  const gainFactors = computeGainFactors(decayRates, dailyTargets);
+  const previousEnergy: Record<Pillar, number> = { Body: initialEnergy, Mind: initialEnergy, Soul: initialEnergy };
+  const series: PropagatedSeriesRow[] = [];
+
+  for (const date of dates) {
+    const xpForDay = xpByDate.get(date) ?? {};
+    const row: PropagatedSeriesRow = { date, Body: 0, Mind: 0, Soul: 0 };
+
+    for (const pillar of PILLARS) {
+      let energy: number;
+
+      if (forceFullGrace) {
+        energy = 100;
+      } else if (dailyTargets[pillar] === 0) {
+        energy = 0;
+      } else if (graceUntilDate && date <= graceUntilDate) {
+        energy = 100;
+      } else {
+        const decay = decayRates[pillar];
+        const gain = gainFactors[pillar];
+        const previous = previousEnergy[pillar];
+        const xpToday = xpForDay[pillar] ?? 0;
+
+        energy = clamp((1 - decay) * previous + gain * xpToday, 0, 100);
+      }
+
+      previousEnergy[pillar] = energy;
+      row[pillar] = Number.isFinite(energy) ? Math.round(energy * 100) / 100 : 0;
+    }
+
+    series.push(row);
+  }
+
+  return {
+    lastEnergy: { ...previousEnergy },
+    series,
+  };
+}
+
+export function formatDateInTimezone(date: Date, timezone?: string | null): string {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone ?? 'UTC',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+
+  return formatter.format(date);
+}

--- a/apps/api/src/lib/simple-cache.ts
+++ b/apps/api/src/lib/simple-cache.ts
@@ -1,0 +1,58 @@
+type CacheEntry<V> = {
+  value: V;
+  expiresAt: number;
+};
+
+/**
+ * Small TTL cache with naive LRU eviction using Map insertion order.
+ */
+export class SimpleTtlCache<V> {
+  private readonly store = new Map<string, CacheEntry<V>>();
+
+  constructor(private readonly options: { ttlMs: number; maxEntries?: number }) {}
+
+  get(key: string): V | undefined {
+    const entry = this.store.get(key);
+
+    if (!entry) {
+      return undefined;
+    }
+
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+
+    // refresh LRU order by re-inserting
+    this.store.delete(key);
+    this.store.set(key, entry);
+
+    return entry.value;
+  }
+
+  set(key: string, value: V): void {
+    const { ttlMs, maxEntries } = this.options;
+
+    this.store.set(key, { value, expiresAt: Date.now() + ttlMs });
+
+    if (typeof maxEntries === 'number' && maxEntries > 0) {
+      while (this.store.size > maxEntries) {
+        const oldestKey = this.store.keys().next().value;
+
+        if (typeof oldestKey === 'undefined') {
+          break;
+        }
+
+        this.store.delete(oldestKey);
+      }
+    }
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -4,6 +4,8 @@ import { getUserDailyXp } from '../controllers/logs/get-user-daily-xp.js';
 import { getUserJourney } from '../controllers/logs/get-user-journey.js';
 import { getUserTasks } from '../controllers/tasks/get-user-tasks.js';
 import { getUserLevel } from '../controllers/users/get-user-level.js';
+import { getUserState } from '../controllers/users/get-user-state.js';
+import { getUserStateTimeseries } from '../controllers/users/get-user-state-timeseries.js';
 import { getUserTotalXp } from '../controllers/users/get-user-total-xp.js';
 import { asyncHandler } from '../lib/async-handler.js';
 
@@ -15,5 +17,7 @@ router.get('/users/:id/xp/total', asyncHandler(getUserTotalXp));
 router.get('/users/:id/level', asyncHandler(getUserLevel));
 router.get('/users/:id/journey', asyncHandler(getUserJourney));
 router.get('/users/:id/emotions', asyncHandler(getUserEmotions));
+router.get('/users/:id/state', asyncHandler(getUserState));
+router.get('/users/:id/state/timeseries', asyncHandler(getUserStateTimeseries));
 
 export default router;


### PR DESCRIPTION
## Summary
- implement user state and timeseries endpoints that derive hp/focus/mood from existing logs and tasks
- add shared utilities and in-memory caching to support deterministic energy propagation across pillars
- cover the new logic with unit tests and extend dashboard integration coverage

## Testing
- npm -w @innerbloom/api test
- npm -w @innerbloom/api run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e40457421c8322950f16a07d9db086