### PR TITLE
Use distinct legacy GMO previews for Change Avatar cards

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -35,7 +35,7 @@ import {
 import { resolveAvatarMedia, resolveAvatarTheme, type AvatarProfile } from "../../lib/avatarProfile";
 import { normalizeGameModeValue, type GameMode } from "../../lib/gameMode";
 import { GAME_MODE_META, GAME_MODE_ORDER, type LocalizedLanguage } from "../../lib/gameModeMeta";
-import { AVATAR_OPTIONS, resolveAvatarOption } from "../../lib/avatarCatalog";
+import { AVATAR_OPTIONS, resolveAvatarOption, resolveTemporaryLegacyAvatarPreviewImage } from "../../lib/avatarCatalog";
 import type { ResolvedTheme } from "../../theme/themePreference";
 import {
   forwardRef,
@@ -1342,6 +1342,7 @@ export function DashboardMenu({
                                 rhythm: normalizedCurrentMode,
                                 surface: "dashboard-menu",
                               });
+                              const previewImageUrl = resolveTemporaryLegacyAvatarPreviewImage(avatarOption) ?? avatarMedia.imageUrl ?? "/FlowMood.jpg";
                               return (
                                 <button
                                   key={avatarOption.avatarId}
@@ -1357,7 +1358,7 @@ export function DashboardMenu({
                                       </span>
                                     </div>
                                     <img
-                                      src={avatarMedia.imageUrl ?? "/FlowMood.jpg"}
+                                      src={previewImageUrl}
                                       alt={avatarMedia.alt}
                                       className="h-20 w-full rounded-xl border border-white/10 object-cover"
                                       loading="lazy"

--- a/apps/web/src/lib/avatarCatalog.legacy-preview.test.ts
+++ b/apps/web/src/lib/avatarCatalog.legacy-preview.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { AVATAR_OPTIONS, resolveTemporaryLegacyAvatarPreviewImage } from './avatarCatalog';
+
+describe('resolveTemporaryLegacyAvatarPreviewImage', () => {
+  it('maps each avatar option to the temporary legacy GMO preview image', () => {
+    const byCode = Object.fromEntries(
+      AVATAR_OPTIONS.map((option) => [option.code, resolveTemporaryLegacyAvatarPreviewImage(option)]),
+    );
+
+    expect(byCode).toEqual({
+      LEGACY_LOW: '/lowGMO.png',
+      LEGACY_CHILL: '/chillGMO.png',
+      LEGACY_FLOW: '/flowGMO.png',
+      LEGACY_EVOLVE: '/evolveGMO.png',
+    });
+  });
+
+  it('returns distinct preview images across all 4 avatar cards', () => {
+    const previewImages = AVATAR_OPTIONS.map((option) => resolveTemporaryLegacyAvatarPreviewImage(option));
+    expect(new Set(previewImages).size).toBe(4);
+  });
+});

--- a/apps/web/src/lib/avatarCatalog.ts
+++ b/apps/web/src/lib/avatarCatalog.ts
@@ -17,6 +17,20 @@ export const AVATAR_OPTIONS: AvatarOption[] = [
 
 const DEFAULT_AVATAR_OPTION: AvatarOption = AVATAR_OPTIONS[1];
 
+
+// Temporary dashboard Change Avatar previews.
+// TODO(rhythm-avatar-decoupling): replace legacy GMO images with final per-avatar assets.
+const TEMP_LEGACY_AVATAR_PREVIEW_BY_CODE: Record<AvatarOption['code'], string> = {
+  LEGACY_LOW: '/lowGMO.png',
+  LEGACY_CHILL: '/chillGMO.png',
+  LEGACY_FLOW: '/flowGMO.png',
+  LEGACY_EVOLVE: '/evolveGMO.png',
+};
+
+export function resolveTemporaryLegacyAvatarPreviewImage(option: AvatarOption): string {
+  return TEMP_LEGACY_AVATAR_PREVIEW_BY_CODE[option.code];
+}
+
 export function getAvatarOptionById(avatarId: number | null | undefined): AvatarOption | null {
   if (typeof avatarId !== 'number') return null;
   return AVATAR_OPTIONS.find((option) => option.avatarId === avatarId) ?? null;


### PR DESCRIPTION
### Motivation
- The Change Avatar picker was showing the same preview image on all four avatar cards, reducing visual clarity and causing user confusion. 
- Provide a narrow temporary visual fix by reusing existing legacy GMO images until final per-avatar assets are available. 
- Preserve current avatar selection flow and do not change rhythm/game_mode logic or any missions code.

### Description
- Added a temporary legacy preview resolver `resolveTemporaryLegacyAvatarPreviewImage` in `apps/web/src/lib/avatarCatalog.ts` and wired it to the Change Avatar UI. 
- Introduced the explicit temporary mapping: `LEGACY_LOW -> /lowGMO.png`, `LEGACY_CHILL -> /chillGMO.png`, `LEGACY_FLOW -> /flowGMO.png`, `LEGACY_EVOLVE -> /evolveGMO.png`. 
- Updated `apps/web/src/components/dashboard-v3/DashboardMenu.tsx` to use `resolveTemporaryLegacyAvatarPreviewImage(avatarOption)` (as `previewImageUrl`) for each avatar card `<img>` `src`, falling back to existing media only if needed. 
- Added focused tests in `apps/web/src/lib/avatarCatalog.legacy-preview.test.ts` and left a TODO comment in `avatarCatalog.ts` indicating this is temporary until final per-avatar assets are provided.

### Testing
- Ran the new unit test and the existing avatar selection test with: `npm --workspace apps/web run test -- src/lib/avatarCatalog.legacy-preview.test.ts src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts`. 
- Both test files passed (total: 2 test files, 5 tests across them; all tests succeeded). 
- Verified that selection behavior tests for the Dashboard menu remained unchanged and green after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5a5a8dac8332ac22c7bba08d78cb)