### PR TITLE
fix(onboarding): force black text on Google OAuth button

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -88,7 +88,7 @@ export function GoogleOAuthButton({
         <path fill="#4CAF50" d="M24 44c5.179 0 9.868-1.977 13.409-5.192l-6.19-5.238C29.146 35.091 26.715 36 24 36c-5.218 0-9.621-3.317-11.283-7.946l-6.522 5.025C9.505 39.556 16.227 44 24 44Z" />
         <path fill="#1976D2" d="M43.611 20.083H42V20H24v8h11.303c-.792 2.237-2.231 4.166-4.091 5.571l.003-.002 6.19 5.238C36.971 39.202 44 34 44 24c0-1.341-.138-2.65-.389-3.917Z" />
       </svg>
-      <span className="text-current">{isRedirecting ? copy.loading : copy.cta}</span>
+      <span className="!text-black">{isRedirecting ? copy.loading : copy.cta}</span>
     </button>
   );
 }


### PR DESCRIPTION
### Motivation
- Ensure the "Continue with Google" CTA is readable in the onboarding surface by forcing the label text to render in black against the white button background.

### Description
- Add an explicit `!text-black` Tailwind utility to the CTA `span` in `apps/web/src/components/auth/GoogleOAuthButton.tsx` so the button label always appears black (`<span className="!text-black">…</span>`).

### Testing
- Ran `pnpm -C apps/web exec eslint src/components/auth/GoogleOAuthButton.tsx` which failed due to repo ESLint v9 expecting an `eslint.config.*` file; no lint errors from this change were reported before the config failure.; Ran `pnpm -C apps/web exec tsc --noEmit` which failed due to pre-existing TypeScript errors elsewhere in the repo and not caused by this one-line change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd2de6b1c8332b221cf506d96e0e3)