### PR TITLE
Reduce emphasis of Delete Account button in DashboardMenu

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -1300,7 +1300,7 @@ export function DashboardMenu({
                 <button
                   type="button"
                   onClick={handleOpenDeleteAccount}
-                  className="mt-2 flex h-10 w-full items-center gap-3 rounded-2xl px-4 text-sm font-semibold text-rose-300 transition hover:bg-rose-500/10 hover:text-rose-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400/40"
+                  className="mt-2 flex h-10 w-full items-center gap-3 rounded-2xl px-4 text-sm font-normal text-rose-300 transition hover:bg-rose-500/10 hover:text-rose-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-400/40"
                 >
                   <MenuIcon className="h-5 w-5 text-rose-300">
                     <path d="M3 6h18" />


### PR DESCRIPTION
### Motivation
- Reduce the visual emphasis of the "Delete Account" action in the dashboard menu so it doesn't draw as much attention as primary actions, matching the intended UI weight.

### Description
- Change the button text weight for the delete account action in `DashboardMenu.tsx` from `font-semibold` to `font-normal` by updating the `className` on the delete button.

### Testing
- Ran the frontend automated checks including `yarn test`, `yarn lint`, and `yarn build`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc6a010388332be41268dffdc8d5b)