### PR TITLE
Normalize numeric emotion identifiers

### DIFF
--- a/apps/web/src/components/dashboard-v3/EmotionTimeline.tsx
+++ b/apps/web/src/components/dashboard-v3/EmotionTimeline.tsx
@@ -50,6 +50,13 @@ type GridComputation = {
 };
 
 const EMOTION_NORMALIZATION: Record<string, EmotionName> = {
+  '1': 'Calma',
+  '2': 'Felicidad',
+  '3': 'Motivación',
+  '4': 'Tristeza',
+  '5': 'Ansiedad',
+  '6': 'Frustración',
+  '7': 'Cansancio',
   calma: 'Calma',
   calm: 'Calma',
   calmness: 'Calma',

--- a/apps/web/src/components/dashboard/EmotionChartCard.tsx
+++ b/apps/web/src/components/dashboard/EmotionChartCard.tsx
@@ -139,6 +139,13 @@ function normalizeEmotion(value: unknown): EmotionValue {
   if (raw === 'neutral') return 'Cansancio';
 
   const mapping: Record<string, EmotionName> = {
+    '1': 'Calma',
+    '2': 'Felicidad',
+    '3': 'Motivación',
+    '4': 'Tristeza',
+    '5': 'Ansiedad',
+    '6': 'Frustración',
+    '7': 'Cansancio',
     calma: 'Calma',
     calm: 'Calma',
     alegria: 'Felicidad',

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -351,6 +351,13 @@ type EmotionLogResponse = {
 };
 
 const EMOTION_LABELS: Record<string, string> = {
+  '1': 'Calma',
+  '2': 'Felicidad',
+  '3': 'Motivación',
+  '4': 'Tristeza',
+  '5': 'Ansiedad',
+  '6': 'Frustración',
+  '7': 'Cansancio',
   calm: 'Calma',
   calma: 'Calma',
   happiness: 'Felicidad',


### PR DESCRIPTION
## Summary
- map numeric emotion identifiers from the API to their canonical emotion labels
- extend Emotion Chart components to normalize numeric emotion values so the heatmap renders correctly

## Testing
- npm --workspace apps/web run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e628428b6c83228ae5b0d663491718