### PR TITLE
Improve mobile responsiveness for Clerk login experience

### DIFF
--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -22,38 +22,38 @@ export function AuthLayout({
   secondaryActionHref
 }: AuthLayoutProps) {
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#040313] px-4 py-8 text-white sm:px-6 lg:px-12">
+    <div className="relative flex min-h-screen flex-col items-stretch justify-start overflow-hidden bg-[#040313] px-4 py-10 text-white sm:px-6 sm:py-12 lg:flex-row lg:items-center lg:justify-center lg:px-12 lg:py-14">
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.18),transparent_55%),radial-gradient(circle_at_bottom_left,_rgba(14,165,233,0.15),transparent_60%),radial-gradient(circle_at_bottom_right,_rgba(217,70,239,0.1),transparent_65%)]" />
         <div className="absolute -left-24 top-32 h-72 w-72 rounded-full bg-[#a855f7]/30 blur-[140px]" />
         <div className="absolute -right-32 bottom-10 h-80 w-80 rounded-full bg-[#0ea5e9]/30 blur-[160px]" />
       </div>
       <div className="relative z-10 w-full max-w-5xl rounded-[28px] border border-white/10 bg-white/5 p-5 shadow-[0_30px_120px_rgba(15,23,42,0.45)] backdrop-blur-3xl sm:rounded-[32px] sm:p-7 md:p-10">
-        <div className="flex flex-col gap-12 lg:grid lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:gap-16">
-          <div className="flex flex-col justify-between gap-10">
-            <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:gap-16">
+          <div className="flex flex-col justify-between gap-8 lg:gap-10">
+            <div className="flex flex-col gap-5 sm:gap-6">
               {secondaryActionLabel && secondaryActionHref ? (
                 <Link
                   to={secondaryActionHref}
-                  className="inline-flex w-full items-center justify-center rounded-full border border-white/30 px-5 py-2.5 text-sm font-semibold text-white/80 transition-colors duration-200 hover:border-white/50 hover:text-white sm:w-fit"
+                  className="inline-flex w-full items-center justify-center rounded-full border border-white/30 px-4 py-2.5 text-sm font-semibold text-white/80 transition-colors duration-200 hover:border-white/50 hover:text-white sm:w-fit sm:px-5"
                 >
                   {secondaryActionLabel}
                 </Link>
               ) : null}
 
-              <div className="flex items-center justify-center gap-2 text-sm font-semibold uppercase tracking-[0.4em] text-white/60 sm:justify-start">
+              <div className="flex items-center justify-center gap-2 text-xs font-semibold uppercase tracking-[0.4em] text-white/60 sm:text-sm lg:justify-start">
                 <span className="h-2 w-2 rounded-full bg-[#7d3cff]" />
                 Innerbloom
               </div>
 
               <div className="space-y-4 text-balance text-center sm:text-left">
                 {typeof title === 'string' ? (
-                  <h1 className="text-4xl font-semibold leading-tight text-white md:text-5xl">{title}</h1>
+                  <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl md:text-5xl">{title}</h1>
                 ) : (
                   title
                 )}
                 {description ? (
-                  <p className="text-base text-white/70 md:text-lg">{description}</p>
+                  <p className="text-sm text-white/70 sm:text-base md:text-lg">{description}</p>
                 ) : null}
               </div>
             </div>

--- a/apps/web/src/lib/clerkAppearance.ts
+++ b/apps/web/src/lib/clerkAppearance.ts
@@ -23,19 +23,19 @@ const gradientButtonClass =
 const baseElements = {
   rootBox: 'w-full',
   card:
-    'mx-auto flex w-full max-w-[440px] flex-col gap-6 rounded-[28px] border border-white/10 bg-white/5 p-5 shadow-[0_25px_80px_rgba(15,23,42,0.35)] backdrop-blur-2xl sm:p-7 md:p-8',
+    'mx-auto flex w-full max-w-full flex-col gap-6 rounded-[24px] border border-white/10 bg-white/5 p-4 shadow-[0_25px_80px_rgba(15,23,42,0.35)] backdrop-blur-2xl sm:max-w-[440px] sm:rounded-[28px] sm:p-6 md:p-8',
   header: 'hidden',
   socialButtons: 'hidden',
   divider: 'hidden',
   form: 'flex flex-col gap-4 text-left',
   formField: 'flex flex-col gap-2',
-  formFieldLabel: 'text-sm font-medium text-white/80',
+  formFieldLabel: 'text-xs font-medium text-white/75 sm:text-sm',
   formFieldInput:
     'rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/40 shadow-[0_6px_20px_rgba(99,102,241,0.15)] focus:border-white/40 focus:outline-none focus-visible:ring-0',
   formFieldInputShowPasswordButton: 'text-sm text-white/60 hover:text-white',
   formButtonPrimary: gradientButtonClass,
   footer:
-    'mt-6 flex flex-col items-center gap-1 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-center text-xs text-white/60 backdrop-blur-xl shadow-none',
+    'mt-6 flex flex-col items-center gap-1 rounded-2xl border border-white/15 bg-white/10 px-3 py-3 text-center text-xs text-white/60 backdrop-blur-xl shadow-none sm:px-4',
   footerTitle: 'text-white/70',
   footerSubtitle: 'text-white/50',
   footerActionText: 'text-white/50',

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -7,14 +7,14 @@ export default function LoginPage() {
   return (
     <AuthLayout
       title={
-        <div className="flex flex-col items-center gap-2 text-center text-3xl font-semibold uppercase tracking-[0.32em] text-white sm:flex-row sm:items-center sm:justify-start sm:gap-3 sm:text-left sm:text-4xl md:text-5xl">
+        <div className="flex flex-col items-center gap-2 text-center text-2xl font-semibold uppercase tracking-[0.22em] text-white sm:flex-row sm:items-center sm:justify-start sm:gap-3 sm:text-left sm:text-4xl sm:tracking-[0.32em] md:text-5xl">
           dashboard
         </div>
       }
       secondaryActionLabel="Volver al inicio"
       secondaryActionHref="/"
     >
-      <div className="w-full max-w-md mx-auto lg:mx-0">
+      <div className="mx-auto w-full max-w-sm sm:max-w-md lg:mx-0">
         <SignIn
           appearance={createAuthAppearance({
             layout: {


### PR DESCRIPTION
## Summary
- adjust the shared auth layout spacing and typography to prioritize small-screen readability
- expand the Clerk SignIn card styles so the login form fills the viewport width on mobile
- tighten the dashboard login heading tracking to avoid overflow on compact devices

## Testing
- pnpm --filter @innerbloom/web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e668e66f308322ac33d3a22d579279