### PR TITLE
Refactor level summary endpoint and wire dashboard progress

### DIFF
--- a/apps/api/src/controllers/users/get-user-level.ts
+++ b/apps/api/src/controllers/users/get-user-level.ts
@@ -3,9 +3,16 @@ import { pool } from '../../db.js';
 import type { AsyncHandler } from '../../lib/async-handler.js';
 import { uuidSchema } from '../../lib/validation.js';
 import { ensureUserExists } from './shared.js';
+import { buildLevelSummary } from './level-summary.js';
+import type { LevelThreshold } from './types.js';
 
 type LevelRow = {
   level: string | number | null;
+  xp_required: string | number | null;
+};
+
+type TotalXpRow = {
+  xp_total: string | number | null;
 };
 
 const paramsSchema = z.object({
@@ -17,14 +24,42 @@ export const getUserLevel: AsyncHandler = async (req, res) => {
 
   await ensureUserExists(id);
 
-  const result = await pool.query<LevelRow>(
-    `SELECT level
-     FROM v_user_level
+  const xpTotalResult = await pool.query<TotalXpRow>(
+    `SELECT COALESCE(total_xp, 0) AS xp_total
+     FROM v_user_total_xp
      WHERE user_id = $1`,
     [id],
   );
 
-  const level = Number(result.rows[0]?.level ?? 0);
+  const rawXpTotal = Number(xpTotalResult.rows[0]?.xp_total ?? 0);
+  const xpTotal = Number.isFinite(rawXpTotal) ? Math.max(0, rawXpTotal) : 0;
 
-  res.json({ level });
+  const thresholdsResult = await pool.query<LevelRow>(
+    `SELECT level, xp_required
+     FROM v_user_level
+     WHERE user_id = $1
+     ORDER BY level ASC`,
+    [id],
+  );
+
+  const thresholds: LevelThreshold[] = thresholdsResult.rows.map((row) => ({
+    level: Number(row.level ?? 0),
+    xpRequired: Number(row.xp_required ?? 0),
+  }));
+
+  // Business rules summary:
+  // - current_level is the highest level whose xp_required threshold is <= xp_total (immediate level ups).
+  // - xp_required_next and progress are measured against the next level, if any (0..50 inclusive).
+  // - xp_to_next never dips below zero and progress is clamped to [0, 100] with one decimal precision.
+  const summary = buildLevelSummary(xpTotal, thresholds);
+
+  res.json({
+    user_id: id,
+    current_level: summary.currentLevel,
+    xp_total: xpTotal,
+    xp_required_current: summary.xpRequiredCurrent,
+    xp_required_next: summary.xpRequiredNext,
+    xp_to_next: summary.xpToNext,
+    progress_percent: summary.progressPercent,
+  });
 };

--- a/apps/api/src/controllers/users/level-summary.test.ts
+++ b/apps/api/src/controllers/users/level-summary.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { buildLevelSummary } from './level-summary.js';
+import type { LevelThreshold } from './types.js';
+
+const THRESHOLDS: LevelThreshold[] = [
+  { level: 0, xpRequired: 0 },
+  { level: 1, xpRequired: 100 },
+  { level: 2, xpRequired: 300 },
+  { level: 3, xpRequired: 600 },
+  { level: 4, xpRequired: 1000 },
+  { level: 5, xpRequired: 1500 },
+  { level: 6, xpRequired: 2100 },
+];
+
+describe('buildLevelSummary', () => {
+  it('handles users without XP', () => {
+    const summary = buildLevelSummary(0, THRESHOLDS);
+
+    expect(summary).toEqual({
+      currentLevel: 0,
+      xpRequiredCurrent: 0,
+      xpRequiredNext: 100,
+      xpToNext: 100,
+      progressPercent: 0,
+    });
+  });
+
+  it('returns zero progress when XP matches the current threshold', () => {
+    const summary = buildLevelSummary(300, THRESHOLDS);
+
+    expect(summary).toEqual({
+      currentLevel: 2,
+      xpRequiredCurrent: 300,
+      xpRequiredNext: 600,
+      xpToNext: 300,
+      progressPercent: 0,
+    });
+  });
+
+  it('calculates intermediate progress within a level', () => {
+    const summary = buildLevelSummary(250, THRESHOLDS);
+
+    expect(summary).toEqual({
+      currentLevel: 1,
+      xpRequiredCurrent: 100,
+      xpRequiredNext: 300,
+      xpToNext: 50,
+      progressPercent: 75,
+    });
+  });
+
+  it('promotes immediately when XP exceeds the next threshold by a single point', () => {
+    const summary = buildLevelSummary(301, THRESHOLDS);
+
+    expect(summary).toEqual({
+      currentLevel: 2,
+      xpRequiredCurrent: 300,
+      xpRequiredNext: 600,
+      xpToNext: 299,
+      progressPercent: 0.3,
+    });
+  });
+
+  it('supports multi-level jumps by picking the highest attained level', () => {
+    const summary = buildLevelSummary(1600, THRESHOLDS);
+
+    expect(summary).toEqual({
+      currentLevel: 5,
+      xpRequiredCurrent: 1500,
+      xpRequiredNext: 2100,
+      xpToNext: 500,
+      progressPercent: 16.7,
+    });
+  });
+
+  it('caps progress when the user reaches the maximum level', () => {
+    const summary = buildLevelSummary(2500, THRESHOLDS);
+
+    expect(summary).toEqual({
+      currentLevel: 6,
+      xpRequiredCurrent: 2100,
+      xpRequiredNext: null,
+      xpToNext: null,
+      progressPercent: 100,
+    });
+  });
+});

--- a/apps/api/src/controllers/users/level-summary.ts
+++ b/apps/api/src/controllers/users/level-summary.ts
@@ -1,0 +1,75 @@
+import type { LevelThreshold } from './types.js';
+
+export type LevelSummaryComputation = {
+  currentLevel: number;
+  xpRequiredCurrent: number;
+  xpRequiredNext: number | null;
+  xpToNext: number | null;
+  progressPercent: number;
+};
+
+function roundToSingleDecimal(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+export function buildLevelSummary(
+  xpTotal: number,
+  thresholds: LevelThreshold[],
+): LevelSummaryComputation {
+  const normalizedThresholds = [...thresholds]
+    .map((threshold) => {
+      const level = Number(threshold.level);
+      const xpRequired = Number(threshold.xpRequired);
+      return {
+        level: Number.isFinite(level) ? level : 0,
+        xpRequired: Number.isFinite(xpRequired) ? Math.max(0, xpRequired) : 0,
+      };
+    })
+    .filter((threshold, index, array) =>
+      array.findIndex((candidate) => candidate.level === threshold.level) === index,
+    )
+    .sort((a, b) => a.level - b.level);
+
+  if (!normalizedThresholds.some((threshold) => threshold.level === 0)) {
+    normalizedThresholds.unshift({ level: 0, xpRequired: 0 });
+  }
+
+  const safeXpTotal = Math.max(0, Number.isFinite(xpTotal) ? xpTotal : 0);
+
+  let current = normalizedThresholds[0]!;
+
+  for (const threshold of normalizedThresholds) {
+    if (safeXpTotal >= threshold.xpRequired) {
+      current = threshold;
+    } else {
+      break;
+    }
+  }
+
+  const next = normalizedThresholds.find((threshold) => threshold.level > current.level) ?? null;
+  const xpRequiredCurrent = Math.max(0, Math.round(current.xpRequired));
+  const xpRequiredNext = next ? Math.max(0, Math.round(next.xpRequired)) : null;
+  const xpToNext = xpRequiredNext === null ? null : Math.max(0, Math.round(xpRequiredNext - safeXpTotal));
+
+  let progressPercent = 100;
+
+  if (xpRequiredNext !== null) {
+    const span = Math.max(xpRequiredNext - xpRequiredCurrent, 1);
+    const rawProgress = ((safeXpTotal - xpRequiredCurrent) / span) * 100;
+    progressPercent = roundToSingleDecimal(
+      Math.min(100, Math.max(0, rawProgress)),
+    );
+  }
+
+  if (xpRequiredNext === null) {
+    progressPercent = 100;
+  }
+
+  return {
+    currentLevel: Math.round(current.level),
+    xpRequiredCurrent,
+    xpRequiredNext,
+    xpToNext,
+    progressPercent,
+  };
+}

--- a/apps/api/src/controllers/users/types.ts
+++ b/apps/api/src/controllers/users/types.ts
@@ -1,0 +1,4 @@
+export type LevelThreshold = {
+  level: number;
+  xpRequired: number;
+};

--- a/apps/web/src/components/dashboard-v3/XpSummaryCard.tsx
+++ b/apps/web/src/components/dashboard-v3/XpSummaryCard.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useRequest } from '../../hooks/useRequest';
 import { getUserLevel, getUserTotalXp } from '../../lib/api';
 
@@ -6,61 +5,64 @@ interface XpSummaryCardProps {
   userId: string;
 }
 
-type LevelSummary = {
-  totalXp: number;
-  level: number;
+type XpProgressData = {
+  xpTotal: number;
+  currentLevel: number;
+  xpToNext: number | null;
+  progressPercent: number;
 };
 
-function estimateLevelBoundaries(level: number) {
-  if (level <= 0) {
-    return { start: 0, end: 120 };
-  }
+const NUMBER_FORMATTER = new Intl.NumberFormat('es-AR');
 
-  const start = Math.max(0, Math.round(level * level * 120));
-  const end = Math.max(start + 120, Math.round((level + 1) * (level + 1) * 120));
-
-  return { start, end };
-}
-
-function buildSummary(data: LevelSummary | null) {
-  if (!data) {
-    return { percent: 0, remaining: 0, totalXp: 0, level: 0 };
-  }
-
-  const { start, end } = estimateLevelBoundaries(data.level);
-  const span = Math.max(end - start, 1);
-  const progress = Math.max(0, data.totalXp - start);
-  const percent = Math.min(100, Math.round((progress / span) * 100));
-  const remaining = Math.max(end - data.totalXp, 0);
-
-  return { percent, remaining, totalXp: data.totalXp, level: data.level };
+function formatInteger(value: number) {
+  return NUMBER_FORMATTER.format(Math.max(0, Math.round(value)));
 }
 
 export function XpSummaryCard({ userId }: XpSummaryCardProps) {
-  const { data, status } = useRequest(async () => {
+  const { data, status } = useRequest<XpProgressData>(async () => {
     const [total, level] = await Promise.all([
       getUserTotalXp(userId),
       getUserLevel(userId),
     ]);
 
+    const xpTotal = Math.max(0, Math.round(total.total_xp ?? 0));
+    const currentLevel = Number.isFinite(level.current_level)
+      ? Math.max(0, Math.round(level.current_level))
+      : 0;
+    const rawXpToNext = level.xp_to_next ?? null;
+    const xpToNext = rawXpToNext === null ? null : Math.max(0, Math.round(rawXpToNext));
+    const progressPercentRaw = Number(level.progress_percent ?? 0);
+    const progressPercent = Number.isFinite(progressPercentRaw)
+      ? Math.min(100, Math.max(0, progressPercentRaw))
+      : 0;
+
     return {
-      totalXp: total.total_xp ?? 0,
-      level: level.level ?? 0,
-    } satisfies LevelSummary;
+      xpTotal,
+      currentLevel,
+      xpToNext,
+      progressPercent,
+    } satisfies XpProgressData;
   }, [userId]);
 
-  const summary = useMemo(() => buildSummary(data), [data]);
+  const showSkeleton = status === 'loading';
+  const showError = status === 'error';
+  const showContent = status === 'success' && data;
+
+  const progressPercent = showContent ? data.progressPercent : 0;
+  const progressLabel = `${progressPercent.toFixed(1)}%`;
+  const xpToNextLabel = showContent
+    ? data.xpToNext === null
+      ? 'Nivel Máximo'
+      : `${formatInteger(data.xpToNext)} XP`
+    : '—';
 
   return (
     <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
       <header className="flex flex-wrap items-center justify-between gap-3 text-white">
         <h3 className="text-lg font-semibold">🏆 Total XP · 🎯 Level</h3>
-        <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide">
-          Estimación client-side
-        </span>
       </header>
 
-      {status === 'loading' && (
+      {showSkeleton && (
         <div className="mt-6 space-y-4">
           <div className="h-8 w-40 animate-pulse rounded bg-white/10" />
           <div className="h-3 w-full animate-pulse rounded bg-white/10" />
@@ -68,22 +70,43 @@ export function XpSummaryCard({ userId }: XpSummaryCardProps) {
         </div>
       )}
 
-      {status === 'error' && (
+      {showError && (
         <p className="mt-6 text-sm text-rose-300">No pudimos cargar tu progreso. Intentalo más tarde.</p>
       )}
 
-      {status === 'success' && (
-        <div className="mt-6 space-y-4">
-          <p className="text-3xl font-semibold text-white">{summary.totalXp.toLocaleString('es-AR')}</p>
-          <div className="flex flex-wrap items-center gap-3 text-sm text-text-muted">
-            <span className="rounded-full bg-white/10 px-3 py-1 text-white">Nivel {summary.level}</span>
-            <span>Te faltan {summary.remaining.toLocaleString('es-AR')} XP para el próximo nivel</span>
+      {showContent && (
+        <div className="mt-6 space-y-4 text-text-muted">
+          <p className="text-3xl font-semibold text-white">
+            XP Total: {formatInteger(data.xpTotal)}
+          </p>
+
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            <span className="rounded-full bg-white/10 px-3 py-1 text-white">
+              Nivel {data.currentLevel}
+            </span>
+            <span>XP para el próximo nivel: {xpToNextLabel}</span>
           </div>
-          <div className="h-3 w-full overflow-hidden rounded-full bg-white/10">
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-xs uppercase tracking-wide">
+              <span>Progreso al próximo nivel</span>
+              <span className="text-sm font-semibold text-white">{progressLabel}</span>
+            </div>
+
             <div
-              className="h-full rounded-full bg-gradient-to-r from-amber-300 via-amber-200 to-amber-100"
-              style={{ width: `${summary.percent}%` }}
-            />
+              className="h-3 w-full overflow-hidden rounded-full bg-white/10"
+              role="progressbar"
+              aria-label="Progreso hacia el próximo nivel"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Number(progressPercent.toFixed(1))}
+              aria-valuetext={`${progressLabel} completado`}
+            >
+              <div
+                className="h-full rounded-full bg-gradient-to-r from-amber-300 via-amber-200 to-amber-100"
+                style={{ width: `${progressPercent.toFixed(1)}%` }}
+              />
+            </div>
           </div>
         </div>
       )}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,8 +1,9 @@
-export const API_BASE = (import.meta.env.VITE_API_URL ?? '').replace(/\/+$/, '');
+const RAW_API_BASE_URL = String(import.meta.env.VITE_API_BASE_URL ?? import.meta.env.VITE_API_URL ?? '').trim();
+export const API_BASE = RAW_API_BASE_URL.replace(/\/+$/, '');
 
 function ensureBase(): string {
   if (!API_BASE) {
-    throw new Error('API base URL is not configured. Set VITE_API_URL to continue.');
+    throw new Error('API base URL is not configured. Set VITE_API_BASE_URL (or legacy VITE_API_URL) to continue.');
   }
   return API_BASE;
 }
@@ -229,7 +230,13 @@ export async function getUserDailyXp(
 }
 
 export type UserLevelResponse = {
-  level: number;
+  user_id: string;
+  current_level: number;
+  xp_total: number;
+  xp_required_current: number;
+  xp_required_next: number | null;
+  xp_to_next: number | null;
+  progress_percent: number;
 };
 
 export async function getUserLevel(userId: string): Promise<UserLevelResponse> {


### PR DESCRIPTION
## Summary
- refactor GET /users/:id/level to return the level summary with thresholds, next step math, and comments on the business rules
- add a reusable level-summary helper plus vitest coverage for the 6 required scenarios
- consume the new summary on dashboard-v3, wiring the progress card to backend data and the new VITE_API_BASE_URL client config

## Testing
- npm -w @innerbloom/api run test
- npm -w @innerbloom/api run typecheck
- npm -w @innerbloom/web run typecheck

## README
- **Endpoints:** `GET /users/:id/xp/total`, `GET /users/:id/level`
- **Variables de entorno:** `VITE_API_BASE_URL`
- **Archivos principales:**
  - `apps/api/src/controllers/users/get-user-level.ts`
  - `apps/api/src/controllers/users/level-summary.ts`
  - `apps/api/src/controllers/users/level-summary.test.ts`
  - `apps/web/src/components/dashboard-v3/XpSummaryCard.tsx`
  - `apps/web/src/lib/api.ts`
- **Casos de prueba manuales:**
  1. Usuario sin XP → esperar nivel 0, progreso 0 %, `xp_to_next > 0`.
  2. XP exacto en umbral → progreso 0 % y `xp_to_next` igual a la brecha al próximo nivel.
  3. XP intermedio → progreso entre 0 % y 100 %, `xp_to_next` consistente.
  4. +1 XP sobre un umbral → subir inmediatamente al siguiente nivel y recalcular progreso.
  5. Salto de varios niveles → endpoint debe devolver el nivel más alto alcanzado y el progreso relativo a su siguiente.
  6. Nivel máximo (50) → progreso 100 %, `xp_required_next` y `xp_to_next` en `null`.

------
https://chatgpt.com/codex/tasks/task_e_68e50c21779c8322895eddfc8ed08c90