### PR TITLE
Fix Clerk login route matching for nested steps

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -41,7 +41,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route
-          path="/login"
+          path="/login/*"
           element={
             <RedirectIfSignedIn>
               <LoginPage />
@@ -49,7 +49,7 @@ export default function App() {
           }
         />
         <Route
-          path="/sign-up"
+          path="/sign-up/*"
           element={
             <RedirectIfSignedIn>
               <SignUpPage />


### PR DESCRIPTION
## Summary
- allow the Clerk sign-in and sign-up routes to match nested paths so multi-step flows render correctly

## Testing
- npm --workspace apps/web run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e4335fd28c832297dc70983c1fad3c