### PR TITLE
fix(web): ensure navbar fallback id is string

### DIFF
--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -9,7 +9,11 @@ export function Navbar() {
     await signOut({ redirectUrl: '/' });
   };
 
-  const displayName = user?.fullName || user?.primaryEmailAddress?.emailAddress || userId?.slice(0, 8);
+  const fallbackId = userId == null ? '' : typeof userId === 'string' ? userId : String(userId);
+  const displayName =
+    user?.fullName ||
+    user?.primaryEmailAddress?.emailAddress ||
+    (fallbackId ? fallbackId.slice(0, 8) : '');
 
   return (
     <header className="sticky top-0 z-40 border-b border-white/5 bg-surface/75 backdrop-blur">


### PR DESCRIPTION
## Summary
- normalize the Clerk user id fallback before slicing in the navbar
- avoid runtime errors when Clerk returns a non-string identifier

## Testing
- npm -w @innerbloom/web run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e56c5d8ed483229ae3f0b8edbe4fd0