### PR TITLE
api: decouple rhythm (game_mode) writes from avatar updates and add avatar update endpoint

### DIFF
--- a/apps/api/src/__tests__/users.me.test.ts
+++ b/apps/api/src/__tests__/users.me.test.ts
@@ -8,6 +8,7 @@ const { mockQuery, mockVerifyToken } = vi.hoisted(() => ({
 
 vi.mock('../db.js', () => ({
   pool: { query: mockQuery },
+  withClient: async (callback: (client: { query: typeof mockQuery }) => unknown) => callback({ query: mockQuery }),
   dbReady: Promise.resolve(),
   runWithDbContext: (_context: string, callback: () => unknown) => callback(),
 }));
@@ -165,5 +166,55 @@ describe('GET /api/users/me', () => {
     });
     expect(mockQuery).not.toHaveBeenCalled();
     expect(mockVerifyToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/users/me/avatar', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockVerifyToken.mockReset();
+    mockVerifyToken.mockResolvedValue({
+      id: 'user-row-id',
+      clerkId: 'user_456',
+      email: 'test@example.com',
+      isNew: false,
+    });
+  });
+
+  it('updates avatar without changing game mode', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ avatar_id: 4 }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          user_id: 'user-row-id',
+          avatar_id: 4,
+          game_mode_id: 13,
+          image_url: 'https://example.com/avatar.png',
+          avatar_url: 'https://example.com/avatar.png',
+        }],
+      });
+
+    const response = await request(app)
+      .put('/api/users/me/avatar')
+      .set('Authorization', 'Bearer token')
+      .send({ avatar_id: 4 });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.user).toMatchObject({
+      user_id: 'user-row-id',
+      avatar_id: 4,
+      game_mode_id: 13,
+    });
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('FROM cat_avatar'),
+      [4],
+    );
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('SET avatar_id = $2'),
+      ['user-row-id', 4],
+    );
   });
 });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -21,9 +21,12 @@ import { updateUserTask } from '../controllers/tasks/update-user-task.js';
 import { getUserRewardsHistory } from '../controllers/users/rewards-history.js';
 import { deleteUserTask } from '../controllers/tasks/delete-user-task.js';
 import { asyncHandler } from '../lib/async-handler.js';
+import { HttpError } from '../lib/http-error.js';
 import { authMiddleware } from '../middlewares/auth-middleware.js';
 import { ownUserGuard } from '../middlewares/own-user-guard.js';
 import { requireActiveSubscription } from '../middlewares/require-active-subscription.js';
+import { withClient } from '../db.js';
+import { resolveAvatarById, updateUserAvatar } from '../services/userAvatarUpdateService.js';
 
 import { getUserStreakPanel } from './users/streak-panel.js';
 import { getUserDailyEnergy } from './users/daily-energy.js';
@@ -60,6 +63,32 @@ userScopedRoutes.get('/rewards/history', asyncHandler(getUserRewardsHistory));
 userScopedRoutes.use('/missions/v2', missionsV2Router);
 
 router.get('/users/me', authMiddleware, asyncHandler(getCurrentUser));
+router.put('/users/me/avatar', authMiddleware, asyncHandler(async (req, res) => {
+  const user = req.user;
+  if (!user) {
+    throw new HttpError(401, 'unauthorized', 'Authentication required');
+  }
+
+  const avatarIdRaw = req.body?.avatar_id;
+  const avatarId =
+    typeof avatarIdRaw === 'number' && Number.isInteger(avatarIdRaw)
+      ? avatarIdRaw
+      : Number.parseInt(String(avatarIdRaw ?? ''), 10);
+
+  if (!Number.isInteger(avatarId) || avatarId <= 0) {
+    throw new HttpError(400, 'invalid_avatar_id', 'avatar_id must be a positive integer');
+  }
+
+  const updated = await withClient(async (client) => {
+    await resolveAvatarById(client, avatarId);
+    return updateUserAvatar(client, {
+      userId: user.id,
+      avatarId,
+    });
+  });
+
+  res.json({ ok: true, user: updated });
+}));
 router.get('/users/me/subscription', authMiddleware, asyncHandler(getUserSubscription));
 router.use('/users/:id', authMiddleware, ownUserGuard, requireActiveSubscription, userScopedRoutes);
 

--- a/apps/api/src/services/__tests__/gameModeUpgradeSuggestionService.test.ts
+++ b/apps/api/src/services/__tests__/gameModeUpgradeSuggestionService.test.ts
@@ -342,7 +342,7 @@ describe('gameModeUpgradeSuggestionService', () => {
       {
         match: (sql) => sql.includes('UPDATE users'),
         handle: (_sql, params) => {
-          expect(params).toEqual(['u1', 12, '/Chill-Mood.jpg', 11]);
+          expect(params).toEqual(['u1', 12, 11]);
           return { rows: [{ user_id: 'u1', game_mode_id: 12, image_url: '/Chill-Mood.jpg', avatar_url: '/Chill-Mood.jpg' }] };
         },
       },

--- a/apps/api/src/services/__tests__/onboardingIntroService.test.ts
+++ b/apps/api/src/services/__tests__/onboardingIntroService.test.ts
@@ -275,10 +275,13 @@ function createSubmitExpectations(options: {
     {
       match: (sql) => {
         const normalized = sql.toLowerCase();
-        return normalized.includes('set game_mode_id = $2') && normalized.includes('avatar_url = $3');
+        const setClause = normalized.split('where')[0] ?? '';
+        return setClause.includes('set game_mode_id = $2')
+          && !setClause.includes('image_url =')
+          && !setClause.includes('avatar_url =');
       },
       handle: (_sql, params) => {
-        expect(params).toEqual([userId, gameModeId, expectedImageUrl, null]);
+        expect(params).toEqual([userId, gameModeId, null]);
         return { rows: [{ user_id: userId, game_mode_id: gameModeId, image_url: expectedImageUrl, avatar_url: expectedImageUrl }] };
       },
     },

--- a/apps/api/src/services/__tests__/userAvatarUpdateService.test.ts
+++ b/apps/api/src/services/__tests__/userAvatarUpdateService.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HttpError } from '../../lib/http-error.js';
+import { resolveAvatarById, updateUserAvatar } from '../userAvatarUpdateService.js';
+
+describe('userAvatarUpdateService', () => {
+  it('updates avatar only and preserves rhythm fields', async () => {
+    const query = vi.fn().mockResolvedValueOnce({
+      rows: [{
+        user_id: 'u1',
+        avatar_id: 7,
+        game_mode_id: 12,
+        image_url: '/FlowMood.jpg',
+        avatar_url: '/FlowMood.jpg',
+      }],
+    });
+
+    const updated = await updateUserAvatar({ query }, { userId: 'u1', avatarId: 7 });
+
+    expect(updated).toMatchObject({
+      user_id: 'u1',
+      avatar_id: 7,
+      game_mode_id: 12,
+    });
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0]?.[0]).toContain('SET avatar_id = $2');
+    expect(query.mock.calls[0]?.[0]).not.toContain('game_mode_id =');
+  });
+
+  it('validates active avatar id', async () => {
+    const query = vi.fn().mockResolvedValueOnce({ rows: [{ avatar_id: 7 }] });
+    await expect(resolveAvatarById({ query }, 7)).resolves.toEqual({ avatar_id: 7 });
+  });
+
+  it('throws invalid_avatar for missing catalog entries', async () => {
+    const query = vi.fn().mockResolvedValueOnce({ rows: [] });
+    await expect(resolveAvatarById({ query }, 999)).rejects.toMatchObject<HttpError>({
+      status: 409,
+      code: 'invalid_avatar',
+    });
+  });
+});

--- a/apps/api/src/services/__tests__/userGameModeChangeService.test.ts
+++ b/apps/api/src/services/__tests__/userGameModeChangeService.test.ts
@@ -13,7 +13,7 @@ describe('userGameModeChangeService', () => {
     delete process.env.WEB_PUBLIC_BASE_URL;
   });
 
-  it('updates game mode and keeps avatar/image parity', async () => {
+  it('updates only game mode without mutating avatar/image fields', async () => {
     const query = vi
       .fn()
       .mockResolvedValueOnce({ rows: [{ user_id: 'u1', game_mode_id: 12, image_url: '/Chill-Mood.jpg', avatar_url: '/Chill-Mood.jpg' }] });
@@ -33,8 +33,12 @@ describe('userGameModeChangeService', () => {
     });
 
     expect(query).toHaveBeenCalledTimes(1);
-    expect(query.mock.calls[0]?.[0]).toContain('SET game_mode_id = $2');
-    expect(query.mock.calls[0]?.[1]).toEqual(['u1', 12, '/Chill-Mood.jpg', 11]);
+    const sql = String(query.mock.calls[0]?.[0] ?? '');
+    const setClause = sql.split('WHERE')[0] ?? '';
+    expect(setClause).toContain('SET game_mode_id = $2');
+    expect(setClause).not.toContain('image_url =');
+    expect(setClause).not.toContain('avatar_url =');
+    expect(query.mock.calls[0]?.[1]).toEqual(['u1', 12, 11]);
   });
 
   it('throws conflict when optimistic condition no longer matches', async () => {

--- a/apps/api/src/services/userAvatarUpdateService.ts
+++ b/apps/api/src/services/userAvatarUpdateService.ts
@@ -1,0 +1,71 @@
+import type { PoolClient } from 'pg';
+import { HttpError } from '../lib/http-error.js';
+
+type QueryClient = Pick<PoolClient, 'query'>;
+
+type AvatarRow = {
+  avatar_id: number;
+};
+
+type UpdatedUserAvatarRow = {
+  user_id: string;
+  avatar_id: number;
+  game_mode_id: number | null;
+  image_url: string | null;
+  avatar_url: string | null;
+};
+
+type UserRow = {
+  user_id: string;
+};
+
+export async function resolveAvatarById(client: QueryClient, avatarId: number): Promise<AvatarRow> {
+  const result = await client.query<AvatarRow>(
+    `SELECT avatar_id
+       FROM cat_avatar
+      WHERE avatar_id = $1
+        AND is_active = true
+      LIMIT 1`,
+    [avatarId],
+  );
+
+  const row = result.rows[0];
+
+  if (!row) {
+    throw new HttpError(409, 'invalid_avatar', 'Invalid avatar');
+  }
+
+  return row;
+}
+
+export async function updateUserAvatar(client: QueryClient, input: {
+  userId: string;
+  avatarId: number;
+}): Promise<UpdatedUserAvatarRow> {
+  const updateResult = await client.query<UpdatedUserAvatarRow>(
+    `UPDATE users
+        SET avatar_id = $2
+      WHERE user_id = $1::uuid
+    RETURNING user_id, avatar_id, game_mode_id, image_url, avatar_url`,
+    [input.userId, input.avatarId],
+  );
+
+  const updatedRow = updateResult.rows[0];
+  if (updatedRow) {
+    return updatedRow;
+  }
+
+  const userResult = await client.query<UserRow>(
+    `SELECT user_id
+       FROM users
+      WHERE user_id = $1::uuid
+      LIMIT 1`,
+    [input.userId],
+  );
+
+  if (!userResult.rows[0]) {
+    throw new HttpError(404, 'user_not_found', 'User not found');
+  }
+
+  throw new HttpError(500, 'avatar_update_failed', 'Failed to update avatar');
+}

--- a/apps/api/src/services/userGameModeChangeService.ts
+++ b/apps/api/src/services/userGameModeChangeService.ts
@@ -88,21 +88,17 @@ export async function changeUserGameMode(client: QueryClient, input: {
   nextModeCode: string;
   expectedCurrentGameModeId?: number | null;
 }): Promise<UpdatedUserModeRow> {
-  const imageUrl = resolveGameModeImageUrl(input.nextModeCode);
-
-  if (!imageUrl) {
-    throw new HttpError(500, 'missing_mode_image', 'Missing mood image for game mode');
-  }
+  // Keep nextModeCode in the signature for API compatibility with existing call sites.
+  // Rhythm (game_mode) writes must not mutate visual identity fields.
+  void input.nextModeCode;
 
   const updateResult = await client.query<UpdatedUserModeRow>(
     `UPDATE users
-        SET game_mode_id = $2,
-            image_url = $3,
-            avatar_url = $3
+        SET game_mode_id = $2
       WHERE user_id = $1::uuid
-        AND ($4::int IS NULL OR game_mode_id = $4)
+        AND ($3::int IS NULL OR game_mode_id = $3)
     RETURNING user_id, game_mode_id, image_url, avatar_url`,
-    [input.userId, input.nextGameModeId, imageUrl, input.expectedCurrentGameModeId ?? null],
+    [input.userId, input.nextGameModeId, input.expectedCurrentGameModeId ?? null],
   );
 
   const updatedRow = updateResult.rows[0];


### PR DESCRIPTION
### Motivation
- Prevent rhythm changes (internal `game_mode`) from mutating visual identity fields and preserve `game_mode` as the behavioral/math source-of-truth. 
- Provide an explicit, safe write path to update a user’s avatar independent of rhythm so avatar changes do not affect weekly targets, onboarding math, or mode history.

### Description
- Refactored `changeUserGameMode` so it updates only `users.game_mode_id` and no longer writes `image_url` or `avatar_url` (apps/api/src/services/userGameModeChangeService.ts). 
- Added a new avatar service `userAvatarUpdateService` with `resolveAvatarById` and `updateUserAvatar` which validates catalog entries and updates only `users.avatar_id` (apps/api/src/services/userAvatarUpdateService.ts). 
- Added `PUT /users/me/avatar` to validate `avatar_id` and apply avatar-only updates via the new service without touching `game_mode_id` or onboarding flows (apps/api/src/routes/users.ts). 
- Updated and added focused tests to assert decoupling: modified game-mode/onboarding/upgrade tests and added avatar service + API tests to prove rhythm changes do not mutate avatar identity and avatar changes do not mutate rhythm. (tests under apps/api/src/services/__tests__ and apps/api/src/__tests__)

### Testing
- Ran the targeted test subset with Vitest: `npm -w @innerbloom/api exec vitest run src/services/__tests__/userGameModeChangeService.test.ts src/services/__tests__/onboardingIntroService.test.ts src/services/__tests__/gameModeUpgradeSuggestionService.test.ts src/services/__tests__/userAvatarUpdateService.test.ts src/__tests__/users.me.test.ts`. 
- All tests in that run passed (33 tests passed); the updated assertions confirm the SQL SET clauses and route behavior reflect the decoupling. 
- Note: legacy visual fields (`image_url` / `avatar_url`) remain present for compatibility and can still be updated by other systems (e.g., Clerk webhook); UI migration to prefer `avatar_id` should follow in the next phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcefea4ac48332b0ba483db2950abc)