### PR TITLE
Decouple dashboard visual identity from game mode (Phase 5): ProfileCard, DashboardMenu, UpgradeRecommendationModal

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -32,7 +32,7 @@ import {
   type ModerationTrackerConfig,
   type ModerationTrackerType,
 } from "../../lib/api";
-import type { AvatarProfile } from "../../lib/avatarProfile";
+import { resolveAvatarMedia, resolveAvatarTheme, type AvatarProfile } from "../../lib/avatarProfile";
 import { normalizeGameModeValue, type GameMode } from "../../lib/gameMode";
 import { GAME_MODE_META, GAME_MODE_ORDER } from "../../lib/gameModeMeta";
 import type { ResolvedTheme } from "../../theme/themePreference";
@@ -70,14 +70,14 @@ type MenuAvatarOption = {
   avatarId: number;
   code: "LEGACY_LOW" | "LEGACY_CHILL" | "LEGACY_FLOW" | "LEGACY_EVOLVE";
   name: string;
-  previewMode: GameMode;
+  accent: string;
 };
 
 const MENU_AVATAR_OPTIONS: MenuAvatarOption[] = [
-  { avatarId: 1, code: "LEGACY_LOW", name: "Legacy Low", previewMode: "Low" },
-  { avatarId: 2, code: "LEGACY_CHILL", name: "Legacy Chill", previewMode: "Chill" },
-  { avatarId: 3, code: "LEGACY_FLOW", name: "Legacy Flow", previewMode: "Flow" },
-  { avatarId: 4, code: "LEGACY_EVOLVE", name: "Legacy Evolve", previewMode: "Evolve" },
+  { avatarId: 1, code: "LEGACY_LOW", name: "Legacy Low", accent: "#58CC02" },
+  { avatarId: 2, code: "LEGACY_CHILL", name: "Legacy Chill", accent: "#00C2FF" },
+  { avatarId: 3, code: "LEGACY_FLOW", name: "Legacy Flow", accent: "#A855F7" },
+  { avatarId: 4, code: "LEGACY_EVOLVE", name: "Legacy Evolve", accent: "#FF6A00" },
 ];
 
 const AVATAR_FALLBACK_BY_MODE: Record<GameMode, MenuAvatarOption["code"]> = {
@@ -128,22 +128,6 @@ export function isDemandingModeJump(currentMode: GameMode | null, selectedMode: 
 }
 
 
-function toMetaModeKey(mode: GameMode): keyof typeof GAME_MODE_META {
-  if (mode === "Low") return "Low";
-  if (mode === "Chill") return "Chill";
-  if (mode === "Flow") return "Flow";
-  return "Evolve";
-}
-
-function getModeBannerObjectPosition(mode: GameMode): string {
-  const positions: Record<GameMode, string> = {
-    Low: '65% 45%',
-    Chill: '60% 45%',
-    Flow: '70% 45%',
-    Evolve: '65% 50%',
-  };
-  return positions[mode];
-}
 export function getWidgetsRefreshingOverlayClass(theme: ResolvedTheme): string {
   return theme === "light"
     ? "bg-[color:var(--color-overlay-3)]"
@@ -412,6 +396,7 @@ export function DashboardMenu({
     () => isDemandingModeJump(normalizedCurrentMode, selectedOrCurrentMode),
     [normalizedCurrentMode, selectedOrCurrentMode],
   );
+  const currentAvatarTheme = useMemo(() => resolveAvatarTheme(currentAvatarProfile), [currentAvatarProfile]);
 
   const menuRowClassName =
     "flex h-12 w-full items-center gap-3 rounded-xl px-3 text-left text-sm font-medium text-[color:var(--color-text-dim)] transition hover:bg-[color:var(--color-overlay-2)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/40";
@@ -1241,7 +1226,7 @@ export function DashboardMenu({
                             {GAME_MODE_ORDER.map((mode) => {
                               const isSelected = (selectedOrCurrentMode ?? 'Flow') === mode;
                               const isCurrent = (normalizedCurrentMode ?? 'Flow') === mode;
-                              const content = GAME_MODE_META[toMetaModeKey(mode)];
+                              const content = GAME_MODE_META[mode];
                               return (
                                 <button
                                   key={mode}
@@ -1249,7 +1234,6 @@ export function DashboardMenu({
                                   onClick={() => handleSelectGameMode(mode)}
                                   className={`relative overflow-hidden rounded-2xl border px-3 py-3 text-left transition ${isSelected ? 'border-[color:var(--color-accent-primary)] bg-[color:var(--color-overlay-3)] shadow-[0_0_0_1px_rgba(125,211,252,0.65),0_0_20px_rgba(56,189,248,0.2)]' : 'border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:bg-[color:var(--color-overlay-2)]'}`}
                                 >
-                                  <span className="absolute inset-y-0 left-0 w-1.5" style={{ backgroundColor: content.accentColor }} aria-hidden />
                                   <div className="ml-2 space-y-2">
                                     <div className="flex items-center justify-between gap-2">
                                       <p className="text-sm font-semibold text-[color:var(--color-text)]">{mode}</p>
@@ -1257,13 +1241,17 @@ export function DashboardMenu({
                                         {content.frequency[language]}
                                       </span>
                                     </div>
-                                    <img
-                                      src={content.avatarSrc}
-                                      alt={content.avatarAlt[language]}
-                                      className="h-20 w-full rounded-xl border border-white/10 object-cover"
-                                      style={{ objectPosition: getModeBannerObjectPosition(mode) }}
-                                      loading="lazy"
-                                    />
+                                    <div
+                                      className="flex h-20 w-full items-center justify-center rounded-xl border border-white/10 px-3 text-center"
+                                      style={{
+                                        background: `linear-gradient(135deg, ${currentAvatarTheme.accent}33, ${currentAvatarTheme.accent}11)`,
+                                      }}
+                                      aria-hidden="true"
+                                    >
+                                      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text)]">
+                                        {mode} · {content.frequency[language]}
+                                      </p>
+                                    </div>
                                     <p className="line-clamp-2 text-[11px] text-[color:var(--color-text-dim)]">{content.objective[language]}</p>
                                     {isCurrent ? (
                                       <span className="inline-flex rounded-full border border-emerald-300/40 bg-emerald-400/15 px-2 py-0.5 text-[10px] font-semibold text-emerald-200">
@@ -1348,7 +1336,17 @@ export function DashboardMenu({
                             {MENU_AVATAR_OPTIONS.map((avatarOption) => {
                               const isSelected = selectedOrCurrentAvatarId === avatarOption.avatarId;
                               const isCurrent = currentAvatarSelection.avatarId === avatarOption.avatarId;
-                              const modeMeta = GAME_MODE_META[toMetaModeKey(avatarOption.previewMode)];
+                              const previewProfile: AvatarProfile = {
+                                avatarId: avatarOption.avatarId,
+                                avatarCode: avatarOption.code,
+                                avatarName: avatarOption.name,
+                                theme: { accent: avatarOption.accent, chip: "aqua" },
+                                isLegacyFallback: true,
+                              };
+                              const avatarMedia = resolveAvatarMedia(previewProfile, {
+                                rhythm: normalizedCurrentMode,
+                                surface: "dashboard-menu",
+                              });
                               return (
                                 <button
                                   key={avatarOption.avatarId}
@@ -1356,19 +1354,17 @@ export function DashboardMenu({
                                   onClick={() => setSelectedAvatarId(avatarOption.avatarId)}
                                   className={`relative overflow-hidden rounded-2xl border px-3 py-3 text-left transition ${isSelected ? 'border-[color:var(--color-accent-primary)] bg-[color:var(--color-overlay-3)] shadow-[0_0_0_1px_rgba(125,211,252,0.65),0_0_20px_rgba(56,189,248,0.2)]' : 'border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:bg-[color:var(--color-overlay-2)]'}`}
                                 >
-                                  <span className="absolute inset-y-0 left-0 w-1.5" style={{ backgroundColor: modeMeta.accentColor }} aria-hidden />
                                   <div className="ml-2 space-y-2">
                                     <div className="flex items-center justify-between gap-2">
                                       <p className="text-sm font-semibold text-[color:var(--color-text)]">{avatarOption.name}</p>
                                       <span className="rounded-full border border-white/20 bg-white/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[color:var(--color-text-dim)]">
-                                        {avatarOption.previewMode}
+                                        {normalizedCurrentMode ?? "Chill"}
                                       </span>
                                     </div>
                                     <img
-                                      src={modeMeta.avatarSrc}
-                                      alt={modeMeta.avatarAlt[language]}
+                                      src={avatarMedia.imageUrl ?? "/FlowMood.jpg"}
+                                      alt={avatarMedia.alt}
                                       className="h-20 w-full rounded-xl border border-white/10 object-cover"
-                                      style={{ objectPosition: getModeBannerObjectPosition(avatarOption.previewMode) }}
                                       loading="lazy"
                                     />
                                     {isCurrent ? (
@@ -1628,6 +1624,7 @@ export function DashboardMenu({
                   open={isUpgradeModalOpen && hasActiveUpgradeCta}
                   currentMode={modeUpgradeSuggestion?.current_mode ?? null}
                   nextMode={modeUpgradeSuggestion?.suggested_mode ?? null}
+                  avatarProfile={currentAvatarProfile}
                   isSubmitting={isUpgradeSubmitting}
                   onConfirm={handleAcceptUpgrade}
                   onClose={() => setIsUpgradeModalOpen(false)}

--- a/apps/web/src/components/dashboard-v3/ModeUpgradeSuggestionCTA.tsx
+++ b/apps/web/src/components/dashboard-v3/ModeUpgradeSuggestionCTA.tsx
@@ -133,6 +133,7 @@ export function ModeUpgradeSuggestionCTA({
         open={isOpen}
         currentMode={suggestion.current_mode}
         nextMode={suggestion.suggested_mode}
+        avatarProfile={null}
         isSubmitting={isSubmitting}
         onConfirm={handleAccept}
         onClose={() => setIsOpen(false)}

--- a/apps/web/src/components/dashboard-v3/ProfileCard.tsx
+++ b/apps/web/src/components/dashboard-v3/ProfileCard.tsx
@@ -13,21 +13,32 @@ export function ProfileCard({ gameMode, avatarProfile }: ProfileCardProps) {
     rhythm: normalizedGameMode,
     surface: 'profile-card',
   });
-  const videoSrc = media.videoUrl ?? '/avatars/flow-basic.mp4';
+  const videoSrc = media.videoUrl;
+  const imageFallback = media.imageUrl ?? '/FlowMood.jpg';
 
   return (
     <CardSection aria-label="Perfil">
       <div className="aspect-[5/6] w-full">
-        <video
-          src={videoSrc}
-          aria-label={media.alt}
-          className="h-full w-full rounded-ib-md object-cover shadow-lg"
-          autoPlay
-          loop
-          muted
-          playsInline
-          preload="metadata"
-        />
+        {videoSrc ? (
+          <video
+            src={videoSrc}
+            poster={imageFallback}
+            aria-label={media.alt}
+            className="h-full w-full rounded-ib-md object-cover shadow-lg"
+            autoPlay
+            loop
+            muted
+            playsInline
+            preload="metadata"
+          />
+        ) : (
+          <img
+            src={imageFallback}
+            alt={media.alt}
+            className="h-full w-full rounded-ib-md object-cover shadow-lg"
+            loading="lazy"
+          />
+        )}
       </div>
     </CardSection>
   );

--- a/apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx
+++ b/apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx
@@ -1,7 +1,7 @@
 import { Sparkles } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
-import { GAME_MODE_META } from '../../lib/gameModeMeta';
+import { resolveAvatarTheme, type AvatarProfile } from '../../lib/avatarProfile';
 import { normalizeGameModeValue } from '../../lib/gameMode';
 import { buildGameModeChip, GameModeChip } from '../common/GameModeChip';
 
@@ -9,6 +9,7 @@ interface UpgradeRecommendationModalProps {
   open: boolean;
   currentMode: string | null;
   nextMode: string | null;
+  avatarProfile: AvatarProfile | null;
   isSubmitting: boolean;
   onConfirm: () => Promise<void>;
   onClose: () => void;
@@ -23,22 +24,17 @@ function formatMode(mode: string | null): string {
   return mode.trim().toUpperCase();
 }
 
-function resolveModeMeta(mode: string | null) {
-  const normalized = normalizeGameModeValue(mode);
-  if (!normalized) return null;
-  return GAME_MODE_META[normalized];
-}
-
 export function UpgradeRecommendationModal({
   open,
   currentMode,
   nextMode,
+  avatarProfile,
   isSubmitting,
   onConfirm,
   onClose,
   onOpenAllModes,
 }: UpgradeRecommendationModalProps) {
-  const { t, language } = usePostLoginLanguage();
+  const { t } = usePostLoginLanguage();
   const [dragProgress, setDragProgress] = useState(0);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -48,8 +44,9 @@ export function UpgradeRecommendationModal({
 
   const confirmInFlightRef = useRef(false);
 
-  const currentMeta = useMemo(() => resolveModeMeta(currentMode), [currentMode]);
-  const nextMeta = useMemo(() => resolveModeMeta(nextMode), [nextMode]);
+  const currentRhythm = useMemo(() => normalizeGameModeValue(currentMode), [currentMode]);
+  const nextRhythm = useMemo(() => normalizeGameModeValue(nextMode), [nextMode]);
+  const avatarTheme = useMemo(() => resolveAvatarTheme(avatarProfile), [avatarProfile]);
   const nextModeChip = useMemo(() => buildGameModeChip(nextMode), [nextMode]);
 
   useEffect(() => {
@@ -181,19 +178,19 @@ export function UpgradeRecommendationModal({
                   <span className="text-3xl font-bold text-black/75" aria-hidden="true">→</span>
                 </div>
 
-                {nextMeta ? (
+                {nextRhythm ? (
                   <div className="pointer-events-none absolute right-2 top-1/2 flex -translate-y-1/2 flex-col items-center gap-1">
-                    <img
-                      src={nextMeta.avatarSrc}
-                      alt={nextMeta.avatarAlt[language]}
-                      draggable={false}
-                      className="h-14 w-14 rounded-xl border border-black/10 object-cover shadow-[0_10px_22px_rgba(15,23,42,0.28)] select-none"
-                    />
+                    <div
+                      className="flex h-14 w-14 items-center justify-center rounded-xl border border-black/10 bg-white/75 text-[10px] font-bold uppercase tracking-[0.14em] shadow-[0_10px_22px_rgba(15,23,42,0.28)]"
+                      aria-hidden="true"
+                    >
+                      NEXT
+                    </div>
                     <p className="text-[11px] font-semibold uppercase tracking-[0.08em]">{formatMode(nextMode)}</p>
                   </div>
                 ) : null}
 
-                {currentMeta ? (
+                {currentRhythm ? (
                   <button
                     ref={handleRef}
                     type="button"
@@ -221,12 +218,13 @@ export function UpgradeRecommendationModal({
                     }}
                     aria-label={t('dashboard.upgradeCta.dragHint')}
                   >
-                    <img
-                      src={currentMeta.avatarSrc}
-                      alt={currentMeta.avatarAlt[language]}
-                      draggable={false}
-                      className="h-14 w-14 rounded-xl border border-black/10 object-cover shadow-[0_10px_22px_rgba(15,23,42,0.28)] select-none"
-                    />
+                    <div
+                      className="flex h-14 w-14 items-center justify-center rounded-xl border border-black/10 text-[10px] font-bold uppercase tracking-[0.14em] text-white shadow-[0_10px_22px_rgba(15,23,42,0.28)]"
+                      style={{ backgroundColor: avatarTheme.accent }}
+                      aria-hidden="true"
+                    >
+                      NOW
+                    </div>
                     <p className="text-[11px] font-semibold uppercase tracking-[0.08em]">{formatMode(currentMode)}</p>
                   </button>
                 ) : null}


### PR DESCRIPTION
### Motivation
- Finish Phase 5 dashboard-only decoupling so post-login visuals are driven by the avatar resolver/theme while leaving `game_mode` as the unchanged internal rhythm/intensity engine and preserving all existing math and behavior.

### Description
- Files changed: `apps/web/src/components/dashboard-v3/ProfileCard.tsx`, `apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx`, `apps/web/src/components/dashboard-v3/DashboardMenu.tsx`, and `apps/web/src/components/dashboard-v3/ModeUpgradeSuggestionCTA.tsx` (prop compatibility update). 
- ProfileCard hardening: it now reads media from the avatar resolver (`resolveAvatarMedia`) and safely renders a video when available or falls back to a rhythm-aware image, removing the previous mode-bound video assumption. 
- DashboardMenu cleanup: removed mode-avatar image/stripe previews, switched mode cards to rhythm text/frequency/objective with a tint block driven by the current avatar theme, and made avatar picker previews resolve through the avatar media resolver rather than `GAME_MODE_META`. 
- UpgradeRecommendationModal refactor: removed side-by-side mode-bound avatar image comparison and replaced it with a rhythm-forward NOW/NEXT affordance and avatar-theme accent on the draggable handle, accepting `avatarProfile` for theme-aware styling; `ModeUpgradeSuggestionCTA` updated to pass a null fallback for the new prop.
- Scope preserved: no missions boards, onboarding primary flows, landing/demo, or rhythm math/analytics were changed; legacy safe fallbacks and resolver-based placeholders are used where final assets are missing.
- Recommended next step: migrate dashboard chip theming (`StreaksPanel` and chip CSS) so chip content remains rhythm-driven and all chip styling is avatar-theme-driven with the same legacy-safe fallbacks.

### Testing
- Unit tests run: `npm --workspace apps/web run test -- DashboardMenu.avatar-selection.test.ts DashboardMenu.mode-jump.test.ts DashboardMenu.theme.test.ts --run` and all related tests passed (8 tests passed).
- Typecheck: `npm run typecheck:web` was attempted but the workspace has pre-existing repository-wide TypeScript issues unrelated to this change (Clerk typings and several test-type mismatches); these failures are known and not caused by the dashboard-only changes.
- No new tests were added in this patch; existing dashboard menu tests were left intact and re-run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcfbe6ccec8332a757a756c5467a8f)