### PR TITLE
Update Neon setup docs to use npm commands

### DIFF
--- a/Docs/NEON_SETUP.md
+++ b/Docs/NEON_SETUP.md
@@ -21,8 +21,8 @@ This project uses a shared PostgreSQL database hosted on [Neon](https://neon.tec
 3. Install dependencies and run the database workflow:
 
    ```bash
-   pnpm install
-   pnpm --filter @innerbloom/api db:all
+   npm install
+   npm --workspace apps/api run db:all
    ```
 
    The `db:all` script will:
@@ -40,10 +40,10 @@ This project uses a shared PostgreSQL database hosted on [Neon](https://neon.tec
 
 ## 4. Verifying the connection
 
-After running `pnpm --filter @innerbloom/api db:all`, start the API locally:
+After running `npm --workspace apps/api run db:all`, start the API locally:
 
 ```bash
-pnpm --filter @innerbloom/api dev
+npm --workspace apps/api run dev
 ```
 
 Then hit the health endpoint in another terminal:


### PR DESCRIPTION
## Summary
- replace pnpm instructions in the Neon setup guide with npm workspace commands

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52540a7a48322bf1d12d551e4de80