### PR TITLE
Adjust desktop Achievements carousel proportions for clean 3-card framing

### DIFF
--- a/apps/web/src/components/dashboard-v3/RewardsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/RewardsSection.tsx
@@ -994,7 +994,7 @@ function AchievedShelf({
               <div
                 ref={carouselTrackRef}
                 onScroll={handleCarouselTrackScroll}
-                className="flex snap-x snap-mandatory gap-2.5 overflow-x-auto px-1 pb-1 sm:gap-3 sm:px-2 lg:gap-3.5 lg:px-3"
+                className="flex snap-x snap-mandatory gap-2.5 overflow-x-auto px-1 pb-1 sm:gap-3 sm:px-2 lg:gap-4 lg:px-4 xl:px-5"
               >
                 {activePillarHabits.map((habit, index) => {
                   const isFlipped = flippedCarouselHabitId === habit.id && activeCarouselIndex === index;
@@ -1006,7 +1006,7 @@ function AchievedShelf({
                       type="button"
                       data-achievement-carousel-index={index}
                       onClick={() => handleCarouselCardClick(habit.id, index)}
-                      className={`ib-card-contour-shadow relative h-[27.5rem] w-[86%] shrink-0 snap-center overflow-hidden rounded-3xl border p-3.5 text-left transition sm:h-[24rem] sm:w-[22.5rem] sm:p-4 lg:h-[26rem] lg:w-[24.5rem] lg:p-5 ${
+                      className={`ib-card-contour-shadow relative h-[27.5rem] w-[86%] shrink-0 snap-center overflow-hidden rounded-3xl border p-3.5 text-left transition sm:h-[24rem] sm:w-[22.5rem] sm:p-4 lg:h-[29rem] lg:w-[calc((100%-2rem)/3)] lg:max-w-[25rem] lg:snap-start lg:p-5 xl:h-[30rem] ${
                         isAchieved
                           ? 'border-[color:var(--color-border-soft)] bg-[color:var(--color-surface-elevated)] shadow-[0_16px_30px_rgba(2,8,23,0.14)] dark:shadow-[0_16px_30px_rgba(2,8,23,0.34)]'
                           : 'border-dashed border-[color:var(--color-border-strong)] bg-[color:var(--color-overlay-1)]/82 shadow-[0_12px_24px_rgba(2,8,23,0.1)] dark:border-[color:var(--color-border-subtle)] dark:shadow-[0_12px_24px_rgba(2,8,23,0.22)]'


### PR DESCRIPTION
### Motivation
- Ajustar solo el layout/proporción del carrusel de Achievements en web/desktop para que se lean exactamente 3 cards en el frame y que el reverso bloqueado (Habit Development) tenga altura útil suficiente. 
- Mantener la lógica, comportamiento y experiencia mobile intactos, y coordinar ancho/alto/gap/padding para evitar que la cuarta card asome o quede “casi 3”.

### Description
- Cambié clases del track del carrusel para desktop: `lg:gap-4 lg:px-4 xl:px-5` (antes `lg:gap-3.5 lg:px-3`) para ajustar framing y padding lateral. 
- Aumenté la altura de las cards en desktop a `lg:h-[29rem]` y `xl:h-[30rem]` (antes `lg:h-[26rem]`) para ganar superficie vertical útil y permitir que el blocked back muestre completo Habit Development. 
- Recalibré el ancho desktop a una disposición 3-up con `lg:w-[calc((100%-2rem)/3)]` más `lg:max-w-[25rem]` y `lg:snap-start` para asegurar lectura visual de 3 cards y evitar que se vea “casi 3” o asome la cuarta. 
- Cambios aplicados en `apps/web/src/components/dashboard-v3/RewardsSection.tsx`, sin tocar lógica de negocio ni comportamiento mobile (`sm`/`w-[86%]`/`sm:*` se mantienen). 

### Testing
- Ejecuté `npm run typecheck:web` y el chequeo de TypeScript falló por errores preexistentes en el repo (tipados y tests en otras áreas) no introducidos por este cambio, por lo que no hubo un `tsc --noEmit` limpio en este entorno. 
- No se ejecutaron tests visuales automatizados; la verificación del framing/blocked-back requiere comprobación en navegador (local review recomendado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5eafd2848332b17b0bbda4afdf7e)