### PR TITLE
Fix dashboards to load backend profile id before fetching data

### DIFF
--- a/apps/web/src/hooks/useBackendUser.ts
+++ b/apps/web/src/hooks/useBackendUser.ts
@@ -1,0 +1,40 @@
+import { useAuth } from '@clerk/clerk-react';
+import { useMemo } from 'react';
+import { getCurrentUserProfile, type CurrentUserProfile } from '../lib/api';
+import { useRequest, type AsyncStatus } from './useRequest';
+
+export type BackendUserState = {
+  clerkUserId: string | null;
+  backendUserId: string | null;
+  profile: CurrentUserProfile | null;
+  status: AsyncStatus;
+  error: Error | null;
+  reload: () => void;
+};
+
+export function useBackendUser(): BackendUserState {
+  const { userId: clerkUserId } = useAuth();
+  const enabled = Boolean(clerkUserId);
+
+  const { data, status, error, reload } = useRequest(
+    () => getCurrentUserProfile(clerkUserId!),
+    [clerkUserId],
+    { enabled },
+  );
+
+  const normalizedStatus: AsyncStatus = enabled ? status : 'idle';
+  const profile = enabled && status === 'success' ? data : null;
+  const backendUserId = profile?.id ?? null;
+
+  return useMemo(
+    () => ({
+      clerkUserId: clerkUserId ?? null,
+      backendUserId,
+      profile,
+      status: normalizedStatus,
+      error: enabled ? error : null,
+      reload,
+    }),
+    [backendUserId, clerkUserId, enabled, error, normalizedStatus, profile, reload],
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -21,11 +21,20 @@ function buildUrl(path: string, params?: Record<string, string | number | undefi
   return url.toString();
 }
 
-async function getJson<T>(path: string, params?: Record<string, string | number | undefined>): Promise<T> {
+async function getJson<T>(
+  path: string,
+  params?: Record<string, string | number | undefined>,
+  init: RequestInit = {},
+): Promise<T> {
+  const { headers: initHeaders, ...rest } = init;
+  const headers = new Headers(initHeaders ?? {});
+  if (!headers.has('Accept')) {
+    headers.set('Accept', 'application/json');
+  }
+
   const response = await fetch(buildUrl(path, params), {
-    headers: {
-      Accept: 'application/json'
-    }
+    ...rest,
+    headers,
   });
 
   if (!response.ok) {
@@ -227,6 +236,29 @@ export async function getUserDailyXp(
   params: { from?: string; to?: string } = {},
 ): Promise<DailyXpResponse> {
   return getJson<DailyXpResponse>(`/users/${encodeURIComponent(userId)}/xp/daily`, params);
+}
+
+export type CurrentUserProfile = {
+  id: string;
+  clerk_user_id: string;
+  email_primary: string | null;
+  full_name: string | null;
+  image_url: string | null;
+  game_mode: string | null;
+  weekly_target: number | null;
+  timezone: string | null;
+  locale: string | null;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export async function getCurrentUserProfile(clerkUserId: string): Promise<CurrentUserProfile> {
+  return getJson<CurrentUserProfile>('/api/users/me', undefined, {
+    headers: {
+      'X-User-Id': clerkUserId,
+    },
+  });
 }
 
 export type UserLevelResponse = {

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from '@clerk/clerk-react';
+import { useBackendUser } from '../hooks/useBackendUser';
 import { AchievementsList } from '../components/dashboard/AchievementsList';
 import { EmotionHeatmap } from '../components/dashboard/EmotionHeatmap';
 import { LevelCard } from '../components/dashboard/LevelCard';
@@ -8,56 +8,105 @@ import { StreakCard } from '../components/dashboard/StreakCard';
 import { Navbar } from '../components/layout/Navbar';
 
 export default function DashboardPage() {
-  const { userId } = useAuth();
+  const { backendUserId, status, error, reload, clerkUserId } = useBackendUser();
 
-  if (!userId) {
+  if (!clerkUserId) {
     return null;
   }
+
+  const isLoadingProfile = status === 'idle' || status === 'loading';
+  const failedToLoadProfile = status === 'error' || !backendUserId;
 
   return (
     <div className="flex min-h-screen flex-col">
       <Navbar />
       <main className="flex-1 px-4 pb-16 pt-6 md:px-8">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
-          <section className="glass-card rounded-3xl border border-white/10 px-6 py-8 text-text shadow-glow">
-            <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-              <div className="space-y-3">
-                <p className="text-xs uppercase tracking-[0.3em] text-text-subtle">Game Mode</p>
-                <h2 className="font-display text-3xl font-semibold text-white">Chill mode engaged</h2>
-                <p className="text-sm text-text-subtle">
-                  Keep stacking wins across Body · Mind · Soul. Your next mission summary lands every Sunday evening.
-                </p>
-              </div>
-              <div className="grid gap-2 rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-sm text-text-subtle">
-                <div className="flex items-center justify-between gap-6">
-                  <span>Daily quests</span>
-                  <strong className="text-xl text-white">3</strong>
+          {isLoadingProfile && <LegacyDashboardSkeleton />}
+
+          {failedToLoadProfile && !isLoadingProfile && (
+            <LegacyDashboardError onRetry={reload} error={error} />
+          )}
+
+          {!failedToLoadProfile && !isLoadingProfile && backendUserId && (
+            <>
+              <section className="glass-card rounded-3xl border border-white/10 px-6 py-8 text-text shadow-glow">
+                <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+                  <div className="space-y-3">
+                    <p className="text-xs uppercase tracking-[0.3em] text-text-subtle">Game Mode</p>
+                    <h2 className="font-display text-3xl font-semibold text-white">Chill mode engaged</h2>
+                    <p className="text-sm text-text-subtle">
+                      Keep stacking wins across Body · Mind · Soul. Your next mission summary lands every Sunday evening.
+                    </p>
+                  </div>
+                  <div className="grid gap-2 rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-sm text-text-subtle">
+                    <div className="flex items-center justify-between gap-6">
+                      <span>Daily quests</span>
+                      <strong className="text-xl text-white">3</strong>
+                    </div>
+                    <div className="flex items-center justify-between gap-6">
+                      <span>XP today</span>
+                      <strong className="text-xl text-white">—</strong>
+                    </div>
+                    <p className="text-xs text-text-muted">TODO: Replace with live mission payload when available.</p>
+                  </div>
                 </div>
-                <div className="flex items-center justify-between gap-6">
-                  <span>XP today</span>
-                  <strong className="text-xl text-white">—</strong>
-                </div>
-                <p className="text-xs text-text-muted">TODO: Replace with live mission payload when available.</p>
-              </div>
-            </div>
-          </section>
+              </section>
 
-          <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-            <LevelCard userId={userId} />
-            <StreakCard userId={userId} />
-          </section>
+              <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+                <LevelCard userId={backendUserId} />
+                <StreakCard userId={backendUserId} />
+              </section>
 
-          <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-            <PillarsSection />
-            <EmotionHeatmap userId={userId} />
-          </section>
+              <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+                <PillarsSection />
+                <EmotionHeatmap userId={backendUserId} />
+              </section>
 
-          <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-            <RecentActivity userId={userId} />
-            <AchievementsList />
-          </section>
+              <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+                <RecentActivity userId={backendUserId} />
+                <AchievementsList />
+              </section>
+            </>
+          )}
         </div>
       </main>
     </div>
+  );
+}
+
+function LegacyDashboardSkeleton() {
+  return (
+    <section className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6 text-text">
+      <div className="h-6 w-40 animate-pulse rounded bg-white/10" />
+      <div className="h-4 w-3/4 animate-pulse rounded bg-white/10" />
+      <div className="h-32 w-full animate-pulse rounded-2xl bg-white/5" />
+    </section>
+  );
+}
+
+interface LegacyDashboardErrorProps {
+  onRetry: () => void;
+  error: Error | null;
+}
+
+function LegacyDashboardError({ onRetry, error }: LegacyDashboardErrorProps) {
+  return (
+    <section className="space-y-4 rounded-3xl border border-rose-500/30 bg-rose-500/10 p-6 text-sm text-rose-100">
+      <div>
+        <h2 className="text-lg font-semibold text-white">No pudimos cargar tu dashboard</h2>
+        <p className="mt-2 text-sm text-rose-100/80">
+          Hubo un problema para conectar con tu progreso. Reintentá en unos segundos.
+        </p>
+      </div>
+      {error?.message && <p className="text-xs text-rose-100/60">{error.message}</p>}
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex items-center justify-center rounded-full border border-rose-300/40 bg-rose-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition hover:border-rose-200/70 hover:bg-rose-200/20"
+      >
+        Reintentar
+      </button>
+    </section>
   );
 }

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -11,7 +11,7 @@
  * Derivaciones client-side: xp faltante y barra de nivel se calculan con una curva estimada; radar usa energía promedio; panel de rachas muestra métricas de XP mientras esperamos daily_log_raw.
  */
 
-import { useAuth, useUser } from '@clerk/clerk-react';
+import { useUser } from '@clerk/clerk-react';
 import { Navbar } from '../components/layout/Navbar';
 import { Alerts } from '../components/dashboard-v3/Alerts';
 import { XpSummaryCard } from '../components/dashboard-v3/XpSummaryCard';
@@ -21,38 +21,52 @@ import { RadarChartCard } from '../components/dashboard-v3/RadarChartCard';
 import { EmotionTimeline } from '../components/dashboard-v3/EmotionTimeline';
 import { StreakPanel } from '../components/dashboard-v3/StreakPanel';
 import { MissionsSection } from '../components/dashboard-v3/MissionsSection';
+import { useBackendUser } from '../hooks/useBackendUser';
 
 export default function DashboardV3Page() {
-  const { userId } = useAuth();
   const { user } = useUser();
+  const { backendUserId, status, error, reload, clerkUserId } = useBackendUser();
 
-  if (!userId) {
+  if (!clerkUserId) {
     return null;
   }
+
+  const isLoadingProfile = status === 'idle' || status === 'loading';
+  const failedToLoadProfile = status === 'error' || !backendUserId;
 
   return (
     <div className="flex min-h-screen flex-col">
       <Navbar />
       <main className="flex-1 px-4 pb-16 pt-6 md:px-8">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
-          <Alerts userId={userId} />
-          <div className="grid gap-6 lg:grid-cols-[320px_1fr_320px]">
-            <div className="space-y-6">
-              <XpSummaryCard userId={userId} />
-              <AvatarCard imageUrl={user?.imageUrl} name={user?.fullName || user?.primaryEmailAddress?.emailAddress || ''} />
-              <EnergyCard userId={userId} />
-              <DailyCultivationSection userId={userId} />
-            </div>
-            <div className="space-y-6">
-              <RadarChartCard userId={userId} />
-              <EmotionTimeline userId={userId} />
-            </div>
-            <div className="space-y-6">
-              <StreakPanel userId={userId} />
-              <RewardsPlaceholder />
-            </div>
-          </div>
-          <MissionsSection userId={userId} />
+          {isLoadingProfile && <ProfileSkeleton />}
+
+          {failedToLoadProfile && !isLoadingProfile && (
+            <ProfileErrorState onRetry={reload} error={error} />
+          )}
+
+          {!failedToLoadProfile && !isLoadingProfile && backendUserId && (
+            <>
+              <Alerts userId={backendUserId} />
+              <div className="grid gap-6 lg:grid-cols-[320px_1fr_320px]">
+                <div className="space-y-6">
+                  <XpSummaryCard userId={backendUserId} />
+                  <AvatarCard imageUrl={user?.imageUrl} name={user?.fullName || user?.primaryEmailAddress?.emailAddress || ''} />
+                  <EnergyCard userId={backendUserId} />
+                  <DailyCultivationSection userId={backendUserId} />
+                </div>
+                <div className="space-y-6">
+                  <RadarChartCard userId={backendUserId} />
+                  <EmotionTimeline userId={backendUserId} />
+                </div>
+                <div className="space-y-6">
+                  <StreakPanel userId={backendUserId} />
+                  <RewardsPlaceholder />
+                </div>
+              </div>
+              <MissionsSection userId={backendUserId} />
+            </>
+          )}
         </div>
       </main>
     </div>
@@ -62,6 +76,43 @@ export default function DashboardV3Page() {
 interface AvatarCardProps {
   imageUrl?: string | null;
   name?: string | null;
+}
+
+function ProfileSkeleton() {
+  return (
+    <section className="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
+      <div className="h-6 w-56 animate-pulse rounded bg-white/10" />
+      <div className="h-4 w-full animate-pulse rounded bg-white/10" />
+      <div className="h-4 w-3/4 animate-pulse rounded bg-white/10" />
+      <div className="h-32 w-full animate-pulse rounded-2xl bg-white/5" />
+    </section>
+  );
+}
+
+interface ProfileErrorStateProps {
+  onRetry: () => void;
+  error: Error | null;
+}
+
+function ProfileErrorState({ onRetry, error }: ProfileErrorStateProps) {
+  return (
+    <section className="space-y-4 rounded-3xl border border-rose-500/30 bg-rose-500/10 p-6 text-sm text-rose-100 backdrop-blur">
+      <div>
+        <h2 className="text-lg font-semibold text-white">No pudimos conectar con tu perfil</h2>
+        <p className="mt-2 text-sm text-rose-100/80">
+          Verificá tu conexión e intentá cargar nuevamente la información de tu Daily Quest.
+        </p>
+      </div>
+      {error?.message && <p className="text-xs text-rose-100/60">{error.message}</p>}
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex items-center justify-center rounded-full border border-rose-300/40 bg-rose-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition hover:border-rose-200/70 hover:bg-rose-200/20"
+      >
+        Reintentar
+      </button>
+    </section>
+  );
 }
 
 function AvatarCard({ imageUrl, name }: AvatarCardProps) {


### PR DESCRIPTION
## Summary
- add a reusable hook that resolves the backend user profile from the Clerk session id
- update both dashboard screens to wait for the backend id, displaying loading and retry states before rendering cards
- extend the API and request helpers so dashboard calls can send custom headers and opt into conditional fetching

## Testing
- pnpm --filter web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e5160d069483228d537d4febb5e263