### PR TITLE
Add Google sign-in (Clerk OAuth) CTA to web auth flows

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -41,6 +41,7 @@ import PrivacyPage from './pages/legal/PrivacyPage';
 import TermsPage from './pages/legal/TermsPage';
 import SupportPage from './pages/legal/SupportPage';
 import AccountDeletionPage from './pages/AccountDeletion';
+import SsoCallbackPage from './pages/SsoCallback';
 
 const CLERK_TOKEN_TEMPLATE = (() => {
   const raw = import.meta.env.VITE_CLERK_TOKEN_TEMPLATE;
@@ -298,6 +299,7 @@ export default function App() {
           }
         />
         <Route path="/mobile-auth" element={<MobileBrowserAuthPage />} />
+        <Route path="/sso-callback" element={<SsoCallbackPage />} />
         <Route path="/privacy" element={<PrivacyPage />} />
         <Route path="/terms" element={<TermsPage />} />
         <Route path="/support" element={<SupportPage />} />

--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useSignIn, useSignUp } from '@clerk/clerk-react';
+
+export type GoogleOAuthMode = 'sign-in' | 'sign-up';
+
+type GoogleOAuthButtonProps = {
+  language: 'es' | 'en';
+  mode: GoogleOAuthMode;
+  redirectUrlComplete: string;
+  className?: string;
+};
+
+const SSO_CALLBACK_PATH = '/sso-callback';
+
+export function GoogleOAuthButton({
+  language,
+  mode,
+  redirectUrlComplete,
+  className = '',
+}: GoogleOAuthButtonProps) {
+  const { isLoaded: isSignInLoaded, signIn } = useSignIn();
+  const { isLoaded: isSignUpLoaded, signUp } = useSignUp();
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  const isLoaded = mode === 'sign-up' ? isSignUpLoaded : isSignInLoaded;
+  const isDisabled = !isLoaded || isRedirecting;
+
+  const copy = useMemo(
+    () => ({
+      cta: language === 'en' ? 'Continue with Google' : 'Continuar con Google',
+      loading: language === 'en' ? 'Connecting to Google…' : 'Conectando con Google…',
+      iconLabel: language === 'en' ? 'Google logo' : 'Logo de Google',
+    }),
+    [language],
+  );
+
+  const handleClick = useCallback(async () => {
+    if (!isLoaded || isRedirecting) {
+      return;
+    }
+
+    setIsRedirecting(true);
+
+    try {
+      if (mode === 'sign-up') {
+        await signUp.authenticateWithRedirect({
+          strategy: 'oauth_google',
+          redirectUrl: SSO_CALLBACK_PATH,
+          redirectUrlComplete,
+        });
+      } else {
+        await signIn.authenticateWithRedirect({
+          strategy: 'oauth_google',
+          redirectUrl: SSO_CALLBACK_PATH,
+          redirectUrlComplete,
+        });
+      }
+    } catch (error) {
+      console.error('[auth] Google OAuth redirect failed', error);
+      setIsRedirecting(false);
+    }
+  }, [isLoaded, isRedirecting, mode, redirectUrlComplete, signIn, signUp]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => void handleClick()}
+      disabled={isDisabled}
+      className={
+        `flex h-12 w-full items-center justify-center gap-3 rounded-full border border-white/20 ` +
+        `bg-white/95 px-4 text-sm font-semibold text-slate-900 shadow-[0_14px_34px_rgba(15,23,42,0.24)] ` +
+        `transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-70 ${className}`
+      }
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true" role="img" className="h-5 w-5" focusable="false">
+        <title>{copy.iconLabel}</title>
+        <path
+          fill="#EA4335"
+          d="M12 10.2v3.9h5.4c-.2 1.2-1.4 3.5-5.4 3.5-3.2 0-5.9-2.7-5.9-6s2.6-6 5.9-6c1.8 0 3 .8 3.7 1.4l2.5-2.4C16.7 2.9 14.6 2 12 2 6.9 2 2.8 6.1 2.8 11.2S6.9 20.4 12 20.4c6.9 0 8.6-4.8 8.6-7.3 0-.5 0-.9-.1-1.3H12Z"
+        />
+        <path
+          fill="#34A853"
+          d="M2.8 11.2c0 1.6.6 3.1 1.6 4.2l3-2.4c-.2-.5-.4-1.1-.4-1.8s.1-1.2.4-1.8l-3-2.4c-1 1.1-1.6 2.6-1.6 4.2Z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M12 20.4c2.6 0 4.8-.9 6.4-2.5l-3-2.5c-.8.6-1.9 1-3.4 1-2.5 0-4.6-1.7-5.4-4l-3 2.3c1.5 3 4.6 5.1 8.4 5.1Z"
+        />
+        <path
+          fill="#4285F4"
+          d="M18.4 17.9c1.8-1.6 2.9-4 2.9-6.7 0-.5 0-.9-.1-1.3H12v3.9h5.3c-.3 1.4-1.1 2.9-2.9 4.1l3 2.4Z"
+        />
+      </svg>
+      <span>{isRedirecting ? copy.loading : copy.cta}</span>
+    </button>
+  );
+}

--- a/apps/web/src/onboarding/steps/ClerkGate.tsx
+++ b/apps/web/src/onboarding/steps/ClerkGate.tsx
@@ -2,6 +2,7 @@ import { SignIn, SignUp } from '@clerk/clerk-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { GoogleOAuthButton } from '../../components/auth/GoogleOAuthButton';
 import { useAuth, useUser } from '../../auth/runtimeAuth';
 import { buildLocalizedAuthPath } from '../../lib/authLanguage';
 import { createAuthAppearance } from '../../lib/clerkAppearance';
@@ -235,7 +236,17 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
           </button>
         ))}
       </div>
-      <div className="mt-6">
+      <div className="mt-6 space-y-4">
+        <GoogleOAuthButton
+          language={language}
+          mode={tab}
+          redirectUrlComplete={currentUrl}
+        />
+        <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-white/45">
+          <span className="h-px flex-1 bg-white/12" aria-hidden />
+          <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
+          <span className="h-px flex-1 bg-white/12" aria-hidden />
+        </div>
         <AnimatePresence mode="wait" initial={false} presenceAffectsLayout={false}>
           {tab === 'sign-up' ? (
             <motion.div

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { SignIn } from '@clerk/clerk-react';
 import { useLocation } from 'react-router-dom';
+import { GoogleOAuthButton } from '../components/auth/GoogleOAuthButton';
 import { AuthLayout } from '../components/layout/AuthLayout';
 import { BrandWordmark } from '../components/layout/BrandWordmark';
 import { DASHBOARD_PATH } from '../config/auth';
@@ -69,18 +70,26 @@ export default function LoginPage() {
       secondaryActionLabel={language === 'en' ? 'Back to home' : 'Volver al inicio'}
       secondaryActionHref={`/?lang=${language}`}
     >
-      <SignIn
-        appearance={createAuthAppearance({
-          elements: {
-            footerActionText: 'text-white/50',
-            footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4'
-          }
-        })}
-        routing="path"
-        path="/login"
-        signUpUrl={buildLocalizedAuthPath('/sign-up', language)}
-        fallbackRedirectUrl={DASHBOARD_PATH}
-      />
+      <div className="mx-auto w-full max-w-xl space-y-4">
+        <GoogleOAuthButton language={language} mode="sign-in" redirectUrlComplete={`${location.pathname}${location.search}${location.hash}`} />
+        <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-white/45">
+          <span className="h-px flex-1 bg-white/12" aria-hidden />
+          <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
+          <span className="h-px flex-1 bg-white/12" aria-hidden />
+        </div>
+        <SignIn
+          appearance={createAuthAppearance({
+            elements: {
+              footerActionText: 'text-white/50',
+              footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4'
+            }
+          })}
+          routing="path"
+          path="/login"
+          signUpUrl={buildLocalizedAuthPath('/sign-up', language)}
+          fallbackRedirectUrl={DASHBOARD_PATH}
+        />
+      </div>
     </AuthLayout>
   );
 }

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -1,6 +1,7 @@
 import { SignUp } from '@clerk/clerk-react';
 import { useRef } from 'react';
 import { useLocation } from 'react-router-dom';
+import { GoogleOAuthButton } from '../components/auth/GoogleOAuthButton';
 import { AuthLayout } from '../components/layout/AuthLayout';
 import { BrandWordmark } from '../components/layout/BrandWordmark';
 import { buildLocalizedAuthPath, resolveAuthLanguage } from '../lib/authLanguage';
@@ -64,18 +65,26 @@ export default function SignUpPage() {
       secondaryActionLabel={language === 'en' ? 'Back to home' : 'Volver al inicio'}
       secondaryActionHref={`/?lang=${language}`}
     >
-      <div
-        ref={signUpContainerRef}
-        className="mx-auto w-full min-w-0 max-w-full px-1 sm:px-0"
-      >
-        <SignUp
-          appearance={appearance}
-          routing="path"
-          path="/sign-up"
-          signInUrl={buildLocalizedAuthPath('/login', language)}
-          // post-signup must continue onboarding
-          fallbackRedirectUrl="/intro-journey"
-        />
+      <div className="mx-auto w-full max-w-xl space-y-4">
+        <GoogleOAuthButton language={language} mode="sign-up" redirectUrlComplete={`${location.pathname}${location.search}${location.hash}`} />
+        <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-white/45">
+          <span className="h-px flex-1 bg-white/12" aria-hidden />
+          <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
+          <span className="h-px flex-1 bg-white/12" aria-hidden />
+        </div>
+        <div
+          ref={signUpContainerRef}
+          className="mx-auto w-full min-w-0 max-w-full px-1 sm:px-0"
+        >
+          <SignUp
+            appearance={appearance}
+            routing="path"
+            path="/sign-up"
+            signInUrl={buildLocalizedAuthPath('/login', language)}
+            // post-signup must continue onboarding
+            fallbackRedirectUrl="/intro-journey"
+          />
+        </div>
       </div>
     </AuthLayout>
   );

--- a/apps/web/src/pages/SsoCallback.tsx
+++ b/apps/web/src/pages/SsoCallback.tsx
@@ -1,0 +1,5 @@
+import { AuthenticateWithRedirectCallback } from '@clerk/clerk-react';
+
+export default function SsoCallbackPage() {
+  return <AuthenticateWithRedirectCallback />;
+}


### PR DESCRIPTION
### Motivation
- Provide a web-first “Continue with Google” option that uses the existing Clerk integration and does not introduce a parallel auth system.  
- Keep Clerk as the source of truth for users, sessions and redirects while matching the Innerbloom UI and i18n.  

### Description
- Added a reusable `GoogleOAuthButton` component that calls Clerk's `signIn.authenticateWithRedirect` / `signUp.authenticateWithRedirect` with `strategy: 'oauth_google'`, shows localized CTA text, and includes loading/disabled state.  
- Added a Clerk redirect completion page and route: new `SsoCallbackPage` (`/sso-callback`) that mounts `AuthenticateWithRedirectCallback` so Clerk can finish the OAuth flow.  
- Integrated the Google CTA above existing email forms in the web entry points: `LoginPage`, `SignUpPage`, and the onboarding `ClerkGate`, preserving the current Clerk email flows and redirect behavior.  
- Files changed or added: `apps/web/src/components/auth/GoogleOAuthButton.tsx` (new), `apps/web/src/pages/SsoCallback.tsx` (new), `apps/web/src/pages/Login.tsx`, `apps/web/src/pages/SignUp.tsx`, `apps/web/src/onboarding/steps/ClerkGate.tsx`, and `apps/web/src/App.tsx` (route registration).  

### Testing
- Built the web app with `pnpm -C apps/web run build` and the build completed successfully.  
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc517af588332b62d7b2e8c882c0b)