### PR TITLE
feat(web): replicate MVP daily energy card

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -468,6 +468,31 @@ export async function getUserState(userId: string): Promise<UserState> {
   return response;
 }
 
+export type DailyEnergySnapshot = {
+  user_id: string;
+  hp_pct: number;
+  mood_pct: number;
+  focus_pct: number;
+  hp_norm: number;
+  mood_norm: number;
+  focus_norm: number;
+};
+
+export async function getUserDailyEnergy(userId: string): Promise<DailyEnergySnapshot | null> {
+  try {
+    const response = await getJson<DailyEnergySnapshot>(`/users/${encodeURIComponent(userId)}/daily-energy`);
+    logShape('user-daily-energy', response);
+    return response;
+  } catch (error) {
+    if (error instanceof Error && /404/.test(error.message)) {
+      logApiDebug('user-daily-energy not found', { userId, message: error.message });
+      return null;
+    }
+
+    throw error;
+  }
+}
+
 export type EnergyTimeseriesPoint = {
   date: string;
   Body: number;

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -67,7 +67,7 @@ export default function DashboardV3Page() {
 
                 <div className="lg:col-span-5 space-y-4 md:space-y-5">
                   <ProfileCard imageUrl={avatarUrl} />
-                  <EnergyCard userId={backendUserId} />
+                  <EnergyCard userId={backendUserId} gameMode={profile?.game_mode} />
                   <StreaksPanel userId={backendUserId} />
 
                   <div className="space-y-6">


### PR DESCRIPTION
## Summary
- add a typed client for `/users/:id/daily-energy` and tolerate 404s without breaking the dashboard
- restyle the daily energy card to match the MVP layout and read data from the daily energy snapshot
- surface the backend game mode on the card while keeping the layout connected to the dashboard profile

## Testing
- pnpm --filter web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e5a184209c83229ae428ddd2ac1b90