### PR TITLE
Fix Dashboard V3 streak panel layout

### DIFF
--- a/apps/web/src/components/dashboard-v3/StreakPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreakPanel.tsx
@@ -1,5 +1,3 @@
-
-export { StreaksPanel as StreakPanel } from '../dashboard/StreaksPanel';
 import { useEffect, useMemo, useState } from 'react';
 import { useRequest } from '../../hooks/useRequest';
 import {

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -22,6 +22,7 @@ import { MetricHeader } from '../components/dashboard/MetricHeader';
 import { RadarChartCard } from '../components/dashboard/RadarChartCard';
 import { EmotionChartCard } from '../components/dashboard/EmotionChartCard';
 import { StreaksPanel } from '../components/dashboard/StreaksPanel';
+import { StreakPanel } from '../components/dashboard-v3/StreakPanel';
 import { Card } from '../components/ui/Card';
 import { useBackendUser } from '../hooks/useBackendUser';
 import { DevErrorBoundary } from '../components/DevErrorBoundary';
@@ -69,14 +70,15 @@ export default function DashboardV3Page() {
                   <EnergyCard userId={backendUserId} />
                   <StreaksPanel userId={backendUserId} />
 
-                <div className="space-y-6">
-                  <StreakPanel
-                    userId={backendUserId}
-                    gameMode={profile?.game_mode}
-                    weeklyTarget={profile?.weekly_target}
-                  />
+                  <div className="space-y-6">
+                    <StreakPanel
+                      userId={backendUserId}
+                      gameMode={profile?.game_mode}
+                      weeklyTarget={profile?.weekly_target}
+                    />
 
-                  <RewardsPlaceholder />
+                    <RewardsPlaceholder />
+                  </div>
                 </div>
 
                 <div className="lg:col-span-12">


### PR DESCRIPTION
## Summary
- import the dashboard v3 streak panel component into DashboardV3
- fix the layout markup so the streak panel column closes correctly
- drop the redundant re-export in the streak panel module to avoid duplicate declarations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59f2940c48322b08cf5dacccee124