### PR TITLE
feat(web): atmospheric light background for dashboard v3 (light mode)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -173,6 +173,11 @@
 
   :root[data-theme='light'] {
     color-scheme: light;
+    --color-dashboard-light-bg:
+      radial-gradient(120% 85% at 10% -12%, rgba(248, 194, 218, 0.35) 0%, rgba(248, 194, 218, 0) 58%),
+      radial-gradient(92% 78% at 86% -6%, rgba(233, 210, 255, 0.32) 0%, rgba(233, 210, 255, 0) 62%),
+      radial-gradient(108% 82% at 52% 115%, rgba(248, 224, 183, 0.22) 0%, rgba(248, 224, 183, 0) 65%),
+      linear-gradient(180deg, #fcf7f2 0%, #f9f6ff 46%, #f5f9ff 100%);
     --color-surface: #f8fafc;
     --color-surface-muted: #f1f5f9;
     --color-surface-elevated: #ffffff;
@@ -272,7 +277,7 @@
   }
 
   :root[data-theme='light'] body {
-    background-image: linear-gradient(180deg, #f8fafc 0%, #f8fafc 100%);
+    background-image: var(--color-dashboard-light-bg);
   }
 
 
@@ -4591,6 +4596,16 @@
   :root[data-theme='light'] [data-light-scope='dashboard-v3'] {
     --color-slate-900-95: rgba(255, 255, 255, 0.96);
     --color-slate-950-80: rgba(241, 245, 255, 0.82);
+    background-image: var(--color-dashboard-light-bg);
+    background-attachment: fixed;
+  }
+
+  :root[data-theme='light'] [data-light-scope='dashboard-v3'] .ib-card-contour-shadow {
+    box-shadow: 0 12px 28px rgba(148, 116, 178, 0.1), 0 3px 10px rgba(15, 23, 42, 0.05);
+  }
+
+  :root[data-theme='light'] [data-light-scope='dashboard-v3'] .rounded-2xl.border {
+    border-color: color-mix(in srgb, var(--color-border-subtle) 82%, #f1dbe9 18%);
   }
 
   :root[data-theme='light'] [data-light-scope='editor'] {


### PR DESCRIPTION
### Motivation
- Dar profundidad y contraste al dashboard en light mode para que las cards blancas “floten” más y el fondo deje de ser blanco/plano.
- Reutilizar la lógica cromática existente de la card “Growth Calibration Results” como referencia para mantener coherencia visual premium y desaturada.
- Aplicar el cambio sólo a light mode sin tocar dark mode ni layout/spacing.

### Description
- Añadí un token semántico `--color-dashboard-light-bg` en `apps/web/src/index.css` con una mezcla blush / lila / crema adaptada a fondo de página en vez de card (radial + linear blends). 
- Apliqué ese token al `body` en light mode y también al scope del dashboard `:root[data-theme='light'] [data-light-scope='dashboard-v3']` para asegurar el efecto específicamente en `DashboardV3`.
- Ajusté muy sutilmente la separación visual en el scope del dashboard aumentando la sombra de contorno de `.ib-card-contour-shadow` y tintando ligeramente `rounded-2xl.border` para mejorar la percepción de floating sin cambiar surfaces blancas internas.
- La paleta de referencia fue extraída de `GrowthCalibrationShelf` en `apps/web/src/components/dashboard-v3/RewardsSection.tsx` (gradiente `from-rose-500/15 via-fuchsia-500/10 to-amber-500/10`) y se adaptó a una versión atmosférica de baja saturación.

### Testing
- Ejecuté el chequeo estático `pnpm -C apps/web run typecheck`, que falló por errores TypeScript preexistentes no relacionados con este cambio (tipados de auth/Clerk, tests/typings en PreviewAchievement y otros); el fallo es heredado y no provocado por la modificación CSS.
- No se modificaron tests unitarios ni de integración en esta PR y no se añadieron nuevos tests automáticos para estilos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90c14c0f88332be908115a681baa5)