### PR TITLE
Migrate missions boards art resolution to avatar-first resolver

### DIFF
--- a/apps/web/src/components/dashboard-v3/MissionsV2Board.tsx
+++ b/apps/web/src/components/dashboard-v3/MissionsV2Board.tsx
@@ -40,6 +40,8 @@ import {
 import { FEATURE_MISSIONS_V2 } from '../../lib/featureFlags';
 import { normalizeGameModeValue, type GameMode } from '../../lib/gameMode';
 import { subscribeToMediaQuery } from '../../lib/mediaQuery';
+import type { AvatarProfile } from '../../lib/avatarProfile';
+import { resolveMissionsArt } from './missionsVisualResolver';
 type Rarity = 'common' | 'rare' | 'epic' | 'legendary';
 
 type ClaimModalState = {
@@ -235,9 +237,6 @@ type MissionCardStyle = CSSProperties & {
 
 type MarketProposalTransition = 'forward' | 'backward' | null;
 
-const DEFAULT_MISSION_ART_MODE: GameMode = 'Flow';
-
-
 type PrimaryAction = {
   key: string;
   label: string;
@@ -246,42 +245,15 @@ type PrimaryAction = {
   tone: 'primary' | 'neutral';
 };
 
-const MISSION_ART_BY_SLOT_AND_MODE: Record<MissionArtSlot, Record<GameMode, string>> = {
-  main: {
-    Flow: '/missions/missions_main_flow.png',
-    Chill: '/missions/missions_main_chill.png',
-    Low: '/missions/missions_main_low.png',
-    Evolve: '/missions/missions_main_evolve.png',
+function buildMissionCardStyle(
+  slot: MissionArtSlot,
+  options: {
+    avatarProfile?: AvatarProfile | null;
+    rhythm?: string | null;
   },
-  hunt: {
-    Flow: '/missions/missions_hunt_flow.png',
-    Chill: '/missions/missions_hunt_chill.png',
-    Low: '/missions/missions_hunt_low.png',
-    Evolve: '/missions/missions_hunt_evolve.png',
-  },
-  skill: {
-    Flow: '/missions/missions_skill_flow.png',
-    Chill: '/missions/missions_skill_chill.png',
-    Low: '/missions/missions_skill_low.png',
-    Evolve: '/missions/missions_skill_evolve.png',
-  },
-  boss: {
-    Flow: '/missions/missions_boss_flow.png',
-    Chill: '/missions/missions_boss_chill.png',
-    Low: '/missions/missions_boss_low.png',
-    Evolve: '/missions/missions_boss_evolve.png',
-  },
-};
-
-function getMissionArt(slot: MissionArtSlot, gameMode: GameMode | null): string {
-  const normalizedMode = gameMode ?? DEFAULT_MISSION_ART_MODE;
-  const artByMode = MISSION_ART_BY_SLOT_AND_MODE[slot];
-  return artByMode?.[normalizedMode] ?? artByMode[DEFAULT_MISSION_ART_MODE];
-}
-
-function buildMissionCardStyle(slot: MissionArtSlot, gameMode: GameMode | null): MissionCardStyle {
+): MissionCardStyle {
   return {
-    '--missions-card-art': `url(${getMissionArt(slot, gameMode)})`,
+    '--missions-card-art': `url(${resolveMissionsArt(slot, options)})`,
     '--missions-card-art-opacity': slot === 'boss' ? '0.55' : '0.7',
   };
 }
@@ -1006,9 +978,11 @@ function ActiveMissionCard({
 export function MissionsV2Board({
   userId,
   gameMode,
+  avatarProfile,
 }: {
   userId: string;
   gameMode?: GameMode | string | null;
+  avatarProfile?: AvatarProfile | null;
 }) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -1799,7 +1773,10 @@ export function MissionsV2Board({
     }
 
     const shield = parseShieldLabel(board.boss.countdown.label) ?? { current: 6, max: 6 };
-    const bossCardStyle = buildMissionCardStyle('boss', normalizedGameMode);
+    const bossCardStyle = buildMissionCardStyle('boss', {
+      avatarProfile,
+      rhythm: normalizedGameMode,
+    });
 
     return (
       <Card
@@ -2782,7 +2759,10 @@ export function MissionsV2Board({
       const relativeOffset = index - activeMarketIndex;
       const deckPosition =
         relativeOffset === 0 ? 'active' : relativeOffset < 0 ? 'before' : 'after';
-      const coverSrc = getMissionArt(slot, normalizedGameMode);
+      const coverSrc = resolveMissionsArt(slot, {
+        avatarProfile,
+        rhythm: normalizedGameMode,
+      });
       const activeProposalIndex = activeMarketProposalBySlot[slot] ?? 0;
       const proposalList = proposals;
       const totalProposals = proposalList.length;
@@ -3363,7 +3343,10 @@ export function MissionsV2Board({
     const resolvedPrimaryAction = primaryAction!;
 
     const slotCardStyle: MissionCardStyle = {
-      ...buildMissionCardStyle(slot.slot, normalizedGameMode),
+      ...buildMissionCardStyle(slot.slot, {
+        avatarProfile,
+        rhythm: normalizedGameMode,
+      }),
       ...(viewMode === 'active'
         ? {
             '--missions-card-art': 'none',

--- a/apps/web/src/components/dashboard-v3/MissionsV3Board.tsx
+++ b/apps/web/src/components/dashboard-v3/MissionsV3Board.tsx
@@ -43,6 +43,8 @@ import {
 import { FEATURE_MISSIONS_V2 } from '../../lib/featureFlags';
 import { normalizeGameModeValue, type GameMode } from '../../lib/gameMode';
 import { subscribeToMediaQuery } from '../../lib/mediaQuery';
+import type { AvatarProfile } from '../../lib/avatarProfile';
+import { resolveMissionsArt } from './missionsVisualResolver';
 import 'swiper/css';
 import 'swiper/css/effect-cards';
 
@@ -256,9 +258,6 @@ type MissionCardStyle = CSSProperties & {
 
 type MarketProposalTransition = 'forward' | 'backward' | null;
 
-const DEFAULT_MISSION_ART_MODE: GameMode = 'Flow';
-
-
 type PrimaryAction = {
   key: string;
   label: string;
@@ -267,42 +266,15 @@ type PrimaryAction = {
   tone: 'primary' | 'neutral';
 };
 
-const MISSION_ART_BY_SLOT_AND_MODE: Record<MissionArtSlot, Record<GameMode, string>> = {
-  main: {
-    Flow: '/missions/missions_main_flow.png',
-    Chill: '/missions/missions_main_chill.png',
-    Low: '/missions/missions_main_low.png',
-    Evolve: '/missions/missions_main_evolve.png',
+function buildMissionCardStyle(
+  slot: MissionArtSlot,
+  options: {
+    avatarProfile?: AvatarProfile | null;
+    rhythm?: string | null;
   },
-  hunt: {
-    Flow: '/missions/missions_hunt_flow.png',
-    Chill: '/missions/missions_hunt_chill.png',
-    Low: '/missions/missions_hunt_low.png',
-    Evolve: '/missions/missions_hunt_evolve.png',
-  },
-  skill: {
-    Flow: '/missions/missions_skill_flow.png',
-    Chill: '/missions/missions_skill_chill.png',
-    Low: '/missions/missions_skill_low.png',
-    Evolve: '/missions/missions_skill_evolve.png',
-  },
-  boss: {
-    Flow: '/missions/missions_boss_flow.png',
-    Chill: '/missions/missions_boss_chill.png',
-    Low: '/missions/missions_boss_low.png',
-    Evolve: '/missions/missions_boss_evolve.png',
-  },
-};
-
-function getMissionArt(slot: MissionArtSlot, gameMode: GameMode | null): string {
-  const normalizedMode = gameMode ?? DEFAULT_MISSION_ART_MODE;
-  const artByMode = MISSION_ART_BY_SLOT_AND_MODE[slot];
-  return artByMode?.[normalizedMode] ?? artByMode[DEFAULT_MISSION_ART_MODE];
-}
-
-function buildMissionCardStyle(slot: MissionArtSlot, gameMode: GameMode | null): MissionCardStyle {
+): MissionCardStyle {
   return {
-    '--missions-card-art': `url(${getMissionArt(slot, gameMode)})`,
+    '--missions-card-art': `url(${resolveMissionsArt(slot, options)})`,
     '--missions-card-art-opacity': slot === 'boss' ? '0.55' : '0.7',
   };
 }
@@ -1079,9 +1051,11 @@ function ActiveMissionCard({
 export function MissionsV3Board({
   userId,
   gameMode,
+  avatarProfile,
 }: {
   userId: string;
   gameMode?: GameMode | string | null;
+  avatarProfile?: AvatarProfile | null;
 }) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -1876,7 +1850,10 @@ export function MissionsV3Board({
     }
 
     const shield = parseShieldLabel(board.boss.countdown.label) ?? { current: 6, max: 6 };
-    const bossCardStyle = buildMissionCardStyle('boss', normalizedGameMode);
+    const bossCardStyle = buildMissionCardStyle('boss', {
+      avatarProfile,
+      rhythm: normalizedGameMode,
+    });
 
     return (
       <Card
@@ -2781,7 +2758,10 @@ export function MissionsV3Board({
       const canActivate = Boolean(slotState && !slotState.mission && slotState.state === 'idle');
       const isFlipped = Boolean(flippedMarketCards[cardKey]);
       const isActiveCard = index === activeMarketIndex;
-      const coverSrc = getMissionArt(slot, normalizedGameMode);
+      const coverSrc = resolveMissionsArt(slot, {
+        avatarProfile,
+        rhythm: normalizedGameMode,
+      });
       const activeProposalIndex = activeMarketProposalBySlot[slot] ?? 0;
       const proposalList = proposals;
       const totalProposals = proposalList.length;
@@ -3492,7 +3472,10 @@ export function MissionsV3Board({
     const resolvedPrimaryAction = primaryAction!;
 
     const slotCardStyle: MissionCardStyle = {
-      ...buildMissionCardStyle(slot.slot, normalizedGameMode),
+      ...buildMissionCardStyle(slot.slot, {
+        avatarProfile,
+        rhythm: normalizedGameMode,
+      }),
       ...(viewMode === 'active'
         ? {
             '--missions-card-art': 'none',

--- a/apps/web/src/components/dashboard-v3/missionsVisualResolver.ts
+++ b/apps/web/src/components/dashboard-v3/missionsVisualResolver.ts
@@ -1,0 +1,29 @@
+import { resolveAvatarMedia, type AvatarProfile } from '../../lib/avatarProfile';
+
+type MissionArtSlot = 'main' | 'hunt' | 'skill' | 'boss';
+
+const DEFAULT_MISSION_ART_BY_SLOT: Record<MissionArtSlot, string> = {
+  main: '/missions/missions_main_flow.png',
+  hunt: '/missions/missions_hunt_flow.png',
+  skill: '/missions/missions_skill_flow.png',
+  boss: '/missions/missions_boss_flow.png',
+};
+
+export function resolveMissionsArt(
+  slot: MissionArtSlot,
+  options: {
+    avatarProfile?: AvatarProfile | null;
+    rhythm?: string | null;
+  },
+): string {
+  const avatarMedia = resolveAvatarMedia(options.avatarProfile ?? null, {
+    rhythm: options.rhythm,
+    surface: 'missions',
+  });
+
+  if (typeof avatarMedia.imageUrl === 'string' && avatarMedia.imageUrl.length > 0) {
+    return avatarMedia.imageUrl;
+  }
+
+  return DEFAULT_MISSION_ART_BY_SLOT[slot];
+}

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -1004,6 +1004,7 @@ export default function DashboardV3Page() {
                     <MissionsV2Route
                       userId={backendUserId}
                       gameMode={gameMode}
+                      avatarProfile={avatarProfile}
                     />
                   }
                 />
@@ -1013,6 +1014,7 @@ export default function DashboardV3Page() {
                     <MissionsV2Route
                       userId={backendUserId}
                       gameMode={gameMode}
+                      avatarProfile={avatarProfile}
                     />
                   }
                 />
@@ -1022,6 +1024,7 @@ export default function DashboardV3Page() {
                     <MissionsV3Route
                       userId={backendUserId}
                       gameMode={gameMode}
+                      avatarProfile={avatarProfile}
                     />
                   }
                 />
@@ -1409,23 +1412,27 @@ function DailyQuestView({
 function MissionsV2Route({
   userId,
   gameMode,
+  avatarProfile,
 }: {
   userId: string;
   gameMode: GameMode | string | null;
+  avatarProfile: AvatarProfile | null;
 }) {
   if (!FEATURE_MISSIONS_V2) {
     return <Navigate to=".." replace />;
   }
 
-  return <MissionsV2View userId={userId} gameMode={gameMode} />;
+  return <MissionsV2View userId={userId} gameMode={gameMode} avatarProfile={avatarProfile} />;
 }
 
 function MissionsV2View({
   userId,
   gameMode,
+  avatarProfile,
 }: {
   userId: string;
   gameMode: GameMode | string | null;
+  avatarProfile: AvatarProfile | null;
 }) {
   const [showWip, setShowWip] = useState(true);
   const navigate = useNavigate();
@@ -1433,7 +1440,7 @@ function MissionsV2View({
   return (
     <div className="relative space-y-6">
       <h1 className="sr-only">Misiones</h1>
-      <MissionsV2Board userId={userId} gameMode={gameMode} />
+      <MissionsV2Board userId={userId} gameMode={gameMode} avatarProfile={avatarProfile} />
       {showWip ? (
         <div className="fixed inset-0 z-20 bg-slate-950/90 px-4 py-6 sm:px-8 sm:py-10">
           <div className="mx-auto flex h-full max-w-2xl flex-col items-center justify-center text-center">
@@ -1472,28 +1479,32 @@ function MissionsV2View({
 function MissionsV3Route({
   userId,
   gameMode,
+  avatarProfile,
 }: {
   userId: string;
   gameMode: GameMode | string | null;
+  avatarProfile: AvatarProfile | null;
 }) {
   if (!FEATURE_MISSIONS_V2) {
     return <Navigate to=".." replace />;
   }
 
-  return <MissionsV3View userId={userId} gameMode={gameMode} />;
+  return <MissionsV3View userId={userId} gameMode={gameMode} avatarProfile={avatarProfile} />;
 }
 
 function MissionsV3View({
   userId,
   gameMode,
+  avatarProfile,
 }: {
   userId: string;
   gameMode: GameMode | string | null;
+  avatarProfile: AvatarProfile | null;
 }) {
   return (
     <div className="space-y-6">
       <h1 className="sr-only">Misiones v3</h1>
-      <MissionsV3Board userId={userId} gameMode={gameMode} />
+      <MissionsV3Board userId={userId} gameMode={gameMode} avatarProfile={avatarProfile} />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Decouple missions surfaces from mode-bound visual assumptions so visuals are driven by the new `avatar` read-model while preserving all existing rhythm/math behavior.
- Introduce a centralized, avatar-first resolver to avoid scattering legacy `game_mode` -> media lookups across missions codepaths and to make future avatar asset wiring incremental and safe.
- Keep a safe placeholder fallback for V1 so the feature does not depend on the final avatar+rhythm asset matrix.

### Description
- Added a new resolver `apps/web/src/components/dashboard-v3/missionsVisualResolver.ts` which calls `resolveAvatarMedia(..., { surface: 'missions', rhythm })` and falls back to deterministic slot art when avatar media is not available.
- Replaced mode-bound mission art logic by removing local `MISSION_ART_BY_SLOT_AND_MODE` usage in `MissionsV2Board` and `MissionsV3Board`, and switched boss/market/slot card art to `resolveMissionsArt(...)`; both boards now accept an optional `avatarProfile` prop. 
- Threaded `avatarProfile` through `DashboardV3` missions routes/views so mission boards can resolve avatar-driven visuals without changing any gameplay/progression/math codepaths. 
- Deferred final work and next step: the full `(avatar, rhythm, slot)` asset matrix and avatar-theme tokenization are left for a follow-up; recommend the next prompt: “Implement missions visual pass 2: add avatar-theme tokenization for missions card gradients/chips and extend `resolveMissionsArt` to consume API-provided `cat_avatar_asset` keyed by `(avatar, rhythm, slot)` while preserving current placeholder fallbacks.”

### Testing
- Ran type-check: `pnpm -C apps/web exec tsc --noEmit`, which failed due to pre-existing, repo-wide TypeScript issues unrelated to the missions changes (Clerk/runtimeAuth and preview achievement typing errors), so no type errors attributable to the missions edits were isolated as part of this pass. (failed)
- Ran linter: `pnpm -C apps/web exec eslint src/components/dashboard-v3/MissionsV2Board.tsx src/components/dashboard-v3/MissionsV3Board.tsx src/components/dashboard-v3/missionsVisualResolver.ts src/pages/DashboardV3.tsx`, which failed in this environment because ESLint requires an `eslint.config` flat config not present here; the changed files follow project patterns and were committed for review. (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcfbe8fc24833295ad1fa58279c163)