### PR TITLE
Phase 4: make rhythm chips and theme styling avatar-driven

### DIFF
--- a/apps/web/src/components/common/GameModeChip.test.ts
+++ b/apps/web/src/components/common/GameModeChip.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { buildGameModeChip } from './GameModeChip';
+import { resolveAvatarProfile } from '../../lib/avatarProfile';
+import type { CurrentUserProfile } from '../../lib/api';
+
+function makeProfile(overrides: Partial<CurrentUserProfile>): CurrentUserProfile {
+  return {
+    user_id: 'user-1',
+    clerk_user_id: 'clerk-1',
+    email_primary: 'test@example.com',
+    full_name: 'Test User',
+    game_mode: 'Flow',
+    weekly_target: 3,
+    image_url: null,
+    avatar_id: null,
+    avatar_code: null,
+    avatar_name: null,
+    avatar_theme_tokens: null,
+    timezone: 'UTC',
+    locale: 'en',
+    created_at: '2026-04-13T00:00:00.000Z',
+    updated_at: '2026-04-13T00:00:00.000Z',
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+describe('buildGameModeChip', () => {
+  it('keeps rhythm label content while using avatar accent styling', () => {
+    const avatarProfile = resolveAvatarProfile(
+      makeProfile({
+        game_mode: 'Flow',
+        avatar_id: 99,
+        avatar_code: 'RED_CAT',
+        avatar_name: 'Red Cat',
+        avatar_theme_tokens: { accent: '#ef4444', chip: 'ember' },
+      }),
+    );
+
+    const chip = buildGameModeChip('Flow', { avatarProfile });
+
+    expect(chip.label).toBe('FLOW');
+    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#ef4444' });
+  });
+
+  it('uses safe legacy fallback accent when avatar is missing', () => {
+    const chip = buildGameModeChip('Flow');
+    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#00C2FF' });
+  });
+});

--- a/apps/web/src/components/common/GameModeChip.tsx
+++ b/apps/web/src/components/common/GameModeChip.tsx
@@ -1,69 +1,59 @@
+import type { CSSProperties } from 'react';
+import { resolveAvatarTheme, type AvatarProfile } from '../../lib/avatarProfile';
 import { normalizeGameModeValue, type GameMode } from '../../lib/gameMode';
 
 interface GameModeChipStyle {
   label: string;
-  backgroundClass: string;
-  glowClass: string;
   animate: boolean;
+  style: CSSProperties;
 }
 
-const GAME_MODE_STYLES: Record<GameMode, GameModeChipStyle> = {
-  Flow: {
-    label: 'FLOW',
-    backgroundClass: 'bg-gradient-to-r from-sky-500/25 via-indigo-500/30 to-purple-500/25 text-[color:var(--color-text)]',
-    glowClass: 'bg-sky-400/40',
-    animate: true,
-  },
-  Chill: {
-    label: 'CHILL',
-    backgroundClass: 'bg-gradient-to-r from-emerald-400/25 via-teal-400/30 to-cyan-400/25 text-[color:var(--color-text)] dark:from-emerald-500/60 dark:via-teal-500/65 dark:to-cyan-500/55 dark:text-emerald-50',
-    glowClass: 'bg-emerald-400/40 dark:bg-emerald-400/60',
-    animate: true,
-  },
-  Evolve: {
-    label: 'EVOLVE',
-    backgroundClass: 'bg-gradient-to-r from-fuchsia-400/25 via-rose-400/30 to-amber-300/25 text-[color:var(--color-text)]',
-    glowClass: 'bg-fuchsia-400/40',
-    animate: true,
-  },
-  Low: {
-    label: 'LOW',
-    backgroundClass: 'bg-gradient-to-r from-rose-500/30 via-red-500/35 to-orange-500/30 text-[color:var(--color-text)]',
-    glowClass: 'bg-rose-500/40',
-    animate: true,
-  },
+const GAME_MODE_LABELS: Record<GameMode, string> = {
+  Flow: 'FLOW',
+  Chill: 'CHILL',
+  Evolve: 'EVOLVE',
+  Low: 'LOW',
 };
 
 const DEFAULT_CHIP_STYLE: GameModeChipStyle = {
   label: 'Modo sin definir',
-  backgroundClass: 'bg-white/10 text-[color:var(--color-text)]',
-  glowClass: 'bg-slate-400/20',
   animate: false,
+  style: {},
 };
 
-export function buildGameModeChip(mode?: string | null): GameModeChipStyle {
+export function buildGameModeChip(
+  mode?: string | null,
+  options?: { avatarProfile?: AvatarProfile | null },
+): GameModeChipStyle {
+  const theme = resolveAvatarTheme(options?.avatarProfile ?? null);
+  const style = {
+    '--ib-chip-accent': theme.accent,
+  } as CSSProperties;
+
   if (!mode) {
-    return DEFAULT_CHIP_STYLE;
+    return { ...DEFAULT_CHIP_STYLE, style };
   }
 
   const normalized = normalizeGameModeValue(mode);
   if (!normalized) {
-    return DEFAULT_CHIP_STYLE;
+    return { ...DEFAULT_CHIP_STYLE, style };
   }
 
-  return GAME_MODE_STYLES[normalized] ?? DEFAULT_CHIP_STYLE;
+  return {
+    label: GAME_MODE_LABELS[normalized] ?? DEFAULT_CHIP_STYLE.label,
+    animate: true,
+    style,
+  };
 }
 
-export function GameModeChip({ label, backgroundClass, glowClass, animate }: GameModeChipStyle) {
+export function GameModeChip({ label, animate, style }: GameModeChipStyle) {
   return (
-    <span className="relative inline-flex items-center">
+    <span className="ib-game-mode-chip relative inline-flex items-center" style={style}>
       <span
-        className={`absolute -inset-[2px] rounded-full blur-md ${glowClass} ${animate ? 'animate-pulse' : ''}`}
+        className={`ib-game-mode-chip__glow absolute -inset-[2px] rounded-full blur-md ${animate ? 'animate-pulse' : ''}`}
         aria-hidden
       />
-      <span
-        className={`relative inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-[0.26rem] text-[10px] font-semibold uppercase tracking-[0.2em] shadow-[0_0_18px_rgba(15,23,42,0.3)] backdrop-blur ${backgroundClass}`}
-      >
+      <span className="ib-game-mode-chip__inner relative inline-flex items-center gap-2 rounded-full border px-3 py-[0.26rem] text-[10px] font-semibold uppercase tracking-[0.2em] backdrop-blur">
         <span className="h-[0.32rem] w-[0.32rem] rounded-full bg-white/80" />
         {label}
       </span>

--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -903,7 +903,7 @@ export function DashboardMenu({
                         <span>{hasActiveUpgradeCta ? t('dashboard.menu.upgradeAvailable') : t('dashboard.menu.changeGameMode')}</span>
                         {hasActiveUpgradeCta ? <span className="rounded-full border border-black/20 bg-white/35 px-2 py-0.5 text-[10px] font-bold uppercase text-black shadow-[0_8px_20px_rgba(167,112,239,0.35)] backdrop-blur-sm">7d</span> : null}
                       </div>
-                      <GameModeChip {...buildGameModeChip(normalizedCurrentMode ?? 'Flow')} />
+                      <GameModeChip {...buildGameModeChip(normalizedCurrentMode ?? 'Flow', { avatarProfile: currentAvatarProfile })} />
                     </button>
                     <div className="mx-3 h-px bg-[color:var(--color-border-subtle)]/80" aria-hidden />
                     <button

--- a/apps/web/src/components/dashboard-v3/MetricHeader.tsx
+++ b/apps/web/src/components/dashboard-v3/MetricHeader.tsx
@@ -7,10 +7,12 @@ import { formatGp } from '../../lib/points';
 import { GameModeChip, buildGameModeChip } from '../common/GameModeChip';
 import { DashboardMeta } from './DashboardTypography';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
+import type { AvatarProfile } from '../../lib/avatarProfile';
 
 interface MetricHeaderProps {
   userId: string;
   gameMode?: string | null;
+  avatarProfile?: AvatarProfile | null;
 }
 
 type XpProgressData = {
@@ -26,7 +28,7 @@ function formatInteger(value: number) {
   return NUMBER_FORMATTER.format(Math.max(0, Math.round(value)));
 }
 
-export function MetricHeader({ userId, gameMode }: MetricHeaderProps) {
+export function MetricHeader({ userId, gameMode, avatarProfile }: MetricHeaderProps) {
   const { t } = usePostLoginLanguage();
 
   const { data, status } = useRequest<XpProgressData>(async () => {
@@ -67,7 +69,10 @@ export function MetricHeader({ userId, gameMode }: MetricHeaderProps) {
     : '';
   const levelLabel = showContent ? formatInteger(data.currentLevel) : '—';
   const totalXpLabel = showContent ? formatInteger(data.xpTotal) : '—';
-  const chipStyle = useMemo(() => buildGameModeChip(gameMode), [gameMode]);
+  const chipStyle = useMemo(
+    () => buildGameModeChip(gameMode, { avatarProfile }),
+    [avatarProfile, gameMode],
+  );
 
   const subtitle = useMemo(() => {
     if (showError) {

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { buildStreakModeChipVisual } from './StreaksPanel';
+import { resolveAvatarProfile } from '../../lib/avatarProfile';
+import type { CurrentUserProfile } from '../../lib/api';
+
+function makeProfile(overrides: Partial<CurrentUserProfile>): CurrentUserProfile {
+  return {
+    user_id: 'user-1',
+    clerk_user_id: 'clerk-1',
+    email_primary: 'test@example.com',
+    full_name: 'Test User',
+    image_url: null,
+    game_mode: 'Flow',
+    weekly_target: 3,
+    avatar_id: null,
+    avatar_code: null,
+    avatar_name: null,
+    avatar_theme_tokens: null,
+    timezone: 'UTC',
+    locale: 'en',
+    created_at: '2026-04-13T00:00:00.000Z',
+    updated_at: '2026-04-13T00:00:00.000Z',
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+describe('buildStreakModeChipVisual', () => {
+  it('uses avatar theme accent regardless of rhythm content', () => {
+    const avatarProfile = resolveAvatarProfile(
+      makeProfile({
+        game_mode: 'Flow',
+        avatar_id: 7,
+        avatar_code: 'RED_CAT',
+        avatar_name: 'Red Cat',
+        avatar_theme_tokens: { accent: '#ef4444', chip: 'ember' },
+      }),
+    );
+
+    const visual = buildStreakModeChipVisual(avatarProfile);
+
+    expect(visual.accent).toBe('#ef4444');
+    expect(visual.glowPrimary).toContain('239, 68, 68');
+    expect(visual.glowSecondary).toContain('239, 68, 68');
+  });
+
+  it('falls back safely when avatar profile is unavailable', () => {
+    const visual = buildStreakModeChipVisual(null);
+    expect(visual.accent).toBe('#00C2FF');
+  });
+});

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
@@ -19,6 +19,7 @@ import { TaskInsightsModal } from './StreakTaskInsightsModal';
 import { DashboardMeta, DashboardTitle } from './DashboardTypography';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
 import { HABIT_ACHIEVEMENT_UPDATED_EVENT } from '../../lib/habitAchievementEvents';
+import { resolveAvatarTheme, type AvatarProfile } from '../../lib/avatarProfile';
 import {
   DASHBOARD_SEGMENTED_BUTTON_ACTIVE,
   DASHBOARD_SEGMENTED_BUTTON_BASE,
@@ -257,6 +258,7 @@ interface StreaksPanelProps {
   userId: string;
   gameMode?: string | null;
   weeklyTarget?: number | null;
+  avatarProfile?: AvatarProfile | null;
   forceLoadingTasks?: boolean;
 }
 
@@ -291,51 +293,46 @@ type GlowChipProps = {
   children: ReactNode;
   className?: string;
   innerClassName?: string;
+  style?: CSSProperties;
 };
 
-function GlowChip({ glowPrimary, glowSecondary, children, className, innerClassName }: GlowChipProps) {
-  const style = {
+function GlowChip({ glowPrimary, glowSecondary, children, className, innerClassName, style }: GlowChipProps) {
+  const chipStyle = {
     '--glow-primary': glowPrimary,
     '--glow-secondary': glowSecondary,
+    ...style,
   } as CSSProperties;
 
   return (
-    <span className={cx('glow-chip inline-flex', className)} style={style}>
+    <span className={cx('glow-chip inline-flex', className)} style={chipStyle}>
       <span className={cx('relative z-[1] inline-flex items-center', innerClassName)}>{children}</span>
     </span>
   );
 }
 
-const MODE_CHIP_STYLES: Record<Mode, { glowPrimary: string; glowSecondary: string; className: string; innerClassName: string }> = {
-  Low: {
-    glowPrimary: 'rgba(248, 113, 113, 0.65)',
-    glowSecondary: 'rgba(239, 68, 68, 0.35)',
-    className: 'ib-streak-mode-chip ib-streak-mode-chip--low',
-    innerClassName:
-      'ib-streak-mode-chip__inner ib-streak-mode-chip__inner--low gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]',
-  },
-  Chill: {
-    glowPrimary: 'rgba(74, 222, 128, 0.6)',
-    glowSecondary: 'rgba(34, 197, 94, 0.3)',
-    className: 'ib-streak-mode-chip ib-streak-mode-chip--chill',
-    innerClassName:
-      'ib-streak-mode-chip__inner ib-streak-mode-chip__inner--chill gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]',
-  },
-  Flow: {
-    glowPrimary: 'rgba(96, 165, 250, 0.6)',
-    glowSecondary: 'rgba(59, 130, 246, 0.35)',
-    className: 'ib-streak-mode-chip ib-streak-mode-chip--flow',
-    innerClassName:
-      'ib-streak-mode-chip__inner ib-streak-mode-chip__inner--flow gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]',
-  },
-  Evolve: {
-    glowPrimary: 'rgba(167, 139, 250, 0.65)',
-    glowSecondary: 'rgba(139, 92, 246, 0.35)',
-    className: 'ib-streak-mode-chip ib-streak-mode-chip--evolve',
-    innerClassName:
-      'ib-streak-mode-chip__inner ib-streak-mode-chip__inner--evolve gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]',
-  },
-};
+function hexToRgba(hex: string, alpha: number): string {
+  const normalized = hex.replace('#', '').trim();
+  const expanded = normalized.length === 3
+    ? normalized.split('').map((chunk) => `${chunk}${chunk}`).join('')
+    : normalized;
+  if (!/^[0-9a-fA-F]{6}$/.test(expanded)) {
+    return `rgba(139, 92, 246, ${alpha})`;
+  }
+  const int = Number.parseInt(expanded, 16);
+  const r = (int >> 16) & 255;
+  const g = (int >> 8) & 255;
+  const b = int & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function buildStreakModeChipVisual(avatarProfile?: AvatarProfile | null) {
+  const avatarTheme = resolveAvatarTheme(avatarProfile ?? null);
+  return {
+    accent: avatarTheme.accent,
+    glowPrimary: hexToRgba(avatarTheme.accent, 0.66),
+    glowSecondary: hexToRgba(avatarTheme.accent, 0.36),
+  };
+}
 
 function normalizeMode(mode?: string | null): Mode {
   return normalizeGameModeValue(mode) ?? 'Flow';
@@ -668,7 +665,7 @@ function TaskItem({
   );
 }
 
-export function StreaksPanel({ userId, gameMode, weeklyTarget, forceLoadingTasks = false }: StreaksPanelProps) {
+export function StreaksPanel({ userId, gameMode, weeklyTarget, avatarProfile, forceLoadingTasks = false }: StreaksPanelProps) {
   const { t, language } = usePostLoginLanguage();
   const [pillar, setPillar] = useState<Pillar>('Body');
   const [range, setRange] = useState<StreakPanelRange>('month');
@@ -880,7 +877,17 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, forceLoadingTasks
           : tab.label,
   }));
   const daysConsecutiveText = (days: string) => t('dashboard.streaks.daysConsecutiveSr', { days });
-  const modeChip = MODE_CHIP_STYLES[normalizedMode];
+  const modeChipVisual = buildStreakModeChipVisual(avatarProfile);
+  const modeChip = {
+    className: 'ib-streak-mode-chip',
+    glowPrimary: modeChipVisual.glowPrimary,
+    glowSecondary: modeChipVisual.glowSecondary,
+    innerClassName:
+      'ib-streak-mode-chip__inner gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]',
+  };
+  const modeChipStyle = {
+    '--ib-chip-accent': modeChipVisual.accent,
+  } as CSSProperties;
 
   return (
     <>
@@ -895,6 +902,7 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, forceLoadingTasks
               glowPrimary={modeChip.glowPrimary}
               glowSecondary={modeChip.glowSecondary}
               innerClassName={modeChip.innerClassName}
+              style={modeChipStyle}
             >
               {modeLabel}
             </GlowChip>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5128,97 +5128,62 @@
       inset 0 0 0 1px rgba(255, 255, 255, 0.9);
   }
 
+  .ib-game-mode-chip {
+    --ib-chip-accent: #8b5cf6;
+  }
+
+  .ib-game-mode-chip__glow {
+    background: color-mix(in srgb, var(--ib-chip-accent) 45%, transparent);
+  }
+
+  .ib-game-mode-chip__inner {
+    border-color: color-mix(in srgb, var(--ib-chip-accent) 58%, rgba(255, 255, 255, 0.24));
+    background: linear-gradient(
+      120deg,
+      color-mix(in srgb, var(--ib-chip-accent) 22%, rgba(255, 255, 255, 0.92)) 0%,
+      color-mix(in srgb, var(--ib-chip-accent) 34%, rgba(255, 255, 255, 0.18)) 100%
+    );
+    color: color-mix(in srgb, var(--ib-chip-accent) 55%, #ffffff);
+    box-shadow:
+      0 0 14px color-mix(in srgb, var(--ib-chip-accent) 24%, transparent),
+      inset 0 0 0 1px color-mix(in srgb, var(--ib-chip-accent) 28%, rgba(255, 255, 255, 0.32));
+  }
+
+  :root[data-theme='light'] .ib-game-mode-chip__inner {
+    color: color-mix(in srgb, var(--ib-chip-accent) 72%, #0f172a);
+  }
+
   .ib-streak-mode-chip {
+    --ib-chip-accent: #8b5cf6;
     --conic-border: 2px;
     --conic-duration: 3.2s;
   }
 
   .ib-streak-mode-chip__inner {
-    border: 1px solid transparent;
+    border: 1px solid;
+    border-color: color-mix(in srgb, var(--ib-chip-accent) 58%, rgba(255, 255, 255, 0.22));
   }
 
-  .ib-streak-mode-chip--low {
-    --glow-primary: rgba(248, 113, 113, 0.65);
-    --glow-secondary: rgba(239, 68, 68, 0.35);
-  }
-
-  .ib-streak-mode-chip--chill {
-    --glow-primary: rgba(74, 222, 128, 0.6);
-    --glow-secondary: rgba(34, 197, 94, 0.3);
-  }
-
-  .ib-streak-mode-chip--flow {
-    --glow-primary: rgba(56, 189, 248, 0.72);
-    --glow-secondary: rgba(14, 116, 144, 0.55);
-  }
-
-  .ib-streak-mode-chip--evolve {
-    --glow-primary: rgba(167, 139, 250, 0.65);
-    --glow-secondary: rgba(139, 92, 246, 0.35);
-  }
-
-  :root[data-theme='light'] .ib-streak-mode-chip__inner--low {
-    border-color: rgba(251, 113, 133, 0.68);
-    background: rgba(255, 228, 230, 0.95);
-    color: rgb(190, 24, 93);
+  :root[data-theme='light'] .ib-streak-mode-chip__inner {
+    background: linear-gradient(
+      120deg,
+      color-mix(in srgb, var(--ib-chip-accent) 20%, #ffffff) 0%,
+      color-mix(in srgb, var(--ib-chip-accent) 12%, rgba(255, 255, 255, 0.94)) 100%
+    );
+    color: color-mix(in srgb, var(--ib-chip-accent) 72%, #0f172a);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
   }
 
-  :root[data-theme='light'] .ib-streak-mode-chip__inner--chill {
-    border-color: rgba(52, 211, 153, 0.68);
-    background: rgba(220, 252, 231, 0.95);
-    color: rgb(6, 95, 70);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
-  }
-
-  :root[data-theme='light'] .ib-streak-mode-chip__inner--flow {
-    border-color: rgba(56, 189, 248, 0.72);
-    background: rgba(224, 242, 254, 0.96);
-    color: rgb(3, 105, 161);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
-  }
-
-  :root[data-theme='light'] .ib-streak-mode-chip__inner--evolve {
-    border-color: rgba(167, 139, 250, 0.72);
-    background: rgba(243, 232, 255, 0.95);
-    color: rgb(109, 40, 217);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
-  }
-
-  :root[data-theme='dark'] .ib-streak-mode-chip__inner--low {
-    border-color: rgba(251, 113, 133, 0.72);
-    background: linear-gradient(120deg, rgba(136, 19, 55, 0.58) 0%, rgba(225, 29, 72, 0.24) 100%);
-    color: rgb(255, 228, 230);
+  :root[data-theme='dark'] .ib-streak-mode-chip__inner {
+    background: linear-gradient(
+      120deg,
+      color-mix(in srgb, var(--ib-chip-accent) 42%, rgba(15, 23, 42, 0.86)) 0%,
+      color-mix(in srgb, var(--ib-chip-accent) 28%, rgba(15, 23, 42, 0.4)) 100%
+    );
+    color: color-mix(in srgb, var(--ib-chip-accent) 24%, #ffffff);
     box-shadow:
-      0 0 12px rgba(225, 29, 72, 0.28),
-      inset 0 0 0 1px rgba(251, 113, 133, 0.24);
-  }
-
-  :root[data-theme='dark'] .ib-streak-mode-chip__inner--chill {
-    border-color: rgba(52, 211, 153, 0.72);
-    background: linear-gradient(120deg, rgba(6, 78, 59, 0.58) 0%, rgba(16, 185, 129, 0.2) 100%);
-    color: rgb(209, 250, 229);
-    box-shadow:
-      0 0 12px rgba(16, 185, 129, 0.24),
-      inset 0 0 0 1px rgba(52, 211, 153, 0.24);
-  }
-
-  :root[data-theme='dark'] .ib-streak-mode-chip__inner--flow {
-    border-color: rgba(56, 189, 248, 0.88);
-    background: linear-gradient(120deg, rgba(8, 47, 73, 0.9) 0%, rgba(3, 105, 161, 0.4) 100%);
-    color: rgb(224, 242, 254);
-    box-shadow:
-      0 0 14px rgba(14, 165, 233, 0.35),
-      inset 0 0 0 1px rgba(125, 211, 252, 0.28);
-  }
-
-  :root[data-theme='dark'] .ib-streak-mode-chip__inner--evolve {
-    border-color: rgba(167, 139, 250, 0.78);
-    background: linear-gradient(120deg, rgba(76, 29, 149, 0.62) 0%, rgba(124, 58, 237, 0.24) 100%);
-    color: rgb(243, 232, 255);
-    box-shadow:
-      0 0 12px rgba(139, 92, 246, 0.3),
-      inset 0 0 0 1px rgba(196, 181, 253, 0.24);
+      0 0 12px color-mix(in srgb, var(--ib-chip-accent) 30%, transparent),
+      inset 0 0 0 1px color-mix(in srgb, var(--ib-chip-accent) 24%, rgba(255, 255, 255, 0.2));
   }
 
   :root[data-theme='light'] .ib-streak-fire-chip {

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -1232,7 +1232,7 @@ export function DashboardOverview({
 
         <div className="order-2 space-y-4 md:space-y-5 lg:order-2 lg:col-span-4">
           <div data-demo-anchor="overall-progress">
-            <MetricHeader userId={userId} gameMode={gameMode} />
+            <MetricHeader userId={userId} gameMode={gameMode} avatarProfile={avatarProfile} />
           </div>
           <ProfileCard gameMode={gameMode} avatarProfile={avatarProfile} />
           <div data-demo-anchor="daily-energy">
@@ -1278,6 +1278,7 @@ export function DashboardOverview({
               userId={userId}
               gameMode={gameMode}
               weeklyTarget={weeklyTarget}
+              avatarProfile={avatarProfile}
               forceLoadingTasks={isJourneyGenerating}
             />
           </div>

--- a/apps/web/src/pages/DemoDashboard.tsx
+++ b/apps/web/src/pages/DemoDashboard.tsx
@@ -244,6 +244,7 @@ export default function DemoDashboardPage() {
         <DashboardOverview
           userId={DEMO_USER_ID}
           gameMode={demoContext.gameMode}
+          avatarProfile={null}
           weeklyTarget={3}
           isJourneyGenerating={false}
           dailyQuestReadiness={DEMO_DAILY_QUEST_READINESS}


### PR DESCRIPTION
### Motivation
- Break the implicit coupling that treated `game_mode` as both intensity and visual identity so rhythm content remains authoritative while avatar controls visual style.  
- Keep all rhythm/math/upgrade/onboarding behavior unchanged while moving chip/glow/gradient ownership to the centralized avatar resolver.

### Description
- Refactored the shared chip to be avatar-themed: `apps/web/src/components/common/GameModeChip.tsx` now builds visual style from `resolveAvatarTheme` and exposes `--ib-chip-accent` instead of mode-specific color classes.  
- Migrated Streaks panel chip visuals to avatar ownership: `apps/web/src/components/dashboard-v3/StreaksPanel.tsx` introduces `buildStreakModeChipVisual` and computes glow/accent from `avatarProfile`, while preserving all rhythm text, weekly target, and streak math.  
- Replaced mode-specific streak chip CSS with tokenized rules using `--ib-chip-accent` so UI no longer assumes mode=color in `apps/web/src/index.css`.  
- Wired avatar context through dashboard surfaces: `MetricHeader.tsx` and `DashboardMenu.tsx` call `buildGameModeChip(..., { avatarProfile })`, `DashboardV3.tsx` passes `avatarProfile` into `MetricHeader` and `StreaksPanel`, and `DemoDashboard.tsx` provides a safe `avatarProfile={null}` demo fallback.  
- Added focused unit tests that assert content remains rhythm-driven and visuals follow avatar tokens: `apps/web/src/components/common/GameModeChip.test.ts` and `apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts`.

### Testing
- Ran focused unit suite: `vitest --run src/components/common/GameModeChip.test.ts src/components/dashboard-v3/StreaksPanel.theme.test.ts src/components/dashboard-v3/DashboardMenu.theme.test.ts`, and all selected tests passed (3 files, 6 tests passed).  
- Ran project typecheck: `npm run typecheck` and observed existing unrelated repo type errors (Clerk typings and preview-achievement typing mismatches); no new type errors were intentionally introduced by this PR's changes.  

Files changed (high level): `GameModeChip.tsx`, `StreaksPanel.tsx`, `MetricHeader.tsx`, `DashboardMenu.tsx`, `DashboardV3.tsx`, `DemoDashboard.tsx`, `index.css`, plus two new focused tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf92d9d5c83329eb6f65e965fbf3a)