### PR TITLE
Restyle login page branding and Clerk footer

### DIFF
--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 
 interface AuthLayoutProps {
   children: ReactNode;
-  title: string;
-  description: string;
+  title: ReactNode;
+  description?: string;
   primaryActionLabel?: string;
   onPrimaryActionClick?: () => void;
   secondaryActionLabel?: string;
@@ -32,19 +32,34 @@ export function AuthLayout({
         <div className="flex flex-col gap-10 md:grid md:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] md:gap-16">
           <div className="flex flex-col justify-between gap-10">
             <div className="flex flex-col gap-6">
+              {secondaryActionLabel && secondaryActionHref ? (
+                <Link
+                  to={secondaryActionHref}
+                  className="inline-flex w-fit items-center justify-center rounded-full border border-white/30 px-5 py-2.5 text-sm font-semibold text-white/80 transition-colors duration-200 hover:border-white/50 hover:text-white"
+                >
+                  {secondaryActionLabel}
+                </Link>
+              ) : null}
+
               <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.4em] text-white/60">
                 <span className="h-2 w-2 rounded-full bg-rose-500" />
                 Innerbloom
               </div>
 
               <div className="space-y-4">
-                <h1 className="text-4xl font-semibold leading-tight text-white md:text-5xl">{title}</h1>
-                <p className="text-base text-white/70 md:text-lg">{description}</p>
+                {typeof title === 'string' ? (
+                  <h1 className="text-4xl font-semibold leading-tight text-white md:text-5xl">{title}</h1>
+                ) : (
+                  title
+                )}
+                {description ? (
+                  <p className="text-base text-white/70 md:text-lg">{description}</p>
+                ) : null}
               </div>
             </div>
 
-            <div className="flex flex-wrap gap-3">
-              {primaryActionLabel ? (
+            {primaryActionLabel ? (
+              <div className="flex flex-wrap gap-3">
                 <button
                   type="button"
                   onClick={onPrimaryActionClick}
@@ -52,17 +67,8 @@ export function AuthLayout({
                 >
                   {primaryActionLabel}
                 </button>
-              ) : null}
-
-              {secondaryActionLabel && secondaryActionHref ? (
-                <Link
-                  to={secondaryActionHref}
-                  className="inline-flex items-center justify-center rounded-full border border-white/30 px-6 py-3 text-sm font-semibold text-white/80 transition-colors duration-200 hover:border-white/50 hover:text-white"
-                >
-                  {secondaryActionLabel}
-                </Link>
-              ) : null}
-            </div>
+              </div>
+            ) : null}
           </div>
 
           <div className="flex items-center justify-center">

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,24 +1,20 @@
 import { SignIn } from '@clerk/clerk-react';
-import { useRef } from 'react';
 import { AuthLayout } from '../components/layout/AuthLayout';
 import { DASHBOARD_PATH } from '../config/auth';
 
 export default function LoginPage() {
-  const signInContainerRef = useRef<HTMLDivElement | null>(null);
-
   return (
     <AuthLayout
-      title="Entrar al Dashboard"
-      description="Ingresá tu correo. Si tu base ya está lista te llevo directo al Dashboard. Si no, te muestro los pasos y espero con vos."
-      primaryActionLabel="Continuar"
-      onPrimaryActionClick={() => {
-        const input = signInContainerRef.current?.querySelector<HTMLInputElement>('input');
-        input?.focus();
-      }}
+      title={
+        <div className="flex items-center gap-3 text-4xl font-semibold uppercase tracking-[0.35em] text-white md:text-5xl">
+          <span className="h-3 w-3 rounded-full bg-rose-500 md:h-4 md:w-4" />
+          innerbloom
+        </div>
+      }
       secondaryActionLabel="Volver al inicio"
       secondaryActionHref="/"
     >
-      <div ref={signInContainerRef} className="w-full max-w-md">
+      <div className="w-full max-w-md">
         <SignIn
           appearance={{
             layout: {
@@ -51,8 +47,12 @@ export default function LoginPage() {
               formFieldInputShowPasswordButton: 'text-sm text-white/60 hover:text-white',
               formButtonPrimary:
                 'mt-3 inline-flex h-12 items-center justify-center rounded-full bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#0ea5e9] text-sm font-semibold uppercase tracking-[0.18em] text-white transition-all duration-200 hover:from-[#8b5cf6] hover:to-[#0ea5e9]/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40',
-              footer: 'flex flex-col items-center gap-2 text-center text-sm text-white/70',
-              footerActionLink: 'font-semibold text-white hover:text-white/80 underline-offset-4',
+              footer:
+                'mt-6 flex flex-col items-center gap-1 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-center text-xs text-white/60 backdrop-blur-xl shadow-none',
+              footerTitle: 'text-white/70',
+              footerSubtitle: 'text-white/50',
+              footerActionText: 'text-white/50',
+              footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4',
               formResendCodeLink: 'text-sm text-white hover:text-white/80',
               identityPreview: 'rounded-2xl border border-white/15 bg-white/10 backdrop-blur-xl text-white/80',
               identityPreviewTitle: 'text-white',


### PR DESCRIPTION
## Summary
- update the auth layout so the return link sits at the top and descriptions are optional
- restyle the login hero heading to match the brand lockup and remove the unused continue action
- soften Clerk's footer styling to make the "Secured by Clerk" badge less intrusive

## Testing
- npm run typecheck:web

------
https://chatgpt.com/codex/tasks/task_e_68e533a5c0d8832289e7a52588af5670