### PR TITLE
Enhance dashboard error handling and avatar card

### DIFF
--- a/apps/web/src/components/DevErrorBoundary.tsx
+++ b/apps/web/src/components/DevErrorBoundary.tsx
@@ -1,25 +1,68 @@
-import { Component, type ReactNode } from 'react';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
 
-export class DevErrorBoundary extends Component<{ children: ReactNode }, { err?: unknown }> {
-  state = { err: undefined as unknown };
+interface DevErrorBoundaryProps {
+  children: ReactNode;
+}
 
-  static getDerivedStateFromError(err: unknown) {
+interface DevErrorBoundaryState {
+  err?: unknown;
+}
+
+const extractMessage = (err: unknown) => {
+  if (!err) {
+    return 'Error desconocido';
+  }
+
+  if (err instanceof Error) {
+    return err.stack ?? err.message;
+  }
+
+  return typeof err === 'string' ? err : JSON.stringify(err, null, 2);
+};
+
+export class DevErrorBoundary extends Component<DevErrorBoundaryProps, DevErrorBoundaryState> {
+  state: DevErrorBoundaryState = { err: undefined };
+
+  static getDerivedStateFromError(err: unknown): DevErrorBoundaryState {
     return { err };
   }
 
-  componentDidCatch(err: unknown, info: unknown) {
+  componentDidCatch(err: unknown, info: ErrorInfo) {
     console.error('[ERRBOUNDARY]', { err, info });
   }
 
+  private handleRetry = () => {
+    this.setState({ err: undefined });
+  };
+
   render() {
-    return this.state.err ? (
-      <pre style={{ whiteSpace: 'pre-wrap', padding: 12, background: '#200', color: '#faa' }}>
-        <b>UI crash atrapado</b>
-        {'\n'}
-        {String((this.state.err as any)?.stack ?? this.state.err)}
-      </pre>
-    ) : (
-      this.props.children
+    if (!this.state.err) {
+      return this.props.children;
+    }
+
+    const message = extractMessage(this.state.err);
+
+    return (
+      <div className="m-4 rounded-2xl border border-rose-500/50 bg-rose-950/80 p-6 text-sm text-rose-100 shadow-lg">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-white">UI crash atrapado</h2>
+            <p className="mt-1 text-sm text-rose-100/80">
+              Algo salió mal dentro del dashboard. Revisá la consola para más detalles o reintentá renderizar.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="rounded-full border border-rose-400/60 bg-rose-500/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white transition hover:border-rose-200/80 hover:bg-rose-500/60"
+          >
+            Reintentar
+          </button>
+        </div>
+        <pre className="mt-4 max-h-96 overflow-auto whitespace-pre-wrap rounded-xl bg-black/40 p-4 text-xs leading-relaxed text-rose-100/90">
+          {message}
+        </pre>
+      </div>
     );
   }
 }

--- a/apps/web/src/components/dashboard-v3/ProfileCard.tsx
+++ b/apps/web/src/components/dashboard-v3/ProfileCard.tsx
@@ -1,0 +1,25 @@
+interface ProfileCardProps {
+  imageUrl?: string | null;
+}
+
+export function ProfileCard({ imageUrl }: ProfileCardProps) {
+  const hasImage = typeof imageUrl === 'string' && imageUrl.trim().length > 0;
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+      <div className="aspect-[5/6] w-full">
+        {hasImage ? (
+          <img
+            src={imageUrl ?? ''}
+            alt="Avatar"
+            className="h-full w-full rounded-2xl object-cover shadow-lg"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center rounded-2xl bg-white/10 text-5xl text-white/80 shadow-lg">
+            👤
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/ui.ts
+++ b/apps/web/src/lib/ui.ts
@@ -1,0 +1,11 @@
+export const dateStr = (v: any): string =>
+  typeof v === 'string'
+    ? v.slice(0, 10)
+    : v instanceof Date
+      ? v.toISOString().slice(0, 10)
+      : typeof v === 'number'
+        ? new Date(v).toISOString().slice(0, 10)
+        : '';
+
+export const asArray = <T = any>(v: any, k?: string): T[] =>
+  Array.isArray(v) ? v : k && Array.isArray(v?.[k]) ? v[k] : [];

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -16,7 +16,7 @@ declare global {
 setApiLoggingEnabled(true);
 
 if (typeof window !== 'undefined') {
-  (window as any).__DBG = true;
+  (window as any).__DBG ??= true;
   (window as any).setDbg = (on: boolean) => ((window as any).__DBG = !!on);
   window.setInnerbloomApiLogging = setApiLoggingEnabled;
   window.isInnerbloomApiLoggingEnabled = isApiLoggingEnabled;

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -21,6 +21,7 @@ import { RadarChartCard } from '../components/dashboard-v3/RadarChartCard';
 import { EmotionTimeline } from '../components/dashboard-v3/EmotionTimeline';
 import { StreakPanel } from '../components/dashboard-v3/StreakPanel';
 import { MissionsSection } from '../components/dashboard-v3/MissionsSection';
+import { ProfileCard } from '../components/dashboard-v3/ProfileCard';
 import { useBackendUser } from '../hooks/useBackendUser';
 import { DevErrorBoundary } from '../components/DevErrorBoundary';
 
@@ -36,9 +37,6 @@ export default function DashboardV3Page() {
   const failedToLoadProfile = status === 'error' || !backendUserId;
 
   const avatarUrl = profile?.image_url || user?.imageUrl;
-  const displayName =
-    profile?.full_name || user?.fullName || user?.primaryEmailAddress?.emailAddress || '';
-
   return (
     <DevErrorBoundary>
       <div className="flex min-h-screen flex-col">
@@ -57,7 +55,7 @@ export default function DashboardV3Page() {
               <div className="grid gap-6 lg:grid-cols-[320px_1fr_320px]">
                 <div className="space-y-6">
                   <XpSummaryCard userId={backendUserId} />
-                  <AvatarCard imageUrl={avatarUrl} name={displayName} email={profile?.email_primary} />
+                  <ProfileCard imageUrl={avatarUrl} />
                   <EnergyCard userId={backendUserId} />
                   <DailyCultivationSection userId={backendUserId} />
                 </div>
@@ -78,12 +76,6 @@ export default function DashboardV3Page() {
       </div>
     </DevErrorBoundary>
   );
-}
-
-interface AvatarCardProps {
-  imageUrl?: string | null;
-  name?: string | null;
-  email?: string | null;
 }
 
 function ProfileSkeleton() {
@@ -119,38 +111,6 @@ function ProfileErrorState({ onRetry, error }: ProfileErrorStateProps) {
       >
         Reintentar
       </button>
-    </section>
-  );
-}
-
-function AvatarCard({ imageUrl, name, email }: AvatarCardProps) {
-  const displayName = name?.trim() || 'Jugador/a';
-  const displayEmail = email?.trim() ?? '';
-
-  return (
-    <section className="flex flex-col items-center gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 text-center text-sm text-text backdrop-blur">
-      <div className="h-28 w-28 overflow-hidden rounded-full border border-white/20 bg-white/10">
-        {imageUrl ? (
-          <img src={imageUrl} alt="Avatar" className="h-full w-full object-cover" />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-3xl text-white">👤</div>
-        )}
-      </div>
-      <div className="space-y-1">
-        <p className="text-sm uppercase tracking-wide text-text-muted">Tu avatar</p>
-        <p className="text-lg font-semibold text-white">{displayName}</p>
-        {displayEmail && <p className="text-xs text-text-muted">{displayEmail}</p>}
-      </div>
-      <button
-        type="button"
-        disabled
-        className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-text"
-      >
-        Próximamente: cambiar avatar
-      </button>
-      <p className="text-[11px] text-text-muted">
-        Imagen sincronizada desde tu perfil (<code className="rounded bg-white/10 px-1 py-px text-[10px]">image_url</code>).
-      </p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add shared UI helpers for formatting dates and arrays
- improve the dashboard error boundary styling and retry handling
- simplify the dashboard avatar card to display only the image and wrap the page in the boundary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e58f6936d8832290d60454ff938a68