### PR TITLE
Align Achievements carousel visuals with Streaks segmented control

### DIFF
--- a/apps/web/src/components/dashboard-v3/RewardsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/RewardsSection.tsx
@@ -21,6 +21,12 @@ import { emitHabitAchievementUpdated } from '../../lib/habitAchievementEvents';
 import { subscribeToMediaQuery } from '../../lib/mediaQuery';
 import { HabitAchievementSeal } from './HabitAchievementSeal';
 import { PreviewAchievementCard } from './PreviewAchievementCard';
+import {
+  DASHBOARD_SEGMENTED_BUTTON_ACTIVE,
+  DASHBOARD_SEGMENTED_BUTTON_BASE,
+  DASHBOARD_SEGMENTED_BUTTON_INACTIVE,
+  DASHBOARD_SEGMENTED_GROUP_BASE,
+} from './segmentedControlStyles';
 
 const REWARDS_PILLAR_ORDER = [
   { code: 'BODY', name: 'Body' },
@@ -196,7 +202,7 @@ export function RewardsSection({
               href="/labs/logros"
               title={language === 'es' ? 'Ver demo guiada de Logros' : 'View guided Achievements demo'}
               aria-label={language === 'es' ? 'Ver demo guiada de Logros' : 'View guided Achievements demo'}
-              className="inline-flex items-center gap-1.5 rounded-full border border-violet-300/45 bg-violet-500/10 px-2.5 py-1 text-xs font-semibold text-violet-100 transition hover:border-violet-200/70 hover:bg-violet-500/16 hover:text-white"
+              className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/55 bg-violet-100/95 px-2.5 py-1 text-xs font-semibold text-violet-700 shadow-[0_4px_12px_rgba(124,58,237,0.16)] transition hover:border-violet-500/60 hover:bg-violet-200/90 hover:text-violet-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-400 disabled:cursor-not-allowed disabled:opacity-45 dark:border-violet-300/50 dark:bg-violet-500/14 dark:text-violet-100 dark:shadow-[0_4px_12px_rgba(124,58,237,0.26)] dark:hover:border-violet-200/75 dark:hover:bg-violet-500/24 dark:hover:text-white"
             >
               <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
               <span>{language === 'es' ? 'Ver guía' : 'View guide'}</span>
@@ -965,7 +971,7 @@ function AchievedShelf({
       {isCarouselView ? (
         <div className="space-y-3">
           <div
-            className="inline-flex w-full rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-1 shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-border-subtle)_62%,transparent)]"
+            className={DASHBOARD_SEGMENTED_GROUP_BASE}
             role="tablist"
             aria-label={language === 'es' ? 'Seleccionar pilar' : 'Select pillar'}
           >
@@ -978,10 +984,10 @@ function AchievedShelf({
                   role="tab"
                   aria-selected={isSelected}
                   onClick={() => setActivePillarCode(pillar.code)}
-                  className={`flex-1 rounded-full px-2 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] transition ${
+                  className={`${DASHBOARD_SEGMENTED_BUTTON_BASE} px-2 py-1.5 tracking-[0.14em] ${
                     isSelected
-                      ? 'border border-violet-300/70 bg-violet-500/85 text-white shadow-[0_6px_18px_rgba(124,58,237,0.35)] dark:border-violet-300/55 dark:bg-violet-500/35 dark:text-violet-50'
-                      : 'text-[color:var(--color-text-dim)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text)]'
+                      ? DASHBOARD_SEGMENTED_BUTTON_ACTIVE
+                      : DASHBOARD_SEGMENTED_BUTTON_INACTIVE
                   }`}
                 >
                   {pillarChipLabels[pillar.code]}
@@ -1013,32 +1019,36 @@ function AchievedShelf({
                       }`}
                     >
                       {!isFlipped ? (
-                        <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+                        <div className="relative flex h-full flex-col text-center">
                           {!isAchieved ? (
-                            <span className="rounded-full border border-amber-300/55 bg-amber-200/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-900 dark:border-[color:var(--color-border-subtle)] dark:bg-[color:var(--color-overlay-1)] dark:text-[color:var(--color-text-dim)]">
+                            <span className="absolute right-0 top-0 z-20 rounded-full border border-amber-300/65 bg-amber-200/90 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-900 shadow-[0_8px_18px_rgba(180,83,9,0.24)] dark:border-amber-300/35 dark:bg-[color:var(--color-overlay-1)] dark:text-[color:var(--color-text-dim)]">
                               {language === 'es' ? 'Bloqueado' : 'Locked'}
                             </span>
                           ) : null}
-                          <HabitAchievementSeal
-                            pillar={habit.pillar ?? activePillarCode}
-                            traitCode={habit.trait?.code}
-                            traitName={habit.trait?.name}
-                            alt={`${habit.taskName} seal`}
-                            disabled={!isAchieved}
-                            className={`h-44 min-h-44 w-44 min-w-44 overflow-hidden rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] shadow-[0_20px_50px_rgba(0,0,0,0.24)] ${isAchieved ? '' : 'opacity-55'}`}
-                            imgClassName="h-full w-full object-cover"
-                            fallback={(
-                              <span className="text-5xl font-semibold leading-none text-[color:var(--color-text-muted)]">
-                                {isAchieved ? (habit.seal.visible ? '🏅' : slotLabel) : slotLabel}
-                              </span>
-                            )}
-                          />
-                          <p className="text-lg font-semibold text-[color:var(--color-text-strong)]">{habit.taskName}</p>
-                          <p className="text-sm text-[color:var(--color-text-muted)]">
-                            {language === 'es'
-                              ? 'Toca para ver más'
-                              : 'Tap to see more'}
-                          </p>
+                          <div className="flex min-h-0 flex-1 items-start justify-center pt-1 sm:pt-2">
+                            <HabitAchievementSeal
+                              pillar={habit.pillar ?? activePillarCode}
+                              traitCode={habit.trait?.code}
+                              traitName={habit.trait?.name}
+                              alt={`${habit.taskName} seal`}
+                              disabled={!isAchieved}
+                              className={`h-[17rem] min-h-[17rem] w-[17rem] min-w-[17rem] overflow-hidden rounded-[2rem] border border-transparent bg-transparent shadow-none sm:h-[15.5rem] sm:min-h-[15.5rem] sm:w-[15.5rem] sm:min-w-[15.5rem] lg:h-[16.8rem] lg:min-h-[16.8rem] lg:w-[16.8rem] lg:min-w-[16.8rem] ${isAchieved ? '' : 'opacity-55'}`}
+                              imgClassName="h-full w-full object-contain drop-shadow-[0_22px_26px_rgba(15,23,42,0.22)]"
+                              fallback={(
+                                <span className="text-6xl font-semibold leading-none text-[color:var(--color-text-muted)] sm:text-7xl">
+                                  {isAchieved ? (habit.seal.visible ? '🏅' : slotLabel) : slotLabel}
+                                </span>
+                              )}
+                            />
+                          </div>
+                          <div className="mt-auto space-y-1.5 pb-1">
+                            <p className="text-lg font-semibold text-[color:var(--color-text-strong)]">{habit.taskName}</p>
+                            <p className="text-sm text-[color:var(--color-text-muted)]">
+                              {language === 'es'
+                                ? 'Toca para ver más'
+                                : 'Tap to see more'}
+                            </p>
+                          </div>
                         </div>
                       ) : isAchieved ? (
                         <div className="flex h-full flex-col gap-3 overflow-hidden">

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
@@ -19,6 +19,12 @@ import { TaskInsightsModal } from './StreakTaskInsightsModal';
 import { DashboardMeta, DashboardTitle } from './DashboardTypography';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
 import { HABIT_ACHIEVEMENT_UPDATED_EVENT } from '../../lib/habitAchievementEvents';
+import {
+  DASHBOARD_SEGMENTED_BUTTON_ACTIVE,
+  DASHBOARD_SEGMENTED_BUTTON_BASE,
+  DASHBOARD_SEGMENTED_BUTTON_INACTIVE,
+  DASHBOARD_SEGMENTED_GROUP_BASE,
+} from './segmentedControlStyles';
 
 export const FEATURE_STREAKS_PANEL_V1 = false;
 
@@ -330,12 +336,6 @@ const MODE_CHIP_STYLES: Record<Mode, { glowPrimary: string; glowSecondary: strin
       'ib-streak-mode-chip__inner ib-streak-mode-chip__inner--evolve gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]',
   },
 };
-
-const TAB_BUTTON_BASE =
-  'flex-1 inline-flex items-center justify-center gap-1 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300 md:text-xs';
-
-const TAB_GROUP_BASE =
-  'inline-flex w-full items-center justify-between gap-1 rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-1 shadow-[var(--shadow-elev-1)]';
 
 function normalizeMode(mode?: string | null): Mode {
   return normalizeGameModeValue(mode) ?? 'Flow';
@@ -904,30 +904,30 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, forceLoadingTasks
         <div className="flex flex-col gap-4">
           <div data-demo-anchor="streaks-top" className="space-y-4">
             <div className="flex items-center justify-center">
-            <div className={cx(TAB_GROUP_BASE, 'max-w-[320px]')}>
-              {PILLAR_TABS.map((tab) => {
-                const isActive = pillar === tab.value;
-                return (
-                  <button
-                    key={tab.value}
-                    type="button"
-                    onClick={() => setPillar(tab.value)}
-                    className={cx(
-                      TAB_BUTTON_BASE,
-                      'leading-none',
-                      isActive
-                        ? 'ib-streak-pill-tab-active border-[color:var(--color-border-soft)] bg-[color:var(--color-surface)] text-[color:var(--color-accent-primary)] shadow-[var(--shadow-elev-1)] dark:border-white/90 dark:bg-white dark:text-black'
-                        : 'border-transparent bg-transparent text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]',
-                    )}
-                    aria-pressed={isActive}
-                  >
-                    <span aria-hidden>{tab.icon}</span>
-                    {tab.label}
-                  </button>
-                );
-              })}
+              <div className={cx(DASHBOARD_SEGMENTED_GROUP_BASE, 'max-w-[320px]')}>
+                {PILLAR_TABS.map((tab) => {
+                  const isActive = pillar === tab.value;
+                  return (
+                    <button
+                      key={tab.value}
+                      type="button"
+                      onClick={() => setPillar(tab.value)}
+                      className={cx(
+                        DASHBOARD_SEGMENTED_BUTTON_BASE,
+                        'leading-none',
+                        isActive
+                          ? DASHBOARD_SEGMENTED_BUTTON_ACTIVE
+                          : DASHBOARD_SEGMENTED_BUTTON_INACTIVE,
+                      )}
+                      aria-pressed={isActive}
+                    >
+                      <span aria-hidden>{tab.icon}</span>
+                      {tab.label}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-          </div>
 
           {isError && (
             <p className="text-sm text-rose-300">
@@ -978,7 +978,7 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, forceLoadingTasks
               placement="top"
               className="flex flex-wrap items-center justify-center gap-2"
             >
-              <div className={cx(TAB_GROUP_BASE, 'max-w-[220px]')}>
+              <div className={cx(DASHBOARD_SEGMENTED_GROUP_BASE, 'max-w-[220px]')}>
                 {rangeTabs.map((tab) => {
                   const isActive = range === tab.value;
                   return (
@@ -987,11 +987,11 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, forceLoadingTasks
                       type="button"
                       onClick={() => setRange(tab.value)}
                       className={cx(
-                        TAB_BUTTON_BASE,
+                        DASHBOARD_SEGMENTED_BUTTON_BASE,
                         'leading-none',
                         isActive
-                          ? 'ib-streak-pill-tab-active border-[color:var(--color-border-soft)] bg-[color:var(--color-surface)] text-[color:var(--color-accent-primary)] shadow-[var(--shadow-elev-1)] dark:border-white/90 dark:bg-white dark:text-black'
-                          : 'border-transparent bg-transparent text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]',
+                          ? DASHBOARD_SEGMENTED_BUTTON_ACTIVE
+                          : DASHBOARD_SEGMENTED_BUTTON_INACTIVE,
                       )}
                       aria-pressed={isActive}
                     >

--- a/apps/web/src/components/dashboard-v3/segmentedControlStyles.ts
+++ b/apps/web/src/components/dashboard-v3/segmentedControlStyles.ts
@@ -1,0 +1,11 @@
+export const DASHBOARD_SEGMENTED_GROUP_BASE =
+  'inline-flex w-full items-center justify-between gap-1 rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-1 shadow-[var(--shadow-elev-1)]';
+
+export const DASHBOARD_SEGMENTED_BUTTON_BASE =
+  'flex-1 inline-flex items-center justify-center gap-1 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300 md:text-xs';
+
+export const DASHBOARD_SEGMENTED_BUTTON_ACTIVE =
+  'ib-streak-pill-tab-active border-[color:var(--color-border-soft)] bg-[color:var(--color-surface)] text-[color:var(--color-accent-primary)] shadow-[var(--shadow-elev-1)] dark:border-white/90 dark:bg-white dark:text-black';
+
+export const DASHBOARD_SEGMENTED_BUTTON_INACTIVE =
+  'border-transparent bg-transparent text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]';


### PR DESCRIPTION
### Motivation
- Unificar visualmente el selector Body/Mind/Soul y el tratamiento de las cards de Logros con el sistema ya usado en `Streaks`, evitando parches aislados.
- Mejorar la legibilidad y contraste del botón `View guide / Ver guía` en light/dark sin elevar su jerarquía visual.
- Hacer que el sello de logro sea protagonista en las cards y mover el chip `Locked/Bloqueado` a una superposición real en la esquina superior derecha.

### Description
- Extraje una base compartida de estilos de segmented control a `apps/web/src/components/dashboard-v3/segmentedControlStyles.ts` (`DASHBOARD_SEGMENTED_GROUP_BASE`, `DASHBOARD_SEGMENTED_BUTTON_BASE`, `DASHBOARD_SEGMENTED_BUTTON_ACTIVE`, `DASHBOARD_SEGMENTED_BUTTON_INACTIVE`) y la importé desde `StreaksPanel.tsx` y `RewardsSection.tsx` para garantizar comportamiento/estados idénticos entre ambos módulos.
- Reemplacé el selector del carrusel de Achievements para usar las clases/tokens compartidos, manteniendo labels/comportamiento y soportando light/dark tal cual Streaks.
- Mejoré el estilo del botón `View guide / Ver guía` en `RewardsSection.tsx` para aumentar contraste, añadir sombras y estados `hover`/`focus`/`disabled` coherentes en ambos modos.
- Refactoricé la composición frontal de las cards del carrusel en `RewardsSection.tsx` para agrandar significativamente el sello (`HabitAchievementSeal`), reducir la visibilidad del contenedor circular, mover el chip `Locked/Bloqueado` a `absolute` top-right con `z-index` y reajustar el balance vertical (imagen arriba, título anclado abajo).
- Archivos modificados: `apps/web/src/components/dashboard-v3/segmentedControlStyles.ts` (nuevo), `apps/web/src/components/dashboard-v3/StreaksPanel.tsx`, `apps/web/src/components/dashboard-v3/RewardsSection.tsx`.

### Testing
- Ejecuté `npm run typecheck:web` y el proceso falló por errores TypeScript preexistentes no relacionados con estos cambios (errores en `auth/clerk` y tipos de `PreviewAchievement`), por lo que no hay una verificación de tipo limpia completa en este entorno.
- No se añadieron tests automatizados; los cambios son visuales/CLASSES-only y requieren verificación visual en la app (mobile + desktop, light/dark) en integración.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da64957d2483329f383417892d1ea3)