### PR TITLE
Increase daily energy bar thickness

### DIFF
--- a/apps/web/src/components/dashboard-v3/EnergyCard.tsx
+++ b/apps/web/src/components/dashboard-v3/EnergyCard.tsx
@@ -116,10 +116,10 @@ function EnergyMeter({ label, percent }: EnergyMeterProps) {
           {clamped}%
         </span>
       </div>
-      <div className="relative h-2.5 w-full overflow-hidden rounded-full border border-white/5 bg-slate-900/40 shadow-[inset_0_1px_1px_rgba(15,23,42,0.45)]">
+      <div className="relative h-5 w-full overflow-hidden rounded-full border border-white/5 bg-slate-900/40 shadow-[inset_0_1px_1px_rgba(15,23,42,0.45)]">
         <div
           className={`${GRADIENTS[label]} h-full rounded-full transition-[width] duration-300 ease-out`}
-          style={{ width: `${width}%`, minWidth: clamped === 0 ? '0.75rem' : undefined }}
+          style={{ width: `${width}%`, minWidth: clamped === 0 ? '1.5rem' : undefined }}
         />
         <div className="absolute inset-y-0 right-1 hidden items-center sm:flex">
           <span className="rounded-full bg-slate-950/90 px-2 py-0.5 text-[11px] font-semibold text-slate-100 shadow-sm">


### PR DESCRIPTION
## Summary
- double the thickness of the Daily Energy progress bars to match the new design
- increase the fallback minimum width for zero values so the doubled bars remain visible when empty

## Testing
- npm -w @innerbloom/web run build

------
https://chatgpt.com/codex/tasks/task_e_68e681f72d308322bff9d7be74598469