### PR TITLE
Fix Express router prefix for API routes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -43,7 +43,7 @@ apiRouter.use((_req, _res, next) => {
   next(new HttpError(404, 'not_found', 'Route not found'));
 });
 
-app.use('/api', apiRouter);
+app.use(apiRouter);
 
 app.use((_req, _res, next) => {
   next(new HttpError(404, 'not_found', 'Route not found'));


### PR DESCRIPTION
## Summary
- expose the Express router at the root path so existing health and user endpoints resolve without requiring a /api prefix

## Testing
- pnpm --filter api typecheck *(fails: missing express-list-endpoints types)*

------
https://chatgpt.com/codex/tasks/task_e_68e53269e73c832293e8ca0fc9d35255