### PR TITLE
Phase 9: Remove mode visual metadata and mode-derived avatar fallback

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts
@@ -10,9 +10,10 @@ describe("resolveMenuAvatarSelection", () => {
       avatarName: "Legacy Chill",
       theme: { accent: "#00C2FF", chip: "aqua" },
       isLegacyFallback: false,
+      fallbackReason: "none",
     } satisfies AvatarProfile;
 
-    expect(resolveMenuAvatarSelection(profile, "Low")).toMatchObject({
+    expect(resolveMenuAvatarSelection(profile)).toMatchObject({
       avatarId: 3,
       code: "LEGACY_FLOW",
     });
@@ -25,16 +26,17 @@ describe("resolveMenuAvatarSelection", () => {
       avatarName: "Legacy Evolve",
       theme: { accent: "#FF6A00", chip: "ember" },
       isLegacyFallback: true,
+      fallbackReason: "missing-avatar-payload",
     } satisfies AvatarProfile;
 
-    expect(resolveMenuAvatarSelection(profile, "Low")).toMatchObject({
+    expect(resolveMenuAvatarSelection(profile)).toMatchObject({
       avatarId: 4,
       code: "LEGACY_EVOLVE",
     });
   });
 
-  it("uses rhythm fallback when avatar data is missing", () => {
-    expect(resolveMenuAvatarSelection(null, "Chill")).toMatchObject({
+  it("uses explicit default avatar fallback when avatar data is missing", () => {
+    expect(resolveMenuAvatarSelection(null)).toMatchObject({
       avatarId: 2,
       code: "LEGACY_CHILL",
     });

--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -72,9 +72,8 @@ const MENU_AVATAR_OPTIONS: MenuAvatarOption[] = AVATAR_OPTIONS;
 
 export function resolveMenuAvatarSelection(
   avatarProfile: AvatarProfile | null,
-  currentMode: GameMode | null,
 ): MenuAvatarOption {
-  return resolveAvatarOption(avatarProfile, currentMode);
+  return resolveAvatarOption(avatarProfile);
 }
 
 
@@ -376,8 +375,8 @@ export function DashboardMenu({
   );
   const selectedOrCurrentMode = selectedMode ?? normalizedCurrentMode;
   const currentAvatarSelection = useMemo(
-    () => resolveMenuAvatarSelection(currentAvatarProfile, normalizedCurrentMode),
-    [currentAvatarProfile, normalizedCurrentMode],
+    () => resolveMenuAvatarSelection(currentAvatarProfile),
+    [currentAvatarProfile],
   );
   const selectedOrCurrentAvatarId = selectedAvatarId ?? currentAvatarSelection.avatarId;
   const modeJumpIsDemanding = useMemo(
@@ -1335,7 +1334,8 @@ export function DashboardMenu({
                                 avatarCode: avatarOption.code,
                                 avatarName: avatarOption.name,
                                 theme: { accent: avatarOption.accent, chip: "aqua" },
-                                isLegacyFallback: true,
+                                isLegacyFallback: false,
+                                fallbackReason: "none",
                               };
                               const avatarMedia = resolveAvatarMedia(previewProfile, {
                                 rhythm: normalizedCurrentMode,

--- a/apps/web/src/config/labsGameModes.ts
+++ b/apps/web/src/config/labsGameModes.ts
@@ -1,5 +1,4 @@
 import { OFFICIAL_LANDING_CONTENT, type Language } from '../content/officialLandingContent';
-import { GAME_MODE_META } from '../lib/gameModeMeta';
 import type { GameMode } from '../lib/gameMode';
 
 export type LabsGameModeId = 'low' | 'chill' | 'flow' | 'evolve';
@@ -18,28 +17,28 @@ export const LABS_GAME_MODES: Record<LabsGameModeId, LabsGameModeConfig> = {
     gameMode: 'Low',
     image: '/LowVertical.png',
     loop: '/avatars/low-basic.mp4',
-    accentColor: GAME_MODE_META.Low.accentColor,
+    accentColor: 'var(--color-accent-secondary)',
   },
   chill: {
     id: 'chill',
     gameMode: 'Chill',
     image: '/ChillVertical.png',
     loop: '/avatars/chill-basic.mp4',
-    accentColor: GAME_MODE_META.Chill.accentColor,
+    accentColor: 'var(--color-accent-secondary)',
   },
   flow: {
     id: 'flow',
     gameMode: 'Flow',
     image: '/FlowVertical.png',
     loop: '/avatars/flow-basic.mp4',
-    accentColor: GAME_MODE_META.Flow.accentColor,
+    accentColor: 'var(--color-accent-secondary)',
   },
   evolve: {
     id: 'evolve',
     gameMode: 'Evolve',
     image: '/EvolveVertical.png',
     loop: '/avatars/evolve-basic.mp4',
-    accentColor: GAME_MODE_META.Evolve.accentColor,
+    accentColor: 'var(--color-accent-secondary)',
   },
 };
 
@@ -75,4 +74,3 @@ export function getLabsGameModeConfig(modeId: string | null | undefined): LabsGa
   const resolvedId = resolveLabsGameModeId(modeId);
   return LABS_GAME_MODES[resolvedId];
 }
-

--- a/apps/web/src/lib/avatarCatalog.ts
+++ b/apps/web/src/lib/avatarCatalog.ts
@@ -1,5 +1,4 @@
 import type { AvatarProfile } from './avatarProfile';
-import type { GameMode } from './gameMode';
 
 export type AvatarOption = {
   avatarId: number;
@@ -16,12 +15,7 @@ export const AVATAR_OPTIONS: AvatarOption[] = [
   { avatarId: 4, code: 'LEGACY_EVOLVE', name: 'Legacy Evolve', accent: '#FF6A00', chip: 'ember' },
 ];
 
-const AVATAR_FALLBACK_BY_MODE: Record<GameMode, AvatarOption['code']> = {
-  Low: 'LEGACY_LOW',
-  Chill: 'LEGACY_CHILL',
-  Flow: 'LEGACY_FLOW',
-  Evolve: 'LEGACY_EVOLVE',
-};
+const DEFAULT_AVATAR_OPTION: AvatarOption = AVATAR_OPTIONS[1];
 
 export function getAvatarOptionById(avatarId: number | null | undefined): AvatarOption | null {
   if (typeof avatarId !== 'number') return null;
@@ -30,7 +24,6 @@ export function getAvatarOptionById(avatarId: number | null | undefined): Avatar
 
 export function resolveAvatarOption(
   avatarProfile: AvatarProfile | null,
-  currentMode: GameMode | null,
 ): AvatarOption {
   if (typeof avatarProfile?.avatarId === 'number') {
     const byId = getAvatarOptionById(avatarProfile.avatarId);
@@ -42,8 +35,7 @@ export function resolveAvatarOption(
     if (byCode) return byCode;
   }
 
-  const fallbackCode = AVATAR_FALLBACK_BY_MODE[currentMode ?? 'Chill'];
-  return AVATAR_OPTIONS.find((option) => option.code === fallbackCode) ?? AVATAR_OPTIONS[1];
+  return DEFAULT_AVATAR_OPTION;
 }
 
 export function buildAvatarPreviewProfile(option: AvatarOption): AvatarProfile {
@@ -53,5 +45,6 @@ export function buildAvatarPreviewProfile(option: AvatarOption): AvatarProfile {
     avatarName: option.name,
     theme: { accent: option.accent, chip: option.chip },
     isLegacyFallback: false,
+    fallbackReason: 'none',
   };
 }

--- a/apps/web/src/lib/avatarFallbackPolicy.test.ts
+++ b/apps/web/src/lib/avatarFallbackPolicy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { CurrentUserProfile } from './api';
+import { resolveAvatarProfile } from './avatarProfile';
+import { resolveAvatarOption } from './avatarCatalog';
+
+function makeProfile(overrides: Partial<CurrentUserProfile>): CurrentUserProfile {
+  return {
+    user_id: 'user-1',
+    clerk_user_id: 'clerk-1',
+    email_primary: 'test@example.com',
+    full_name: 'Test User',
+    game_mode: 'Flow',
+    weekly_target: 3,
+    image_url: null,
+    avatar_id: null,
+    avatar_code: null,
+    avatar_name: null,
+    avatar_theme_tokens: null,
+    timezone: 'UTC',
+    locale: 'en',
+    created_at: '2026-04-13T00:00:00.000Z',
+    updated_at: '2026-04-13T00:00:00.000Z',
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+describe('avatar fallback policy', () => {
+  it('does not infer avatar identity from game_mode when avatar payload is missing', () => {
+    const lowFallback = resolveAvatarProfile(makeProfile({ game_mode: 'Low' }));
+    const evolveFallback = resolveAvatarProfile(makeProfile({ game_mode: 'Evolve' }));
+
+    expect(lowFallback?.avatarCode).toBe('LEGACY_CHILL');
+    expect(evolveFallback?.avatarCode).toBe('LEGACY_CHILL');
+    expect(lowFallback?.fallbackReason).toBe('missing-avatar-payload');
+    expect(evolveFallback?.fallbackReason).toBe('missing-avatar-payload');
+  });
+
+  it('uses deterministic default avatar option when resolver input is empty', () => {
+    const resolved = resolveAvatarOption(null);
+    expect(resolved.avatarId).toBe(2);
+    expect(resolved.code).toBe('LEGACY_CHILL');
+  });
+});

--- a/apps/web/src/lib/avatarProfile.ts
+++ b/apps/web/src/lib/avatarProfile.ts
@@ -22,11 +22,13 @@ export type AvatarProfile = {
   avatarName: string;
   theme: AvatarThemeTokens;
   isLegacyFallback: boolean;
+  fallbackReason: 'none' | 'missing-avatar-payload';
 };
 
-type LegacyAvatarFallback = {
+type DefaultAvatarFallback = {
   avatarCode: string;
   avatarName: string;
+  avatarId: number;
   theme: AvatarThemeTokens;
   media: Record<AvatarRhythm, AvatarMedia>;
 };
@@ -58,35 +60,15 @@ const LEGACY_MEDIA_BY_RHYTHM: Record<AvatarRhythm, AvatarMedia> = {
   },
 };
 
-const LEGACY_AVATAR_FALLBACK_BY_GAME_MODE: Record<AvatarRhythm, LegacyAvatarFallback> = {
-  LOW: {
-    avatarCode: 'LEGACY_LOW',
-    avatarName: 'Legacy Low',
-    theme: { accent: '#58CC02', chip: 'leaf' },
-    media: LEGACY_MEDIA_BY_RHYTHM,
-  },
-  CHILL: {
-    avatarCode: 'LEGACY_CHILL',
-    avatarName: 'Legacy Chill',
-    theme: { accent: '#00C2FF', chip: 'aqua' },
-    media: LEGACY_MEDIA_BY_RHYTHM,
-  },
-  FLOW: {
-    avatarCode: 'LEGACY_FLOW',
-    avatarName: 'Legacy Flow',
-    theme: { accent: '#A855F7', chip: 'violet' },
-    media: LEGACY_MEDIA_BY_RHYTHM,
-  },
-  EVOLVE: {
-    avatarCode: 'LEGACY_EVOLVE',
-    avatarName: 'Legacy Evolve',
-    theme: { accent: '#FF6A00', chip: 'ember' },
-    media: LEGACY_MEDIA_BY_RHYTHM,
-  },
+const DEFAULT_AVATAR_FALLBACK: DefaultAvatarFallback = {
+  avatarId: 2,
+  avatarCode: 'LEGACY_CHILL',
+  avatarName: 'Legacy Chill',
+  theme: { accent: '#00C2FF', chip: 'aqua' },
+  media: LEGACY_MEDIA_BY_RHYTHM,
 };
 
 const DEFAULT_RHYTHM: AvatarRhythm = 'FLOW';
-const DEFAULT_LEGACY_AVATAR = LEGACY_AVATAR_FALLBACK_BY_GAME_MODE.CHILL;
 
 function normalizeRhythm(value: string | null | undefined): AvatarRhythm {
   const normalized = (value ?? '').trim().toUpperCase();
@@ -117,21 +99,24 @@ export function resolveAvatarProfile(profile: CurrentUserProfile | null): Avatar
     return null;
   }
 
-  const modeKey = normalizeRhythm(profile.game_mode);
-  const legacyFallback = LEGACY_AVATAR_FALLBACK_BY_GAME_MODE[modeKey] ?? DEFAULT_LEGACY_AVATAR;
+  const hasAvatarCode = typeof profile.avatar_code === 'string' && profile.avatar_code.trim().length > 0;
+  const hasAvatarName = typeof profile.avatar_name === 'string' && profile.avatar_name.trim().length > 0;
+  const hasAvatarId = typeof profile.avatar_id === 'number';
+  const shouldFallbackIdentity = !hasAvatarCode && !hasAvatarId;
   const apiTheme = normalizeThemeTokens(profile.avatar_theme_tokens);
 
   return {
-    avatarId: profile.avatar_id,
-    avatarCode: profile.avatar_code ?? legacyFallback.avatarCode,
-    avatarName: profile.avatar_name ?? legacyFallback.avatarName,
-    theme: apiTheme ?? legacyFallback.theme,
-    isLegacyFallback: profile.avatar_id == null,
+    avatarId: hasAvatarId ? profile.avatar_id : DEFAULT_AVATAR_FALLBACK.avatarId,
+    avatarCode: hasAvatarCode ? profile.avatar_code!.trim() : DEFAULT_AVATAR_FALLBACK.avatarCode,
+    avatarName: hasAvatarName ? profile.avatar_name!.trim() : DEFAULT_AVATAR_FALLBACK.avatarName,
+    theme: apiTheme ?? DEFAULT_AVATAR_FALLBACK.theme,
+    isLegacyFallback: shouldFallbackIdentity,
+    fallbackReason: shouldFallbackIdentity ? 'missing-avatar-payload' : 'none',
   };
 }
 
 export function resolveAvatarTheme(profile: AvatarProfile | null): AvatarThemeTokens {
-  return profile?.theme ?? DEFAULT_LEGACY_AVATAR.theme;
+  return profile?.theme ?? DEFAULT_AVATAR_FALLBACK.theme;
 }
 
 export function resolveAvatarMedia(
@@ -156,9 +141,4 @@ export function resolveAvatarMedia(
     alt: `${profile.avatarName} expression for ${rhythm.toLowerCase()} rhythm`,
     isPlaceholder: profile.isLegacyFallback,
   };
-}
-
-export function resolveLegacyAvatarFallback(gameMode: string | null | undefined): LegacyAvatarFallback {
-  const rhythm = normalizeRhythm(gameMode);
-  return LEGACY_AVATAR_FALLBACK_BY_GAME_MODE[rhythm] ?? DEFAULT_LEGACY_AVATAR;
 }

--- a/apps/web/src/lib/gameModeMeta.ts
+++ b/apps/web/src/lib/gameModeMeta.ts
@@ -7,9 +7,6 @@ export interface GameModeMeta {
   frequency: Record<LocalizedLanguage, string>;
   state: Record<LocalizedLanguage, string>;
   objective: Record<LocalizedLanguage, string>;
-  accentColor: string;
-  avatarSrc: string;
-  avatarAlt: Record<LocalizedLanguage, string>;
 }
 
 export const GAME_MODE_ORDER: GameMode[] = ['Low', 'Chill', 'Flow', 'Evolve'];
@@ -20,47 +17,23 @@ export const GAME_MODE_META: Record<GameMode, GameModeMeta> = {
     frequency: { es: '3x/semana', en: '3x/week' },
     state: { es: 'En foco. En movimiento.', en: 'Focused. In motion.' },
     objective: { es: 'Canalizar energía en metas concretas.', en: 'Channel your energy into concrete goals.' },
-    accentColor: '#49C2F2',
-    avatarSrc: '/flowGMO.png',
-    avatarAlt: {
-      es: 'Avatar del modo Flow en movimiento y enfocado.',
-      en: 'Flow mode avatar in motion and focused.',
-    },
   },
   Low: {
     title: 'LOW MOOD',
     frequency: { es: '1x/semana', en: '1x/week' },
     state: { es: 'Baja energía. Saturado.', en: 'Low energy. Overwhelmed.' },
     objective: { es: 'Activar lo mínimo vital con pasos pequeños.', en: 'Activate the essentials with small steps.' },
-    accentColor: '#FF6B6B',
-    avatarSrc: '/lowGMO.png',
-    avatarAlt: {
-      es: 'Avatar del modo Low con expresión de descanso.',
-      en: 'Low mode avatar with a resting expression.',
-    },
   },
   Chill: {
     title: 'CHILL MOOD',
     frequency: { es: '2x/semana', en: '2x/week' },
     state: { es: 'Estable. Sin presión.', en: 'Stable. No pressure.' },
     objective: { es: 'Sostener hábitos simples con constancia.', en: 'Sustain simple habits consistently.' },
-    accentColor: '#6EDC8C',
-    avatarSrc: '/chillGMO.png',
-    avatarAlt: {
-      es: 'Avatar del modo Chill con expresión de calma.',
-      en: 'Chill mode avatar with a calm expression.',
-    },
   },
   Evolve: {
     title: 'EVOLVE MOOD',
     frequency: { es: '4x/semana', en: '4x/week' },
     state: { es: 'Ambicioso. Determinado.', en: 'Ambitious. Determined.' },
     objective: { es: 'Sostener ritmo alto con estructura clara.', en: 'Keep a high pace with clear structure.' },
-    accentColor: '#9B6CFF',
-    avatarSrc: '/evolveGMO.png',
-    avatarAlt: {
-      es: 'Avatar del modo Evolve con expresión determinada.',
-      en: 'Evolve mode avatar with a determined expression.',
-    },
   },
 };

--- a/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
+++ b/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
@@ -12,7 +12,7 @@ import { HUD } from './ui/HUD';
 import { NavButtons } from './ui/NavButtons';
 import { GameModeChip as SharedGameModeChip, buildGameModeChip } from '../components/common/GameModeChip';
 import { buildAvatarPreviewProfile, getAvatarOptionById } from '../lib/avatarCatalog';
-import { resolveAvatarMedia } from '../lib/avatarProfile';
+import { resolveAvatarMedia, resolveAvatarTheme, type AvatarThemeTokens } from '../lib/avatarProfile';
 
 type Pillar = 'Body' | 'Mind' | 'Soul';
 type Step = 'body' | 'mind' | 'soul' | 'moderation' | 'summary' | 'setup';
@@ -551,35 +551,21 @@ const GAME_MODE_META_KEY: Record<GameMode, keyof typeof GAME_MODE_META> = {
   EVOLVE: 'Evolve',
 };
 
-const MODE_ACCENT: Record<GameMode, string> = {
-  LOW: GAME_MODE_META.Low.accentColor,
-  CHILL: GAME_MODE_META.Chill.accentColor,
-  FLOW: GAME_MODE_META.Flow.accentColor,
-  EVOLVE: GAME_MODE_META.Evolve.accentColor,
+const MODE_SOFT_STYLES: Record<GameMode, { tint: string; border: string; glow: string }> = {
+  LOW: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
+  CHILL: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
+  FLOW: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
+  EVOLVE: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
 };
 
-const MODE_SOFT_STYLES: Record<GameMode, { tint: string; border: string; glow: string }> = {
-  LOW: {
-    tint: `color-mix(in srgb, ${MODE_ACCENT.LOW} 20%, transparent)`,
-    border: `color-mix(in srgb, ${MODE_ACCENT.LOW} 40%, transparent)`,
-    glow: `color-mix(in srgb, ${MODE_ACCENT.LOW} 22%, transparent)`,
-  },
-  CHILL: {
-    tint: `color-mix(in srgb, ${MODE_ACCENT.CHILL} 18%, transparent)`,
-    border: `color-mix(in srgb, ${MODE_ACCENT.CHILL} 38%, transparent)`,
-    glow: `color-mix(in srgb, ${MODE_ACCENT.CHILL} 20%, transparent)`,
-  },
-  FLOW: {
-    tint: `color-mix(in srgb, ${MODE_ACCENT.FLOW} 20%, transparent)`,
-    border: `color-mix(in srgb, ${MODE_ACCENT.FLOW} 42%, transparent)`,
-    glow: `color-mix(in srgb, ${MODE_ACCENT.FLOW} 22%, transparent)`,
-  },
-  EVOLVE: {
-    tint: `color-mix(in srgb, ${MODE_ACCENT.EVOLVE} 22%, transparent)`,
-    border: `color-mix(in srgb, ${MODE_ACCENT.EVOLVE} 42%, transparent)`,
-    glow: `color-mix(in srgb, ${MODE_ACCENT.EVOLVE} 24%, transparent)`,
-  },
-};
+function buildAvatarSoftStyles(theme: AvatarThemeTokens | null): { tint: string; border: string; glow: string } {
+  const accent = theme?.accent ?? 'var(--color-accent-secondary)';
+  return {
+    tint: `color-mix(in srgb, ${accent} 20%, transparent)`,
+    border: `color-mix(in srgb, ${accent} 40%, transparent)`,
+    glow: `color-mix(in srgb, ${accent} 22%, transparent)`,
+  };
+}
 
 function buildVisibleRoute(includeModeration: boolean): Step[] {
   return includeModeration ? STEP_ORDER : STEP_ORDER.filter((step) => step !== 'moderation');
@@ -753,6 +739,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
   const copy = COPY[language];
   const selectedAvatarOption = getAvatarOptionById(avatarId);
   const selectedAvatarProfile = selectedAvatarOption ? buildAvatarPreviewProfile(selectedAvatarOption) : null;
+  const selectedAvatarTheme = resolveAvatarTheme(selectedAvatarProfile);
   const selectedAvatarMedia = resolveAvatarMedia(selectedAvatarProfile, { rhythm: gameMode, surface: 'onboarding' });
 
   const minimum = MODE_MINIMUMS[gameMode];
@@ -1050,7 +1037,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
     }
 
     const tasks = copy.tasks[currentPillar];
-    const modeStyle = MODE_SOFT_STYLES[gameMode];
+    const modeStyle = selectedAvatarProfile ? buildAvatarSoftStyles(selectedAvatarTheme) : MODE_SOFT_STYLES[gameMode];
 
     return (
       <section className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">

--- a/apps/web/src/pages/QuickStartPreview.tsx
+++ b/apps/web/src/pages/QuickStartPreview.tsx
@@ -15,7 +15,7 @@ import { HUD } from '../onboarding/ui/HUD';
 import { NavButtons } from '../onboarding/ui/NavButtons';
 import { GameModeChip as SharedGameModeChip, buildGameModeChip } from '../components/common/GameModeChip';
 import { buildAvatarPreviewProfile, getAvatarOptionById } from '../lib/avatarCatalog';
-import { resolveAvatarMedia } from '../lib/avatarProfile';
+import { resolveAvatarMedia, resolveAvatarTheme, type AvatarThemeTokens } from '../lib/avatarProfile';
 
 type Pillar = 'Body' | 'Mind' | 'Soul';
 type Step = 'game-mode' | 'avatar' | 'branch' | 'body' | 'mind' | 'soul' | 'moderation' | 'summary' | 'setup';
@@ -554,35 +554,21 @@ const GAME_MODE_META_KEY: Record<GameMode, keyof typeof GAME_MODE_META> = {
   EVOLVE: 'Evolve',
 };
 
-const MODE_ACCENT: Record<GameMode, string> = {
-  LOW: GAME_MODE_META.Low.accentColor,
-  CHILL: GAME_MODE_META.Chill.accentColor,
-  FLOW: GAME_MODE_META.Flow.accentColor,
-  EVOLVE: GAME_MODE_META.Evolve.accentColor,
+const MODE_SOFT_STYLES: Record<GameMode, { tint: string; border: string; glow: string }> = {
+  LOW: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
+  CHILL: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
+  FLOW: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
+  EVOLVE: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
 };
 
-const MODE_SOFT_STYLES: Record<GameMode, { tint: string; border: string; glow: string }> = {
-  LOW: {
-    tint: `color-mix(in srgb, ${MODE_ACCENT.LOW} 20%, transparent)`,
-    border: `color-mix(in srgb, ${MODE_ACCENT.LOW} 40%, transparent)`,
-    glow: `color-mix(in srgb, ${MODE_ACCENT.LOW} 22%, transparent)`,
-  },
-  CHILL: {
-    tint: `color-mix(in srgb, ${MODE_ACCENT.CHILL} 18%, transparent)`,
-    border: `color-mix(in srgb, ${MODE_ACCENT.CHILL} 38%, transparent)`,
-    glow: `color-mix(in srgb, ${MODE_ACCENT.CHILL} 20%, transparent)`,
-  },
-  FLOW: {
-    tint: `color-mix(in srgb, ${MODE_ACCENT.FLOW} 20%, transparent)`,
-    border: `color-mix(in srgb, ${MODE_ACCENT.FLOW} 42%, transparent)`,
-    glow: `color-mix(in srgb, ${MODE_ACCENT.FLOW} 22%, transparent)`,
-  },
-  EVOLVE: {
-    tint: `color-mix(in srgb, ${MODE_ACCENT.EVOLVE} 22%, transparent)`,
-    border: `color-mix(in srgb, ${MODE_ACCENT.EVOLVE} 42%, transparent)`,
-    glow: `color-mix(in srgb, ${MODE_ACCENT.EVOLVE} 24%, transparent)`,
-  },
-};
+function buildAvatarSoftStyles(theme: AvatarThemeTokens | null): { tint: string; border: string; glow: string } {
+  const accent = theme?.accent ?? 'var(--color-accent-secondary)';
+  return {
+    tint: `color-mix(in srgb, ${accent} 20%, transparent)`,
+    border: `color-mix(in srgb, ${accent} 40%, transparent)`,
+    glow: `color-mix(in srgb, ${accent} 22%, transparent)`,
+  };
+}
 
 function getDefaultLanguage(searchParams: URLSearchParams): OnboardingLanguage {
   const lang = searchParams.get('lang');
@@ -758,6 +744,7 @@ export default function QuickStartPreviewPage() {
   const copy = COPY[language];
   const selectedAvatarOption = getAvatarOptionById(avatarId);
   const selectedAvatarProfile = selectedAvatarOption ? buildAvatarPreviewProfile(selectedAvatarOption) : null;
+  const selectedAvatarTheme = resolveAvatarTheme(selectedAvatarProfile);
   const selectedAvatarMedia = resolveAvatarMedia(selectedAvatarProfile, { rhythm: gameMode, surface: 'onboarding' });
 
   const minimum = MODE_MINIMUMS[gameMode];
@@ -1065,7 +1052,7 @@ export default function QuickStartPreviewPage() {
     }
 
     const tasks = copy.tasks[currentPillar];
-    const modeStyle = MODE_SOFT_STYLES[gameMode];
+    const modeStyle = selectedAvatarProfile ? buildAvatarSoftStyles(selectedAvatarTheme) : MODE_SOFT_STYLES[gameMode];
 
     return (
       <section className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">


### PR DESCRIPTION
### Motivation
- Finish Phase 9 cleanup by removing remaining mode=visual assumptions so rhythm (behavior/math) and avatar (appearance) are decoupled.
- Replace implicit, mode-derived avatar identity fallbacks with a deterministic, observable default policy to avoid accidental identity writes and make visual resolution explicit.

### Description
- Converted `apps/web/src/lib/gameModeMeta.ts` to rhythm-only metadata by removing `accentColor`, `avatarSrc`, and `avatarAlt` and keeping `title`, `frequency`, `state`, `objective`, and `GAME_MODE_ORDER`.
- Migrated onboarding and quick-start preview styling to use avatar theme tokens when available and a neutral rhythm-safe CSS token fallback, and updated `apps/web/src/config/labsGameModes.ts` to stop reading `GAME_MODE_META.*.accentColor`.
- Removed mode-derived avatar identity fallbacks in `apps/web/src/lib/avatarProfile.ts` and `apps/web/src/lib/avatarCatalog.ts` and stopped passing `currentMode` into avatar fallback selection in `DashboardMenu`; introduced an explicit deterministic default avatar (`LEGACY_CHILL`, `avatarId = 2`) and a `fallbackReason` flag for observability.
- Small callsite updates and tests: `DashboardMenu` now resolves avatar selection without mode, avatar preview profiles set `fallbackReason`, and `buildAvatarSoftStyles` helper was added to apply avatar-driven accents safely.

### Testing
- Ran focused unit tests with Vitest: `src/lib/avatarFallbackPolicy.test.ts`, `src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts`, `src/components/dashboard-v3/DashboardMenu.rhythm-cards.test.ts`, `src/components/common/GameModeChip.test.ts`, and `src/components/dashboard-v3/StreaksPanel.theme.test.ts`; all selected tests passed (11 tests total passed).
- Verified via search that visual fields were removed/stop being referenced (no remaining runtime consumers of `GAME_MODE_META.*.accentColor|avatarSrc|avatarAlt` in the targeted surfaces).
- Ran project typecheck; `npm run typecheck:web` failed due to pre-existing, unrelated repository-wide TypeScript errors not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd09e4eb8c8332af27defd6a34d4d3)