### PR TITLE
Adjust emotion timeline layout for extended months

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -81,17 +81,19 @@
 
 @layer components {
   .emotion-grid--weekcols {
-    --emotion-cell-size: var(--cell-size, var(--cell, 14px));
-    --emotion-cell-gap: var(--cell-gap, 8px);
-    display: grid;
+    --emotion-cell-size: var(--cell-size, var(--cell, 12px));
+    --emotion-cell-gap: var(--cell-gap, 6px);
+    display: inline-grid;
     grid-auto-flow: column;
     grid-auto-columns: var(--emotion-cell-size);
-    justify-content: center;
+    justify-content: flex-start;
+    align-content: flex-start;
     gap: var(--emotion-cell-gap);
-    padding: clamp(12px, 4vw, 16px) clamp(14px, 5vw, 20px);
+    padding: clamp(10px, 3.5vw, 16px) clamp(12px, 4vw, 18px);
     border-radius: 20px;
     background: linear-gradient(145deg, rgba(15, 33, 66, 0.65), rgba(16, 23, 45, 0.35));
     transition: padding 0.2s ease;
+    width: max(100%, var(--grid-width, 0px));
   }
 
   .emotion-col {


### PR DESCRIPTION
## Summary
- extend the emotion timeline window so the first record anchors the view while showing additional future weeks
- update grid sizing logic and expose layout variables so the heatmap remains legible on mobile
- tweak the CSS grid shell to left-align the timeline and support smaller responsive cell dimensions

## Testing
- npm --workspace apps/web run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e66675483c832282433182c005d71d