### PR TITLE
docs: map dashboard endpoints to UI modules

### DIFF
--- a/Docs/dashboard-data-sources.md
+++ b/Docs/dashboard-data-sources.md
@@ -1,0 +1,20 @@
+# Mapeo de endpoints → vistas del dashboard
+
+| Endpoint | Vista / Insight | Datos consumidos | Descripción funcional |
+| --- | --- | --- | --- |
+| `GET /users/me` | Hook `useBackendUser` → Navbar + layout general | Perfil (`user_id`, `game_mode`, `weekly_target`, `image_url`) | Determina el identificador interno que usan el resto de llamadas y muestra modo de juego/avatar. |
+| `GET /users/:id/xp/total` + `GET /users/:id/level` | Tarjeta "Progreso general" (V3) · `MetricHeader` | Total de XP, nivel actual, porcentaje y XP faltante | Renderiza los KPIs principales del jugador en la cabecera del dashboard nuevo. |
+| `GET /users/:id/level` (derivado vía `getProgress`) | Tarjeta legacy "Level Progress" · `LevelCard` | Total XP, nivel, XP restante, etiqueta del próximo nivel | Replica el módulo de progreso histórico del MVP en la vista legacy. |
+| `GET /users/:id/xp/daily` | "Daily Cultivation" (V3) · `DailyCultivationSection` | Serie diaria `{ date, xp_day }` | Grafica la tendencia mensual y resume total/promedio de XP por mes. |
+| `GET /users/:id/xp/daily` | Panel de rachas legacy · `LegacyStreaksPanel` | Serie diaria `{ date, xp_day }` | Calcula XP semanal aproximado cuando la API aún no entrega métricas específicas. |
+| `GET /users/:id/xp/daily` | Tarjeta legacy "Streak" · `StreakCard` | Serie diaria `{ date, xp_day }` | Computa `current` y `longest streak` contando días con XP positivo. |
+| `GET /users/:id/streaks/panel` | Panel de rachas V3 · `StreaksPanel` | `topStreaks` y `tasks` con métricas por rango | Alimenta el ranking de misiones consistentes y detalla XP/completitud por semana, mes y trimestre. |
+| `GET /users/:id/tasks` | "Missions" (V3) · `MissionsSection` | Lista de tareas activas (`task`, `pillar_id`, `xp_base`) | Presenta el backlog de misiones hasta que exista un endpoint dedicado a quests. |
+| `GET /users/:id/tasks` | Panel de rachas legacy · `LegacyStreaksPanel` | Lista de tareas activas | Muestra las misiones filtrables por pilar junto al XP base. |
+| `GET /users/:id/daily-energy` | Tarjeta "Daily Energy" (V3) · `EnergyCard` | Porcentajes normalizados de HP, Mood y Focus | Dibuja las barras de energía con el promedio móvil de 7 días. |
+| `GET /users/:id/xp/by-trait` | Tarjeta "Radar Chart" (V3) · `RadarChartCard` | Totales de XP por rasgo/pilar | Calcula el polígono de fuerzas (Body/Mind/Soul) con acumulados por trait. |
+| `GET /users/:id/emotions` | "Emotion Timeline" (V3) · `EmotionChartCard` | Lista `{ date, emotion_id }` | Genera el heatmap y resumen de emociones destacadas en el periodo seleccionado. |
+| `GET /users/:id/emotions` | Heatmap legacy · `EmotionHeatmap` | Lista `{ date, emotion_id }` | Replica la cuadrícula de estados de ánimo usada en el MVP. |
+| `GET /task-logs` | "Recent Activity" · `RecentActivity` | Logs (`taskTitle`, `completedAt`, `xpAwarded`) | Lista las últimas quests completadas con fecha normalizada. |
+| `GET /users/:id/journey` | Banner de alertas (V3) · `Alerts` | `days_of_journey`, `quantity_daily_logs` | Decide si mostrar recordatorios para confirmar base o agendar Daily Quest. |
+| `GET /pillars` | Sección legacy "Pillars" · `PillarsSection` | Catálogo de pilares (`name`, `description`, `focusAreas`) | Carga la información estática de Body · Mind · Soul para la vista histórica. |

--- a/Docs/dashboard-endpoints.md
+++ b/Docs/dashboard-endpoints.md
@@ -1,0 +1,94 @@
+# API del dashboard
+
+Este documento resume los endpoints HTTP que consume el dashboard web (versiones legacy y V3), con el método, los parámetros relevantes y un resumen del payload que espera cada vista.
+
+## Autenticación y perfil
+
+### `GET /users/me`
+* **Uso en frontend:** `useBackendUser` solicita el perfil asociado al usuario de Clerk para obtener el `user_id` interno, modo de juego y target semanal.
+* **Headers:** `X-User-Id` con el identificador de Clerk.
+* **Respuesta principal:** objeto `user` con campos como `user_id`, `game_mode`, `weekly_target`, `full_name`, `image_url` y metadatos (`created_at`, `updated_at`).
+
+## Progreso y XP
+
+### `GET /users/:id/xp/total`
+* **Uso:** Tarjeta "Progreso general" (Dashboard V3) y lógica de nivel legacy, para mostrar el acumulado histórico de XP.
+* **Respuesta:** `{ total_xp: number }`.
+
+### `GET /users/:id/level`
+* **Uso:** Tarjetas de progreso (Metric Header y Level Card). Se combina con `/xp/total` para renderizar nivel actual, porcentaje al siguiente nivel y XP faltante.
+* **Respuesta:** `{ current_level, xp_total, xp_required_current, xp_required_next, xp_to_next, progress_percent }`.
+
+### `GET /users/:id/xp/daily`
+* **Uso:**
+  * Sección "Daily Cultivation" (tendencia mensual de XP).
+  * Panel de rachas (cálculo de XP semanal y métricas por tarea).
+  * Cálculo de rachas legacy (`getStreaks`) y determinación de rango de fechas.
+* **Parámetros:** `from`, `to` (YYYY-MM-DD).
+* **Respuesta:** `{ from, to, series: Array<{ date, xp_day }> }`.
+
+### `GET /users/:id/xp/by-trait`
+* **Uso:** Tarjeta "Radar Chart" para distribuir XP acumulado por rasgo/pilar.
+* **Parámetros:** opcional `from`, `to` para acotar el periodo (no utilizados actualmente).
+* **Respuesta:** `{ traits: Array<{ trait, xp }> }`.
+
+## Energía y estado
+
+### `GET /users/:id/daily-energy`
+* **Uso:** Tarjeta "Daily Energy" muestra el promedio de HP, Mood y Focus.
+* **Respuesta:** `{ hp_pct, mood_pct, focus_pct, hp_norm, mood_norm, focus_norm }`. El frontend usa los porcentajes.
+* **Notas:** Si la API responde 404 se interpreta como "sin datos".
+
+### `GET /users/:id/state`
+* **Uso previsto:** Estructura base para game mode y barras de energía (se consulta desde utilidades, aunque la tarjeta actual usa `/daily-energy`).
+* **Respuesta:** Snapshot con modo (`mode`), objetivo semanal (`weekly_target`), flags de gracia y métricas por pilar (`xp_today`, `xp_obj_day`).
+
+### `GET /users/:id/state/timeseries`
+* **Uso previsto:** Radar histórico de energía (aún no montado en UI V3). Devuelve series diarias por pilar.
+* **Respuesta:** `{ series: Array<{ date, Body, Mind, Soul }> }`.
+
+## Hábitos, tareas y rachas
+
+### `GET /users/:id/tasks`
+* **Uso:**
+  * "Missions" (V3) reutiliza las tareas activas.
+  * Panel de rachas (legacy y nuevo) toma la lista para presentar métricas por misión.
+* **Respuesta:** lista de tareas `{ task_id, task, pillar_id, xp_base, active, ... }`.
+
+### `GET /users/:id/streaks/panel`
+* **Uso:** Panel de rachas V3 (cuando la feature flag está activa) obtiene `topStreaks` y `tasks` con métricas por rango.
+* **Parámetros:** `pillar` (`Body|Mind|Soul`), `range` (`week|month|qtr`), `mode` (tier actual) y `query` opcional.
+* **Respuesta:** `{ topStreaks: Array<{ id, name, stat, weekDone, streakWeeks }>, tasks: Array<{ id, name, metrics: { week, month, qtr } }> }`.
+
+### `GET /users/:id/streaks`
+* **Uso:** Tarjeta legacy "Streak" calcula las rachas a partir de los XP diarios (la API todavía no expone un resumen directo).
+* **Respuesta derivada:** El frontend procesa el `series` devuelto por `/xp/daily` para computar `current` y `longest`.
+
+### `GET /task-logs`
+* **Uso:** Módulo "Recent Activity" lista los últimos completados.
+* **Parámetros:** `userId` obligatorio, `limit` opcional.
+* **Respuesta:** lista de logs con `id`, `taskId`, `taskTitle`, `completedAt/doneAt`, `xpAwarded`.
+
+## Emociones y journey
+
+### `GET /users/:id/emotions`
+* **Uso:**
+  * Tarjeta "Emotion Timeline" (V3) y heatmap legacy.
+  * Se mapea `emotion_id` → etiqueta legible (`Calma`, `Felicidad`, etc.).
+* **Parámetros:** `from`, `to` o `days` (el cliente deriva un rango si solo se pasa `days`).
+* **Respuesta:** `{ emotions: Array<{ date, emotion_id }> }`.
+
+### `GET /users/:id/journey`
+* **Uso:** Banner de alertas (V3) determina si pedir confirmación de base o activar scheduler.
+* **Respuesta:** `{ first_date_log, days_of_journey, quantity_daily_logs }`.
+
+## Catálogos y leaderboard
+
+### `GET /pillars`
+* **Uso:** Sección legacy "Pillars" muestra descripción y foco de cada pilar.
+* **Respuesta:** `{ pillars: Array<{ id, name, description, score, focusAreas }> }`.
+
+### `GET /leaderboard`
+* **Uso previsto:** Rankings sociales (aún no montados en el dashboard actual).
+* **Respuesta:** Lista de usuarios con `userId`, `displayName`, `totalXp`, `rank`.
+


### PR DESCRIPTION
## Summary
- document each backend endpoint consumed by the dashboard and its payloads
- add a matrix that links endpoints to the specific dashboard insights that use them

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68e6691b54ec8322ac4d02b5177f13a8