### PR TITLE
Adjust scheduler alert visibility and order

### DIFF
--- a/apps/api/src/__tests__/dashboard.test.ts
+++ b/apps/api/src/__tests__/dashboard.test.ts
@@ -81,6 +81,7 @@ describeIfReady('Dashboard endpoints', () => {
     expect(response.body).toHaveProperty('first_date_log');
     expect(typeof response.body.days_of_journey).toBe('number');
     expect(typeof response.body.quantity_daily_logs).toBe('number');
+    expect(typeof response.body.first_programmed).toBe('boolean');
   });
 
   it('returns emotion logs', async () => {

--- a/apps/web/src/components/dashboard-v3/Alerts.tsx
+++ b/apps/web/src/components/dashboard-v3/Alerts.tsx
@@ -13,6 +13,8 @@ function shouldShowBbddWarning(journey: UserJourneySummary | null): boolean {
 
 function shouldShowSchedulerWarning(journey: UserJourneySummary | null): boolean {
   if (!journey) return false;
+  if (journey.first_programmed) return false;
+
   const logs = journey.quantity_daily_logs ?? 0;
   const days = journey.days_of_journey ?? 0;
   return logs > 0 && days >= 7;
@@ -34,29 +36,6 @@ export function Alerts({ userId }: AlertsProps) {
 
   return (
     <div className="space-y-4">
-      {showBbdd && (
-        <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm text-amber-100">
-          <div className="flex items-start gap-3">
-            <span className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full bg-amber-300" aria-hidden />
-            <div className="space-y-1">
-              <p className="font-semibold text-white">Confirmá tu base</p>
-              <p className="text-amber-100/80">
-                Abrí el menú y revisá tu base para que podamos generar tu próxima Daily Quest.
-              </p>
-            </div>
-            <a
-              href="/MVP/gamificationweblanding/index-bbdd.html"
-              className="ml-auto inline-flex rounded-full border border-amber-200/50 bg-amber-200/10 px-3 py-1 text-xs font-semibold text-white backdrop-blur"
-            >
-              Editar base
-            </a>
-          </div>
-          <p className="mt-2 text-xs text-amber-100/70">
-            Este aviso desaparece cuando tu registro diario queda confirmado en la nueva app.
-          </p>
-        </div>
-      )}
-
       {showScheduler && (
         <div className="rounded-2xl border border-indigo-400/30 bg-indigo-500/10 p-4 text-sm text-indigo-100">
           <div className="flex items-start gap-3">
@@ -80,6 +59,30 @@ export function Alerts({ userId }: AlertsProps) {
           </p>
         </div>
       )}
+
+      {showBbdd && (
+        <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm text-amber-100">
+          <div className="flex items-start gap-3">
+            <span className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full bg-amber-300" aria-hidden />
+            <div className="space-y-1">
+              <p className="font-semibold text-white">Confirmá tu base</p>
+              <p className="text-amber-100/80">
+                Abrí el menú y revisá tu base para que podamos generar tu próxima Daily Quest.
+              </p>
+            </div>
+            <a
+              href="/MVP/gamificationweblanding/index-bbdd.html"
+              className="ml-auto inline-flex rounded-full border border-amber-200/50 bg-amber-200/10 px-3 py-1 text-xs font-semibold text-white backdrop-blur"
+            >
+              Editar base
+            </a>
+          </div>
+          <p className="mt-2 text-xs text-amber-100/70">
+            Este aviso desaparece cuando tu registro diario queda confirmado en la nueva app.
+          </p>
+        </div>
+      )}
+
     </div>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -670,6 +670,7 @@ export type UserJourneySummary = {
   first_date_log: string | null;
   days_of_journey: number;
   quantity_daily_logs: number;
+  first_programmed: boolean;
 };
 
 export async function getUserJourney(userId: string): Promise<UserJourneySummary> {

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -57,8 +57,8 @@ export default function DashboardV3Page() {
             {!failedToLoadProfile && !isLoadingProfile && backendUserId && (
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-5 lg:grid-cols-12 lg:gap-6">
                 <div className="lg:col-span-12 space-y-4">
-                  <MetricHeader userId={backendUserId} />
                   <Alerts userId={backendUserId} />
+                  <MetricHeader userId={backendUserId} />
                 </div>
 
                 <div className="lg:col-span-7 space-y-4 md:space-y-5">


### PR DESCRIPTION
## Summary
- expose the `first_programmed` flag from the journey endpoint so the dashboard can hide the scheduler notice after first use
- render the Daily Quest scheduler notification before other alerts and move the alerts block above the metric header

## Testing
- pnpm --filter @innerbloom/api test

------
https://chatgpt.com/codex/tasks/task_e_68e66b23968c83229bec854065a621f8