### PR TITLE
feat(api): add daily energy endpoint

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -9,6 +9,7 @@ import { getUserState } from '../controllers/users/get-user-state.js';
 import { getUserStateTimeseries } from '../controllers/users/get-user-state-timeseries.js';
 import { getUserTotalXp } from '../controllers/users/get-user-total-xp.js';
 import { asyncHandler } from '../lib/async-handler.js';
+import { getUserDailyEnergy } from './users/daily-energy.js';
 import { getUserXpByTrait } from './users/xp-by-trait.js';
 
 const router = Router();
@@ -18,6 +19,7 @@ router.get('/users/:id/xp/daily', asyncHandler(getUserDailyXp));
 router.get('/users/:id/xp/total', asyncHandler(getUserTotalXp));
 router.get('/users/:id/xp/by-trait', asyncHandler(getUserXpByTrait));
 router.get('/users/:id/level', asyncHandler(getUserLevel));
+router.get('/users/:id/daily-energy', asyncHandler(getUserDailyEnergy));
 router.get('/users/:id/journey', asyncHandler(getUserJourney));
 router.get('/users/:id/emotions', asyncHandler(getUserEmotions));
 router.get('/users/:id/state', asyncHandler(getUserState));

--- a/apps/api/src/routes/users/daily-energy.test.ts
+++ b/apps/api/src/routes/users/daily-energy.test.ts
@@ -1,0 +1,94 @@
+import type { Request, Response } from 'express';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { getUserDailyEnergy } from './daily-energy.js';
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+}));
+
+vi.mock('../../db.js', () => ({
+  pool: {
+    query: mockQuery,
+  },
+}));
+
+function createMockResponse() {
+  const json = vi.fn();
+  const status = vi.fn().mockReturnThis();
+
+  return {
+    status,
+    json,
+  } as unknown as Response;
+}
+
+describe('getUserDailyEnergy', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('returns 400 when the user id is not a valid uuid', async () => {
+    const req = { params: { id: 'invalid-id' } } as unknown as Request;
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    await getUserDailyEnergy(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'bad_request', detail: 'invalid uuid' });
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when no daily energy row is found', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const req = { params: { id: '4a6f8b1e-12f0-4a22-8e8a-7cbf8250a49d' } } as unknown as Request;
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    await getUserDailyEnergy(req, res, next);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'not_found' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns the normalized daily energy snapshot when present', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          user_id: 'dedb5d95-244c-47b7-922c-c256d8930723',
+          hp_pct: '56.2',
+          mood_pct: '30.1',
+          focus_pct: '34.0',
+          hp_norm: '0.562',
+          mood_norm: '0.301',
+          focus_norm: '0.34',
+        },
+      ],
+    });
+
+    const req = { params: { id: 'dedb5d95-244c-47b7-922c-c256d8930723' } } as unknown as Request;
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    await getUserDailyEnergy(req, res, next);
+
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('FROM v_user_daily_energy'), [
+      'dedb5d95-244c-47b7-922c-c256d8930723',
+    ]);
+    expect(res.json).toHaveBeenCalledWith({
+      user_id: 'dedb5d95-244c-47b7-922c-c256d8930723',
+      hp_pct: 56.2,
+      mood_pct: 30.1,
+      focus_pct: 34,
+      hp_norm: 0.562,
+      mood_norm: 0.301,
+      focus_norm: 0.34,
+    });
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/users/daily-energy.ts
+++ b/apps/api/src/routes/users/daily-energy.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import { pool } from '../../db.js';
+import type { AsyncHandler } from '../../lib/async-handler.js';
+import { uuidSchema } from '../../lib/validation.js';
+
+type DailyEnergyRow = {
+  user_id: string;
+  hp_pct: string | number | null;
+  mood_pct: string | number | null;
+  focus_pct: string | number | null;
+  hp_norm: string | number | null;
+  mood_norm: string | number | null;
+  focus_norm: string | number | null;
+};
+
+const paramsSchema = z.object({
+  id: uuidSchema,
+});
+
+const toNumber = (value: string | number | null | undefined): number => {
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+/**
+ * @openapi
+ * /users/{id}/daily-energy:
+ *   get:
+ *     summary: Get today's daily energy snapshot for a user
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       '200':
+ *         description: Daily energy was found
+ *       '400':
+ *         description: Invalid user id
+ *       '404':
+ *         description: Daily energy not found
+ */
+export const getUserDailyEnergy: AsyncHandler = async (req, res) => {
+  // TODO: Add Clerk authentication middleware (Level 1)
+  const parsed = paramsSchema.safeParse(req.params);
+
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'bad_request', detail: 'invalid uuid' });
+  }
+
+  const { id } = parsed.data;
+
+  const sql = `
+    SELECT user_id,
+           ROUND(hp_pct::numeric, 1)   AS hp_pct,
+           ROUND(mood_pct::numeric, 1) AS mood_pct,
+           ROUND(focus_pct::numeric, 1) AS focus_pct,
+           hp_norm,
+           mood_norm,
+           focus_norm
+      FROM v_user_daily_energy
+     WHERE user_id = $1
+  `;
+
+  const result = await pool.query<DailyEnergyRow>(sql, [id]);
+
+  if (result.rows.length === 0) {
+    return res.status(404).json({ error: 'not_found' });
+  }
+
+  const row = result.rows[0];
+
+  return res.json({
+    user_id: row.user_id,
+    hp_pct: toNumber(row.hp_pct),
+    mood_pct: toNumber(row.mood_pct),
+    focus_pct: toNumber(row.focus_pct),
+    hp_norm: toNumber(row.hp_norm),
+    mood_norm: toNumber(row.mood_norm),
+    focus_norm: toNumber(row.focus_norm),
+  });
+};


### PR DESCRIPTION
## Summary
- add a GET /users/:id/daily-energy route that queries v_user_daily_energy and returns rounded metrics
- validate UUIDs, surface 400/404 errors, and document the handler with OpenAPI notes
- cover success and error scenarios with a unit test that mocks the database client

## Testing
- npm --workspace apps/api run test

------
https://chatgpt.com/codex/tasks/task_e_68e599f15688832280945cc6ebe5f18a