### PR TITLE
feat: port emotion chart heatmap to dashboard

### DIFF
--- a/apps/web/src/styles/panel-rachas.overrides.css
+++ b/apps/web/src/styles/panel-rachas.overrides.css
@@ -1,0 +1,55 @@
+#emotionChart {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+#emotionChart .grid-box {
+  width: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#emotionChart .month-row {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 6px;
+  color: rgba(226, 232, 255, 0.45);
+  text-align: center;
+}
+
+#emotionChart .month-chip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--cell);
+  min-height: 12px;
+}
+
+.emotion-grid--weekcols {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 6px;
+  contain: content;
+}
+
+.emotion-col {
+  display: grid;
+  grid-template-rows: repeat(7, var(--cell));
+  gap: 6px;
+}
+
+.emotion-cell {
+  width: var(--cell);
+  height: var(--cell);
+  border-radius: 4px;
+  background-color: #555555;
+}
+
+@media (max-width: 420px) {
+  .emotion-cell {
+    border-radius: 3px;
+  }
+}


### PR DESCRIPTION
## Summary
- port the Emotion Chart helpers from MVP/dashboardv3.js into the dashboard card so the heatmap uses the same parsing, normalization, grid, and window.GJEmotion hooks
- compute the heatmap cell size from the #emotionChart .grid-box width (gap 6px, 26 columns) and expose it through --cell to avoid overflow while adding the required overrides stylesheet
- fix the highlight card to show the emotion name and color for the 15-day mode instead of the numeric value while keeping the legend and period labels aligned

## Notes
- Helpers copied and adapted from MVP/dashboardv3.js (Emotion Chart block).
- cellSize = floor((maxWidth - (cols - 1) * 6) / cols) applied to --cell on #emotionChart .grid-box so the grid stays inside the card.
- Highlight now counts normalized emotion names over the last 15 days and renders the winning emotion name/color instead of the count “1”.

## Testing
- pnpm --filter web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e61d0bf1388322afcdd6c823e904fe