### PR TITLE
Fix auth layout alignment on mobile

### DIFF
--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -71,7 +71,7 @@ export function AuthLayout({
             ) : null}
           </div>
 
-          <div className="flex items-center justify-center">
+          <div className="flex w-full items-center justify-center">
             {children}
           </div>
         </div>

--- a/apps/web/src/lib/clerkAppearance.ts
+++ b/apps/web/src/lib/clerkAppearance.ts
@@ -23,7 +23,7 @@ const gradientButtonClass =
 const baseElements = {
   rootBox: 'w-full',
   card:
-    'flex w-full flex-col gap-6 rounded-[28px] border border-white/10 bg-white/5 p-5 shadow-[0_25px_80px_rgba(15,23,42,0.35)] backdrop-blur-2xl sm:p-7 md:p-8',
+    'mx-auto flex w-full max-w-[440px] flex-col gap-6 rounded-[28px] border border-white/10 bg-white/5 p-5 shadow-[0_25px_80px_rgba(15,23,42,0.35)] backdrop-blur-2xl sm:p-7 md:p-8',
   header: 'hidden',
   socialButtons: 'hidden',
   divider: 'hidden',

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -14,7 +14,7 @@ export default function LoginPage() {
       secondaryActionLabel="Volver al inicio"
       secondaryActionHref="/"
     >
-      <div className="w-full max-w-md">
+      <div className="w-full max-w-md mx-auto lg:mx-0">
         <SignIn
           appearance={createAuthAppearance({
             layout: {

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -19,7 +19,7 @@ export default function SignUpPage() {
       secondaryActionLabel="Volver al inicio"
       secondaryActionHref="/"
     >
-      <div ref={signUpContainerRef} className="w-full max-w-md">
+      <div ref={signUpContainerRef} className="w-full max-w-md mx-auto lg:mx-0">
         <SignUp
           appearance={createAuthAppearance({
             elements: {


### PR DESCRIPTION
## Summary
- ensure the auth layout column stretches to the viewport so auth forms stay centered on mobile
- center the Clerk auth card and constrain its width for consistent spacing

## Testing
- npm -w @innerbloom/web run build

------
https://chatgpt.com/codex/tasks/task_e_68e61829672c8322b9d68640c8437de0