### PR TITLE
Refine shared auth spacing rhythm around Clerk forms

### DIFF
--- a/apps/web/src/lib/clerkAppearance.ts
+++ b/apps/web/src/lib/clerkAppearance.ts
@@ -2,6 +2,10 @@ import type { Theme } from '@clerk/types';
 
 // Keep auth widgets fluid across breakpoints so desktop side margins match the tighter mobile framing.
 export const AUTH_LOGIN_MAX_WIDTH = 'max-w-full';
+export const AUTH_STACK_CLASS = 'mx-auto w-full max-w-xl space-y-3';
+export const AUTH_DIVIDER_CLASS =
+  'flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-white/45';
+export const AUTH_CLERK_FORM_SHELL_CLASS = 'mx-auto w-full min-w-0 max-w-full px-1 sm:px-0';
 
 const baseLayout = {
   logoPlacement: 'none' as const,
@@ -27,7 +31,7 @@ const baseElements = {
   rootBox: `w-full min-w-0 ${AUTH_LOGIN_MAX_WIDTH} mx-auto`,
   cardBox: `w-full min-w-0 ${AUTH_LOGIN_MAX_WIDTH} mx-auto flex justify-center`,
   card:
-    `mx-auto flex w-full min-w-0 ${AUTH_LOGIN_MAX_WIDTH} flex-col gap-4 overflow-hidden rounded-[26px] border border-white/8 bg-[linear-gradient(180deg,rgba(255,255,255,0.055),rgba(255,255,255,0.025))] p-3 shadow-[0_20px_50px_rgba(7,12,32,0.24)] backdrop-blur-[18px] sm:rounded-[30px] sm:p-4 md:p-5`,
+    `mx-auto flex w-full min-w-0 ${AUTH_LOGIN_MAX_WIDTH} flex-col gap-3 overflow-hidden rounded-[26px] border border-white/8 bg-[linear-gradient(180deg,rgba(255,255,255,0.055),rgba(255,255,255,0.025))] p-3 shadow-[0_20px_50px_rgba(7,12,32,0.24)] backdrop-blur-[18px] sm:rounded-[30px] sm:p-4 md:p-5`,
   header: 'hidden',
   socialButtons: 'hidden',
   socialButtonsBlockButton: 'hidden',
@@ -50,11 +54,11 @@ const baseElements = {
     '!appearance-none !ring-0',
 
   footer:
-    'mt-2 w-full max-w-none rounded-2xl bg-[linear-gradient(135deg,rgba(122,138,196,0.2),rgba(108,63,197,0.2))] !px-2 !py-1 shadow-[0_18px_40px_rgba(9,16,40,0.24)] backdrop-blur-md',
+    'mt-1 w-full max-w-none rounded-xl bg-[linear-gradient(135deg,rgba(122,138,196,0.14),rgba(108,63,197,0.12))] !px-2 !py-1 shadow-[0_10px_26px_rgba(9,16,40,0.16)] backdrop-blur-md',
 
   // 1) CONTENEDOR 1 (cl-footerAction__signIn): reducir alto y aumentar ancho
   footerAction:
-    '!flex !w-full !max-w-none items-center justify-start gap-1 rounded-xl bg-white/[0.06] !px-3 !py-1 text-[10px] !leading-[12px] text-white/60 backdrop-blur-sm',
+    '!flex !w-full !max-w-none items-center justify-start gap-1 rounded-lg bg-white/[0.045] !px-2.5 !py-1 text-[10px] !leading-[12px] text-white/58 backdrop-blur-sm',
   footerActionText:
     '!whitespace-nowrap text-white/55',
   footerActionLink:
@@ -62,7 +66,7 @@ const baseElements = {
 
   // 2) CONTENEDOR 2 (“Secured by clerk”): reducir alto y aumentar ancho
   footerPages:
-    '!mt-1 !flex !w-full !max-w-none items-center justify-center gap-1 rounded-xl bg-white/[0.06] !px-3 !py-1 text-[9px] !leading-[11px] text-white/45 backdrop-blur-sm',
+    '!mt-1 !flex !w-full !max-w-none items-center justify-center gap-1 rounded-lg bg-white/[0.04] !px-2.5 !py-1 text-[9px] !leading-[11px] text-white/40 backdrop-blur-sm',
   footerPageLink:
     'inline-flex items-center gap-1 text-white/40 hover:text-white/60',
 

--- a/apps/web/src/onboarding/steps/ClerkGate.tsx
+++ b/apps/web/src/onboarding/steps/ClerkGate.tsx
@@ -5,7 +5,11 @@ import { useLocation } from 'react-router-dom';
 import { GoogleOAuthButton } from '../../components/auth/GoogleOAuthButton';
 import { useAuth, useUser } from '../../auth/runtimeAuth';
 import { buildLocalizedAuthPath } from '../../lib/authLanguage';
-import { createAuthAppearance } from '../../lib/clerkAppearance';
+import {
+  AUTH_CLERK_FORM_SHELL_CLASS,
+  AUTH_DIVIDER_CLASS,
+  createAuthAppearance,
+} from '../../lib/clerkAppearance';
 import { buildWebAbsoluteUrl } from '../../lib/siteUrl';
 import {
   buildNativeAppUrl,
@@ -236,13 +240,13 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
           </button>
         ))}
       </div>
-      <div className="mt-6 space-y-4">
+      <div className="mt-6 space-y-3">
         <GoogleOAuthButton
           language={language}
           mode={tab}
           redirectUrlComplete={currentUrl}
         />
-        <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-white/45">
+        <div className={AUTH_DIVIDER_CLASS}>
           <span className="h-px flex-1 bg-white/12" aria-hidden />
           <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
           <span className="h-px flex-1 bg-white/12" aria-hidden />
@@ -255,15 +259,17 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -12 }}
               transition={{ duration: 0.2, ease: 'easeOut' }}
-              className="onboarding-surface-ghost rounded-2xl px-0 py-4 sm:px-4 sm:py-6"
+              className="onboarding-surface-ghost rounded-2xl px-0 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4"
             >
-              <SignUp
-                appearance={clerkAppearance}
-                routing="virtual"
-                signInUrl={currentUrl}
-                fallbackRedirectUrl={currentUrl}
-                forceRedirectUrl={currentUrl}
-              />
+              <div className={AUTH_CLERK_FORM_SHELL_CLASS}>
+                <SignUp
+                  appearance={clerkAppearance}
+                  routing="virtual"
+                  signInUrl={currentUrl}
+                  fallbackRedirectUrl={currentUrl}
+                  forceRedirectUrl={currentUrl}
+                />
+              </div>
             </motion.div>
           ) : (
             <motion.div
@@ -272,15 +278,17 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -12 }}
               transition={{ duration: 0.2, ease: 'easeOut' }}
-              className="onboarding-surface-ghost rounded-2xl px-0 py-4 sm:px-4 sm:py-6"
+              className="onboarding-surface-ghost rounded-2xl px-0 pt-2 pb-3 sm:px-4 sm:pt-3 sm:pb-4"
             >
-              <SignIn
-                appearance={clerkAppearance}
-                routing="virtual"
-                signUpUrl={currentUrl}
-                fallbackRedirectUrl={currentUrl}
-                forceRedirectUrl={currentUrl}
-              />
+              <div className={AUTH_CLERK_FORM_SHELL_CLASS}>
+                <SignIn
+                  appearance={clerkAppearance}
+                  routing="virtual"
+                  signUpUrl={currentUrl}
+                  fallbackRedirectUrl={currentUrl}
+                  forceRedirectUrl={currentUrl}
+                />
+              </div>
             </motion.div>
           )}
         </AnimatePresence>

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -5,7 +5,12 @@ import { AuthLayout } from '../components/layout/AuthLayout';
 import { BrandWordmark } from '../components/layout/BrandWordmark';
 import { DASHBOARD_PATH } from '../config/auth';
 import { buildLocalizedAuthPath, resolveAuthLanguage } from '../lib/authLanguage';
-import { createAuthAppearance } from '../lib/clerkAppearance';
+import {
+  AUTH_CLERK_FORM_SHELL_CLASS,
+  AUTH_DIVIDER_CLASS,
+  AUTH_STACK_CLASS,
+  createAuthAppearance,
+} from '../lib/clerkAppearance';
 import { usePageMeta } from '../lib/seo';
 import {
   isNativeCapacitorPlatform,
@@ -70,25 +75,27 @@ export default function LoginPage() {
       secondaryActionLabel={language === 'en' ? 'Back to home' : 'Volver al inicio'}
       secondaryActionHref={`/?lang=${language}`}
     >
-      <div className="mx-auto w-full max-w-xl space-y-4">
+      <div className={AUTH_STACK_CLASS}>
         <GoogleOAuthButton language={language} mode="sign-in" redirectUrlComplete={`${location.pathname}${location.search}${location.hash}`} />
-        <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-white/45">
+        <div className={AUTH_DIVIDER_CLASS}>
           <span className="h-px flex-1 bg-white/12" aria-hidden />
           <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
           <span className="h-px flex-1 bg-white/12" aria-hidden />
         </div>
-        <SignIn
-          appearance={createAuthAppearance({
-            elements: {
-              footerActionText: 'text-white/50',
-              footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4'
-            }
-          })}
-          routing="path"
-          path="/login"
-          signUpUrl={buildLocalizedAuthPath('/sign-up', language)}
-          fallbackRedirectUrl={DASHBOARD_PATH}
-        />
+        <div className={AUTH_CLERK_FORM_SHELL_CLASS}>
+          <SignIn
+            appearance={createAuthAppearance({
+              elements: {
+                footerActionText: 'text-white/50',
+                footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4'
+              }
+            })}
+            routing="path"
+            path="/login"
+            signUpUrl={buildLocalizedAuthPath('/sign-up', language)}
+            fallbackRedirectUrl={DASHBOARD_PATH}
+          />
+        </div>
       </div>
     </AuthLayout>
   );

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -5,7 +5,12 @@ import { GoogleOAuthButton } from '../components/auth/GoogleOAuthButton';
 import { AuthLayout } from '../components/layout/AuthLayout';
 import { BrandWordmark } from '../components/layout/BrandWordmark';
 import { buildLocalizedAuthPath, resolveAuthLanguage } from '../lib/authLanguage';
-import { createAuthAppearance } from '../lib/clerkAppearance';
+import {
+  AUTH_CLERK_FORM_SHELL_CLASS,
+  AUTH_DIVIDER_CLASS,
+  AUTH_STACK_CLASS,
+  createAuthAppearance,
+} from '../lib/clerkAppearance';
 import {
   isNativeCapacitorPlatform,
   openUrlInCapacitorBrowser,
@@ -65,16 +70,16 @@ export default function SignUpPage() {
       secondaryActionLabel={language === 'en' ? 'Back to home' : 'Volver al inicio'}
       secondaryActionHref={`/?lang=${language}`}
     >
-      <div className="mx-auto w-full max-w-xl space-y-4">
+      <div className={AUTH_STACK_CLASS}>
         <GoogleOAuthButton language={language} mode="sign-up" redirectUrlComplete={`${location.pathname}${location.search}${location.hash}`} />
-        <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-white/45">
+        <div className={AUTH_DIVIDER_CLASS}>
           <span className="h-px flex-1 bg-white/12" aria-hidden />
           <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
           <span className="h-px flex-1 bg-white/12" aria-hidden />
         </div>
         <div
           ref={signUpContainerRef}
-          className="mx-auto w-full min-w-0 max-w-full px-1 sm:px-0"
+          className={AUTH_CLERK_FORM_SHELL_CLASS}
         >
           <SignUp
             appearance={appearance}


### PR DESCRIPTION
### Motivation
- Normalize the vertical rhythm between the custom Google CTA, the external divider, and the Clerk form so the auth flow reads as a single, coherent system. 
- Remove redundant vertical whitespace that made the Clerk card feel visually disconnected from the divider and CTA. 
- Prefer shared appearance/wrapper fixes so spacing is consistent across Login, Sign up, and onboarding ClerkGate while preserving page-specific behavior.

### Description
- Introduced shared layout classes in `apps/web/src/lib/clerkAppearance.ts`: `AUTH_STACK_CLASS`, `AUTH_DIVIDER_CLASS`, and `AUTH_CLERK_FORM_SHELL_CLASS`, and reduced the Clerk card gap and footer visual weight to avoid the footer competing with the main CTA/form area.
- Replaced per-page inline spacing with the shared classes on Login (`apps/web/src/pages/Login.tsx`) and Sign up (`apps/web/src/pages/SignUp.tsx`) so Google button → divider → Clerk form follows the same spacing system.
- Aligned onboarding `ClerkGate` (`apps/web/src/onboarding/steps/ClerkGate.tsx`) to the same divider/form shell rhythm, reduced the section spacing from `space-y-4` to `space-y-3`, and tightened the Clerk ghost container top/bottom padding so the form doesn't feel dropped too far after the divider.
- Files touched: `apps/web/src/lib/clerkAppearance.ts`, `apps/web/src/pages/Login.tsx`, `apps/web/src/pages/SignUp.tsx`, `apps/web/src/onboarding/steps/ClerkGate.tsx`.

### Testing
- Ran TypeScript typecheck: `pnpm -C apps/web run typecheck` which failed due to existing, repo-wide TypeScript errors unrelated to these spacing-only changes.
- Ran ESLint on the changed files: `pnpm -C apps/web exec eslint src/pages/Login.tsx src/pages/SignUp.tsx src/onboarding/steps/ClerkGate.tsx src/lib/clerkAppearance.ts` which failed because the repository uses ESLint v9 but does not have the new flat `eslint.config.*` config (pre-existing environment issue).
- No visual regressions automated; changes are CSS/class adjustments and should be verified in-browser (mobile and desktop) to confirm the tighter vertical rhythm and footer de-emphasis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbcf80f0688332819d3b6f3164ced2)