### PR TITLE
Add legal docs for store readiness

### DIFF
--- a/Docs/legal/legal-publishing-checklist.md
+++ b/Docs/legal/legal-publishing-checklist.md
@@ -1,0 +1,87 @@
+# Innerbloom Legal Publishing Checklist
+
+This checklist is the operational reference for publishing Innerbloom’s legal and support pages before App Store and Play Store submission.
+
+## 1. Files created
+
+- `Docs/legal/privacy-policy.md`
+- `Docs/legal/terms-of-service.md`
+- `Docs/legal/support.md`
+- `Docs/legal/legal-publishing-checklist.md`
+
+## 2. Public pages to publish on the landing website
+
+These documents should be exposed as public website routes:
+
+- `/privacy`
+- `/terms`
+- `/support`
+
+## 3. Required manual replacement before publishing
+
+Replace this placeholder in the legal documents:
+
+- **[FULL LEGAL NAME OF THE OPERATOR]**
+
+Files where it appears:
+
+- `Docs/legal/privacy-policy.md`
+- `Docs/legal/terms-of-service.md`
+
+## 4. Confirmed policy and publishing assumptions
+
+These points were treated as confirmed when preparing the documents:
+
+- operator type: **individual / natural person**
+- jurisdiction / country: **Spain**
+- minimum age: **16+**
+- governing law for Terms: **Spain**
+- privacy contact: **privacy@innerbloomjourney.org**
+- support contact: **support@innerbloomjourney.org**
+- GA4 on web: **yes**
+- reminder / transactional emails in production: **yes**
+- ads: **no**
+- push notifications: **yes**
+- local notifications: **yes**
+
+## 5. What still needs implementation in the product/site
+
+### Website / landing
+
+- create public pages for `/privacy`, `/terms`, and `/support`
+- add footer links to those pages in the landing
+- optionally add those URLs to the public sitemap
+
+### Product / onboarding
+
+Recommended next step after publishing the pages:
+
+- add a required acceptance checkbox at sign-up or onboarding start
+- link to `/terms` and `/privacy`
+- store acceptance timestamp and policy version if possible
+
+Suggested text:
+
+> I agree to the Terms of Service and acknowledge the Privacy Policy.
+
+## 6. Store-facing use
+
+These URLs are intended to be used for:
+
+- Apple App Store Connect Privacy Policy URL
+- Apple Support URL
+- Google Play Privacy Policy URL
+- general reviewer-facing public legal/support references
+
+## 7. Practical recommendation
+
+For this B1 release, prioritize:
+
+1. publish the three public web pages
+2. verify they are publicly accessible without auth
+3. use those URLs in App Store Connect and Play Console
+4. then implement in-product consent flow
+
+---
+
+This checklist is meant to keep the legal publishing work operational and focused, not to replace legal advice.

--- a/Docs/legal/privacy-policy.md
+++ b/Docs/legal/privacy-policy.md
@@ -1,0 +1,204 @@
+# Innerbloom Privacy Policy
+
+**Last updated:** 2026-04-11
+
+Innerbloom (“**Innerbloom**,” “**we**,” “**us**,” or “**our**”) provides an adaptive habit-building experience that helps users organize routines, complete guided daily actions, track progress, and reflect on emotional patterns over time.
+
+This Privacy Policy explains what information we collect, how we use it, when we share it, and the choices available to users.
+
+> Before publishing, replace this placeholder wherever it appears:
+>
+> **[FULL LEGAL NAME OF THE OPERATOR]**
+
+## 1. Who operates Innerbloom
+
+Innerbloom is operated by **[FULL LEGAL NAME OF THE OPERATOR]**, an individual based in Spain.
+
+Service name: **Innerbloom**
+
+Website: **https://innerbloomjourney.org**
+
+API domain used by the product: **https://apiv2.innerbloomjourney.org**
+
+Contact emails:
+
+- Privacy: **privacy@innerbloomjourney.org**
+- Support: **support@innerbloomjourney.org**
+
+## 2. Information we collect
+
+Depending on how you use Innerbloom, we may collect and process the following categories of information.
+
+### a. Account and profile information
+
+We may collect:
+
+- email address
+- first name
+- last name
+- full name
+- profile image URL
+- authentication provider user ID
+
+We use this information to create and manage accounts, authenticate users, and provide access to the service.
+
+### b. Habit, onboarding, and journey information
+
+We may collect:
+
+- onboarding responses
+- selected rhythm, mode, or preference settings
+- task and habit configuration
+- task completion history
+- missions, streaks, rewards, and progress signals
+- daily reflections or emotional check-in data
+- reminder preferences
+- timezone settings
+
+We use this information to personalize the experience, generate plans, adapt tasks, display progress, and improve how the product responds to each user’s journey.
+
+### c. Device, technical, and usage information
+
+We may collect:
+
+- basic technical request data needed to operate the service
+- app interaction events
+- diagnostics and product telemetry
+- analytics data on the web experience
+
+We use this information to maintain the service, diagnose issues, understand usage patterns, and improve the product.
+
+### d. Notifications and communications
+
+We may collect:
+
+- push notification preferences
+- local notification settings
+- email delivery metadata related to reminders or transactional emails
+- communications sent to our support or privacy email addresses
+
+We use this information to deliver reminders, service communications, account-related notifications, and support responses.
+
+## 3. How we use information
+
+We may use personal information to:
+
+- authenticate users and secure accounts
+- create and maintain a personalized habit journey
+- deliver tasks, daily quests, reminders, and progress insights
+- display emotional and habit patterns over time
+- provide support and troubleshoot issues
+- measure usage and improve the product
+- send essential service, account, reminder, or transactional communications
+- comply with legal obligations and enforce our terms
+
+## 4. Legal bases
+
+Depending on the user’s location, our legal bases for processing may include:
+
+- performance of a contract
+- legitimate interests in operating, securing, and improving the service
+- user consent, where required
+- compliance with legal obligations
+
+## 5. Analytics, cookies, and tracking
+
+Innerbloom uses **Google Analytics 4 (GA4)** on the web experience.
+
+Where required by law, analytics are activated only after the user gives consent through the website’s cookie settings flow. Users can later change that choice through the website’s cookie controls, where available.
+
+Innerbloom does **not** serve third-party advertising in the product at this stage.
+
+## 6. Notifications
+
+Innerbloom may use:
+
+- push notifications
+- local notifications
+- transactional emails
+- reminder emails
+
+These are used to support core product functionality such as reminders, account-related events, and service communications.
+
+## 7. Sharing of information
+
+We may share information with service providers that help us operate the service, such as providers used for:
+
+- authentication
+- hosting and infrastructure
+- email delivery and email receiving
+- payments and billing, if applicable
+- analytics
+
+We do not sell personal information to advertisers.
+
+## 8. Third-party providers and processors
+
+Based on the current product setup, Innerbloom may rely on third-party providers such as:
+
+- **Clerk** for authentication
+- **Resend** for email delivery and related email operations
+- hosting and infrastructure providers used to run the product
+- **Google Analytics 4** for analytics on the web experience
+- payment providers, if subscriptions or billing features are enabled
+
+This list may change over time as the service evolves.
+
+## 9. Data retention
+
+We retain personal information only for as long as reasonably necessary to:
+
+- provide the service
+- maintain account and product functionality
+- comply with legal obligations
+- resolve disputes
+- enforce agreements
+
+## 10. Data security
+
+We use reasonable technical and organizational safeguards designed to protect personal information. However, no system can guarantee absolute security.
+
+## 11. International data transfers
+
+Your information may be processed in countries other than your own, depending on where our service providers operate. When applicable, we take reasonable steps intended to provide appropriate safeguards for such transfers.
+
+## 12. Your rights
+
+Depending on your location, you may have the right to:
+
+- access personal information we hold about you
+- request correction of inaccurate information
+- request deletion of your information
+- object to or restrict certain processing
+- withdraw consent where processing depends on consent
+
+To exercise privacy rights, contact: **privacy@innerbloomjourney.org**
+
+## 13. Children
+
+Innerbloom is not directed to children under **16 years of age**.
+
+If you believe that a child has provided personal information in violation of this policy, contact us at **privacy@innerbloomjourney.org**.
+
+## 14. Account deletion
+
+If you want to delete your account, use the deletion flow made available in the product or follow the instructions published on the Innerbloom account deletion page.
+
+If you need help with deletion or another privacy request, contact:
+
+- **support@innerbloomjourney.org**
+- **privacy@innerbloomjourney.org**
+
+## 15. Changes to this Privacy Policy
+
+We may update this Privacy Policy from time to time. When we do, we will update the “Last updated” date above. If a change is materially significant, we may provide additional notice where appropriate.
+
+## 16. Contact
+
+Privacy inquiries: **privacy@innerbloomjourney.org**
+
+Support inquiries: **support@innerbloomjourney.org**
+
+---
+
+This document is intended as an operational publishing draft for Innerbloom and should be reviewed before final public release.

--- a/Docs/legal/support.md
+++ b/Docs/legal/support.md
@@ -1,0 +1,51 @@
+# Innerbloom Support
+
+If you need help with Innerbloom, you can contact us through the channels below.
+
+## 1. General support
+
+Email: **support@innerbloomjourney.org**
+
+Use this contact for:
+
+- account issues
+- login problems
+- billing questions
+- subscription questions
+- bug reports
+- general product support
+
+## 2. Privacy requests
+
+Email: **privacy@innerbloomjourney.org**
+
+Use this contact for:
+
+- privacy questions
+- personal data access requests
+- correction requests
+- deletion-related privacy requests
+- data protection concerns
+
+## 3. What to include when contacting support
+
+To help us review your request faster, include as much of the following as possible:
+
+- the email address used for your Innerbloom account
+- the device you are using
+- whether you are on iPhone, Android, or web
+- the steps that caused the issue
+- screenshots, if relevant
+- the approximate time the issue happened
+
+## 4. Response expectations
+
+We aim to respond as soon as reasonably possible, but response times may vary depending on request type and support volume.
+
+## 5. Website
+
+Official website: **https://innerbloomjourney.org**
+
+---
+
+This document is intended as an operational publishing draft for Innerbloom and can be used as the base content for the public `/support` page.

--- a/Docs/legal/terms-of-service.md
+++ b/Docs/legal/terms-of-service.md
@@ -1,0 +1,144 @@
+# Innerbloom Terms of Service
+
+**Last updated:** 2026-04-11
+
+These Terms of Service (“**Terms**”) govern your access to and use of Innerbloom, including the website, mobile applications, and related services (collectively, the “**Service**”).
+
+By creating an account, accessing, or using Innerbloom, you agree to these Terms.
+
+> Before publishing, replace this placeholder wherever it appears:
+>
+> **[FULL LEGAL NAME OF THE OPERATOR]**
+
+## 1. Operator
+
+Innerbloom is operated by **[FULL LEGAL NAME OF THE OPERATOR]**, an individual based in Spain.
+
+Contact:
+
+- Support: **support@innerbloomjourney.org**
+- Privacy: **privacy@innerbloomjourney.org**
+
+## 2. Eligibility
+
+You may use the Service only if:
+
+- you can form a binding agreement under applicable law, and
+- you are at least **16 years old**, or the minimum age required by the laws that apply to you.
+
+## 3. The Service
+
+Innerbloom is an adaptive habit and self-organization product that may include onboarding flows, tasks, routines, emotional reflections, progress systems, reminders, and related features.
+
+We may update, modify, improve, suspend, or discontinue parts of the Service from time to time.
+
+## 4. Accounts
+
+To use certain features, you may need to create an account.
+
+You agree to:
+
+- provide accurate information
+- keep your login credentials secure
+- notify us if you believe your account has been accessed without authorization
+- remain responsible for activity that occurs under your account, unless prohibited by law
+
+## 5. Acceptable use
+
+You agree not to:
+
+- use the Service for unlawful, fraudulent, or abusive purposes
+- interfere with or disrupt the Service
+- attempt to gain unauthorized access to systems or accounts
+- copy, reverse engineer, scrape, or exploit the Service except as allowed by law
+- upload or transmit malicious code
+- use the Service to harass, harm, or violate the rights of others
+
+We may suspend or terminate access if we reasonably believe you have violated these Terms or created risk for the Service or other users.
+
+## 6. User content and data
+
+You may submit information to the Service, including onboarding responses, habit data, progress records, reflections, or other inputs (“**User Content**”).
+
+You retain ownership of your User Content. However, you grant us the rights reasonably necessary to host, process, store, reproduce, adapt, and display that content for the purpose of operating, maintaining, and improving the Service.
+
+You are responsible for ensuring that you have the rights needed to submit any content you provide.
+
+## 7. Privacy
+
+Our handling of personal information is described in the **Privacy Policy**. By using the Service, you acknowledge that your information may be processed as described there.
+
+## 8. Subscriptions, billing, and paid features
+
+Certain features of Innerbloom may be offered on a paid basis, including subscriptions or premium access.
+
+If paid features are offered:
+
+- pricing, billing terms, and renewal mechanics will be shown before purchase
+- you authorize the applicable payment provider to charge the selected payment method
+- fees are generally non-refundable except where required by law or expressly stated otherwise
+
+If mobile in-app purchases are later introduced, those purchases may also be subject to Apple App Store or Google Play billing terms.
+
+## 9. No medical, psychological, therapeutic, legal, or financial advice
+
+Innerbloom is intended for general informational, organizational, motivational, and habit-building purposes.
+
+Innerbloom is **not** a medical device and does **not** provide medical, psychiatric, psychological, therapeutic, legal, financial, or other professional advice. The Service is not intended to diagnose, treat, cure, or prevent any disease or condition.
+
+You should seek qualified professional advice for medical, mental health, legal, financial, or other professional matters.
+
+## 10. Availability and changes
+
+We do not guarantee that the Service will always be available, uninterrupted, secure, or error-free.
+
+We may change the Service, including features, designs, eligibility, pricing, or availability, at any time.
+
+## 11. Intellectual property
+
+The Service, including its software, branding, visual design, text, graphics, interfaces, and related materials, is owned by or licensed to Innerbloom and is protected by intellectual property laws.
+
+Except for the limited right to use the Service under these Terms, no rights are granted to you.
+
+## 12. Termination
+
+You may stop using the Service at any time.
+
+We may suspend or terminate your access if:
+
+- you violate these Terms
+- we are required to do so by law
+- continued access creates legal, security, or operational risk
+- we discontinue the Service
+
+## 13. Disclaimers
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, THE SERVICE IS PROVIDED ON AN “AS IS” AND “AS AVAILABLE” BASIS.
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
+
+## 14. Limitation of liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, INNERBLOOM AND ITS OPERATOR, AFFILIATES, SERVICE PROVIDERS, AND LICENSORS WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, REVENUE, DATA, GOODWILL, OR BUSINESS OPPORTUNITY, ARISING OUT OF OR RELATED TO YOUR USE OF THE SERVICE.
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, OUR TOTAL LIABILITY FOR CLAIMS ARISING OUT OF OR RELATED TO THE SERVICE WILL NOT EXCEED THE AMOUNT YOU PAID US FOR THE SERVICE IN THE 12 MONTHS BEFORE THE CLAIM AROSE, OR EUR 100 IF YOU HAVE NOT PAID US ANYTHING, UNLESS APPLICABLE LAW REQUIRES OTHERWISE.
+
+Some jurisdictions do not allow certain limitations, so parts of this section may not apply to you.
+
+## 15. Governing law
+
+These Terms are governed by the laws of **Spain**, without regard to conflict of law principles, except where mandatory law in your jurisdiction requires otherwise.
+
+## 16. Changes to these Terms
+
+We may update these Terms from time to time. When we do, we will update the “Last updated” date above. Continued use of the Service after updated Terms become effective means you agree to the updated Terms, to the extent permitted by law.
+
+## 17. Contact
+
+Support: **support@innerbloomjourney.org**
+
+Privacy: **privacy@innerbloomjourney.org**
+
+---
+
+This document is intended as an operational publishing draft for Innerbloom and should be reviewed before final public release.


### PR DESCRIPTION
This PR adds the initial public legal/support document drafts needed for App Store and Play Store readiness.

Included:
- Docs/legal/privacy-policy.md
- Docs/legal/terms-of-service.md
- Docs/legal/support.md
- Docs/legal/legal-publishing-checklist.md

Notes:
- The placeholder `[FULL LEGAL NAME OF THE OPERATOR]` intentionally remains in the privacy and terms documents and should be replaced before final public publishing.
- These docs are intended to be the source of truth for the next step: implementing `/privacy`, `/terms`, and `/support` in the landing app.