### PR TITLE
Align emotion timeline start date and add interactive tooltips

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -45,10 +45,71 @@
   }
 
   .emotion-cell {
+    position: relative;
     width: 14px;
     height: 14px;
+    border: none;
+    padding: 0;
     border-radius: 5px;
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+    cursor: pointer;
+    background: transparent;
+    appearance: none;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .emotion-cell:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 2px;
+  }
+
+  .emotion-cell::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    left: 50%;
+    bottom: calc(100% + 6px);
+    transform: translate(-50%, 0) scale(0.95);
+    transform-origin: bottom center;
+    white-space: nowrap;
+    background: rgba(10, 22, 48, 0.95);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    padding: 6px 8px;
+    border-radius: 6px;
+    box-shadow: 0 8px 16px rgba(5, 12, 28, 0.45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 10;
+  }
+
+  .emotion-cell::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    bottom: 100%;
+    transform: translate(-50%, 4px) scale(0.95);
+    width: 10px;
+    height: 10px;
+    background: rgba(10, 22, 48, 0.95);
+    border-radius: 2px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 9;
+    clip-path: polygon(50% 100%, 0 0, 100% 0);
+  }
+
+  .emotion-cell:hover::after,
+  .emotion-cell:hover::before,
+  .emotion-cell:focus-visible::after,
+  .emotion-cell:focus-visible::before,
+  .emotion-cell[data-active='true']::after,
+  .emotion-cell[data-active='true']::before {
+    opacity: 1;
+    transform: translate(-50%, -2px) scale(1);
   }
 
   @media (max-width: 420px) {


### PR DESCRIPTION
## Summary
- align the emotion heatmap to start with the first recorded week instead of showing empty months
- add tooltip metadata to emotion cells and manage active state for hover/touch interactions
- style heatmap cells as interactive buttons with custom tooltip visuals for desktop and mobile

## Testing
- pnpm --filter web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e632500b9c8322bba1634ca1565099