### PR TITLE
Fix Clerk sign-in responsiveness and API base URL

### DIFF
--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -22,13 +22,13 @@ export function AuthLayout({
   secondaryActionHref
 }: AuthLayoutProps) {
   return (
-    <div className="relative flex min-h-screen min-h-dvh flex-col items-stretch justify-start overflow-hidden bg-[#040313] px-4 pb-[calc(env(safe-area-inset-bottom)+2.5rem)] pt-10 text-white sm:px-6 sm:pb-[calc(env(safe-area-inset-bottom)+3rem)] sm:pt-12 lg:flex-row lg:items-center lg:justify-center lg:px-12 lg:pb-[calc(env(safe-area-inset-bottom)+3.5rem)] lg:pt-14">
+    <div className="relative flex min-h-screen min-h-dvh flex-col items-stretch justify-start overflow-x-hidden overflow-y-auto bg-[#040313] px-4 pb-[calc(env(safe-area-inset-bottom)+2.5rem)] pt-10 text-white sm:px-6 sm:pb-[calc(env(safe-area-inset-bottom)+3rem)] sm:pt-12 lg:flex-row lg:items-center lg:justify-center lg:overflow-hidden lg:px-12 lg:pb-[calc(env(safe-area-inset-bottom)+3.5rem)] lg:pt-14">
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.18),transparent_55%),radial-gradient(circle_at_bottom_left,_rgba(14,165,233,0.15),transparent_60%),radial-gradient(circle_at_bottom_right,_rgba(217,70,239,0.1),transparent_65%)]" />
         <div className="absolute -left-24 top-32 h-72 w-72 rounded-full bg-[#a855f7]/30 blur-[140px]" />
         <div className="absolute -right-32 bottom-10 h-80 w-80 rounded-full bg-[#0ea5e9]/30 blur-[160px]" />
       </div>
-      <div className="relative z-10 w-full max-w-5xl rounded-[28px] border border-white/10 bg-white/5 p-5 shadow-[0_30px_120px_rgba(15,23,42,0.45)] backdrop-blur-3xl sm:rounded-[32px] sm:p-7 md:p-10">
+      <div className="relative z-10 mx-auto w-full min-w-0 max-w-5xl rounded-[28px] border border-white/10 bg-white/5 p-5 shadow-[0_30px_120px_rgba(15,23,42,0.45)] backdrop-blur-3xl sm:rounded-[32px] sm:p-7 md:p-10">
         <div className="flex min-w-0 flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:gap-16">
           <div className="flex flex-col justify-between gap-8 lg:gap-10">
             <div className="flex flex-col gap-5 sm:gap-6">

--- a/apps/web/src/lib/clerkAppearance.ts
+++ b/apps/web/src/lib/clerkAppearance.ts
@@ -2,7 +2,8 @@ import type { Theme } from '@clerk/types';
 
 const baseLayout = {
   logoPlacement: 'none' as const,
-  socialButtonsVariant: 'blockButton' as const
+  socialButtonsVariant: 'blockButton' as const,
+  unsafe_disableDevelopmentModeWarnings: true
 };
 
 const baseVariables = {
@@ -21,9 +22,9 @@ const gradientButtonClass =
   'mt-3 inline-flex h-12 w-full items-center justify-center rounded-full bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#0ea5e9] text-sm font-semibold uppercase tracking-[0.18em] text-white transition-all duration-200 hover:from-[#8b5cf6] hover:to-[#0ea5e9]/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40 sm:w-auto';
 
 const baseElements = {
-  rootBox: 'w-full min-w-0',
+  rootBox: 'w-full min-w-0 max-w-full',
   card:
-    'mx-auto flex w-full min-w-0 max-w-full flex-col gap-6 rounded-[24px] border border-white/10 bg-white/5 p-4 shadow-[0_25px_80px_rgba(15,23,42,0.35)] backdrop-blur-2xl sm:max-w-[440px] sm:rounded-[28px] sm:p-6 md:p-8',
+    'mx-auto flex w-full min-w-0 max-w-full flex-col gap-6 rounded-[24px] border border-white/10 bg-white/5 p-4 shadow-[0_25px_80px_rgba(15,23,42,0.35)] backdrop-blur-2xl sm:max-w-[420px] sm:rounded-[28px] sm:p-6 md:p-8',
   header: 'hidden',
   socialButtons: 'hidden',
   divider: 'hidden',
@@ -31,11 +32,11 @@ const baseElements = {
   formField: 'flex flex-col gap-2',
   formFieldLabel: 'text-xs font-medium text-white/75 sm:text-sm',
   formFieldInput:
-    'rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/40 shadow-[0_6px_20px_rgba(99,102,241,0.15)] focus:border-white/40 focus:outline-none focus-visible:ring-0',
+    'rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-[16px] leading-6 text-white placeholder:text-white/40 shadow-[0_6px_20px_rgba(99,102,241,0.15)] focus:border-white/40 focus:outline-none focus-visible:ring-0',
   formFieldInputShowPasswordButton: 'text-sm text-white/60 hover:text-white',
   formButtonPrimary: gradientButtonClass,
   footer:
-    'mt-6 flex flex-col items-center gap-1 rounded-2xl border border-white/15 bg-white/10 px-3 py-3 text-center text-xs text-white/60 backdrop-blur-xl shadow-none sm:px-4',
+    'mt-6 w-full max-w-full flex flex-col items-center gap-1 rounded-2xl border border-white/15 bg-white/10 px-3 py-3 text-center text-xs text-white/60 backdrop-blur-xl shadow-none sm:px-4',
   footerTitle: 'text-white/70',
   footerSubtitle: 'text-white/50',
   footerActionText: 'text-white/50',

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -14,7 +14,7 @@ export default function LoginPage() {
       secondaryActionLabel="Volver al inicio"
       secondaryActionHref="/"
     >
-      <div className="mx-auto w-full min-w-0 max-w-sm sm:max-w-md lg:mx-0">
+      <div className="mx-auto w-full min-w-0 max-w-[min(100%,420px)] lg:mx-0">
         <SignIn
           appearance={createAuthAppearance({
             layout: {

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -19,7 +19,7 @@ export default function SignUpPage() {
       secondaryActionLabel="Volver al inicio"
       secondaryActionHref="/"
     >
-      <div ref={signUpContainerRef} className="mx-auto w-full min-w-0 max-w-md lg:mx-0">
+      <div ref={signUpContainerRef} className="mx-auto w-full min-w-0 max-w-[min(100%,420px)] lg:mx-0">
         <SignUp
           appearance={createAuthAppearance({
             elements: {

--- a/railway.toml
+++ b/railway.toml
@@ -8,4 +8,4 @@ command = "npm --workspace apps/api run start"
 command = "npm --workspace apps/web run start"
 
   [service.web.env]
-  VITE_API_BASE_URL = "https://web-dev-dfa2.up.railway.app"
+  VITE_API_BASE_URL = "https://innerbloom-api.up.railway.app"


### PR DESCRIPTION
## Summary
- allow the auth layout container to scroll vertically on small screens and keep the glass card constrained without horizontal overflow
- update the shared Clerk appearance so the card stays within the viewport, keeps 16px inputs, and hides the development banner that was stretching the iframe
- point the Railway web service to the real API host so client requests stop hitting the web deployment and returning 502s

## Testing
- `VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy VITE_API_BASE_URL=https://example.com npm --workspace apps/web run build`

## Diagnóstico 502
- Request: `GET https://web-dev-dfa2.up.railway.app/api/health/db` devolvía 502 porque el front consultaba su propio servicio en Railway en lugar del API.
- Fix: `railway.toml` (líneas 7-11) ahora setea `VITE_API_BASE_URL=https://innerbloom-api.up.railway.app`.
- Nota: desde la sandbox las peticiones directas al dominio de Railway devuelven `403 Domain forbidden`, por lo que la validación final debe hacerse desde un origen permitido (por ejemplo, el front desplegado).


------
https://chatgpt.com/codex/tasks/task_e_68e676a51f748322bc74a4abfcdb30a2