### PR TITLE
Harden mobile auth callback to stop using legacy image_url by default

### DIFF
--- a/apps/web/src/pages/MobileBrowserAuth.tsx
+++ b/apps/web/src/pages/MobileBrowserAuth.tsx
@@ -48,11 +48,21 @@ function buildSignedOutUrl(search: string): string {
   return resolveReturnTo(search, CAPACITOR_SIGNED_OUT_HOST);
 }
 
-function buildRedirectUrl(
+type MobileCallbackLegacyOptions = {
+  includeLegacyImageUrl: boolean;
+};
+
+export function shouldIncludeLegacyProfileImage(search: string): boolean {
+  const params = new URLSearchParams(search);
+  return params.get('legacy_profile_image') === '1';
+}
+
+export function buildRedirectUrl(
   baseUrl: string,
   user: ReturnType<typeof useUser>['user'],
   token: string,
   mode: 'sign-in' | 'sign-up' | 'refresh',
+  options: MobileCallbackLegacyOptions,
 ): string {
   const callbackUrl = new URL(baseUrl);
   callbackUrl.searchParams.set('token', token);
@@ -68,7 +78,10 @@ function buildRedirectUrl(
     callbackUrl.searchParams.set('full_name', user.fullName);
   }
   if (user?.imageUrl) {
-    callbackUrl.searchParams.set('image_url', user.imageUrl);
+    callbackUrl.searchParams.set('clerk_image_url', user.imageUrl);
+    if (options.includeLegacyImageUrl) {
+      callbackUrl.searchParams.set('image_url', user.imageUrl);
+    }
   }
   if (user?.firstName) {
     callbackUrl.searchParams.set('first_name', user.firstName);
@@ -151,6 +164,10 @@ export default function MobileBrowserAuthPage() {
     const params = new URLSearchParams(location.search);
     return params.get('handoff') === '1';
   }, [location.search]);
+  const includeLegacyImageUrl = useMemo(
+    () => shouldIncludeLegacyProfileImage(location.search),
+    [location.search],
+  );
   const createdSessionId = signIn?.createdSessionId ?? signUp?.createdSessionId ?? null;
 
   useEffect(() => {
@@ -334,6 +351,7 @@ export default function MobileBrowserAuthPage() {
             user,
             token,
             mode === 'refresh' ? 'refresh' : mode,
+            { includeLegacyImageUrl },
           );
           console.info('[mobile-auth-page] callback-build', {
             callbackUrl: resolvedCallbackUrl,
@@ -393,6 +411,7 @@ export default function MobileBrowserAuthPage() {
     mode,
     returnTo,
     isHandoffStep,
+    includeLegacyImageUrl,
     session?.id,
     signOut,
     signedOutUrl,

--- a/apps/web/src/pages/__tests__/MobileBrowserAuth.test.ts
+++ b/apps/web/src/pages/__tests__/MobileBrowserAuth.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { buildRedirectUrl, shouldIncludeLegacyProfileImage } from '../MobileBrowserAuth';
+
+describe('MobileBrowserAuth callback URL hardening', () => {
+  const baseUrl = 'innerbloom://auth-callback';
+  const token = 'test-token';
+  const mode = 'sign-in' as const;
+  const user = {
+    id: 'user_123',
+    imageUrl: 'https://images.example.com/clerk-user.png',
+    primaryEmailAddress: { emailAddress: 'test@example.com' },
+  };
+
+  it('omits legacy image_url by default and writes clerk_image_url', () => {
+    const callbackUrl = new URL(buildRedirectUrl(baseUrl, user as never, token, mode, {
+      includeLegacyImageUrl: false,
+    }));
+
+    expect(callbackUrl.searchParams.get('token')).toBe(token);
+    expect(callbackUrl.searchParams.get('auth_mode')).toBe(mode);
+    expect(callbackUrl.searchParams.get('user_id')).toBe(user.id);
+    expect(callbackUrl.searchParams.get('email')).toBe('test@example.com');
+    expect(callbackUrl.searchParams.get('clerk_image_url')).toBe(user.imageUrl);
+    expect(callbackUrl.searchParams.has('image_url')).toBe(false);
+  });
+
+  it('supports short compatibility dual-write when legacy flag is enabled', () => {
+    const callbackUrl = new URL(buildRedirectUrl(baseUrl, user as never, token, mode, {
+      includeLegacyImageUrl: true,
+    }));
+
+    expect(callbackUrl.searchParams.get('clerk_image_url')).toBe(user.imageUrl);
+    expect(callbackUrl.searchParams.get('image_url')).toBe(user.imageUrl);
+  });
+
+  it('parses legacy_profile_image query flag safely', () => {
+    expect(shouldIncludeLegacyProfileImage('?legacy_profile_image=1')).toBe(true);
+    expect(shouldIncludeLegacyProfileImage('?legacy_profile_image=0')).toBe(false);
+    expect(shouldIncludeLegacyProfileImage('')).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent cross-platform identity drift by stopping the mobile/native callback from being treated as the canonical product avatar identity.  
- Preserve auth/session flow stability while making the change additive and reversible for a short compatibility window.  
- Provide a clear, non-canonical name for the third-party profile photo to nudge native clients toward the new `avatar` model without breaking existing clients immediately.  

### Description
- Changed `apps/web/src/pages/MobileBrowserAuth.tsx` to add `shouldIncludeLegacyProfileImage(search: string)` and accept an `options` argument in `buildRedirectUrl(...)`, emit `clerk_image_url` for Clerk profile photos, and only emit legacy `image_url` when `legacy_profile_image=1` is present.  
- Kept all existing session/auth metadata intact (`token`, `auth_mode`, `user_id`, `username`, `email`, etc.) and did not alter rhythm/missions/mission-related code paths.  
- Added unit tests at `apps/web/src/pages/__tests__/MobileBrowserAuth.test.ts` validating that `image_url` is omitted by default, `clerk_image_url` is always emitted when available, and that the `legacy_profile_image` flag enables the short compatibility dual-write.  

### Testing
- Ran the focused unit tests: `cd apps/web && npm run test -- src/pages/__tests__/MobileBrowserAuth.test.ts`.  
- Result: 1 test file executed, 3 tests passed and all assertions succeeded.  
- No changes were made to auth/session resolution behavior and no other automated tests were touched.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd002ef1508332ab0597ef55296ec9)