### PR TITLE
Fix month grouping for daily XP series

### DIFF
--- a/apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx
+++ b/apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx
@@ -32,7 +32,9 @@ function groupByMonth(series: NormalizedDailyXpPoint[]): MonthBucket[] {
   const map = new Map<string, NormalizedDailyXpPoint[]>();
 
   for (const point of series) {
-    const key = (point.day || point.date || '').slice(0, 7);
+    const rawKey = point.day ?? point.date ?? '';
+    const keySource = typeof rawKey === 'string' ? rawKey : dateStr(rawKey);
+    const key = keySource ? keySource.slice(0, 7) : '';
     if (!key) continue;
     const arr = map.get(key) ?? [];
     arr.push(point);


### PR DESCRIPTION
## Summary
- normalize the month grouping key in the daily cultivation section so non-string dates are handled safely

## Testing
- npm run typecheck:web

------
https://chatgpt.com/codex/tasks/task_e_68e55e15fd508322a52217a09e94fc48