### PR TITLE
Rebuild /labs/logros guided tour on top of carousel achievements UI

### DIFF
--- a/apps/web/src/components/dashboard-v3/RewardsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/RewardsSection.tsx
@@ -47,10 +47,17 @@ interface RewardsSectionProps {
   mockPreviewAchievementByTaskId?: Record<string, NonNullable<TaskInsightsResponse['previewAchievement']>>;
   demoAnchors?: {
     shelves?: string;
+    carouselStructure?: string;
+    pillarSelector?: string;
+    carouselTrack?: string;
     achievedCard?: string;
     achievedCardTaskId?: string;
+    achievedCardFront?: string;
+    achievedCardBack?: string;
     blockedCard?: string;
     blockedCardTaskId?: string;
+    blockedCardFront?: string;
+    blockedCardBack?: string;
     sealPath?: string;
     achievementFront?: string;
     achievementBack?: string;
@@ -60,6 +67,7 @@ interface RewardsSectionProps {
   };
   demoConfig?: {
     disableRemote?: boolean;
+    forceAchievementsViewMode?: AchievementViewMode;
     mockPreviewAchievementByTaskId?: Record<string, NonNullable<TaskInsightsResponse['previewAchievement']>>;
     anchors?: RewardsSectionProps['demoAnchors'];
     controls?: {
@@ -70,8 +78,11 @@ interface RewardsSectionProps {
 }
 
 export type RewardsSectionDemoControls = {
+  selectPillar: (pillarCode: 'BODY' | 'MIND' | 'SOUL') => void;
+  focusCarouselCard: (taskId: string) => void;
   openAchievedCard: () => void;
   openBlockedCard: () => void;
+  focusBlockedCarouselCard: () => void;
   focusBlockedShelfCard: () => void;
   flipAchievementCard: () => void;
   ensureAchievementBackFace: () => void;
@@ -93,6 +104,7 @@ export function RewardsSection({
 }: RewardsSectionProps) {
   const { language } = usePostLoginLanguage();
   const resolvedDisableRemote = demoConfig?.disableRemote ?? disableRemote;
+  const forcedAchievementsViewMode = demoConfig?.forceAchievementsViewMode;
   const resolvedMockPreviewAchievementByTaskId = demoConfig?.mockPreviewAchievementByTaskId ?? mockPreviewAchievementByTaskId;
   const resolvedDemoAnchors = demoConfig?.anchors ?? demoAnchors;
 
@@ -105,6 +117,10 @@ export function RewardsSection({
   const [achievementsViewMode, setAchievementsViewMode] = useState<AchievementViewMode>('shelves');
 
   useEffect(() => {
+    if (forcedAchievementsViewMode) {
+      setAchievementsViewMode(forcedAchievementsViewMode);
+      return;
+    }
     if (typeof window === 'undefined') {
       return;
     }
@@ -112,15 +128,19 @@ export function RewardsSection({
     if (savedMode === 'carousel' || savedMode === 'shelves') {
       setAchievementsViewMode(savedMode);
     }
-  }, []);
+  }, [forcedAchievementsViewMode]);
 
   const handleChangeAchievementsViewMode = useCallback((nextMode: AchievementViewMode) => {
+    if (forcedAchievementsViewMode) {
+      setAchievementsViewMode(forcedAchievementsViewMode);
+      return;
+    }
     setAchievementsViewMode(nextMode);
     if (typeof window === 'undefined') {
       return;
     }
     window.localStorage.setItem(REWARDS_VIEW_MODE_STORAGE_KEY, nextMode);
-  }, []);
+  }, [forcedAchievementsViewMode]);
 
   const { data, status, error, reload } = useRequest(() => getRewardsHistory(userId), [userId], {
     enabled: !resolvedDisableRemote && Boolean(userId),
@@ -217,6 +237,9 @@ export function RewardsSection({
               { id: 'carousel', label: language === 'es' ? 'Carrusel' : 'Carousel' },
               { id: 'shelves', label: language === 'es' ? 'Estantes' : 'Shelves' },
             ] as const).map((option) => {
+              if (forcedAchievementsViewMode && option.id !== forcedAchievementsViewMode) {
+                return null;
+              }
               const isSelected = achievementsViewMode === option.id;
               return (
                 <button
@@ -226,6 +249,7 @@ export function RewardsSection({
                   aria-selected={isSelected}
                   tabIndex={isSelected ? 0 : -1}
                   onClick={() => handleChangeAchievementsViewMode(option.id)}
+                  disabled={Boolean(forcedAchievementsViewMode)}
                   className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
                     isSelected
                       ? 'border border-violet-300/70 bg-violet-500/85 text-white shadow-[0_6px_18px_rgba(124,58,237,0.35)] dark:border-violet-300/55 dark:bg-violet-500/35 dark:text-violet-50'
@@ -788,6 +812,7 @@ function AchievedShelf({
   const resolvedBlockedTaskId = demoAnchors?.blockedCardTaskId;
   const isShelfFocusStep = demoStepId === 'logros-shelves';
   const isDemoExperience = Boolean(demoStepId);
+  const isCarouselView = viewMode === 'carousel';
 
   useEffect(() => {
     if (viewMode !== 'shelves') {
@@ -830,7 +855,59 @@ function AchievedShelf({
     }
   }, []);
 
+  const scrollCarouselToIndex = useCallback((targetIndex: number) => {
+    const track = carouselTrackRef.current;
+    if (!track) {
+      return;
+    }
+    const clampedIndex = Math.max(0, Math.min(targetIndex, Math.max(activePillarHabits.length - 1, 0)));
+    const targetCard = track.querySelector<HTMLElement>(`[data-achievement-carousel-index="${clampedIndex}"]`);
+    if (!targetCard) {
+      return;
+    }
+    if (typeof targetCard.scrollIntoView === 'function') {
+      targetCard.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', inline: 'center', block: 'nearest' });
+    }
+    setActiveCarouselIndex(clampedIndex);
+  }, [activePillarHabits.length, carouselTrackRef, prefersReducedMotion, setActiveCarouselIndex]);
+
+  const resolveHabitLocationByTaskId = useCallback((taskId: string) => {
+    for (const group of normalizedGroups) {
+      const habitIndex = group.habits.findIndex((habit) => habit.taskId === taskId);
+      if (habitIndex >= 0) {
+        return {
+          pillarCode: (group.pillar.code?.toUpperCase() ?? 'BODY') as (typeof REWARDS_PILLAR_ORDER)[number]['code'],
+          index: habitIndex,
+          habit: group.habits[habitIndex],
+        };
+      }
+    }
+    return null;
+  }, [normalizedGroups]);
+
+  const focusCarouselCardByTaskId = useCallback((taskId: string) => {
+    const location = resolveHabitLocationByTaskId(taskId);
+    if (!location) {
+      return;
+    }
+    setActiveHabitId(null);
+    setPreviewHabit(null);
+    setShowBackFace(false);
+    setFlippedCarouselHabitId(null);
+    setActivePillarCode(location.pillarCode);
+    window.setTimeout(() => {
+      scrollCarouselToIndex(location.index);
+    }, 40);
+  }, [resolveHabitLocationByTaskId, scrollCarouselToIndex]);
+
   const openAchievedCard = useCallback(() => {
+    if (isCarouselView) {
+      if (!resolvedAchievedTaskId) {
+        return;
+      }
+      focusCarouselCardByTaskId(resolvedAchievedTaskId);
+      return;
+    }
     const target = normalizedGroups
       .flatMap((group) => group.habits)
       .find((habit) => habit.taskId === resolvedAchievedTaskId && habit.status !== 'not_achieved');
@@ -840,9 +917,30 @@ function AchievedShelf({
     setPreviewHabit(null);
     setShowBackFace(false);
     setActiveHabitId(target.id);
-  }, [normalizedGroups, resolvedAchievedTaskId]);
+  }, [focusCarouselCardByTaskId, isCarouselView, normalizedGroups, resolvedAchievedTaskId]);
 
   const openBlockedCard = useCallback(() => {
+    if (isCarouselView) {
+      if (!resolvedBlockedTaskId) {
+        return;
+      }
+      const location = resolveHabitLocationByTaskId(resolvedBlockedTaskId);
+      if (!location) {
+        return;
+      }
+      setActiveHabitId(null);
+      setShowBackFace(false);
+      setPreviewHabit(null);
+      setFlippedCarouselHabitId(null);
+      setActivePillarCode(location.pillarCode);
+      window.setTimeout(() => {
+        scrollCarouselToIndex(location.index);
+        window.setTimeout(() => {
+          setFlippedCarouselHabitId(location.habit.id);
+        }, prefersReducedMotion ? 0 : 120);
+      }, 40);
+      return;
+    }
     const target = normalizedGroups
       .flatMap((group) => group.habits)
       .find((habit) => habit.taskId === resolvedBlockedTaskId && habit.status === 'not_achieved');
@@ -852,14 +950,55 @@ function AchievedShelf({
     setActiveHabitId(null);
     setShowBackFace(false);
     setPreviewHabit(target);
-  }, [normalizedGroups, resolvedBlockedTaskId]);
+  }, [
+    isCarouselView,
+    normalizedGroups,
+    prefersReducedMotion,
+    resolveHabitLocationByTaskId,
+    resolvedBlockedTaskId,
+    scrollCarouselToIndex,
+  ]);
 
   useEffect(() => {
     onDemoControlsReady?.({
+      selectPillar: (pillarCode) => {
+        setActiveHabitId(null);
+        setPreviewHabit(null);
+        setShowBackFace(false);
+        setFlippedCarouselHabitId(null);
+        setActivePillarCode(pillarCode);
+        window.setTimeout(() => {
+          scrollCarouselToIndex(0);
+        }, 40);
+      },
+      focusCarouselCard: (taskId) => {
+        focusCarouselCardByTaskId(taskId);
+      },
       openAchievedCard,
       openBlockedCard,
+      focusBlockedCarouselCard: () => {
+        if (!resolvedBlockedTaskId) {
+          return;
+        }
+        focusCarouselCardByTaskId(resolvedBlockedTaskId);
+      },
       focusBlockedShelfCard,
       flipAchievementCard: () => {
+        if (isCarouselView) {
+          if (!resolvedAchievedTaskId) {
+            return;
+          }
+          const location = resolveHabitLocationByTaskId(resolvedAchievedTaskId);
+          if (!location) {
+            return;
+          }
+          setActivePillarCode(location.pillarCode);
+          scrollCarouselToIndex(location.index);
+          window.setTimeout(() => {
+            setFlippedCarouselHabitId((current) => (current === location.habit.id ? null : location.habit.id));
+          }, prefersReducedMotion ? 0 : 120);
+          return;
+        }
         if (activeHabitId) {
           setShowBackFace((current) => !current);
           return;
@@ -870,6 +1009,21 @@ function AchievedShelf({
         }, 80);
       },
       ensureAchievementBackFace: () => {
+        if (isCarouselView) {
+          if (!resolvedAchievedTaskId) {
+            return;
+          }
+          const location = resolveHabitLocationByTaskId(resolvedAchievedTaskId);
+          if (!location) {
+            return;
+          }
+          setActivePillarCode(location.pillarCode);
+          scrollCarouselToIndex(location.index);
+          window.setTimeout(() => {
+            setFlippedCarouselHabitId(location.habit.id);
+          }, prefersReducedMotion ? 0 : 120);
+          return;
+        }
         if (activeHabitId) {
           setShowBackFace(true);
           return;
@@ -888,31 +1042,29 @@ function AchievedShelf({
         setActiveHabitId(null);
         setShowBackFace(false);
         setPreviewHabit(null);
+        setFlippedCarouselHabitId(null);
       },
     });
-  }, [activeHabitId, focusBlockedShelfCard, onDemoControlsReady, openAchievedCard, openBlockedCard]);
+  }, [
+    activeHabitId,
+    focusBlockedShelfCard,
+    focusCarouselCardByTaskId,
+    isCarouselView,
+    onDemoControlsReady,
+    openAchievedCard,
+    openBlockedCard,
+    prefersReducedMotion,
+    resolveHabitLocationByTaskId,
+    resolvedAchievedTaskId,
+    resolvedBlockedTaskId,
+    scrollCarouselToIndex,
+  ]);
 
   const getSealBadge = (habit: HabitAchievementShelfItem) => {
     const pillarCode = (habit.pillar ?? 'X').slice(0, 1).toUpperCase();
     const traitCode = habit.trait?.code?.slice(0, 3).toUpperCase() ?? '---';
     return `${pillarCode}-${traitCode}`;
   };
-
-  const scrollCarouselToIndex = useCallback((targetIndex: number) => {
-    const track = carouselTrackRef.current;
-    if (!track) {
-      return;
-    }
-    const clampedIndex = Math.max(0, Math.min(targetIndex, Math.max(activePillarHabits.length - 1, 0)));
-    const targetCard = track.querySelector<HTMLElement>(`[data-achievement-carousel-index="${clampedIndex}"]`);
-    if (!targetCard) {
-      return;
-    }
-    if (typeof targetCard.scrollIntoView === 'function') {
-      targetCard.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', inline: 'center', block: 'nearest' });
-    }
-    setActiveCarouselIndex(clampedIndex);
-  }, [activePillarHabits.length, carouselTrackRef, prefersReducedMotion, setActiveCarouselIndex]);
 
   const handleCarouselCardClick = useCallback((habitId: string, index: number) => {
     if (index !== activeCarouselIndex) {
@@ -935,7 +1087,6 @@ function AchievedShelf({
     }
   }, [onToggleMaintained]);
 
-  const isCarouselView = viewMode === 'carousel';
   const pillarChipLabels: Record<(typeof REWARDS_PILLAR_ORDER)[number]['code'], string> = {
     BODY: language === 'es' ? 'Cuerpo' : 'Body',
     MIND: language === 'es' ? 'Mente' : 'Mind',
@@ -969,11 +1120,12 @@ function AchievedShelf({
         </div>
       ) : null}
       {isCarouselView ? (
-        <div className="space-y-3">
+        <div className="space-y-3" data-demo-anchor={demoAnchors?.carouselStructure}>
           <div
             className={DASHBOARD_SEGMENTED_GROUP_BASE}
             role="tablist"
             aria-label={language === 'es' ? 'Seleccionar pilar' : 'Select pillar'}
+            data-demo-anchor={demoAnchors?.pillarSelector}
           >
             {REWARDS_PILLAR_ORDER.map((pillar) => {
               const isSelected = activePillarCode === pillar.code;
@@ -1001,6 +1153,7 @@ function AchievedShelf({
                 ref={carouselTrackRef}
                 onScroll={handleCarouselTrackScroll}
                 className="flex snap-x snap-mandatory gap-2.5 overflow-x-auto px-1 pb-1 sm:gap-3 sm:px-2 lg:gap-4 lg:px-4 xl:px-5"
+                data-demo-anchor={demoAnchors?.carouselTrack}
               >
                 {activePillarHabits.map((habit, index) => {
                   const isFlipped = flippedCarouselHabitId === habit.id && activeCarouselIndex === index;
@@ -1011,6 +1164,13 @@ function AchievedShelf({
                       key={habit.id}
                       type="button"
                       data-achievement-carousel-index={index}
+                      data-demo-anchor={
+                        demoAnchors?.achievedCardTaskId === habit.taskId
+                          ? demoAnchors?.achievedCard
+                          : demoAnchors?.blockedCardTaskId === habit.taskId
+                            ? demoAnchors?.blockedCard
+                            : undefined
+                      }
                       onClick={() => handleCarouselCardClick(habit.id, index)}
                       className={`ib-card-contour-shadow relative h-[27.5rem] w-[86%] shrink-0 snap-center overflow-hidden rounded-3xl border p-3.5 text-left transition sm:h-[24rem] sm:w-[22.5rem] sm:p-4 lg:h-[29rem] lg:w-[calc((100%-2rem)/3)] lg:max-w-[25rem] lg:snap-start lg:p-5 xl:h-[30rem] ${
                         isAchieved
@@ -1019,7 +1179,16 @@ function AchievedShelf({
                       }`}
                     >
                       {!isFlipped ? (
-                        <div className="relative flex h-full flex-col text-center">
+                        <div
+                          className="relative flex h-full flex-col text-center"
+                          data-demo-anchor={
+                            demoAnchors?.achievedCardTaskId === habit.taskId
+                              ? demoAnchors?.achievedCardFront
+                              : demoAnchors?.blockedCardTaskId === habit.taskId
+                                ? demoAnchors?.blockedCardFront
+                                : undefined
+                          }
+                        >
                           {!isAchieved ? (
                             <span className="absolute right-0 top-0 z-20 rounded-full border border-amber-300/65 bg-amber-200/90 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-900 shadow-[0_8px_18px_rgba(180,83,9,0.24)] dark:border-amber-300/35 dark:bg-[color:var(--color-overlay-1)] dark:text-[color:var(--color-text-dim)]">
                               {language === 'es' ? 'Bloqueado' : 'Locked'}
@@ -1051,7 +1220,10 @@ function AchievedShelf({
                           </div>
                         </div>
                       ) : isAchieved ? (
-                        <div className="flex h-full flex-col gap-3 overflow-hidden">
+                        <div
+                          className="flex h-full flex-col gap-3 overflow-hidden"
+                          data-demo-anchor={demoAnchors?.achievedCardBack}
+                        >
                           <AchievedHabitBackContent
                             habit={habit}
                             language={language}
@@ -1064,7 +1236,10 @@ function AchievedShelf({
                           </p>
                         </div>
                       ) : (
-                        <div className="flex h-full flex-col gap-1 overflow-hidden sm:gap-0.5">
+                        <div
+                          className="flex h-full flex-col gap-1 overflow-hidden sm:gap-0.5"
+                          data-demo-anchor={demoAnchors?.blockedCardBack}
+                        >
                           <div className="space-y-0.5 sm:space-y-0">
                             <p className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-dim)]">
                               {language === 'es' ? 'Logro bloqueado' : 'Achievement locked'}

--- a/apps/web/src/config/labsLogrosGuidedTour.ts
+++ b/apps/web/src/config/labsLogrosGuidedTour.ts
@@ -14,9 +14,9 @@ export const LABS_LOGROS_GUIDED_STEPS: GuidedStep[] = [
   },
   {
     id: 'logros-shelves',
-    targetSelector: '[data-demo-anchor="logros-shelves-pillars"]',
+    targetSelector: '[data-demo-anchor="logros-carousel-structure"]',
     tooltipPlacement: 'top',
-    title: { es: 'Estantes de Logros', en: 'Achievement shelves' },
+    title: { es: 'Estructura en carrusel', en: 'Carousel structure' },
     body: {
       es: 'Se divide en Cuerpo, Mente y Alma. Cada tarea puede convertirse en un sello: algunas ya están logradas y otras siguen en camino.',
       en: 'It is divided into Body, Mind, and Soul. Every task can become a seal: some are achieved and others are still in progress.',
@@ -34,7 +34,7 @@ export const LABS_LOGROS_GUIDED_STEPS: GuidedStep[] = [
   },
   {
     id: 'logros-achievement-front',
-    targetSelector: '[data-demo-anchor="logros-achievement-front"]',
+    targetSelector: '[data-demo-anchor="logros-achieved-card-front"]',
     tooltipPlacement: 'top',
     title: { es: 'Vista frontal', en: 'Front face' },
     body: {
@@ -44,7 +44,7 @@ export const LABS_LOGROS_GUIDED_STEPS: GuidedStep[] = [
   },
   {
     id: 'logros-achievement-back',
-    targetSelector: '[data-demo-anchor="logros-achievement-card"]',
+    targetSelector: '[data-demo-anchor="logros-achieved-card-back"]',
     tooltipPlacement: 'right',
     title: { es: 'Reverso del logro', en: 'Achievement back side' },
     body: {
@@ -64,7 +64,7 @@ export const LABS_LOGROS_GUIDED_STEPS: GuidedStep[] = [
   },
   {
     id: 'logros-seal-path',
-    targetSelector: '[data-demo-anchor="logros-seal-path"]',
+    targetSelector: '[data-demo-anchor="logros-blocked-card-back"]',
     tooltipPlacement: 'top',
     title: { es: 'Ruta del sello', en: 'Seal path' },
     body: {
@@ -74,7 +74,7 @@ export const LABS_LOGROS_GUIDED_STEPS: GuidedStep[] = [
   },
   {
     id: 'logros-seal-concept',
-    targetSelector: '[data-demo-anchor="logros-seal-path"]',
+    targetSelector: '[data-demo-anchor="logros-blocked-card-back"]',
     tooltipPlacement: 'top',
     title: { es: 'Cómo se consolida', en: 'How consolidation works' },
     body: {
@@ -84,7 +84,7 @@ export const LABS_LOGROS_GUIDED_STEPS: GuidedStep[] = [
   },
   {
     id: 'logros-seal-score',
-    targetSelector: '[data-demo-anchor="logros-seal-path"] [data-tour-anchor="achievement-preview-overview"]',
+    targetSelector: '[data-demo-anchor="logros-blocked-card-back"] [data-tour-anchor="achievement-preview-overview"]',
     tooltipPlacement: 'left',
     title: { es: 'Score', en: 'Score' },
     body: {
@@ -94,7 +94,7 @@ export const LABS_LOGROS_GUIDED_STEPS: GuidedStep[] = [
   },
   {
     id: 'logros-seal-scale',
-    targetSelector: '[data-demo-anchor="logros-seal-path"] [data-tour-anchor="achievement-preview-scale"]',
+    targetSelector: '[data-demo-anchor="logros-blocked-card-back"] [data-tour-anchor="achievement-preview-scale"]',
     tooltipPlacement: 'top',
     title: { es: 'Escala de solidez', en: 'Strength scale' },
     body: {
@@ -104,7 +104,7 @@ export const LABS_LOGROS_GUIDED_STEPS: GuidedStep[] = [
   },
   {
     id: 'logros-seal-months',
-    targetSelector: '[data-demo-anchor="logros-seal-path"] [data-tour-anchor="achievement-preview-months-section"]',
+    targetSelector: '[data-demo-anchor="logros-blocked-card-back"] [data-tour-anchor="achievement-preview-months-section"]',
     tooltipPlacement: 'top',
     title: { es: 'Últimos meses', en: 'Recent months' },
     body: {

--- a/apps/web/src/pages/labs/LogrosDemoPage.tsx
+++ b/apps/web/src/pages/labs/LogrosDemoPage.tsx
@@ -7,10 +7,17 @@ import { demoLogrosData, demoLogrosPreviewByTaskId } from '../../data/demoLogros
 
 const DEMO_ANCHORS = {
   shelves: 'logros-shelves',
+  carouselStructure: 'logros-carousel-structure',
+  pillarSelector: 'logros-pillar-selector',
+  carouselTrack: 'logros-carousel-track',
   achievedCard: 'logros-achieved-card',
   achievedCardTaskId: 'task-dinner-before-22',
+  achievedCardFront: 'logros-achieved-card-front',
+  achievedCardBack: 'logros-achieved-card-back',
   blockedCard: 'logros-blocked-card',
   blockedCardTaskId: 'task-gym',
+  blockedCardFront: 'logros-blocked-card-front',
+  blockedCardBack: 'logros-blocked-card-back',
   sealPath: 'logros-seal-path',
   achievementFront: 'logros-achievement-front',
   achievementBack: 'logros-achievement-back',
@@ -29,6 +36,7 @@ export default function LabsLogrosDemoPage() {
   const demoConfig = useMemo(
     () => ({
       disableRemote: true,
+      forceAchievementsViewMode: 'carousel' as const,
       mockPreviewAchievementByTaskId: demoLogrosPreviewByTaskId,
       anchors: DEMO_ANCHORS,
       controls: {
@@ -43,7 +51,14 @@ export default function LabsLogrosDemoPage() {
     const controls = demoControlsRef.current;
 
     if (stepId === 'logros-shelves') {
-      controls?.focusBlockedShelfCard();
+      controls?.selectPillar('BODY');
+      controls?.focusCarouselCard(DEMO_ANCHORS.achievedCardTaskId);
+      return;
+    }
+
+    if (stepId === 'logros-achieved-card') {
+      controls?.selectPillar('BODY');
+      controls?.focusCarouselCard(DEMO_ANCHORS.achievedCardTaskId);
       return;
     }
 
@@ -66,7 +81,7 @@ export default function LabsLogrosDemoPage() {
 
     if (stepId === 'logros-blocked-card') {
       controls?.closeAllOverlays();
-      controls?.focusBlockedShelfCard();
+      controls?.focusBlockedCarouselCard();
       return;
     }
 


### PR DESCRIPTION
### Motivation
- The existing labs Logros walkthrough was broken by the UI migration from shelves to a carousel, leaving steps 1–11 without meaningful focus targets. 
- The goal is to restore the original 14-step narrative while running on the real carousel UI, mobile-first, and without changing production behavior except for the labs demo activation.

### Description
- Forced carousel-only demo mode via a new `demoConfig.forceAchievementsViewMode` option so `/labs/logros` runs against the real carousel while leaving default product behavior unchanged.  
- Added carousel-oriented demo controls to `RewardsSection`: `selectPillar`, `focusCarouselCard`, `focusBlockedCarouselCard`, plus stable flip/open helpers and a `taskId -> pillar+index` resolver with `scrollCarouselToIndex` to reliably center cards.  
- Added and wired new demo anchors for the carousel structure and card fronts/backs (`logros-carousel-structure`, `logros-pillar-selector`, `logros-carousel-track`, `logros-achieved-card-front/back`, `logros-blocked-card-front/back`) and retargeted guided step selectors to these anchors.  
- Updated labs orchestration to rebuild steps 1/14–11/14 on top of the carousel (select pillar, center intended card, open/flip achieved & blocked cards), while keeping steps 12–14 (weekly/monthly/end) intact.  
- Files changed: `apps/web/src/components/dashboard-v3/RewardsSection.tsx`, `apps/web/src/pages/labs/LogrosDemoPage.tsx`, `apps/web/src/config/labsLogrosGuidedTour.ts`.

### Testing
- `npm --workspace apps/web run build` completed successfully and produced a working web build.  
- `npm run typecheck:web` still fails due to pre-existing unrelated type errors in other areas of the repo and did not indicate any new walkthrough-specific type failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6ba151bc83328b2922a0ff420191)