### PR TITLE
Decouple avatar identity from rhythm and fix avatar id->theme mapping

### DIFF
--- a/apps/api/src/controllers/users/get-user-me.ts
+++ b/apps/api/src/controllers/users/get-user-me.ts
@@ -9,10 +9,10 @@ export const SELECT_USER_SQL = `SELECT u.user_id,
        u.image_url,
        gm.code AS game_mode,
        gm.weekly_target AS weekly_target,
-       COALESCE(u.avatar_id, gm_avatar.avatar_id) AS avatar_id,
-       COALESCE(a.code, gm_avatar.code) AS avatar_code,
-       COALESCE(a.name, gm_avatar.name) AS avatar_name,
-       COALESCE(a.theme_tokens, gm_avatar.theme_tokens, '{}'::jsonb) AS avatar_theme_tokens,
+       COALESCE(u.avatar_id, fallback_avatar.avatar_id) AS avatar_id,
+       COALESCE(a.code, fallback_avatar.code) AS avatar_code,
+       COALESCE(a.name, fallback_avatar.name) AS avatar_name,
+       COALESCE(a.theme_tokens, fallback_avatar.theme_tokens, '{}'::jsonb) AS avatar_theme_tokens,
        u.timezone,
        NULL::text AS locale,
        u.created_at,
@@ -23,14 +23,8 @@ export const SELECT_USER_SQL = `SELECT u.user_id,
          ON gm.game_mode_id = u.game_mode_id
   LEFT JOIN cat_avatar a
          ON a.avatar_id = u.avatar_id
-  LEFT JOIN cat_avatar gm_avatar
-         ON gm_avatar.code = CASE gm.code
-           WHEN 'LOW' THEN 'LEGACY_LOW'
-           WHEN 'CHILL' THEN 'LEGACY_CHILL'
-           WHEN 'FLOW' THEN 'LEGACY_FLOW'
-           WHEN 'EVOLVE' THEN 'LEGACY_EVOLVE'
-           ELSE 'LEGACY_CHILL'
-         END
+  LEFT JOIN cat_avatar fallback_avatar
+         ON fallback_avatar.code = 'BLUE_AMPHIBIAN'
  WHERE u.user_id = $1
  LIMIT 1`;
 

--- a/apps/api/src/db/migrations/202604130002_avatar_identity_catalog_fix.sql
+++ b/apps/api/src/db/migrations/202604130002_avatar_identity_catalog_fix.sql
@@ -1,0 +1,30 @@
+UPDATE cat_avatar
+SET
+  code = CASE avatar_id
+    WHEN 1 THEN 'BLUE_AMPHIBIAN'
+    WHEN 2 THEN 'GREEN_BEAR'
+    WHEN 3 THEN 'RED_CAT'
+    WHEN 4 THEN 'VIOLET_OWL'
+    ELSE code
+  END,
+  name = CASE avatar_id
+    WHEN 1 THEN 'Blue Amphibian'
+    WHEN 2 THEN 'Green Bear'
+    WHEN 3 THEN 'Red Cat'
+    WHEN 4 THEN 'Violet Owl'
+    ELSE name
+  END,
+  theme_tokens = CASE avatar_id
+    WHEN 1 THEN jsonb_build_object('accent', '#00C2FF', 'chip', 'aqua')
+    WHEN 2 THEN jsonb_build_object('accent', '#58CC02', 'chip', 'leaf')
+    WHEN 3 THEN jsonb_build_object('accent', '#EF4444', 'chip', 'ember')
+    WHEN 4 THEN jsonb_build_object('accent', '#A855F7', 'chip', 'violet')
+    ELSE theme_tokens
+  END,
+  is_active = true,
+  updated_at = now()
+WHERE avatar_id IN (1, 2, 3, 4);
+
+UPDATE users
+SET avatar_id = 1
+WHERE avatar_id IS NULL;

--- a/apps/web/src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts
@@ -6,8 +6,8 @@ describe("resolveMenuAvatarSelection", () => {
   it("prefers avatar_id from /users/me payload", () => {
     const profile = {
       avatarId: 3,
-      avatarCode: "LEGACY_CHILL",
-      avatarName: "Legacy Chill",
+      avatarCode: "BLUE_AMPHIBIAN",
+      avatarName: "Blue Amphibian",
       theme: { accent: "#00C2FF", chip: "aqua" },
       isLegacyFallback: false,
       fallbackReason: "none",
@@ -15,7 +15,7 @@ describe("resolveMenuAvatarSelection", () => {
 
     expect(resolveMenuAvatarSelection(profile)).toMatchObject({
       avatarId: 3,
-      code: "LEGACY_FLOW",
+      code: "RED_CAT",
     });
   });
 
@@ -23,22 +23,22 @@ describe("resolveMenuAvatarSelection", () => {
     const profile = {
       avatarId: null,
       avatarCode: "LEGACY_EVOLVE",
-      avatarName: "Legacy Evolve",
+      avatarName: "Legacy Evolve (compat)",
       theme: { accent: "#FF6A00", chip: "ember" },
       isLegacyFallback: true,
       fallbackReason: "missing-avatar-payload",
     } satisfies AvatarProfile;
 
     expect(resolveMenuAvatarSelection(profile)).toMatchObject({
-      avatarId: 4,
-      code: "LEGACY_EVOLVE",
+      avatarId: 3,
+      code: "RED_CAT",
     });
   });
 
   it("uses explicit default avatar fallback when avatar data is missing", () => {
     expect(resolveMenuAvatarSelection(null)).toMatchObject({
-      avatarId: 2,
-      code: "LEGACY_CHILL",
+      avatarId: 1,
+      code: "BLUE_AMPHIBIAN",
     });
   });
 });

--- a/apps/web/src/lib/avatarCatalog.identity-mapping.test.ts
+++ b/apps/web/src/lib/avatarCatalog.identity-mapping.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { getAvatarOptionById, resolveAvatarOption } from './avatarCatalog';
+import { resolveAvatarProfile } from './avatarProfile';
+import type { CurrentUserProfile } from './api';
+
+function makeProfile(overrides: Partial<CurrentUserProfile>): CurrentUserProfile {
+  return {
+    user_id: 'user-1',
+    clerk_user_id: 'clerk-1',
+    email_primary: 'test@example.com',
+    full_name: 'Test User',
+    game_mode: 'Flow',
+    weekly_target: 3,
+    image_url: null,
+    avatar_id: null,
+    avatar_code: null,
+    avatar_name: null,
+    avatar_theme_tokens: null,
+    timezone: 'UTC',
+    locale: 'en',
+    created_at: '2026-04-13T00:00:00.000Z',
+    updated_at: '2026-04-13T00:00:00.000Z',
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+describe('avatar identity mapping catalog', () => {
+  it('maps avatar ids to the intended identity colors', () => {
+    expect(getAvatarOptionById(1)).toMatchObject({ code: 'BLUE_AMPHIBIAN', accent: '#00C2FF' });
+    expect(getAvatarOptionById(2)).toMatchObject({ code: 'GREEN_BEAR', accent: '#58CC02' });
+    expect(getAvatarOptionById(3)).toMatchObject({ code: 'RED_CAT', accent: '#EF4444' });
+    expect(getAvatarOptionById(4)).toMatchObject({ code: 'VIOLET_OWL', accent: '#A855F7' });
+  });
+
+  it('keeps avatar resolution independent from rhythm names', () => {
+    const profileFromLow = resolveAvatarProfile(makeProfile({ game_mode: 'Low', avatar_id: 1 }));
+    const profileFromFlow = resolveAvatarProfile(makeProfile({ game_mode: 'Flow', avatar_id: 1 }));
+
+    expect(resolveAvatarOption(profileFromLow).code).toBe('BLUE_AMPHIBIAN');
+    expect(resolveAvatarOption(profileFromFlow).code).toBe('BLUE_AMPHIBIAN');
+  });
+
+  it('supports persisted legacy codes via compatibility aliases', () => {
+    const resolved = resolveAvatarOption({
+      avatarId: null,
+      avatarCode: 'LEGACY_FLOW',
+      avatarName: 'Legacy Flow',
+      theme: { accent: '#A855F7', chip: 'violet' },
+      isLegacyFallback: true,
+      fallbackReason: 'missing-avatar-payload',
+    });
+
+    expect(resolved).toMatchObject({ avatarId: 4, code: 'VIOLET_OWL' });
+  });
+});

--- a/apps/web/src/lib/avatarCatalog.ts
+++ b/apps/web/src/lib/avatarCatalog.ts
@@ -2,20 +2,27 @@ import type { AvatarProfile } from './avatarProfile';
 
 export type AvatarOption = {
   avatarId: number;
-  code: 'LEGACY_LOW' | 'LEGACY_CHILL' | 'LEGACY_FLOW' | 'LEGACY_EVOLVE';
+  code: 'BLUE_AMPHIBIAN' | 'GREEN_BEAR' | 'RED_CAT' | 'VIOLET_OWL';
   name: string;
   accent: string;
   chip: 'leaf' | 'aqua' | 'violet' | 'ember';
 };
 
 export const AVATAR_OPTIONS: AvatarOption[] = [
-  { avatarId: 1, code: 'LEGACY_LOW', name: 'Legacy Low', accent: '#58CC02', chip: 'leaf' },
-  { avatarId: 2, code: 'LEGACY_CHILL', name: 'Legacy Chill', accent: '#00C2FF', chip: 'aqua' },
-  { avatarId: 3, code: 'LEGACY_FLOW', name: 'Legacy Flow', accent: '#A855F7', chip: 'violet' },
-  { avatarId: 4, code: 'LEGACY_EVOLVE', name: 'Legacy Evolve', accent: '#FF6A00', chip: 'ember' },
+  { avatarId: 1, code: 'BLUE_AMPHIBIAN', name: 'Blue Amphibian', accent: '#00C2FF', chip: 'aqua' },
+  { avatarId: 2, code: 'GREEN_BEAR', name: 'Green Bear', accent: '#58CC02', chip: 'leaf' },
+  { avatarId: 3, code: 'RED_CAT', name: 'Red Cat', accent: '#EF4444', chip: 'ember' },
+  { avatarId: 4, code: 'VIOLET_OWL', name: 'Violet Owl', accent: '#A855F7', chip: 'violet' },
 ];
 
-const DEFAULT_AVATAR_OPTION: AvatarOption = AVATAR_OPTIONS[1];
+const LEGACY_CODE_ALIASES: Record<string, AvatarOption['code']> = {
+  LEGACY_CHILL: 'BLUE_AMPHIBIAN',
+  LEGACY_LOW: 'GREEN_BEAR',
+  LEGACY_EVOLVE: 'RED_CAT',
+  LEGACY_FLOW: 'VIOLET_OWL',
+};
+
+const DEFAULT_AVATAR_OPTION: AvatarOption = AVATAR_OPTIONS[0];
 
 export function getAvatarOptionById(avatarId: number | null | undefined): AvatarOption | null {
   if (typeof avatarId !== 'number') return null;
@@ -31,7 +38,8 @@ export function resolveAvatarOption(
   }
 
   if (typeof avatarProfile?.avatarCode === 'string') {
-    const byCode = AVATAR_OPTIONS.find((option) => option.code === avatarProfile.avatarCode);
+    const normalizedCode = LEGACY_CODE_ALIASES[avatarProfile.avatarCode] ?? avatarProfile.avatarCode;
+    const byCode = AVATAR_OPTIONS.find((option) => option.code === normalizedCode);
     if (byCode) return byCode;
   }
 

--- a/apps/web/src/lib/avatarFallbackPolicy.test.ts
+++ b/apps/web/src/lib/avatarFallbackPolicy.test.ts
@@ -30,15 +30,29 @@ describe('avatar fallback policy', () => {
     const lowFallback = resolveAvatarProfile(makeProfile({ game_mode: 'Low' }));
     const evolveFallback = resolveAvatarProfile(makeProfile({ game_mode: 'Evolve' }));
 
-    expect(lowFallback?.avatarCode).toBe('LEGACY_CHILL');
-    expect(evolveFallback?.avatarCode).toBe('LEGACY_CHILL');
+    expect(lowFallback?.avatarCode).toBe('BLUE_AMPHIBIAN');
+    expect(evolveFallback?.avatarCode).toBe('BLUE_AMPHIBIAN');
     expect(lowFallback?.fallbackReason).toBe('missing-avatar-payload');
     expect(evolveFallback?.fallbackReason).toBe('missing-avatar-payload');
   });
 
   it('uses deterministic default avatar option when resolver input is empty', () => {
     const resolved = resolveAvatarOption(null);
+    expect(resolved.avatarId).toBe(1);
+    expect(resolved.code).toBe('BLUE_AMPHIBIAN');
+  });
+
+  it('maps legacy avatar codes to the new identity catalog safely', () => {
+    const resolved = resolveAvatarOption({
+      avatarId: null,
+      avatarCode: 'LEGACY_LOW',
+      avatarName: 'Legacy Low',
+      theme: { accent: '#58CC02', chip: 'leaf' },
+      isLegacyFallback: true,
+      fallbackReason: 'missing-avatar-payload',
+    });
+
     expect(resolved.avatarId).toBe(2);
-    expect(resolved.code).toBe('LEGACY_CHILL');
+    expect(resolved.code).toBe('GREEN_BEAR');
   });
 });

--- a/apps/web/src/lib/avatarProfile.ts
+++ b/apps/web/src/lib/avatarProfile.ts
@@ -61,9 +61,9 @@ const LEGACY_MEDIA_BY_RHYTHM: Record<AvatarRhythm, AvatarMedia> = {
 };
 
 const DEFAULT_AVATAR_FALLBACK: DefaultAvatarFallback = {
-  avatarId: 2,
-  avatarCode: 'LEGACY_CHILL',
-  avatarName: 'Legacy Chill',
+  avatarId: 1,
+  avatarCode: 'BLUE_AMPHIBIAN',
+  avatarName: 'Blue Amphibian',
   theme: { accent: '#00C2FF', chip: 'aqua' },
   media: LEGACY_MEDIA_BY_RHYTHM,
 };


### PR DESCRIPTION
### Motivation
- Users were seeing avatar-driven UI colors that did not match their selected avatar because legacy rhythm-based avatar codes and a `/users/me` fallback derived from `game_mode` leaked mode semantics into avatar identity.  
- The intent is to make avatar identity authoritative for visuals (avatar -> theme) while preserving `game_mode` for intensity/math behavior and keeping persisted IDs stable.

### Description
- Replaced legacy rhythm-coded catalog values with canonical avatar identities and accents and added compatibility aliases for legacy codes by updating `apps/web/src/lib/avatarCatalog.ts` and `apps/web/src/lib/avatarProfile.ts`.  
- Stopped inferring avatar identity from rhythm on the read path by changing `/users/me` fallback logic in `apps/api/src/controllers/users/get-user-me.ts` to use a deterministic avatar fallback instead of `game_mode` mapping.  
- Added a DB migration `apps/api/src/db/migrations/202604130002_avatar_identity_catalog_fix.sql` that corrects `cat_avatar` metadata by `avatar_id` and backfills null `users.avatar_id` to a safe default.  
- Updated and added focused tests and small frontend test adjustments to validate id/code -> theme mappings, rhythm-independence, and legacy-code compatibility (changed files include `apps/web/src/lib/avatarFallbackPolicy.test.ts`, `apps/web/src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts`, and new `apps/web/src/lib/avatarCatalog.identity-mapping.test.ts`).

### Testing
- Ran frontend unit tests for the affected suites with `npm --workspace apps/web run test -- src/lib/avatarFallbackPolicy.test.ts src/lib/avatarCatalog.identity-mapping.test.ts src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts src/components/dashboard-v3/StreaksPanel.theme.test.ts src/components/common/GameModeChip.test.ts` and all selected tests passed.  
- Ran API tests for the users endpoint with `npm --workspace apps/api run test -- src/__tests__/users.me.test.ts` and the `GET /api/users/me` tests passed.  
- Tests verify: avatar id -> expected accent mapping, avatar resolution is independent of rhythm names, and legacy `avatar_code` values map safely to the new canonical identities.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd57dad99883328d91eb35b9ed0150)