### PR TITLE
Fix current user API path for dashboards

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -395,7 +395,7 @@ export type CurrentUserProfile = {
 };
 
 export async function getCurrentUserProfile(clerkUserId: string): Promise<CurrentUserProfile> {
-  return getJson<CurrentUserProfile>('/api/users/me', undefined, {
+  return getJson<CurrentUserProfile>('/users/me', undefined, {
     headers: {
       'X-User-Id': clerkUserId,
     },


### PR DESCRIPTION
## Summary
- correct the current user profile request path to match the API router
- prevent dashboard fetches from hitting missing /api/api endpoints

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68e534c91f9483229025140b57116624