### PR TITLE
Improve login layout responsiveness

### DIFF
--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -21,32 +21,31 @@ export function AuthLayout({
   secondaryActionHref
 }: AuthLayoutProps) {
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#040313] px-4 py-10 text-white">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#040313] px-4 py-10 text-white sm:px-6 lg:px-12">
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.18),transparent_55%),radial-gradient(circle_at_bottom_left,_rgba(14,165,233,0.15),transparent_60%),radial-gradient(circle_at_bottom_right,_rgba(217,70,239,0.1),transparent_65%)]" />
         <div className="absolute -left-24 top-32 h-72 w-72 rounded-full bg-[#a855f7]/30 blur-[140px]" />
         <div className="absolute -right-32 bottom-10 h-80 w-80 rounded-full bg-[#0ea5e9]/30 blur-[160px]" />
       </div>
-
-      <div className="relative z-10 w-full max-w-5xl rounded-[32px] border border-white/10 bg-white/5 p-8 shadow-[0_30px_120px_rgba(15,23,42,0.45)] backdrop-blur-3xl md:p-12">
+      <div className="relative z-10 w-full max-w-5xl rounded-[28px] border border-white/10 bg-white/5 p-6 shadow-[0_30px_120px_rgba(15,23,42,0.45)] backdrop-blur-3xl sm:rounded-[32px] sm:p-8 md:p-12">
         <div className="flex flex-col gap-10 md:grid md:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] md:gap-16">
           <div className="flex flex-col justify-between gap-10">
             <div className="flex flex-col gap-6">
               {secondaryActionLabel && secondaryActionHref ? (
                 <Link
                   to={secondaryActionHref}
-                  className="inline-flex w-fit items-center justify-center rounded-full border border-white/30 px-5 py-2.5 text-sm font-semibold text-white/80 transition-colors duration-200 hover:border-white/50 hover:text-white"
+                  className="inline-flex w-full items-center justify-center rounded-full border border-white/30 px-5 py-2.5 text-sm font-semibold text-white/80 transition-colors duration-200 hover:border-white/50 hover:text-white sm:w-fit"
                 >
                   {secondaryActionLabel}
                 </Link>
               ) : null}
 
-              <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.4em] text-white/60">
+              <div className="flex items-center justify-center gap-2 text-sm font-semibold uppercase tracking-[0.4em] text-white/60 sm:justify-start">
                 <span className="h-2 w-2 rounded-full bg-rose-500" />
                 Innerbloom
               </div>
 
-              <div className="space-y-4">
+              <div className="space-y-4 text-center sm:text-left">
                 {typeof title === 'string' ? (
                   <h1 className="text-4xl font-semibold leading-tight text-white md:text-5xl">{title}</h1>
                 ) : (

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -6,9 +6,9 @@ export default function LoginPage() {
   return (
     <AuthLayout
       title={
-        <div className="flex items-center gap-3 text-4xl font-semibold uppercase tracking-[0.35em] text-white md:text-5xl">
-          <span className="h-3 w-3 rounded-full bg-rose-500 md:h-4 md:w-4" />
-          innerbloom
+        <div className="flex flex-col items-center gap-3 text-center text-3xl font-semibold uppercase tracking-[0.32em] text-white sm:flex-row sm:items-center sm:justify-start sm:gap-3 sm:text-left sm:text-4xl md:text-5xl">
+          <span className="h-2.5 w-2.5 rounded-full bg-rose-500 sm:h-3 sm:w-3 md:h-4 md:w-4" />
+          dashboard
         </div>
       }
       secondaryActionLabel="Volver al inicio"
@@ -35,7 +35,7 @@ export default function LoginPage() {
             },
             elements: {
               rootBox: 'w-full',
-              card: 'flex w-full flex-col gap-6 bg-white/5 p-8 backdrop-blur-xl border border-white/10 rounded-3xl shadow-[0_25px_80px_rgba(15,23,42,0.35)]',
+              card: 'flex w-full flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_80px_rgba(15,23,42,0.35)] backdrop-blur-xl sm:p-8',
               header: 'hidden',
               socialButtons: 'hidden',
               divider: 'hidden',
@@ -46,7 +46,7 @@ export default function LoginPage() {
                 'rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/40 shadow-[0_6px_20px_rgba(99,102,241,0.15)] focus:border-white/40 focus:outline-none focus-visible:ring-0',
               formFieldInputShowPasswordButton: 'text-sm text-white/60 hover:text-white',
               formButtonPrimary:
-                'mt-3 inline-flex h-12 items-center justify-center rounded-full bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#0ea5e9] text-sm font-semibold uppercase tracking-[0.18em] text-white transition-all duration-200 hover:from-[#8b5cf6] hover:to-[#0ea5e9]/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40',
+                'mt-3 inline-flex h-12 w-full items-center justify-center rounded-full bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#0ea5e9] text-sm font-semibold uppercase tracking-[0.18em] text-white transition-all duration-200 hover:from-[#8b5cf6] hover:to-[#0ea5e9]/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40 sm:w-auto',
               footer:
                 'mt-6 flex flex-col items-center gap-1 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-center text-xs text-white/60 backdrop-blur-xl shadow-none',
               footerTitle: 'text-white/70',


### PR DESCRIPTION
## Summary
- soften the AuthLayout spacing so the login view scales better on small screens
- update the login title to read DASHBOARD and tweak Clerk card styling for mobile widths

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e53fc399fc8322b022c4149154f247