### PR TITLE
feat: add dashboard v3 page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { useAuth } from '@clerk/clerk-react';
 import DashboardPage from './pages/Dashboard';
+import DashboardV3Page from './pages/DashboardV3';
 import LoginPage from './pages/Login';
 import LandingPage from './pages/Landing';
 import SignUpPage from './pages/SignUp';
@@ -61,6 +62,14 @@ export default function App() {
           element={
             <RequireUser>
               <DashboardPage />
+            </RequireUser>
+          }
+        />
+        <Route
+          path="/dashboard-v3"
+          element={
+            <RequireUser>
+              <DashboardV3Page />
             </RequireUser>
           }
         />

--- a/apps/web/src/components/dashboard-v3/Alerts.tsx
+++ b/apps/web/src/components/dashboard-v3/Alerts.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from 'react';
+import { useRequest } from '../../hooks/useRequest';
+import { getUserJourney, type UserJourneySummary } from '../../lib/api';
+
+interface AlertsProps {
+  userId: string;
+}
+
+function shouldShowBbddWarning(journey: UserJourneySummary | null): boolean {
+  if (!journey) return false;
+  return (journey.quantity_daily_logs ?? 0) === 0;
+}
+
+function shouldShowSchedulerWarning(journey: UserJourneySummary | null): boolean {
+  if (!journey) return false;
+  const logs = journey.quantity_daily_logs ?? 0;
+  const days = journey.days_of_journey ?? 0;
+  return logs > 0 && days >= 7;
+}
+
+export function Alerts({ userId }: AlertsProps) {
+  const { data, status } = useRequest(() => getUserJourney(userId), [userId]);
+
+  const showBbdd = useMemo(() => shouldShowBbddWarning(data), [data]);
+  const showScheduler = useMemo(() => shouldShowSchedulerWarning(data), [data]);
+
+  if (status === 'loading') {
+    return (
+      <div className="space-y-3">
+        <div className="animate-pulse rounded-2xl border border-white/5 bg-white/5/40 p-4" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {showBbdd && (
+        <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm text-amber-100">
+          <div className="flex items-start gap-3">
+            <span className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full bg-amber-300" aria-hidden />
+            <div className="space-y-1">
+              <p className="font-semibold text-white">Confirmá tu base</p>
+              <p className="text-amber-100/80">
+                Abrí el menú y revisá tu base para que podamos generar tu próxima Daily Quest.
+              </p>
+            </div>
+            <a
+              href="/MVP/gamificationweblanding/index-bbdd.html"
+              className="ml-auto inline-flex rounded-full border border-amber-200/50 bg-amber-200/10 px-3 py-1 text-xs font-semibold text-white backdrop-blur"
+            >
+              Editar base
+            </a>
+          </div>
+          <p className="mt-2 text-xs text-amber-100/70">
+            Este aviso desaparece cuando tu registro diario queda confirmado en la nueva app.
+          </p>
+        </div>
+      )}
+
+      {showScheduler && (
+        <div className="rounded-2xl border border-indigo-400/30 bg-indigo-500/10 p-4 text-sm text-indigo-100">
+          <div className="flex items-start gap-3">
+            <span className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full bg-indigo-300" aria-hidden />
+            <div className="space-y-1">
+              <p className="font-semibold text-white">Tu Daily Quest está listo</p>
+              <p className="text-indigo-100/80">
+                Programá tu recordatorio para recibirlo automáticamente cada día.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="ml-auto inline-flex rounded-full border border-indigo-200/50 bg-indigo-200/10 px-3 py-1 text-xs font-semibold text-white backdrop-blur"
+              disabled
+            >
+              Programar Daily Quest
+            </button>
+          </div>
+          <p className="mt-2 text-xs text-indigo-100/70">
+            El programador todavía no está conectado en esta vista, pero el aviso replica el flujo del MVP.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx
+++ b/apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useRequest } from '../../hooks/useRequest';
+import { getUserDailyXp, type DailyXpPoint } from '../../lib/api';
+
+interface DailyCultivationSectionProps {
+  userId: string;
+}
+
+type MonthBucket = {
+  label: string;
+  key: string;
+  days: DailyXpPoint[];
+};
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function createRange(daysBack: number) {
+  const to = new Date();
+  const from = new Date();
+  from.setUTCDate(from.getUTCDate() - daysBack);
+  return { from: formatDate(from), to: formatDate(to) };
+}
+
+function groupByMonth(series: DailyXpPoint[]): MonthBucket[] {
+  const map = new Map<string, DailyXpPoint[]>();
+
+  for (const point of series) {
+    const key = point.date.slice(0, 7);
+    const arr = map.get(key) ?? [];
+    arr.push(point);
+    map.set(key, arr);
+  }
+
+  return Array.from(map.entries())
+    .sort(([a], [b]) => (a > b ? -1 : 1))
+    .map(([key, days]) => {
+      const [year, month] = key.split('-');
+      const formatter = new Intl.DateTimeFormat('es-AR', { month: 'short', year: 'numeric' });
+      const label = formatter.format(new Date(Number(year), Number(month) - 1));
+      return { key, label, days: days.sort((a, b) => (a.date > b.date ? 1 : -1)) } satisfies MonthBucket;
+    });
+}
+
+export function DailyCultivationSection({ userId }: DailyCultivationSectionProps) {
+  const range = useMemo(() => createRange(120), []);
+  const { data, status } = useRequest(() => getUserDailyXp(userId, range), [userId, range.from, range.to]);
+
+  const buckets = useMemo(() => groupByMonth(data?.series ?? []), [data?.series]);
+  const [selectedMonth, setSelectedMonth] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedMonth && buckets.length > 0) {
+      setSelectedMonth(buckets[0].key);
+    }
+  }, [buckets, selectedMonth]);
+
+  const activeBucket = buckets.find((bucket) => bucket.key === selectedMonth) ?? buckets[0];
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
+      <header className="flex flex-wrap items-center justify-between gap-3 text-white">
+        <h3 className="text-lg font-semibold">🪴 Daily Cultivation</h3>
+        {buckets.length > 0 && (
+          <label className="flex items-center gap-2 text-xs uppercase tracking-wide text-text-muted">
+            <span>Mes</span>
+            <select
+              className="rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-white"
+              value={selectedMonth ?? ''}
+              onChange={(event) => setSelectedMonth(event.target.value)}
+            >
+              {buckets.map((bucket) => (
+                <option key={bucket.key} value={bucket.key}>
+                  {bucket.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+      </header>
+
+      {status === 'loading' && (
+        <div className="mt-6 h-48 w-full animate-pulse rounded-2xl bg-white/10" />
+      )}
+
+      {status === 'error' && (
+        <p className="mt-6 text-sm text-rose-300">No pudimos cargar tus XP diarios.</p>
+      )}
+
+      {status === 'success' && (!activeBucket || activeBucket.days.length === 0) && (
+        <p className="mt-6 text-sm text-text-muted">Todavía no registraste XP este mes.</p>
+      )}
+
+      {status === 'success' && activeBucket && activeBucket.days.length > 0 && (
+        <div className="mt-6 space-y-4">
+          <div className="flex items-end gap-1 rounded-2xl border border-white/10 bg-white/5 p-4">
+            <BarChart days={activeBucket.days} />
+          </div>
+          <p className="text-xs text-text-muted">
+            Cada barra representa los XP obtenidos en el día. Replicamos la vista mensual del MVP usando los datos del endpoint
+            <code className="ml-1 rounded bg-white/10 px-1 py-px text-[10px]">/users/:id/xp/daily</code>.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface BarChartProps {
+  days: DailyXpPoint[];
+}
+
+function BarChart({ days }: BarChartProps) {
+  const maxValue = Math.max(...days.map((day) => day.xp_day), 1);
+
+  return (
+    <div className="flex w-full items-end gap-[6px]">
+      {days.map((day) => {
+        const height = Math.round((day.xp_day / maxValue) * 100);
+        const date = new Date(day.date);
+        const label = date.getDate();
+        return (
+          <div key={day.date} className="flex flex-1 flex-col items-center justify-end">
+            <div
+              className="flex w-full max-w-[18px] flex-col justify-end rounded-full bg-gradient-to-t from-purple-800 via-violet-500 to-violet-300"
+              style={{ height: `${height}%`, minHeight: '8px' }}
+              title={`${day.date}: ${day.xp_day} XP`}
+            />
+            <span className="mt-2 text-[10px] text-text-muted">{label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard-v3/EmotionTimeline.tsx
+++ b/apps/web/src/components/dashboard-v3/EmotionTimeline.tsx
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+import { useRequest } from '../../hooks/useRequest';
+import { getEmotions, type EmotionSnapshot } from '../../lib/api';
+
+interface EmotionTimelineProps {
+  userId: string;
+}
+
+const EMOTION_COLORS: Record<string, string> = {
+  Calma: '#2ECC71',
+  Felicidad: '#F1C40F',
+  Motivación: '#9B59B6',
+  Tristeza: '#3498DB',
+  Ansiedad: '#E74C3C',
+  Frustración: '#8D6E63',
+  Cansancio: '#16A085',
+};
+
+function countEmotions(entries: EmotionSnapshot[]): { name: string; count: number } | null {
+  const map = new Map<string, number>();
+  for (const entry of entries) {
+    if (!entry.mood) continue;
+    const key = entry.mood;
+    map.set(key, (map.get(key) ?? 0) + 1);
+  }
+
+  let top: { name: string; count: number } | null = null;
+  for (const [name, count] of map.entries()) {
+    if (!top || count > top.count) {
+      top = { name, count };
+    }
+  }
+  return top;
+}
+
+export function EmotionTimeline({ userId }: EmotionTimelineProps) {
+  const { data, status } = useRequest(() => getEmotions(userId, { days: 30 }), [userId]);
+  const mostFrequent = useMemo(() => countEmotions(data ?? []), [data]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
+      <header className="flex flex-wrap items-center justify-between gap-3 text-white">
+        <h3 className="text-lg font-semibold">💗 Emotion Chart</h3>
+        <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-wide text-text-muted">
+          Últimos 30 días
+        </span>
+      </header>
+
+      {status === 'loading' && <div className="mt-6 h-48 w-full animate-pulse rounded-2xl bg-white/10" />}
+
+      {status === 'error' && (
+        <p className="mt-6 text-sm text-rose-300">Todavía no pudimos cargar tus emociones.</p>
+      )}
+
+      {status === 'success' && (!data || data.length === 0) && (
+        <p className="mt-6 text-sm text-text-muted">Registrá tu primera emoción para ver la línea temporal.</p>
+      )}
+
+      {status === 'success' && data && data.length > 0 && (
+        <div className="mt-6 space-y-4">
+          <div className="grid grid-cols-7 gap-2">
+            {data.map((entry) => {
+              const color = EMOTION_COLORS[entry.mood ?? ''] ?? 'rgba(255,255,255,0.2)';
+              return (
+                <div
+                  key={entry.date}
+                  className="flex flex-col items-center gap-2 rounded-2xl border border-white/5 bg-white/5 p-3 text-center text-[11px]"
+                >
+                  <div className="h-12 w-12 rounded-full" style={{ backgroundColor: color }} />
+                  <div className="space-y-1">
+                    <p className="font-semibold text-white">{entry.mood ?? '—'}</p>
+                    <p className="text-[10px] text-text-muted">{new Date(entry.date).toLocaleDateString('es-AR')}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {mostFrequent && (
+            <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+              <div
+                className="h-10 w-10 rounded-full"
+                style={{ backgroundColor: EMOTION_COLORS[mostFrequent.name] ?? 'rgba(255,255,255,0.25)' }}
+              />
+              <div>
+                <p className="font-semibold text-white">{mostFrequent.name}</p>
+                <p className="text-xs text-text-muted">
+                  Emoción más frecuente en los últimos 30 días ({mostFrequent.count} registros)
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/dashboard-v3/EnergyCard.tsx
+++ b/apps/web/src/components/dashboard-v3/EnergyCard.tsx
@@ -1,0 +1,111 @@
+import { useMemo } from 'react';
+import { useRequest } from '../../hooks/useRequest';
+import { getUserState, type UserState } from '../../lib/api';
+
+interface EnergyCardProps {
+  userId: string;
+}
+
+function toPercent(value: number | undefined): number {
+  if (value == null) return 0;
+  if (value <= 1) return Math.round(Math.max(value, 0) * 100);
+  return Math.round(Math.max(0, Math.min(value, 100)));
+}
+
+function normalize(state: UserState | null) {
+  if (!state) {
+    return {
+      mode: 'Flow',
+      Body: { hp: 0, xpToday: 0, target: 0 },
+      Mind: { focus: 0, xpToday: 0, target: 0 },
+      Soul: { mood: 0, xpToday: 0, target: 0 },
+    };
+  }
+
+  return {
+    mode: state.mode || 'Flow',
+    Body: {
+      hp: toPercent(state.pillars.Body.hp),
+      xpToday: state.pillars.Body.xp_today ?? 0,
+      target: state.pillars.Body.xp_obj_day ?? 0,
+    },
+    Mind: {
+      focus: toPercent(state.pillars.Mind.focus),
+      xpToday: state.pillars.Mind.xp_today ?? 0,
+      target: state.pillars.Mind.xp_obj_day ?? 0,
+    },
+    Soul: {
+      mood: toPercent(state.pillars.Soul.mood),
+      xpToday: state.pillars.Soul.xp_today ?? 0,
+      target: state.pillars.Soul.xp_obj_day ?? 0,
+    },
+  };
+}
+
+export function EnergyCard({ userId }: EnergyCardProps) {
+  const { data, status } = useRequest(() => getUserState(userId), [userId]);
+  const normalized = useMemo(() => normalize(data), [data]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
+      <header className="flex flex-wrap items-center justify-between gap-3 text-white">
+        <h3 className="text-lg font-semibold">💠 Daily Energy</h3>
+        <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-wide text-text-muted">
+          Modo: {normalized.mode}
+        </span>
+      </header>
+
+      {status === 'loading' && (
+        <div className="mt-6 space-y-4">
+          {Array.from({ length: 3 }).map((_, idx) => (
+            <div key={idx} className="h-4 w-full animate-pulse rounded bg-white/10" />
+          ))}
+        </div>
+      )}
+
+      {status === 'error' && (
+        <p className="mt-6 text-sm text-rose-300">No pudimos cargar tu energía diaria.</p>
+      )}
+
+      {status === 'success' && (
+        <div className="mt-6 space-y-5">
+          <EnergyMeter label="HP" value={normalized.Body.hp} xpToday={normalized.Body.xpToday} target={normalized.Body.target} />
+          <EnergyMeter label="Mood" value={normalized.Soul.mood} xpToday={normalized.Soul.xpToday} target={normalized.Soul.target} />
+          <EnergyMeter label="Focus" value={normalized.Mind.focus} xpToday={normalized.Mind.xpToday} target={normalized.Mind.target} />
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface EnergyMeterProps {
+  label: string;
+  value: number;
+  xpToday: number;
+  target: number;
+}
+
+function EnergyMeter({ label, value, xpToday, target }: EnergyMeterProps) {
+  const percent = Math.min(100, Math.max(value, 0));
+  const palette: Record<string, string> = {
+    HP: 'from-rose-300 via-rose-200 to-rose-100',
+    Mood: 'from-emerald-300 via-emerald-200 to-emerald-100',
+    Focus: 'from-sky-300 via-sky-200 to-sky-100',
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-xs uppercase tracking-wide text-text-muted">
+        <span>{label}</span>
+        <span>{percent}%</span>
+      </div>
+      <div className="h-3 w-full overflow-hidden rounded-full bg-white/10">
+        <div
+          className={`h-full rounded-full bg-gradient-to-r ${palette[label] ?? 'from-indigo-300 via-indigo-200 to-indigo-100'}`}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <p className="text-xs text-text-muted">XP hoy: {xpToday.toFixed(1)} · Objetivo diario: {target.toFixed(1)}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard-v3/MissionsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/MissionsSection.tsx
@@ -1,0 +1,53 @@
+import { useRequest } from '../../hooks/useRequest';
+import { getTasks } from '../../lib/api';
+
+interface MissionsSectionProps {
+  userId: string;
+}
+
+export function MissionsSection({ userId }: MissionsSectionProps) {
+  const { data, status } = useRequest(() => getTasks(userId), [userId]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
+      <header className="mb-4 flex flex-wrap items-center justify-between gap-3 text-white">
+        <h3 className="text-lg font-semibold">🗂️ Misiones</h3>
+        <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-wide text-text-muted">
+          Lectura solamente
+        </span>
+      </header>
+
+      {status === 'loading' && <div className="h-32 w-full animate-pulse rounded-2xl bg-white/10" />}
+
+      {status === 'error' && <p className="text-sm text-rose-300">No pudimos listar las misiones.</p>}
+
+      {status === 'success' && data && data.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {data.slice(0, 6).map((task) => (
+            <article key={task.task_id} className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4">
+              <h4 className="font-semibold text-white">🎯 {task.task}</h4>
+              <p className="text-xs text-text-muted">Pilar: {task.pillar_id ?? '—'}</p>
+              <p className="text-xs text-text-muted">XP base: {task.xp_base}</p>
+              <p className="text-xs text-text-muted">Constancia requerida: próximamente</p>
+              <button
+                type="button"
+                className="w-full rounded-full border border-white/10 bg-white/5 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-text"
+                disabled
+              >
+                Activar
+              </button>
+            </article>
+          ))}
+        </div>
+      )}
+
+      {status === 'success' && data && data.length === 0 && (
+        <p className="text-sm text-text-muted">Tu base todavía no tiene misiones configuradas.</p>
+      )}
+
+      <p className="mt-4 text-xs text-text-muted">
+        Mientras el endpoint de misiones dedicado no esté disponible reutilizamos las tareas activas como referencia visual.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/components/dashboard-v3/RadarChartCard.tsx
+++ b/apps/web/src/components/dashboard-v3/RadarChartCard.tsx
@@ -1,0 +1,148 @@
+import { useMemo } from 'react';
+import { useRequest } from '../../hooks/useRequest';
+import { getUserStateTimeseries, type EnergyTimeseriesPoint } from '../../lib/api';
+
+interface RadarChartCardProps {
+  userId: string;
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function buildRange(daysBack: number) {
+  const to = new Date();
+  const from = new Date();
+  from.setUTCDate(from.getUTCDate() - daysBack);
+  return { from: formatDate(from), to: formatDate(to) };
+}
+
+function average(values: number[]) {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function toPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value <= 1) return Math.round(value * 100);
+  return Math.round(Math.min(value, 120));
+}
+
+function computeDataset(series: EnergyTimeseriesPoint[] | null) {
+  if (!series || series.length === 0) {
+    return {
+      values: [0, 0, 0],
+      max: 100,
+    };
+  }
+
+  const body = toPercent(average(series.map((row) => row.Body ?? 0)));
+  const mind = toPercent(average(series.map((row) => row.Mind ?? 0)));
+  const soul = toPercent(average(series.map((row) => row.Soul ?? 0)));
+  const max = Math.max(100, body, mind, soul);
+
+  return { values: [body, mind, soul], max };
+}
+
+export function RadarChartCard({ userId }: RadarChartCardProps) {
+  const range = useMemo(() => buildRange(60), []);
+  const { data, status } = useRequest(() => getUserStateTimeseries(userId, range), [userId, range.from, range.to]);
+  const dataset = useMemo(() => computeDataset(data), [data]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
+      <header className="flex flex-wrap items-center justify-between gap-3 text-white">
+        <h3 className="text-lg font-semibold">🧿 Radar Chart</h3>
+        <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-wide text-text-muted">
+          Energía promedio · últimos 60 días
+        </span>
+      </header>
+
+      {status === 'loading' && <div className="mt-6 h-64 w-full animate-pulse rounded-2xl bg-white/10" />}
+
+      {status === 'error' && (
+        <p className="mt-6 text-sm text-rose-300">No pudimos construir el radar. Probá más tarde.</p>
+      )}
+
+      {status === 'success' && (
+        <div className="mt-6 flex flex-col items-center gap-4">
+          <Radar values={dataset.values} max={dataset.max} />
+          <p className="text-xs text-text-muted text-center">
+            Ante la falta del agregado <code className="rounded bg-white/10 px-1 py-px text-[10px]">habitos_by_rasgo</code>, usamos la
+            energía media de cada pilar como proxy visual.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface RadarProps {
+  values: number[];
+  max: number;
+}
+
+function Radar({ values, max }: RadarProps) {
+  const radius = 120;
+  const center = radius + 12;
+  const axes = ['Body', 'Mind', 'Soul'];
+
+  const angleFor = (index: number) => (-Math.PI / 2) + (index * (2 * Math.PI / axes.length));
+
+  const pointFor = (value: number, index: number) => {
+    const normalized = Math.max(0, Math.min(value / max, 1));
+    const angle = angleFor(index);
+    const x = center + radius * normalized * Math.cos(angle);
+    const y = center + radius * normalized * Math.sin(angle);
+    return `${x},${y}`;
+  };
+
+  const polygonPoints = values.map((value, index) => pointFor(value, index)).join(' ');
+
+  const gridLevels = [0.33, 0.66, 1];
+
+  return (
+    <svg width={center * 2} height={center * 2} viewBox={`0 0 ${center * 2} ${center * 2}`} className="max-w-full">
+      <defs>
+        <linearGradient id="radarFill" x1="0%" x2="100%" y1="0%" y2="100%">
+          <stop offset="0%" stopColor="rgba(102, 0, 204, 0.45)" />
+          <stop offset="100%" stopColor="rgba(102, 0, 204, 0.15)" />
+        </linearGradient>
+      </defs>
+
+      {gridLevels.map((level) => {
+        const points = axes
+          .map((_, index) => {
+            const angle = angleFor(index);
+            const x = center + radius * level * Math.cos(angle);
+            const y = center + radius * level * Math.sin(angle);
+            return `${x},${y}`;
+          })
+          .join(' ');
+        return <polygon key={level} points={points} fill="none" stroke="rgba(255,255,255,0.12)" />;
+      })}
+
+      {axes.map((axis, index) => {
+        const angle = angleFor(index);
+        const x = center + radius * Math.cos(angle);
+        const y = center + radius * Math.sin(angle);
+        return (
+          <g key={axis}>
+            <line x1={center} y1={center} x2={x} y2={y} stroke="rgba(255,255,255,0.12)" />
+            <text
+              x={center + (radius + 16) * Math.cos(angle)}
+              y={center + (radius + 16) * Math.sin(angle)}
+              textAnchor="middle"
+              alignmentBaseline="middle"
+              className="fill-white text-xs font-semibold"
+            >
+              {axis}
+            </text>
+          </g>
+        );
+      })}
+
+      <polygon points={polygonPoints} fill="url(#radarFill)" stroke="rgba(102,0,204,0.7)" strokeWidth={2} />
+    </svg>
+  );
+}

--- a/apps/web/src/components/dashboard-v3/StreakPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreakPanel.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from 'react';
+import { useRequest } from '../../hooks/useRequest';
+import { getTasks, getUserDailyXp, type DailyXpPoint, type UserTask } from '../../lib/api';
+
+interface StreakPanelProps {
+  userId: string;
+}
+
+type PanelData = {
+  tasks: UserTask[];
+  xpSeries: DailyXpPoint[];
+};
+
+function buildRange(daysBack: number) {
+  const to = new Date();
+  const from = new Date();
+  from.setUTCDate(from.getUTCDate() - daysBack);
+  const format = (date: Date) => date.toISOString().slice(0, 10);
+  return { from: format(from), to: format(to) };
+}
+
+function computeWeeklyXp(series: DailyXpPoint[]): number {
+  const sorted = [...series].sort((a, b) => (a.date > b.date ? -1 : 1));
+  const recent = sorted.slice(0, 7);
+  return recent.reduce((sum, entry) => sum + (entry.xp_day ?? 0), 0);
+}
+
+export function StreakPanel({ userId }: StreakPanelProps) {
+  const range = useMemo(() => buildRange(30), []);
+  const { data, status } = useRequest<PanelData>(async () => {
+    const [tasks, xp] = await Promise.all([
+      getTasks(userId),
+      getUserDailyXp(userId, range),
+    ]);
+
+    return {
+      tasks,
+      xpSeries: xp.series ?? [],
+    };
+  }, [userId, range.from, range.to]);
+
+  const weeklyXp = useMemo(() => computeWeeklyXp(data?.xpSeries ?? []), [data?.xpSeries]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
+      <header className="flex flex-wrap items-center justify-between gap-3 text-white">
+        <h3 className="text-lg font-semibold">🔥 Panel de Rachas</h3>
+        <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-wide text-text-muted">
+          Vista read-only
+        </span>
+      </header>
+
+      {status === 'loading' && <div className="mt-6 h-56 w-full animate-pulse rounded-2xl bg-white/10" />}
+
+      {status === 'error' && (
+        <p className="mt-6 text-sm text-rose-300">No pudimos cargar tus tareas activas.</p>
+      )}
+
+      {status === 'success' && data && (
+        <div className="mt-6 space-y-4">
+          <p className="text-xs text-text-muted">
+            La API actual aún no expone <code className="rounded bg-white/10 px-1 py-px text-[10px]">daily_log_raw</code>. Listamos tus tareas activas y
+            calculamos el XP semanal total como referencia.
+          </p>
+
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <p className="text-sm text-text-muted">XP total últimos 7 días</p>
+            <p className="text-2xl font-semibold text-white">{weeklyXp.toLocaleString('es-AR')} XP</p>
+          </div>
+
+          <div className="space-y-3">
+            {data.tasks.slice(0, 8).map((task) => (
+              <article key={task.task_id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-white">{task.task}</p>
+                    <p className="text-xs text-text-muted">Pilar: {task.pillar_id ?? '—'}</p>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-text-muted">
+                    <span className="rounded-full bg-white/10 px-2 py-1 text-white">+{task.xp_base} XP</span>
+                    <span className="rounded-full border border-white/10 px-2 py-1">✓×—</span>
+                  </div>
+                </div>
+              </article>
+            ))}
+
+            {data.tasks.length === 0 && (
+              <p className="text-sm text-text-muted">Sin tareas activas para mostrar.</p>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/dashboard-v3/XpSummaryCard.tsx
+++ b/apps/web/src/components/dashboard-v3/XpSummaryCard.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from 'react';
+import { useRequest } from '../../hooks/useRequest';
+import { getUserLevel, getUserTotalXp } from '../../lib/api';
+
+interface XpSummaryCardProps {
+  userId: string;
+}
+
+type LevelSummary = {
+  totalXp: number;
+  level: number;
+};
+
+function estimateLevelBoundaries(level: number) {
+  if (level <= 0) {
+    return { start: 0, end: 120 };
+  }
+
+  const start = Math.max(0, Math.round(level * level * 120));
+  const end = Math.max(start + 120, Math.round((level + 1) * (level + 1) * 120));
+
+  return { start, end };
+}
+
+function buildSummary(data: LevelSummary | null) {
+  if (!data) {
+    return { percent: 0, remaining: 0, totalXp: 0, level: 0 };
+  }
+
+  const { start, end } = estimateLevelBoundaries(data.level);
+  const span = Math.max(end - start, 1);
+  const progress = Math.max(0, data.totalXp - start);
+  const percent = Math.min(100, Math.round((progress / span) * 100));
+  const remaining = Math.max(end - data.totalXp, 0);
+
+  return { percent, remaining, totalXp: data.totalXp, level: data.level };
+}
+
+export function XpSummaryCard({ userId }: XpSummaryCardProps) {
+  const { data, status } = useRequest(async () => {
+    const [total, level] = await Promise.all([
+      getUserTotalXp(userId),
+      getUserLevel(userId),
+    ]);
+
+    return {
+      totalXp: total.total_xp ?? 0,
+      level: level.level ?? 0,
+    } satisfies LevelSummary;
+  }, [userId]);
+
+  const summary = useMemo(() => buildSummary(data), [data]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
+      <header className="flex flex-wrap items-center justify-between gap-3 text-white">
+        <h3 className="text-lg font-semibold">🏆 Total XP · 🎯 Level</h3>
+        <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide">
+          Estimación client-side
+        </span>
+      </header>
+
+      {status === 'loading' && (
+        <div className="mt-6 space-y-4">
+          <div className="h-8 w-40 animate-pulse rounded bg-white/10" />
+          <div className="h-3 w-full animate-pulse rounded bg-white/10" />
+          <div className="h-4 w-48 animate-pulse rounded bg-white/10" />
+        </div>
+      )}
+
+      {status === 'error' && (
+        <p className="mt-6 text-sm text-rose-300">No pudimos cargar tu progreso. Intentalo más tarde.</p>
+      )}
+
+      {status === 'success' && (
+        <div className="mt-6 space-y-4">
+          <p className="text-3xl font-semibold text-white">{summary.totalXp.toLocaleString('es-AR')}</p>
+          <div className="flex flex-wrap items-center gap-3 text-sm text-text-muted">
+            <span className="rounded-full bg-white/10 px-3 py-1 text-white">Nivel {summary.level}</span>
+            <span>Te faltan {summary.remaining.toLocaleString('es-AR')} XP para el próximo nivel</span>
+          </div>
+          <div className="h-3 w-full overflow-hidden rounded-full bg-white/10">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-amber-300 via-amber-200 to-amber-100"
+              style={{ width: `${summary.percent}%` }}
+            />
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -1,4 +1,5 @@
 import { useAuth, useUser } from '@clerk/clerk-react';
+import { NavLink } from 'react-router-dom';
 
 export function Navbar() {
   const { userId, signOut } = useAuth();
@@ -17,7 +18,33 @@ export function Navbar() {
           <p className="text-xs uppercase tracking-[0.35em] text-text-muted">Innerbloom</p>
           <h1 className="font-display text-xl font-semibold text-white md:text-2xl">Daily Quest Dashboard</h1>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-1 items-center justify-end gap-3">
+          <nav className="hidden items-center gap-2 md:flex">
+            <NavLink
+              to="/dashboard"
+              className={({ isActive }) =>
+                `rounded-lg border px-3 py-2 text-xs font-semibold uppercase tracking-wide transition ${
+                  isActive
+                    ? 'border-white/40 bg-white/20 text-white'
+                    : 'border-white/10 bg-white/5 text-text hover:border-white/20 hover:bg-white/10'
+                }`
+              }
+            >
+              Dashboard clásico
+            </NavLink>
+            <NavLink
+              to="/dashboard-v3"
+              className={({ isActive }) =>
+                `rounded-lg border px-3 py-2 text-xs font-semibold uppercase tracking-wide transition ${
+                  isActive
+                    ? 'border-white/40 bg-white/20 text-white'
+                    : 'border-white/10 bg-white/5 text-text hover:border-white/20 hover:bg-white/10'
+                }`
+              }
+            >
+              Dashboard v3
+            </NavLink>
+          </nav>
           {displayName && (
             <span className="hidden rounded-full bg-white/10 px-3 py-1 text-xs text-text-muted md:inline-flex">
               {displayName}

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -1,0 +1,102 @@
+/**
+ * Endpoints utilizados en esta vista:
+ * - GET /users/:id/xp/total → XP total para la tarjeta principal.
+ * - GET /users/:id/level → Nivel actual; el XP restante se estima client-side con una curva cuadrática.
+ * - GET /users/:id/state → Game mode y barras de Daily Energy.
+ * - GET /users/:id/xp/daily → Serie diaria de XP (Daily Cultivation + XP semanal del panel de rachas).
+ * - GET /users/:id/state/timeseries → Radar Chart (usa la energía promedio como proxy de XP por rasgo ante la falta de habitos_by_rasgo).
+ * - GET /users/:id/emotions → Línea temporal de emociones (mapa emotion_id → etiqueta legible).
+ * - GET /users/:id/tasks → Tareas activas reutilizadas para panel de rachas y misiones.
+ * - GET /users/:id/journey → Avisos iniciales (confirmación de base / scheduler).
+ * Derivaciones client-side: xp faltante y barra de nivel se calculan con una curva estimada; radar usa energía promedio; panel de rachas muestra métricas de XP mientras esperamos daily_log_raw.
+ */
+
+import { useAuth, useUser } from '@clerk/clerk-react';
+import { Navbar } from '../components/layout/Navbar';
+import { Alerts } from '../components/dashboard-v3/Alerts';
+import { XpSummaryCard } from '../components/dashboard-v3/XpSummaryCard';
+import { EnergyCard } from '../components/dashboard-v3/EnergyCard';
+import { DailyCultivationSection } from '../components/dashboard-v3/DailyCultivationSection';
+import { RadarChartCard } from '../components/dashboard-v3/RadarChartCard';
+import { EmotionTimeline } from '../components/dashboard-v3/EmotionTimeline';
+import { StreakPanel } from '../components/dashboard-v3/StreakPanel';
+import { MissionsSection } from '../components/dashboard-v3/MissionsSection';
+
+export default function DashboardV3Page() {
+  const { userId } = useAuth();
+  const { user } = useUser();
+
+  if (!userId) {
+    return null;
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex-1 px-4 pb-16 pt-6 md:px-8">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
+          <Alerts userId={userId} />
+          <div className="grid gap-6 lg:grid-cols-[320px_1fr_320px]">
+            <div className="space-y-6">
+              <XpSummaryCard userId={userId} />
+              <AvatarCard imageUrl={user?.imageUrl} name={user?.fullName || user?.primaryEmailAddress?.emailAddress || ''} />
+              <EnergyCard userId={userId} />
+              <DailyCultivationSection userId={userId} />
+            </div>
+            <div className="space-y-6">
+              <RadarChartCard userId={userId} />
+              <EmotionTimeline userId={userId} />
+            </div>
+            <div className="space-y-6">
+              <StreakPanel userId={userId} />
+              <RewardsPlaceholder />
+            </div>
+          </div>
+          <MissionsSection userId={userId} />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+interface AvatarCardProps {
+  imageUrl?: string | null;
+  name?: string | null;
+}
+
+function AvatarCard({ imageUrl, name }: AvatarCardProps) {
+  return (
+    <section className="flex flex-col items-center gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 text-center text-sm text-text backdrop-blur">
+      <div className="h-28 w-28 overflow-hidden rounded-full border border-white/20 bg-white/10">
+        {imageUrl ? (
+          <img src={imageUrl} alt="Avatar" className="h-full w-full object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-3xl text-white">👤</div>
+        )}
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm uppercase tracking-wide text-text-muted">Tu avatar</p>
+        <p className="text-lg font-semibold text-white">{name || 'Jugador/a'}</p>
+      </div>
+      <button
+        type="button"
+        disabled
+        className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-text"
+      >
+        Próximamente: cambiar avatar
+      </button>
+    </section>
+  );
+}
+
+function RewardsPlaceholder() {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
+      <h3 className="text-lg font-semibold text-white">🎁 Rewards</h3>
+      <p className="mt-4 text-sm text-text-muted">
+        El módulo de recompensas del MVP todavía no tiene endpoints públicos. Lo habilitaremos en esta vista cuando esté
+        disponible.
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new `/dashboard-v3` page that mirrors the MVP dashboard layout with read-only cards backed by the existing API endpoints
- extend the frontend API helpers to expose user state, XP, task, and emotion data while adapting the task/emotion mappers to current responses
- update the authenticated navigation to link to the new dashboard experience alongside the original view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4476a7bb08322a6d59229d30741a5