### PR TITLE
feat(web): wire dashboard v3 to backend data

### DIFF
--- a/apps/web/src/components/dashboard-v3/XpSummaryCard.tsx
+++ b/apps/web/src/components/dashboard-v3/XpSummaryCard.tsx
@@ -55,6 +55,11 @@ export function XpSummaryCard({ userId }: XpSummaryCardProps) {
       ? 'Nivel Máximo'
       : `${formatInteger(data.xpToNext)} XP`
     : '—';
+  const xpToNextMessage = showContent
+    ? data.xpToNext === null
+      ? 'Alcanzaste el nivel máximo disponible en esta etapa.'
+      : `Te faltan ${formatInteger(data.xpToNext)} XP para el próximo nivel.`
+    : '';
 
   return (
     <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
@@ -108,6 +113,8 @@ export function XpSummaryCard({ userId }: XpSummaryCardProps) {
               />
             </div>
           </div>
+
+          {xpToNextMessage && <p className="text-xs text-text-muted">{xpToNextMessage}</p>}
         </div>
       )}
     </section>

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -25,7 +25,7 @@ import { useBackendUser } from '../hooks/useBackendUser';
 
 export default function DashboardV3Page() {
   const { user } = useUser();
-  const { backendUserId, status, error, reload, clerkUserId } = useBackendUser();
+  const { backendUserId, status, error, reload, clerkUserId, profile } = useBackendUser();
 
   if (!clerkUserId) {
     return null;
@@ -33,6 +33,10 @@ export default function DashboardV3Page() {
 
   const isLoadingProfile = status === 'idle' || status === 'loading';
   const failedToLoadProfile = status === 'error' || !backendUserId;
+
+  const avatarUrl = profile?.image_url || user?.imageUrl;
+  const displayName =
+    profile?.full_name || user?.fullName || user?.primaryEmailAddress?.emailAddress || '';
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -51,7 +55,7 @@ export default function DashboardV3Page() {
               <div className="grid gap-6 lg:grid-cols-[320px_1fr_320px]">
                 <div className="space-y-6">
                   <XpSummaryCard userId={backendUserId} />
-                  <AvatarCard imageUrl={user?.imageUrl} name={user?.fullName || user?.primaryEmailAddress?.emailAddress || ''} />
+                  <AvatarCard imageUrl={avatarUrl} name={displayName} email={profile?.email_primary} />
                   <EnergyCard userId={backendUserId} />
                   <DailyCultivationSection userId={backendUserId} />
                 </div>
@@ -76,6 +80,7 @@ export default function DashboardV3Page() {
 interface AvatarCardProps {
   imageUrl?: string | null;
   name?: string | null;
+  email?: string | null;
 }
 
 function ProfileSkeleton() {
@@ -115,7 +120,10 @@ function ProfileErrorState({ onRetry, error }: ProfileErrorStateProps) {
   );
 }
 
-function AvatarCard({ imageUrl, name }: AvatarCardProps) {
+function AvatarCard({ imageUrl, name, email }: AvatarCardProps) {
+  const displayName = name?.trim() || 'Jugador/a';
+  const displayEmail = email?.trim() ?? '';
+
   return (
     <section className="flex flex-col items-center gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 text-center text-sm text-text backdrop-blur">
       <div className="h-28 w-28 overflow-hidden rounded-full border border-white/20 bg-white/10">
@@ -127,7 +135,8 @@ function AvatarCard({ imageUrl, name }: AvatarCardProps) {
       </div>
       <div className="space-y-1">
         <p className="text-sm uppercase tracking-wide text-text-muted">Tu avatar</p>
-        <p className="text-lg font-semibold text-white">{name || 'Jugador/a'}</p>
+        <p className="text-lg font-semibold text-white">{displayName}</p>
+        {displayEmail && <p className="text-xs text-text-muted">{displayEmail}</p>}
       </div>
       <button
         type="button"
@@ -136,6 +145,9 @@ function AvatarCard({ imageUrl, name }: AvatarCardProps) {
       >
         Próximamente: cambiar avatar
       </button>
+      <p className="text-[11px] text-text-muted">
+        Imagen sincronizada desde tu perfil (<code className="rounded bg-white/10 px-1 py-px text-[10px]">image_url</code>).
+      </p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- hydrate the Dashboard v3 avatar card with the profile data served by the API
- replace the placeholder Daily Cultivation view with an SVG line chart fed by `/users/:id/xp/daily`, including monthly stats
- refresh the Emotion Chart to query the last 15 days from the backend and surface the most frequent emotion
- polish the XP summary copy so it highlights the remaining XP provided by the level endpoint

## Testing
- npm run --prefix apps/web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e539a19a1c83229450c2bf01318cf6