### PR TITLE
Fix emotion chart tooltips to show correct dates

### DIFF
--- a/apps/web/src/components/dashboard-v3/EmotionTimeline.tsx
+++ b/apps/web/src/components/dashboard-v3/EmotionTimeline.tsx
@@ -139,6 +139,13 @@ function parseAnyDate(value: unknown): Date | null {
     return Number.isNaN(date.getTime()) ? null : date;
   }
 
+  const extendedIsoMatch = /^([0-9]{4}-[0-9]{2}-[0-9]{2})(?:[T\s]|$)/.exec(str);
+  if (extendedIsoMatch) {
+    const [y, m, d] = extendedIsoMatch[1].split('-').map((part) => Number(part));
+    const date = new Date(y, m - 1, d);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
   const esMatch = /^([0-9]{2})\/([0-9]{2})\/([0-9]{4})$/.exec(str);
   if (esMatch) {
     const [, d, m, y] = esMatch;

--- a/apps/web/src/components/dashboard/EmotionChartCard.tsx
+++ b/apps/web/src/components/dashboard/EmotionChartCard.tsx
@@ -108,6 +108,13 @@ function parseAnyDate(value: unknown): Date | null {
     return new Date(y, m - 1, d, 0, 0, 0, 0);
   }
 
+  const isoDateMatch = raw.match(/^(\d{4}-\d{2}-\d{2})(?:[T\s]|$)/);
+  if (isoDateMatch) {
+    const [y, m, d] = isoDateMatch[1].split('-').map((part) => parseInt(part, 10));
+    if (!y || !m || !d) return null;
+    return new Date(y, m - 1, d, 0, 0, 0, 0);
+  }
+
   if (/^\d{2}\/\d{2}\/\d{4}$/.test(raw)) {
     const [d, m, y] = raw.split('/').map((part) => parseInt(part, 10));
     if (!y || !m || !d) return null;


### PR DESCRIPTION
## Summary
- ensure ISO formatted emotion log dates with timezones are parsed into the correct calendar day in the dashboard emotion chart
- align the legacy dashboard emotion timeline parser with the same ISO date handling so both tooltips reflect real dates

## Testing
- npm run typecheck:web

------
https://chatgpt.com/codex/tasks/task_e_68e636efba208322b56cef4a3198a028