### PR TITLE
Handle non-array dashboard payloads

### DIFF
--- a/apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx
+++ b/apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx
@@ -34,7 +34,7 @@ function groupByMonth(series: NormalizedDailyXpPoint[]): MonthBucket[] {
   for (const point of series) {
     const rawKey = point.day ?? point.date ?? '';
     const keySource = typeof rawKey === 'string' ? rawKey : dateStr(rawKey);
-    const key = keySource ? keySource.slice(0, 7) : '';
+    const key = keySource ? String(keySource).slice(0, 7) : '';
     if (!key) continue;
     const arr = map.get(key) ?? [];
     arr.push(point);

--- a/apps/web/src/lib/safe.ts
+++ b/apps/web/src/lib/safe.ts
@@ -1,5 +1,38 @@
-export const asArray = <T = any>(v: any, key?: string): T[] =>
-  Array.isArray(v) ? v : key && Array.isArray(v?.[key]) ? v[key] : [];
+const toArray = <T = any>(value: any): T[] => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (value == null) {
+    return [];
+  }
+
+  if (typeof value === 'object') {
+    if (typeof (value as Iterable<T>)[Symbol.iterator] === 'function') {
+      return Array.from(value as Iterable<T>);
+    }
+
+    return Object.values(value as Record<string, T>);
+  }
+
+  return [];
+};
+
+export const asArray = <T = any>(value: any, key?: string): T[] => {
+  if (key && value != null) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) {
+      return toArray<T>((value as Record<string, unknown>)[key]);
+    }
+
+    if (Array.isArray(value)) {
+      return toArray<T>(value);
+    }
+
+    return [];
+  }
+
+  return toArray<T>(value);
+};
 
 export const dateStr = (v: any): string =>
   typeof v === 'string'


### PR DESCRIPTION
## Summary
- expand the `asArray` helper so dashboard cards can coerce iterable/object API payloads into arrays safely
- guard month-key generation in the daily cultivation section by stringifying the source before slicing

## Testing
- npm run typecheck:web

------
https://chatgpt.com/codex/tasks/task_e_68e561566ab883228685aebb7399fd61