### PR TITLE
Improve EmotionTimeline heatmap responsiveness

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -62,27 +62,32 @@
 
 @layer components {
   .emotion-grid--weekcols {
+    --emotion-cell-size: var(--cell-size, var(--cell, 14px));
+    --emotion-cell-gap: var(--cell-gap, 8px);
     display: grid;
     grid-auto-flow: column;
-    gap: 8px;
-    padding: 16px 20px;
+    grid-auto-columns: var(--emotion-cell-size);
+    justify-content: center;
+    gap: var(--emotion-cell-gap);
+    padding: clamp(12px, 4vw, 16px) clamp(14px, 5vw, 20px);
     border-radius: 20px;
     background: linear-gradient(145deg, rgba(15, 33, 66, 0.65), rgba(16, 23, 45, 0.35));
+    transition: padding 0.2s ease;
   }
 
   .emotion-col {
     display: grid;
-    grid-template-rows: repeat(7, 14px);
-    gap: 8px;
+    grid-template-rows: repeat(7, var(--emotion-cell-size));
+    gap: var(--emotion-cell-gap);
   }
 
   .emotion-cell {
     position: relative;
-    width: 14px;
-    height: 14px;
+    width: var(--emotion-cell-size);
+    height: var(--emotion-cell-size);
     border: none;
     padding: 0;
-    border-radius: 5px;
+    border-radius: clamp(3px, calc(var(--emotion-cell-size) * 0.35), 6px);
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
     cursor: pointer;
     background: transparent;
@@ -146,20 +151,7 @@
 
   @media (max-width: 420px) {
     .emotion-grid--weekcols {
-      gap: 6px;
-      padding: 12px 14px;
       border-radius: 16px;
-    }
-
-    .emotion-col {
-      grid-template-rows: repeat(7, 10px);
-      gap: 4px;
-    }
-
-    .emotion-cell {
-      width: 10px;
-      height: 10px;
-      border-radius: 3px;
     }
   }
 }


### PR DESCRIPTION
## Summary
- compute dynamic cell sizing for the EmotionTimeline heatmap so it adapts responsively to the available width
- expose the calculated dimensions to the grid via CSS variables and center the layout with consistent gaps
- refresh the heatmap styles to keep spacing uniform across rows and columns while supporting smaller viewports

## Testing
- pnpm --filter web lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e65d6b1e288322acaae26bb300cbb5