### PR TITLE
Mount Express router under /api prefix

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -34,7 +34,16 @@ const app = express();
 app.use(cors(corsOptions));
 app.options('*', cors(corsOptions));
 app.use(express.json());
-app.use(routes);
+
+const apiRouter = express.Router();
+
+apiRouter.use(routes);
+
+apiRouter.use((_req, _res, next) => {
+  next(new HttpError(404, 'not_found', 'Route not found'));
+});
+
+app.use('/api', apiRouter);
 
 app.use((_req, _res, next) => {
   next(new HttpError(404, 'not_found', 'Route not found'));


### PR DESCRIPTION
## Summary
- mount the Express router on the /api prefix so requests reach Fastify routes such as /api/users/me
- keep API-specific 404 handling within the /api namespace while retaining the global fallback

## Testing
- pnpm --filter @innerbloom/api lint *(fails: existing lint violations in controllers unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e5220fed20832281b3e0055497ef8e