### PR TITLE
Add XP by trait radar data

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -9,12 +9,14 @@ import { getUserState } from '../controllers/users/get-user-state.js';
 import { getUserStateTimeseries } from '../controllers/users/get-user-state-timeseries.js';
 import { getUserTotalXp } from '../controllers/users/get-user-total-xp.js';
 import { asyncHandler } from '../lib/async-handler.js';
+import { getUserXpByTrait } from './users/xp-by-trait.js';
 
 const router = Router();
 
 router.get('/users/:id/tasks', asyncHandler(getUserTasks));
 router.get('/users/:id/xp/daily', asyncHandler(getUserDailyXp));
 router.get('/users/:id/xp/total', asyncHandler(getUserTotalXp));
+router.get('/users/:id/xp/by-trait', asyncHandler(getUserXpByTrait));
 router.get('/users/:id/level', asyncHandler(getUserLevel));
 router.get('/users/:id/journey', asyncHandler(getUserJourney));
 router.get('/users/:id/emotions', asyncHandler(getUserEmotions));

--- a/apps/api/src/routes/users/xp-by-trait.ts
+++ b/apps/api/src/routes/users/xp-by-trait.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import { pool } from '../../db.js';
+import type { AsyncHandler } from '../../lib/async-handler.js';
+import {
+  dateRangeQuerySchema,
+  formatAsDateString,
+  resolveDateRange,
+  uuidSchema,
+} from '../../lib/validation.js';
+import { ensureUserExists } from '../../controllers/users/shared.js';
+
+const TRAIT_ORDER = [
+  'core',
+  'bienestar',
+  'autogestion',
+  'intelecto',
+  'psiquis',
+  'salud_fisica',
+] as const;
+
+type TraitKey = (typeof TRAIT_ORDER)[number];
+
+type Row = {
+  trait_code: string | null;
+  xp: string | number | null;
+};
+
+const paramsSchema = z.object({
+  id: uuidSchema,
+});
+
+const querySchema = dateRangeQuerySchema;
+
+function normalizeTraitCode(code: string | null | undefined): TraitKey | null {
+  if (!code) {
+    return null;
+  }
+
+  const sanitized = code
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+  const matched = TRAIT_ORDER.find((trait) => {
+    if (trait === sanitized) {
+      return true;
+    }
+
+    switch (trait) {
+      case 'autogestion':
+        return ['auto_gestion', 'autogestion', 'gestion', 'auto-gestion'].includes(sanitized);
+      case 'salud_fisica':
+        return [
+          'salud_fisica',
+          'saludfisica',
+          'salud_fisico',
+          'salud_fisica_total',
+          'salud-fisica',
+          'salud_fisica_foundations',
+        ].includes(sanitized);
+      case 'psiquis':
+        return ['psiquis', 'psique', 'psiquis_total'].includes(sanitized);
+      case 'bienestar':
+        return ['bienestar', 'bien_estar'].includes(sanitized);
+      case 'intelecto':
+        return ['intelecto', 'intelectual'].includes(sanitized);
+      case 'core':
+        return ['core', 'corazon', 'core_total'].includes(sanitized);
+      default:
+        return false;
+    }
+  });
+
+  return matched ?? null;
+}
+
+export const getUserXpByTrait: AsyncHandler = async (req, res) => {
+  const { id } = paramsSchema.parse(req.params);
+  const { from, to } = querySchema.parse(req.query);
+
+  await ensureUserExists(id);
+
+  const range = resolveDateRange({ from, to }, 60);
+
+  const totals: Record<TraitKey, number> = {
+    core: 0,
+    bienestar: 0,
+    autogestion: 0,
+    intelecto: 0,
+    psiquis: 0,
+    salud_fisica: 0,
+  };
+
+  const result = await pool.query<Row>(
+    `SELECT ct.code AS trait_code,
+            SUM(dl.quantity * t.xp_base) AS xp
+       FROM daily_log dl
+       JOIN tasks t ON t.task_id = dl.task_id
+  LEFT JOIN cat_trait ct ON ct.trait_id = t.trait_id
+      WHERE dl.user_id = $1
+        AND dl.date BETWEEN $2 AND $3
+   GROUP BY ct.code`,
+    [id, formatAsDateString(range.from), formatAsDateString(range.to)],
+  );
+
+  for (const row of result.rows) {
+    const trait = normalizeTraitCode(row.trait_code);
+
+    if (!trait) {
+      continue;
+    }
+
+    const xp = Number(row.xp ?? 0);
+    totals[trait] = (totals[trait] ?? 0) + (Number.isFinite(xp) ? xp : 0);
+  }
+
+  res.json({
+    traits: TRAIT_ORDER.map((trait) => ({
+      trait,
+      xp: Math.round(totals[trait] ?? 0),
+    })),
+  });
+};

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -504,6 +504,30 @@ export async function getUserDailyXp(
   return response;
 }
 
+export type TraitXpEntry = {
+  trait: string;
+  xp: number;
+};
+
+export type UserXpByTraitResponse = {
+  traits: TraitXpEntry[];
+};
+
+export async function getUserXpByTrait(
+  userId: string,
+  params: { from?: string; to?: string } = {},
+): Promise<UserXpByTraitResponse> {
+  const response = await getJson<unknown>(`/users/${encodeURIComponent(userId)}/xp/by-trait`, params);
+  logShape('user-xp-by-trait', response);
+
+  const traits = extractArray<TraitXpEntry>(response, 'traits', 'items', 'data').map((item) => ({
+    trait: String((item as TraitXpEntry)?.trait ?? '').trim(),
+    xp: Number((item as TraitXpEntry)?.xp ?? 0) || 0,
+  }));
+
+  return { traits };
+}
+
 export type CurrentUserProfile = {
   user_id: string;
   clerk_user_id: string;


### PR DESCRIPTION
## Summary
- add a new GET /users/:id/xp/by-trait endpoint that aggregates XP per trait over a configurable date range
- expose the XP-by-trait client helper and use it in the dashboard radar card with the updated six-trait visualization and styling

## Testing
- npm run typecheck:api
- npm run typecheck:web

------
https://chatgpt.com/codex/tasks/task_e_68e591b7a42c83228e6f8c3728fda937