### PR TITLE
Unify Logros demo language using post-login language and localized demo factories

### DIFF
--- a/apps/web/src/data/demoLogrosData.ts
+++ b/apps/web/src/data/demoLogrosData.ts
@@ -1,3 +1,4 @@
+import type { PostLoginLanguage } from '../i18n/postLoginLanguage';
 import type {
   HabitAchievementShelfItem,
   MonthlyWrappedRecord,
@@ -7,6 +8,10 @@ import type {
 } from '../lib/api';
 
 const DEMO_USER_ID = 'labs-logros-demo';
+
+type DemoTextByLanguage = Record<PostLoginLanguage, string>;
+
+const text = (es: string, en: string): DemoTextByLanguage => ({ es, en });
 
 const createHabit = (input: Partial<HabitAchievementShelfItem> & Pick<HabitAchievementShelfItem, 'id' | 'taskId' | 'taskName' | 'pillar' | 'status'>): HabitAchievementShelfItem => ({
   id: input.id,
@@ -77,204 +82,242 @@ const monthlyWrapups: MonthlyWrappedRecord[] = [
   },
 ];
 
-export const demoLogrosData: RewardsHistorySummary = {
-  weeklyWrapups,
-  weeklyUnseenCount: 0,
-  monthlyWrapups,
+const DEMO_TEXT = {
   growthCalibration: {
-    countdownDays: 22,
-    latestPeriodLabel: '2026-03',
-    summary: { up: 1, keep: 1, down: 1, total: 3 },
-    latestResults: [
-      {
-        taskId: 'task-water',
-        taskTitle: '2L de agua',
-        pillar: 'Body',
-        difficultyBefore: 'easy',
-        difficultyAfter: 'normal',
-        expectedTarget: 5,
-        actualCompletions: 6,
-        completionRatePct: 120,
-        finalAction: 'up',
-        result: 'increased',
-        reason: 'High completion consistency',
-        clampApplied: false,
-        clampReason: null,
-        evaluatedAt: '2026-04-01T00:00:00.000Z',
-        evaluationMonthLabel: '2026-03',
-      },
-      {
-        taskId: 'task-gym',
-        taskTitle: 'Gimnasio',
-        pillar: 'Body',
-        difficultyBefore: 'normal',
-        difficultyAfter: 'normal',
-        expectedTarget: 4,
-        actualCompletions: 4,
-        completionRatePct: 100,
-        finalAction: 'keep',
-        result: 'kept',
-        reason: 'Target met',
-        clampApplied: false,
-        clampReason: null,
-        evaluatedAt: '2026-04-01T00:00:00.000Z',
-        evaluationMonthLabel: '2026-03',
-      },
-      {
-        taskId: 'task-english',
-        taskTitle: 'Hablar en inglés',
-        pillar: 'Mind',
-        difficultyBefore: 'hard',
-        difficultyAfter: 'normal',
-        expectedTarget: 5,
-        actualCompletions: 2,
-        completionRatePct: 40,
-        finalAction: 'down',
-        result: 'decreased',
-        reason: 'Low completion rate',
-        clampApplied: true,
-        clampReason: 'Guardrail: floor reached',
-        evaluatedAt: '2026-04-01T00:00:00.000Z',
-        evaluationMonthLabel: '2026-03',
-      },
-    ],
+    waterTaskTitle: text('2L de agua', '2L of water'),
+    gymTaskTitle: text('Gimnasio', 'Gym'),
+    englishTaskTitle: text('Hablar en inglés', 'Speak English'),
+    highCompletionConsistency: text('Alta consistencia de cumplimiento', 'High completion consistency'),
+    targetMet: text('Meta cumplida', 'Target met'),
+    lowCompletionRate: text('Baja tasa de cumplimiento', 'Low completion rate'),
+    guardrailFloorReached: text('Límite de seguridad: piso alcanzado', 'Guardrail: floor reached'),
   },
-  habitAchievements: {
-    pendingCount: 0,
-    achievedByPillar: [
-      {
-        pillar: { id: 'body', code: 'BODY', name: 'Body' },
-        habits: [
-          createHabit({
-            id: 'habit-water',
-            taskId: 'task-water',
-            taskName: '2L de agua',
-            pillar: 'BODY',
-            trait: { id: 't-hydration', code: 'HYDRATION', name: 'Hidratación' },
-            status: 'stored',
-            achievedAt: '2026-02-10T00:00:00.000Z',
-            gpBeforeAchievement: 168,
-          }),
-          createHabit({
-            id: 'habit-dinner',
-            taskId: 'task-dinner-before-22',
-            taskName: 'Cenar antes de las 22 horas',
-            pillar: 'BODY',
-            // Usamos NUTRITION porque tiene sello existente en /sellos y evita crear assets nuevos.
-            trait: { id: 't-nutrition', code: 'NUTRITION', name: 'Nutrición' },
-            status: 'maintained',
-            maintainEnabled: true,
-            achievedAt: '2026-03-18T00:00:00.000Z',
-            gpBeforeAchievement: 214,
-          }),
-          createHabit({
-            id: 'habit-gym',
-            taskId: 'task-gym',
-            taskName: 'Gimnasio',
-            pillar: 'BODY',
-            trait: { id: 't-strength', code: 'STRENGTH', name: 'Fuerza' },
-            status: 'not_achieved',
-          }),
-          createHabit({
-            id: 'habit-steps',
-            taskId: 'task-steps',
-            taskName: '10.000 pasos',
-            pillar: 'BODY',
-            trait: { id: 't-resistance', code: 'RESISTANCE', name: 'Resistencia' },
-            status: 'not_achieved',
-          }),
-        ],
-      },
-      {
-        pillar: { id: 'mind', code: 'MIND', name: 'Mind' },
-        habits: [
-          createHabit({
-            id: 'habit-english',
-            taskId: 'task-english',
-            taskName: 'Hablar en inglés',
-            pillar: 'MIND',
-            trait: { id: 't-focus', code: 'FOCUS', name: 'Enfoque' },
-            status: 'stored',
-            achievedAt: '2026-01-22T00:00:00.000Z',
-            gpBeforeAchievement: 192,
-          }),
-          createHabit({
-            id: 'habit-project',
-            taskId: 'task-project-60',
-            taskName: '60 min de mi proyecto ongoing',
-            pillar: 'MIND',
-            trait: { id: 't-discipline', code: 'DISCIPLINE', name: 'Disciplina' },
-            status: 'not_achieved',
-          }),
-        ],
-      },
-      {
-        pillar: { id: 'soul', code: 'SOUL', name: 'Soul' },
-        habits: [
-          createHabit({
-            id: 'habit-family-call',
-            taskId: 'task-family-call',
-            taskName: 'Videollamada con la flia',
-            pillar: 'SOUL',
-            trait: { id: 't-connection', code: 'CONNECTION', name: 'Conexión' },
-            status: 'stored',
-            achievedAt: '2026-02-02T00:00:00.000Z',
-            gpBeforeAchievement: 186,
-          }),
-          createHabit({
-            id: 'habit-board-games',
-            taskId: 'task-board-games',
-            taskName: 'Jugar juegos de mesa',
-            pillar: 'SOUL',
-            trait: { id: 't-play', code: 'PLAY', name: 'Juego' },
-            status: 'not_achieved',
-          }),
-        ],
-      },
-    ],
+  habits: {
+    waterTaskName: text('2L de agua', '2L of water'),
+    hydrationTrait: text('Hidratación', 'Hydration'),
+    dinnerTaskName: text('Cenar antes de las 22 horas', 'Eat dinner before 10 PM'),
+    nutritionTrait: text('Nutrición', 'Nutrition'),
+    gymTaskName: text('Gimnasio', 'Gym'),
+    strengthTrait: text('Fuerza', 'Strength'),
+    stepsTaskName: text('10.000 pasos', '10,000 steps'),
+    resistanceTrait: text('Resistencia', 'Endurance'),
+    englishTaskName: text('Hablar en inglés', 'Speak English'),
+    focusTrait: text('Enfoque', 'Focus'),
+    projectTaskName: text('60 min de mi proyecto ongoing', '60 min on my ongoing project'),
+    disciplineTrait: text('Disciplina', 'Discipline'),
+    familyCallTaskName: text('Videollamada con la flia', 'Video call with family'),
+    connectionTrait: text('Conexión', 'Connection'),
+    boardGamesTaskName: text('Jugar juegos de mesa', 'Play board games'),
+    playTrait: text('Juego', 'Play'),
   },
-};
+} as const;
 
-export const demoLogrosPreviewByTaskId: Record<string, NonNullable<TaskInsightsResponse['previewAchievement']>> = {
-  'task-gym': {
-    score: 46,
-    status: 'fragile',
-    consolidationStrength: 41,
-    recentMonths: [
-      { periodKey: '2025-12', completionRate: 0.28, state: 'invalid', closed: true },
-      { periodKey: '2026-01', completionRate: 0.43, state: 'weak', closed: true },
-      { periodKey: '2026-02', completionRate: 0.51, state: 'building', closed: true },
-      { periodKey: '2026-03', completionRate: 0.49, state: 'floor_only', closed: true },
-      { periodKey: '2026-04', projectedCompletionRate: 0.58, state: 'projected_floor_only', closed: false },
-    ],
-    windowProximity: {
-      slots: ['invalid', 'floor_only', 'projected_floor_only'],
+function localizedText(language: PostLoginLanguage, copy: DemoTextByLanguage): string {
+  return copy[language];
+}
+
+export function getDemoLogrosData(language: PostLoginLanguage): RewardsHistorySummary {
+  return {
+    weeklyWrapups,
+    weeklyUnseenCount: 0,
+    monthlyWrapups,
+    growthCalibration: {
+      countdownDays: 22,
+      latestPeriodLabel: '2026-03',
+      summary: { up: 1, keep: 1, down: 1, total: 3 },
+      latestResults: [
+        {
+          taskId: 'task-water',
+          taskTitle: localizedText(language, DEMO_TEXT.growthCalibration.waterTaskTitle),
+          pillar: 'Body',
+          difficultyBefore: 'easy',
+          difficultyAfter: 'normal',
+          expectedTarget: 5,
+          actualCompletions: 6,
+          completionRatePct: 120,
+          finalAction: 'up',
+          result: 'increased',
+          reason: localizedText(language, DEMO_TEXT.growthCalibration.highCompletionConsistency),
+          clampApplied: false,
+          clampReason: null,
+          evaluatedAt: '2026-04-01T00:00:00.000Z',
+          evaluationMonthLabel: '2026-03',
+        },
+        {
+          taskId: 'task-gym',
+          taskTitle: localizedText(language, DEMO_TEXT.growthCalibration.gymTaskTitle),
+          pillar: 'Body',
+          difficultyBefore: 'normal',
+          difficultyAfter: 'normal',
+          expectedTarget: 4,
+          actualCompletions: 4,
+          completionRatePct: 100,
+          finalAction: 'keep',
+          result: 'kept',
+          reason: localizedText(language, DEMO_TEXT.growthCalibration.targetMet),
+          clampApplied: false,
+          clampReason: null,
+          evaluatedAt: '2026-04-01T00:00:00.000Z',
+          evaluationMonthLabel: '2026-03',
+        },
+        {
+          taskId: 'task-english',
+          taskTitle: localizedText(language, DEMO_TEXT.growthCalibration.englishTaskTitle),
+          pillar: 'Mind',
+          difficultyBefore: 'hard',
+          difficultyAfter: 'normal',
+          expectedTarget: 5,
+          actualCompletions: 2,
+          completionRatePct: 40,
+          finalAction: 'down',
+          result: 'decreased',
+          reason: localizedText(language, DEMO_TEXT.growthCalibration.lowCompletionRate),
+          clampApplied: true,
+          clampReason: localizedText(language, DEMO_TEXT.growthCalibration.guardrailFloorReached),
+          evaluatedAt: '2026-04-01T00:00:00.000Z',
+          evaluationMonthLabel: '2026-03',
+        },
+      ],
     },
-  },
-  'task-family-call': {
-    score: 74,
-    status: 'building',
-    consolidationStrength: 69,
-    recentMonths: [
-      { periodKey: '2025-12', completionRate: 0.38, state: 'weak', closed: true },
-      { periodKey: '2026-01', completionRate: 0.61, state: 'building', closed: true },
-      { periodKey: '2026-02', completionRate: 0.8, state: 'strong', closed: true },
-      { periodKey: '2026-03', completionRate: 0.7, state: 'building', closed: true },
-      { periodKey: '2026-04', projectedCompletionRate: 0.77, state: 'projected_valid', closed: false },
-    ],
-    windowProximity: {
-      slots: ['floor_only', 'valid', 'valid'],
+    habitAchievements: {
+      pendingCount: 0,
+      achievedByPillar: [
+        {
+          pillar: { id: 'body', code: 'BODY', name: 'Body' },
+          habits: [
+            createHabit({
+              id: 'habit-water',
+              taskId: 'task-water',
+              taskName: localizedText(language, DEMO_TEXT.habits.waterTaskName),
+              pillar: 'BODY',
+              trait: { id: 't-hydration', code: 'HYDRATION', name: localizedText(language, DEMO_TEXT.habits.hydrationTrait) },
+              status: 'stored',
+              achievedAt: '2026-02-10T00:00:00.000Z',
+              gpBeforeAchievement: 168,
+            }),
+            createHabit({
+              id: 'habit-dinner',
+              taskId: 'task-dinner-before-22',
+              taskName: localizedText(language, DEMO_TEXT.habits.dinnerTaskName),
+              pillar: 'BODY',
+              // Usamos NUTRITION porque tiene sello existente en /sellos y evita crear assets nuevos.
+              trait: { id: 't-nutrition', code: 'NUTRITION', name: localizedText(language, DEMO_TEXT.habits.nutritionTrait) },
+              status: 'maintained',
+              maintainEnabled: true,
+              achievedAt: '2026-03-18T00:00:00.000Z',
+              gpBeforeAchievement: 214,
+            }),
+            createHabit({
+              id: 'habit-gym',
+              taskId: 'task-gym',
+              taskName: localizedText(language, DEMO_TEXT.habits.gymTaskName),
+              pillar: 'BODY',
+              trait: { id: 't-strength', code: 'STRENGTH', name: localizedText(language, DEMO_TEXT.habits.strengthTrait) },
+              status: 'not_achieved',
+            }),
+            createHabit({
+              id: 'habit-steps',
+              taskId: 'task-steps',
+              taskName: localizedText(language, DEMO_TEXT.habits.stepsTaskName),
+              pillar: 'BODY',
+              trait: { id: 't-resistance', code: 'RESISTANCE', name: localizedText(language, DEMO_TEXT.habits.resistanceTrait) },
+              status: 'not_achieved',
+            }),
+          ],
+        },
+        {
+          pillar: { id: 'mind', code: 'MIND', name: 'Mind' },
+          habits: [
+            createHabit({
+              id: 'habit-english',
+              taskId: 'task-english',
+              taskName: localizedText(language, DEMO_TEXT.habits.englishTaskName),
+              pillar: 'MIND',
+              trait: { id: 't-focus', code: 'FOCUS', name: localizedText(language, DEMO_TEXT.habits.focusTrait) },
+              status: 'stored',
+              achievedAt: '2026-01-22T00:00:00.000Z',
+              gpBeforeAchievement: 192,
+            }),
+            createHabit({
+              id: 'habit-project',
+              taskId: 'task-project-60',
+              taskName: localizedText(language, DEMO_TEXT.habits.projectTaskName),
+              pillar: 'MIND',
+              trait: { id: 't-discipline', code: 'DISCIPLINE', name: localizedText(language, DEMO_TEXT.habits.disciplineTrait) },
+              status: 'not_achieved',
+            }),
+          ],
+        },
+        {
+          pillar: { id: 'soul', code: 'SOUL', name: 'Soul' },
+          habits: [
+            createHabit({
+              id: 'habit-family-call',
+              taskId: 'task-family-call',
+              taskName: localizedText(language, DEMO_TEXT.habits.familyCallTaskName),
+              pillar: 'SOUL',
+              trait: { id: 't-connection', code: 'CONNECTION', name: localizedText(language, DEMO_TEXT.habits.connectionTrait) },
+              status: 'stored',
+              achievedAt: '2026-02-02T00:00:00.000Z',
+              gpBeforeAchievement: 186,
+            }),
+            createHabit({
+              id: 'habit-board-games',
+              taskId: 'task-board-games',
+              taskName: localizedText(language, DEMO_TEXT.habits.boardGamesTaskName),
+              pillar: 'SOUL',
+              trait: { id: 't-play', code: 'PLAY', name: localizedText(language, DEMO_TEXT.habits.playTrait) },
+              status: 'not_achieved',
+            }),
+          ],
+        },
+      ],
     },
-  },
-  'task-english': {
-    score: 82,
-    status: 'strong',
-    consolidationStrength: 81,
-    recentMonths: [
-      { periodKey: '2025-12', completionRate: 0.67, state: 'building', closed: true },
-      { periodKey: '2026-01', completionRate: 0.84, state: 'strong', closed: true },
-      { periodKey: '2026-02', completionRate: 0.85, state: 'strong', closed: true },
-      { periodKey: '2026-03', completionRate: 0.88, state: 'strong', closed: true },
-    ],
-  },
-};
+  };
+}
+
+export function getDemoLogrosPreviewByTaskId(_language: PostLoginLanguage): Record<string, NonNullable<TaskInsightsResponse['previewAchievement']>> {
+  return {
+    'task-gym': {
+      score: 46,
+      status: 'fragile',
+      consolidationStrength: 41,
+      recentMonths: [
+        { periodKey: '2025-12', completionRate: 0.28, state: 'invalid', closed: true },
+        { periodKey: '2026-01', completionRate: 0.43, state: 'weak', closed: true },
+        { periodKey: '2026-02', completionRate: 0.51, state: 'building', closed: true },
+        { periodKey: '2026-03', completionRate: 0.49, state: 'floor_only', closed: true },
+        { periodKey: '2026-04', projectedCompletionRate: 0.58, state: 'projected_floor_only', closed: false },
+      ],
+      windowProximity: {
+        slots: ['invalid', 'floor_only', 'projected_floor_only'],
+      },
+    },
+    'task-family-call': {
+      score: 74,
+      status: 'building',
+      consolidationStrength: 69,
+      recentMonths: [
+        { periodKey: '2025-12', completionRate: 0.38, state: 'weak', closed: true },
+        { periodKey: '2026-01', completionRate: 0.61, state: 'building', closed: true },
+        { periodKey: '2026-02', completionRate: 0.8, state: 'strong', closed: true },
+        { periodKey: '2026-03', completionRate: 0.7, state: 'building', closed: true },
+        { periodKey: '2026-04', projectedCompletionRate: 0.77, state: 'projected_valid', closed: false },
+      ],
+      windowProximity: {
+        slots: ['floor_only', 'valid', 'valid'],
+      },
+    },
+    'task-english': {
+      score: 82,
+      status: 'strong',
+      consolidationStrength: 81,
+      recentMonths: [
+        { periodKey: '2025-12', completionRate: 0.67, state: 'building', closed: true },
+        { periodKey: '2026-01', completionRate: 0.84, state: 'strong', closed: true },
+        { periodKey: '2026-02', completionRate: 0.85, state: 'strong', closed: true },
+        { periodKey: '2026-03', completionRate: 0.88, state: 'strong', closed: true },
+      ],
+    },
+  } as Record<string, NonNullable<TaskInsightsResponse['previewAchievement']>>;
+}

--- a/apps/web/src/pages/labs/LogrosDemoPage.tsx
+++ b/apps/web/src/pages/labs/LogrosDemoPage.tsx
@@ -3,7 +3,8 @@ import { Link } from 'react-router-dom';
 import { GuidedDemoOverlay } from '../../components/demo/GuidedDemoOverlay';
 import { RewardsSection, type RewardsSectionDemoControls } from '../../components/dashboard-v3/RewardsSection';
 import { LABS_LOGROS_GUIDED_STEPS } from '../../config/labsLogrosGuidedTour';
-import { demoLogrosData, demoLogrosPreviewByTaskId } from '../../data/demoLogrosData';
+import { getDemoLogrosData, getDemoLogrosPreviewByTaskId } from '../../data/demoLogrosData';
+import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
 
 const DEMO_ANCHORS = {
   shelves: 'logros-shelves',
@@ -27,6 +28,7 @@ const DEMO_ANCHORS = {
 } as const;
 
 export default function LabsLogrosDemoPage() {
+  const { language } = usePostLoginLanguage();
   const [showGuidedTour, setShowGuidedTour] = useState(true);
   const [activeStepId, setActiveStepId] = useState<string | null>(LABS_LOGROS_GUIDED_STEPS[0]?.id ?? null);
   const demoControlsRef = useRef<RewardsSectionDemoControls | null>(null);
@@ -37,13 +39,13 @@ export default function LabsLogrosDemoPage() {
     () => ({
       disableRemote: true,
       forceAchievementsViewMode: 'carousel' as const,
-      mockPreviewAchievementByTaskId: demoLogrosPreviewByTaskId,
+      mockPreviewAchievementByTaskId: getDemoLogrosPreviewByTaskId(language),
       anchors: DEMO_ANCHORS,
       controls: {
         onReady: rememberDemoControls,
       },
     }),
-    [rememberDemoControls],
+    [language, rememberDemoControls],
   );
 
   const handleStepChange = useCallback((stepId: string) => {
@@ -95,11 +97,11 @@ export default function LabsLogrosDemoPage() {
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
             <p className="text-[0.62rem] uppercase tracking-[0.22em] text-[color:var(--color-text-subtle)] md:text-xs">Innerbloom</p>
-            <h1 className="font-display text-[1.05rem] font-semibold text-[color:var(--color-text)] md:text-xl">Logros</h1>
+            <h1 className="font-display text-[1.05rem] font-semibold text-[color:var(--color-text)] md:text-xl">{language === 'es' ? 'Logros' : 'Achievements'}</h1>
           </div>
           <Link
             to="/dashboard-v3/rewards"
-            aria-label="Cerrar demo de Logros y volver al dashboard"
+            aria-label={language === 'es' ? 'Cerrar demo de Logros y volver al dashboard' : 'Close Achievements demo and return to dashboard'}
             className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[color:var(--glass-border)] bg-[color:var(--color-surface-soft)] text-lg font-semibold leading-none text-[color:var(--color-text)] transition-colors hover:bg-[color:var(--color-surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-bg)]"
           >
             <span aria-hidden>×</span>
@@ -109,7 +111,7 @@ export default function LabsLogrosDemoPage() {
 
       {showGuidedTour ? (
         <GuidedDemoOverlay
-          language="es"
+          language={language}
           steps={LABS_LOGROS_GUIDED_STEPS}
           onFinish={() => setShowGuidedTour(false)}
           onSkip={() => setShowGuidedTour(false)}
@@ -124,7 +126,7 @@ export default function LabsLogrosDemoPage() {
       <main className="mx-auto w-full max-w-4xl px-3 py-4 md:px-5 md:py-6" data-demo-anchor="logros-intro">
         <RewardsSection
           userId=""
-          initialData={demoLogrosData}
+          initialData={getDemoLogrosData(language)}
           demoConfig={demoConfig}
           demoStepId={activeStepId}
         />


### PR DESCRIPTION
### Motivation
- El demo de Logros mezclaba tres fuentes de idioma y mostraba textos en español/inglés inconsistente; el objetivo es un único source of truth (`es`/`en`) controlado por `usePostLoginLanguage()`.
- Evitar traducciones dispersas en el árbol y preparar la data mock para generar contenido localizado según el `language` post-login.

### Description
- `apps/web/src/pages/labs/LogrosDemoPage.tsx`: importé y uso `usePostLoginLanguage()` y ahora paso `language` al `GuidedDemoOverlay`, al título del header, al `aria-label` del botón cerrar demo, y obtengo `initialData` + `mockPreviewAchievementByTaskId` desde las factories localizadas. (archivo modificado)
- `apps/web/src/data/demoLogrosData.ts`: reemplacé las exportaciones estáticas por factories `getDemoLogrosData(language)` y `getDemoLogrosPreviewByTaskId(language)`, añadí `DEMO_TEXT` bilingüe y el helper `localizedText`, y localicé los textos visibles del mock manteniendo intactos `taskId`, `habit id`, `DEMO_ANCHORS` y la estructura de negocio. (archivo modificado)
- Textos localizados en la factory: `growthCalibration.latestResults[].taskTitle`, `reason`, `clampReason`, y dentro de `habitAchievements`: `habits[].taskName` y `trait.name`; asimismo el header y el `aria-label` de cierre en la página. (no se cambió lógica del guided tour ni anchors)
- Mantuve compatibilidad con `RewardsSection` y `PreviewAchievementCard` consumiendo los datos generados por las nuevas factories.

### Testing
- Ejecuté `npm run typecheck:web` (comando: `npm --workspace apps/web run typecheck`); el comando falló con errores de tipado preexistentes en el repo no relacionados con estos cambios (errores en `PreviewAchievementCard`, Clerk types y otros módulos), por lo que la comprobación de tipos globales no pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7edcaad08332840fccbe3e3863db)