### PR TITLE
[codex] Polish onboarding and deletion UI copy

### DIFF
--- a/apps/web/src/components/dashboard-v3/Alerts.tsx
+++ b/apps/web/src/components/dashboard-v3/Alerts.tsx
@@ -155,9 +155,6 @@ export function Alerts({
               </button>
             )}
           </div>
-          <p className="mt-2 text-xs text-indigo-100/70">
-            Configurá tu recordatorio desde el scheduler que está más abajo en el dashboard.
-          </p>
         </div>
       )}
     </div>

--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -1238,11 +1238,6 @@ export function DashboardMenu({
                       <p className="mt-3 text-sm leading-6 text-[color:var(--color-text-dim)]">
                         {t("dashboard.menu.deleteAccountBody")}
                       </p>
-                      <ul className="mt-3 space-y-2 text-xs leading-5 text-[color:var(--color-text-faint)]">
-                        <li>{t("dashboard.menu.deleteAccountDeletesProfile")}</li>
-                        <li>{t("dashboard.menu.deleteAccountDeletesProgress")}</li>
-                        <li>{t("dashboard.menu.deleteAccountDeletesClerk")}</li>
-                      </ul>
 
                       <label className="mt-4 block text-left">
                         <span className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--color-text-faint)]">

--- a/apps/web/src/i18n/post-login/dashboard.ts
+++ b/apps/web/src/i18n/post-login/dashboard.ts
@@ -86,18 +86,6 @@ export const dashboardTranslations = {
     es: 'Esta acción elimina tu cuenta de forma permanente. No vas a poder recuperar tu perfil ni tu progreso después de confirmar.',
     en: 'This permanently deletes your account. You will not be able to recover your profile or progress after confirming.',
   },
-  'dashboard.menu.deleteAccountDeletesProfile': {
-    es: 'Se elimina tu perfil, email y datos personales asociados.',
-    en: 'Your profile, email, and associated personal data are deleted.',
-  },
-  'dashboard.menu.deleteAccountDeletesProgress': {
-    es: 'Se eliminan progreso, tareas, registros, emociones, recordatorios y preferencias.',
-    en: 'Progress, tasks, logs, emotions, reminders, and preferences are deleted.',
-  },
-  'dashboard.menu.deleteAccountDeletesClerk': {
-    es: 'También se elimina tu usuario de autenticación.',
-    en: 'Your authentication user is also deleted.',
-  },
   'dashboard.menu.deleteAccountConfirmLabel': {
     es: 'Escribí {{keyword}} para confirmar',
     en: 'Type {{keyword}} to confirm',

--- a/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
+++ b/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
@@ -1147,8 +1147,8 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
                       <p className="text-sm font-semibold text-white">{card.icon} {card.title}</p>
                       <p className="mt-1 text-xs text-white/65">{card.description}</p>
                     </div>
-                    <span className={`h-5 w-10 rounded-full p-0.5 ${enabled ? 'bg-violet-300/70' : 'bg-white/20'}`}>
-                      <span className={`block h-4 w-4 rounded-full bg-white transition ${enabled ? 'translate-x-5' : ''}`} />
+                    <span className={`inline-flex h-5 w-10 shrink-0 items-center overflow-hidden rounded-full p-0.5 ${enabled ? 'bg-violet-300/70' : 'bg-white/20'}`}>
+                      <span className={`block h-4 w-4 shrink-0 rounded-full bg-white transition-transform ${enabled ? 'translate-x-[1.125rem]' : ''}`} />
                     </span>
                   </button>
                 );

--- a/apps/web/src/onboarding/steps/QuickStartModerationStep.tsx
+++ b/apps/web/src/onboarding/steps/QuickStartModerationStep.tsx
@@ -85,8 +85,8 @@ export function QuickStartModerationStep({ language = 'es', selectedModerations,
                 <p className="text-sm font-semibold text-white">{OPTIONS[option].icon} {card.title}</p>
                 <p className="mt-1 text-xs text-white/65">{card.description}</p>
               </div>
-              <span className={`h-5 w-10 rounded-full p-0.5 ${enabled ? 'bg-violet-300/70' : 'bg-white/20'}`}>
-                <span className={`block h-4 w-4 rounded-full bg-white transition ${enabled ? 'translate-x-5' : ''}`} />
+              <span className={`inline-flex h-5 w-10 shrink-0 items-center overflow-hidden rounded-full p-0.5 ${enabled ? 'bg-violet-300/70' : 'bg-white/20'}`}>
+                <span className={`block h-4 w-4 shrink-0 rounded-full bg-white transition-transform ${enabled ? 'translate-x-[1.125rem]' : ''}`} />
               </span>
             </button>
           );

--- a/apps/web/src/pages/QuickStartPreview.tsx
+++ b/apps/web/src/pages/QuickStartPreview.tsx
@@ -1223,8 +1223,8 @@ export default function QuickStartPreviewPage() {
                       <p className="text-sm font-semibold text-white">{card.icon} {card.title}</p>
                       <p className="mt-1 text-xs text-white/65">{card.description}</p>
                     </div>
-                    <span className={`h-5 w-10 rounded-full p-0.5 ${enabled ? 'bg-violet-300/70' : 'bg-white/20'}`}>
-                      <span className={`block h-4 w-4 rounded-full bg-white transition ${enabled ? 'translate-x-5' : ''}`} />
+                    <span className={`inline-flex h-5 w-10 shrink-0 items-center overflow-hidden rounded-full p-0.5 ${enabled ? 'bg-violet-300/70' : 'bg-white/20'}`}>
+                      <span className={`block h-4 w-4 shrink-0 rounded-full bg-white transition-transform ${enabled ? 'translate-x-[1.125rem]' : ''}`} />
                     </span>
                   </button>
                 );


### PR DESCRIPTION
## Summary
- Remove extra explanatory copy from the account deletion confirmation modal.
- Remove the outdated secondary reminder scheduler hint from the dashboard onboarding banner.
- Keep Quick Start moderation toggles contained by fixing the thumb sizing/translation in the integrated flow, reusable step, and preview page.

## Validation
- Ran `pnpm --filter @innerbloom/web typecheck`.
- Typecheck still fails on existing unrelated issues in Clerk/auth typing, PreviewAchievement recent month typing, ES lib `replaceAll`, and related tests. No errors pointed to the files changed in this PR.