### PR TITLE
Fix frontend API base URL normalization and align dashboard data fetchers

### DIFF
--- a/apps/web/src/lib/logger.ts
+++ b/apps/web/src/lib/logger.ts
@@ -1,0 +1,29 @@
+let apiLoggingEnabled = true;
+
+export function setApiLoggingEnabled(enabled: boolean) {
+  apiLoggingEnabled = enabled;
+  const status = enabled ? 'enabled' : 'disabled';
+  console.info(`[API] Logging ${status}.`);
+}
+
+export function isApiLoggingEnabled() {
+  return apiLoggingEnabled;
+}
+
+export function logApiDebug(message: string, data?: unknown) {
+  if (!apiLoggingEnabled) return;
+  if (data !== undefined) {
+    console.debug(`[API] ${message}`, data);
+  } else {
+    console.debug(`[API] ${message}`);
+  }
+}
+
+export function logApiError(message: string, data?: unknown) {
+  if (!apiLoggingEnabled) return;
+  if (data !== undefined) {
+    console.error(`[API] ${message}`, data);
+  } else {
+    console.error(`[API] ${message}`);
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,22 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
+import { isApiLoggingEnabled, setApiLoggingEnabled } from './lib/logger';
+
+declare global {
+  interface Window {
+    setInnerbloomApiLogging?: (enabled: boolean) => void;
+    isInnerbloomApiLoggingEnabled?: () => boolean;
+  }
+}
+
+setApiLoggingEnabled(true);
+
+if (typeof window !== 'undefined') {
+  window.setInnerbloomApiLogging = setApiLoggingEnabled;
+  window.isInnerbloomApiLoggingEnabled = isApiLoggingEnabled;
+  console.info('[API] Use window.setInnerbloomApiLogging(false) to disable API logs.');
+}
 
 const rootElement = document.getElementById('root');
 


### PR DESCRIPTION
## Summary
- normalize the configured API base URL so missing protocols no longer break requests and log the resolved value
- add a toggleable API logger to trace requests/responses and expose helpers on window for runtime control
- update dashboard data fetchers to use available backend endpoints, derive progress and streak stats, and query task logs via the legacy route

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68e51d0312e08322b8c034f081ef410f