### PR TITLE
feat: improve auth responsiveness and shared styling

### DIFF
--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
+import { getGradientButtonClass } from '../../lib/clerkAppearance';
 
 interface AuthLayoutProps {
   children: ReactNode;
@@ -21,14 +22,14 @@ export function AuthLayout({
   secondaryActionHref
 }: AuthLayoutProps) {
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#040313] px-4 py-10 text-white sm:px-6 lg:px-12">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#040313] px-4 py-8 text-white sm:px-6 lg:px-12">
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.18),transparent_55%),radial-gradient(circle_at_bottom_left,_rgba(14,165,233,0.15),transparent_60%),radial-gradient(circle_at_bottom_right,_rgba(217,70,239,0.1),transparent_65%)]" />
         <div className="absolute -left-24 top-32 h-72 w-72 rounded-full bg-[#a855f7]/30 blur-[140px]" />
         <div className="absolute -right-32 bottom-10 h-80 w-80 rounded-full bg-[#0ea5e9]/30 blur-[160px]" />
       </div>
-      <div className="relative z-10 w-full max-w-5xl rounded-[28px] border border-white/10 bg-white/5 p-6 shadow-[0_30px_120px_rgba(15,23,42,0.45)] backdrop-blur-3xl sm:rounded-[32px] sm:p-8 md:p-12">
-        <div className="flex flex-col gap-10 md:grid md:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] md:gap-16">
+      <div className="relative z-10 w-full max-w-5xl rounded-[28px] border border-white/10 bg-white/5 p-5 shadow-[0_30px_120px_rgba(15,23,42,0.45)] backdrop-blur-3xl sm:rounded-[32px] sm:p-7 md:p-10">
+        <div className="flex flex-col gap-12 lg:grid lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:gap-16">
           <div className="flex flex-col justify-between gap-10">
             <div className="flex flex-col gap-6">
               {secondaryActionLabel && secondaryActionHref ? (
@@ -45,7 +46,7 @@ export function AuthLayout({
                 Innerbloom
               </div>
 
-              <div className="space-y-4 text-center sm:text-left">
+              <div className="space-y-4 text-balance text-center sm:text-left">
                 {typeof title === 'string' ? (
                   <h1 className="text-4xl font-semibold leading-tight text-white md:text-5xl">{title}</h1>
                 ) : (
@@ -62,7 +63,7 @@ export function AuthLayout({
                 <button
                   type="button"
                   onClick={onPrimaryActionClick}
-                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#0ea5e9] px-7 py-3 text-sm font-semibold text-white shadow-[0_12px_35px_rgba(99,102,241,0.35)] transition-transform duration-200 hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+                  className={getGradientButtonClass()}
                 >
                   {primaryActionLabel}
                 </button>

--- a/apps/web/src/lib/clerkAppearance.ts
+++ b/apps/web/src/lib/clerkAppearance.ts
@@ -1,0 +1,66 @@
+import type { Theme } from '@clerk/types';
+
+const baseLayout = {
+  logoPlacement: 'none' as const,
+  socialButtonsVariant: 'blockButton' as const
+};
+
+const baseVariables = {
+  colorPrimary: '#7c3aed',
+  colorBackground: 'transparent',
+  colorInputBackground: 'rgba(15, 23, 42, 0.55)',
+  colorInputText: '#f8fafc',
+  colorText: '#f8fafc',
+  colorTextSecondary: 'rgba(226, 232, 240, 0.8)',
+  borderRadius: '18px',
+  fontSize: '16px',
+  fontFamily: '"Manrope", "Inter", system-ui, sans-serif'
+};
+
+const gradientButtonClass =
+  'mt-3 inline-flex h-12 w-full items-center justify-center rounded-full bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#0ea5e9] text-sm font-semibold uppercase tracking-[0.18em] text-white transition-all duration-200 hover:from-[#8b5cf6] hover:to-[#0ea5e9]/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40 sm:w-auto';
+
+const baseElements = {
+  rootBox: 'w-full',
+  card:
+    'flex w-full flex-col gap-6 rounded-[28px] border border-white/10 bg-white/5 p-5 shadow-[0_25px_80px_rgba(15,23,42,0.35)] backdrop-blur-2xl sm:p-7 md:p-8',
+  header: 'hidden',
+  socialButtons: 'hidden',
+  divider: 'hidden',
+  form: 'flex flex-col gap-4 text-left',
+  formField: 'flex flex-col gap-2',
+  formFieldLabel: 'text-sm font-medium text-white/80',
+  formFieldInput:
+    'rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/40 shadow-[0_6px_20px_rgba(99,102,241,0.15)] focus:border-white/40 focus:outline-none focus-visible:ring-0',
+  formFieldInputShowPasswordButton: 'text-sm text-white/60 hover:text-white',
+  formButtonPrimary: gradientButtonClass,
+  footer:
+    'mt-6 flex flex-col items-center gap-1 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-center text-xs text-white/60 backdrop-blur-xl shadow-none',
+  footerTitle: 'text-white/70',
+  footerSubtitle: 'text-white/50',
+  footerActionText: 'text-white/50',
+  footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4',
+  formResendCodeLink: 'text-sm text-white hover:text-white/80',
+  identityPreview: 'rounded-2xl border border-white/15 bg-white/10 backdrop-blur-xl text-white/80',
+  identityPreviewTitle: 'text-white',
+  identityPreviewSubtitle: 'text-white/70',
+  identityPreviewEditButton: 'text-white hover:text-white/80'
+};
+
+type AppearanceOverrides = {
+  layout?: Record<string, unknown>;
+  variables?: Record<string, string>;
+  elements?: Record<string, string>;
+};
+
+export function createAuthAppearance(overrides: AppearanceOverrides = {}): Theme {
+  return {
+    layout: { ...baseLayout, ...overrides.layout },
+    variables: { ...baseVariables, ...overrides.variables },
+    elements: { ...baseElements, ...overrides.elements }
+  } as Theme;
+}
+
+export function getGradientButtonClass() {
+  return gradientButtonClass;
+}

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,12 +1,13 @@
 import { SignIn } from '@clerk/clerk-react';
 import { AuthLayout } from '../components/layout/AuthLayout';
 import { DASHBOARD_PATH } from '../config/auth';
+import { createAuthAppearance } from '../lib/clerkAppearance';
 
 export default function LoginPage() {
   return (
     <AuthLayout
       title={
-        <div className="flex flex-col items-center gap-3 text-center text-3xl font-semibold uppercase tracking-[0.32em] text-white sm:flex-row sm:items-center sm:justify-start sm:gap-3 sm:text-left sm:text-4xl md:text-5xl">
+        <div className="flex flex-col items-center gap-2 text-center text-3xl font-semibold uppercase tracking-[0.32em] text-white sm:flex-row sm:items-center sm:justify-start sm:gap-3 sm:text-left sm:text-4xl md:text-5xl">
           dashboard
         </div>
       }
@@ -15,50 +16,15 @@ export default function LoginPage() {
     >
       <div className="w-full max-w-md">
         <SignIn
-          appearance={{
+          appearance={createAuthAppearance({
             layout: {
-              logoPlacement: 'none',
-              socialButtonsVariant: 'blockButton',
               showOptionalFields: false
             },
-            variables: {
-              colorPrimary: '#7c3aed',
-              colorBackground: 'transparent',
-              colorInputBackground: 'rgba(15, 23, 42, 0.55)',
-              colorInputText: '#f8fafc',
-              colorText: '#f8fafc',
-              colorTextSecondary: 'rgba(226, 232, 240, 0.8)',
-              borderRadius: '18px',
-              fontSize: '16px',
-              fontFamily: '"Manrope", "Inter", system-ui, sans-serif'
-            },
             elements: {
-              rootBox: 'w-full',
-              card: 'flex w-full flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_80px_rgba(15,23,42,0.35)] backdrop-blur-xl sm:p-8',
-              header: 'hidden',
-              socialButtons: 'hidden',
-              divider: 'hidden',
-              form: 'flex flex-col gap-4 text-left',
-              formField: 'flex flex-col gap-2',
-              formFieldLabel: 'text-sm font-medium text-white/80',
-              formFieldInput:
-                'rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/40 shadow-[0_6px_20px_rgba(99,102,241,0.15)] focus:border-white/40 focus:outline-none focus-visible:ring-0',
-              formFieldInputShowPasswordButton: 'text-sm text-white/60 hover:text-white',
-              formButtonPrimary:
-                'mt-3 inline-flex h-12 w-full items-center justify-center rounded-full bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#0ea5e9] text-sm font-semibold uppercase tracking-[0.18em] text-white transition-all duration-200 hover:from-[#8b5cf6] hover:to-[#0ea5e9]/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40 sm:w-auto',
-              footer:
-                'mt-6 flex flex-col items-center gap-1 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-center text-xs text-white/60 backdrop-blur-xl shadow-none',
-              footerTitle: 'text-white/70',
-              footerSubtitle: 'text-white/50',
               footerActionText: 'text-white/50',
-              footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4',
-              formResendCodeLink: 'text-sm text-white hover:text-white/80',
-              identityPreview: 'rounded-2xl border border-white/15 bg-white/10 backdrop-blur-xl text-white/80',
-              identityPreviewTitle: 'text-white',
-              identityPreviewSubtitle: 'text-white/70',
-              identityPreviewEditButton: 'text-white hover:text-white/80'
+              footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4'
             }
-          }}
+          })}
           routing="path"
           path="/login"
           signUpUrl="/sign-up"

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -2,6 +2,7 @@ import { SignUp } from '@clerk/clerk-react';
 import { useRef } from 'react';
 import { AuthLayout } from '../components/layout/AuthLayout';
 import { DASHBOARD_PATH } from '../config/auth';
+import { createAuthAppearance } from '../lib/clerkAppearance';
 
 export default function SignUpPage() {
   const signUpContainerRef = useRef<HTMLDivElement | null>(null);
@@ -20,45 +21,14 @@ export default function SignUpPage() {
     >
       <div ref={signUpContainerRef} className="w-full max-w-md">
         <SignUp
-          appearance={{
-            layout: {
-              logoPlacement: 'none',
-              socialButtonsVariant: 'blockButton'
-            },
-            variables: {
-              colorPrimary: '#7c3aed',
-              colorBackground: 'transparent',
-              colorInputBackground: 'rgba(15, 23, 42, 0.55)',
-              colorInputText: '#f8fafc',
-              colorText: '#f8fafc',
-              colorTextSecondary: 'rgba(226, 232, 240, 0.8)',
-              borderRadius: '18px',
-              fontSize: '16px',
-              fontFamily: '"Manrope", "Inter", system-ui, sans-serif'
-            },
+          appearance={createAuthAppearance({
             elements: {
-              rootBox: 'w-full',
-              card: 'flex w-full flex-col gap-6 bg-white/5 p-8 backdrop-blur-xl border border-white/10 rounded-3xl shadow-[0_25px_80px_rgba(15,23,42,0.35)]',
-              header: 'hidden',
-              socialButtons: 'hidden',
-              divider: 'hidden',
-              form: 'flex flex-col gap-4 text-left',
-              formField: 'flex flex-col gap-2',
-              formFieldLabel: 'text-sm font-medium text-white/80',
-              formFieldInput:
-                'rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/40 shadow-[0_6px_20px_rgba(99,102,241,0.15)] focus:border-white/40 focus:outline-none focus-visible:ring-0',
-              formFieldInputShowPasswordButton: 'text-sm text-white/60 hover:text-white',
-              formButtonPrimary:
-                'mt-3 inline-flex h-12 items-center justify-center rounded-full bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#0ea5e9] text-sm font-semibold uppercase tracking-[0.18em] text-white transition-all duration-200 hover:from-[#8b5cf6] hover:to-[#0ea5e9]/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40',
-              footer: 'flex flex-col items-center gap-2 text-center text-sm text-white/70',
-              footerActionLink: 'font-semibold text-white hover:text-white/80 underline-offset-4',
-              formFieldSuccessText: 'text-sm text-emerald-200',
-              identityPreview: 'rounded-2xl border border-white/15 bg-white/10 backdrop-blur-xl text-white/80',
-              identityPreviewTitle: 'text-white',
-              identityPreviewSubtitle: 'text-white/70',
-              identityPreviewEditButton: 'text-white hover:text-white/80'
+              footer: 'mt-6 flex flex-col items-center gap-1 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-center text-xs text-white/60 backdrop-blur-xl shadow-none',
+              footerActionText: 'text-white/50',
+              footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4',
+              formFieldSuccessText: 'text-sm text-emerald-200'
             }
-          }}
+          })}
           routing="path"
           path="/sign-up"
           signInUrl="/login"


### PR DESCRIPTION
## Summary
- add a shared Clerk appearance helper to keep login and sign-up styling consistent
- refresh the auth layout spacing and button styling for better responsiveness on small screens
- update the login and sign-up pages to consume the shared theme and match the redesigned login look

## Testing
- npm --prefix apps/web run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e60c7748f48322ad78284fb6782183