### PR TITLE
Adjust login branding accents

### DIFF
--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -41,7 +41,7 @@ export function AuthLayout({
               ) : null}
 
               <div className="flex items-center justify-center gap-2 text-sm font-semibold uppercase tracking-[0.4em] text-white/60 sm:justify-start">
-                <span className="h-2 w-2 rounded-full bg-rose-500" />
+                <span className="h-2 w-2 rounded-full bg-[#7d3cff]" />
                 Innerbloom
               </div>
 

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -7,7 +7,6 @@ export default function LoginPage() {
     <AuthLayout
       title={
         <div className="flex flex-col items-center gap-3 text-center text-3xl font-semibold uppercase tracking-[0.32em] text-white sm:flex-row sm:items-center sm:justify-start sm:gap-3 sm:text-left sm:text-4xl md:text-5xl">
-          <span className="h-2.5 w-2.5 rounded-full bg-rose-500 sm:h-3 sm:w-3 md:h-4 md:w-4" />
           dashboard
         </div>
       }


### PR DESCRIPTION
## Summary
- remove the dashboard title indicator dot from the login screen
- align the Innerbloom accent dot with the landing page purple

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68e560a01384832283f19e86aeb0ef20