### PR TITLE
Adjust desktop Achievements carousel card layout to fit blocked back content

### DIFF
--- a/apps/web/src/components/dashboard-v3/RewardsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/RewardsSection.tsx
@@ -994,7 +994,7 @@ function AchievedShelf({
               <div
                 ref={carouselTrackRef}
                 onScroll={handleCarouselTrackScroll}
-                className="flex snap-x snap-mandatory gap-2.5 overflow-x-auto px-1 pb-1"
+                className="flex snap-x snap-mandatory gap-2.5 overflow-x-auto px-1 pb-1 sm:gap-3 sm:px-2 lg:gap-3.5 lg:px-3"
               >
                 {activePillarHabits.map((habit, index) => {
                   const isFlipped = flippedCarouselHabitId === habit.id && activeCarouselIndex === index;
@@ -1006,7 +1006,7 @@ function AchievedShelf({
                       type="button"
                       data-achievement-carousel-index={index}
                       onClick={() => handleCarouselCardClick(habit.id, index)}
-                      className={`ib-card-contour-shadow relative h-[27.5rem] w-[86%] shrink-0 snap-center overflow-hidden rounded-3xl border p-3.5 text-left transition sm:h-[23rem] sm:w-[22rem] sm:p-5 ${
+                      className={`ib-card-contour-shadow relative h-[27.5rem] w-[86%] shrink-0 snap-center overflow-hidden rounded-3xl border p-3.5 text-left transition sm:h-[24rem] sm:w-[22.5rem] sm:p-4 lg:h-[26rem] lg:w-[24.5rem] lg:p-5 ${
                         isAchieved
                           ? 'border-[color:var(--color-border-soft)] bg-[color:var(--color-surface-elevated)] shadow-[0_16px_30px_rgba(2,8,23,0.14)] dark:shadow-[0_16px_30px_rgba(2,8,23,0.34)]'
                           : 'border-dashed border-[color:var(--color-border-strong)] bg-[color:var(--color-overlay-1)]/82 shadow-[0_12px_24px_rgba(2,8,23,0.1)] dark:border-[color:var(--color-border-subtle)] dark:shadow-[0_12px_24px_rgba(2,8,23,0.22)]'
@@ -1054,12 +1054,12 @@ function AchievedShelf({
                           </p>
                         </div>
                       ) : (
-                        <div className="flex h-full flex-col gap-1 overflow-hidden">
-                          <div className="space-y-0.5">
+                        <div className="flex h-full flex-col gap-1 overflow-hidden sm:gap-0.5">
+                          <div className="space-y-0.5 sm:space-y-0">
                             <p className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-dim)]">
                               {language === 'es' ? 'Logro bloqueado' : 'Achievement locked'}
                             </p>
-                            <h3 className="truncate text-[15px] font-semibold leading-[1.2] text-[color:var(--color-text-strong)]">{habit.taskName}</h3>
+                            <h3 className="text-[15px] font-semibold leading-[1.2] text-[color:var(--color-text-strong)] sm:text-base">{habit.taskName}</h3>
                           </div>
                           <div className="min-h-0 flex-1">
                             <LockedAchievementHabitDevelopment


### PR DESCRIPTION
### Motivation
- Resolver un problema de layout en web/desktop donde el reverso de los *blocked achievements* cortaba el bloque real de `Habit Development` sin cambiar la lógica ni tocar backend/contratos.  
- Priorizar una solución responsive que aumente el área útil de la card en desktop ~20% y preserve el comportamiento de carrusel y la experiencia mobile existente.

### Description
- Incrementé los tamaños y padding del track/carousel para breakpoints `sm` y `lg` añadiendo `sm:gap-3 sm:px-2 lg:gap-3.5 lg:px-3` en el contenedor del track (`carouselTrackRef`).
- Agrandé las cards en breakpoints: mantuve la base mobile (`h-[27.5rem] w-[86%]`), cambié `sm` de `h-[23rem] w-[22rem]` a `h-[24rem] w-[22.5rem]`, y añadí `lg:h-[26rem] lg:w-[24.5rem]` para desktop, dando ~+20% de superficie útil en `lg`.
- Compacté el header del reverso bloqueado para desktop quitando `truncate` y reduciendo espacios (`sm:gap-0.5` y `sm:space-y-0`) para liberar espacio vertical/horizontal al componente reutilizado `LockedAchievementHabitDevelopment` sin introducir scroll interno ni alterar su contenido.
- Todos los cambios son solo de CSS/ Tailwind en `apps/web/src/components/dashboard-v3/RewardsSection.tsx` y no modifican lógica de flip/carrusel/estantes, backend, contratos ni componentes del bloque real.

### Testing
- Ejecuté el chequeo de tipos con `npm run typecheck:web`, que falló por errores TypeScript preexistentes en módulos no relacionados con este cambio.  
- No se modificaron tests unitarios ni lógica de negocio, por lo que el cambio es una actualización quirúrgica de layout en `RewardsSection.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da57d3cddc8332b8ed7d59afa17008)