### PR TITLE
Fix dashboard data normalization to avoid slice crashes

### DIFF
--- a/apps/web/src/components/dashboard-v3/MissionsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/MissionsSection.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from 'react';
 import { useRequest } from '../../hooks/useRequest';
-import { getTasks } from '../../lib/api';
+import { getTasks, type UserTask } from '../../lib/api';
+import { asArray } from '../../lib/safe';
 
 interface MissionsSectionProps {
   userId: string;
@@ -7,6 +9,10 @@ interface MissionsSectionProps {
 
 export function MissionsSection({ userId }: MissionsSectionProps) {
   const { data, status } = useRequest(() => getTasks(userId), [userId]);
+  const tasks = useMemo(() => {
+    console.info('[DASH] dataset', { keyNames: Object.keys(data ?? {}), isArray: Array.isArray(data) });
+    return asArray<UserTask>(data, 'tasks');
+  }, [data]);
 
   return (
     <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">
@@ -21,9 +27,9 @@ export function MissionsSection({ userId }: MissionsSectionProps) {
 
       {status === 'error' && <p className="text-sm text-rose-300">No pudimos listar las misiones.</p>}
 
-      {status === 'success' && data && data.length > 0 && (
+      {status === 'success' && tasks.length > 0 && (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {data.slice(0, 6).map((task) => (
+          {tasks.slice(0, 6).map((task) => (
             <article key={task.task_id} className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4">
               <h4 className="font-semibold text-white">🎯 {task.task}</h4>
               <p className="text-xs text-text-muted">Pilar: {task.pillar_id ?? '—'}</p>
@@ -41,7 +47,7 @@ export function MissionsSection({ userId }: MissionsSectionProps) {
         </div>
       )}
 
-      {status === 'success' && data && data.length === 0 && (
+      {status === 'success' && tasks.length === 0 && (
         <p className="text-sm text-text-muted">Tu base todavía no tiene misiones configuradas.</p>
       )}
 

--- a/apps/web/src/components/dashboard-v3/RadarChartCard.tsx
+++ b/apps/web/src/components/dashboard-v3/RadarChartCard.tsx
@@ -1,20 +1,17 @@
 import { useMemo } from 'react';
 import { useRequest } from '../../hooks/useRequest';
 import { getUserStateTimeseries, type EnergyTimeseriesPoint } from '../../lib/api';
+import { asArray, dateStr } from '../../lib/safe';
 
 interface RadarChartCardProps {
   userId: string;
-}
-
-function formatDate(date: Date): string {
-  return date.toISOString().slice(0, 10);
 }
 
 function buildRange(daysBack: number) {
   const to = new Date();
   const from = new Date();
   from.setUTCDate(from.getUTCDate() - daysBack);
-  return { from: formatDate(from), to: formatDate(to) };
+  return { from: dateStr(from), to: dateStr(to) };
 }
 
 function average(values: number[]) {
@@ -47,7 +44,11 @@ function computeDataset(series: EnergyTimeseriesPoint[] | null) {
 export function RadarChartCard({ userId }: RadarChartCardProps) {
   const range = useMemo(() => buildRange(60), []);
   const { data, status } = useRequest(() => getUserStateTimeseries(userId, range), [userId, range.from, range.to]);
-  const dataset = useMemo(() => computeDataset(data), [data]);
+  const series = useMemo(() => {
+    console.info('[DASH] dataset', { keyNames: Object.keys(data ?? {}), isArray: Array.isArray(data) });
+    return asArray<EnergyTimeseriesPoint>(data);
+  }, [data]);
+  const dataset = useMemo(() => computeDataset(series), [series]);
 
   return (
     <section className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-text backdrop-blur">

--- a/apps/web/src/lib/safe.ts
+++ b/apps/web/src/lib/safe.ts
@@ -1,0 +1,13 @@
+export const asArray = <T = any>(v: any, key?: string): T[] =>
+  Array.isArray(v) ? v : key && Array.isArray(v?.[key]) ? v[key] : [];
+
+export const dateStr = (v: any): string =>
+  typeof v === 'string'
+    ? v.slice(0, 10)
+    : v instanceof Date
+    ? v.toISOString().slice(0, 10)
+    : typeof v === 'number'
+    ? new Date(v).toISOString().slice(0, 10)
+    : v?.toString
+    ? new Date(v).toISOString().slice(0, 10)
+    : '';


### PR DESCRIPTION
## Summary
- add `asArray` and `dateStr` defensive helpers for dashboard data parsing
- normalize streak, cultivation, emotion, radar, missions, and recent activity datasets before rendering to avoid `.slice` crashes
- add temporary dashboard dataset logs to help debug unexpected API payloads

## Testing
- `pnpm --filter @innerbloom/web typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68e55a484bd48322acf1054c6078d2cb