### PR TITLE
Align emotion chart colors with landing accent

### DIFF
--- a/apps/web/src/components/dashboard-v3/EmotionTimeline.tsx
+++ b/apps/web/src/components/dashboard-v3/EmotionTimeline.tsx
@@ -7,12 +7,14 @@ interface EmotionTimelineProps {
   userId: string;
 }
 
+const INNERBLOOM_ACCENT = '#7D3CFF';
+
 const EMOTION_COLORS: Record<string, string> = {
   Calma: '#2ECC71',
   Felicidad: '#F1C40F',
-  Motivación: '#9B59B6',
+  Motivación: INNERBLOOM_ACCENT,
   Tristeza: '#3498DB',
-  Ansiedad: '#E74C3C',
+  Ansiedad: INNERBLOOM_ACCENT,
   Frustración: '#8D6E63',
   Cansancio: '#16A085',
 };


### PR DESCRIPTION
## Summary
- update the emotion timeline color palette to reuse the Innerbloom accent purple for motivation and anxiety entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e55d80491483229cb49b7b67566285