### PR TITLE
Fix avatar picker preview and legacy alias mapping

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { resolveMenuAvatarSelection } from "./DashboardMenu";
+import {
+  resolveMenuAvatarPreviewImage,
+  resolveMenuAvatarSelection,
+  resolveMenuAvatarTheme,
+} from "./DashboardMenu";
+import { AVATAR_OPTIONS } from "../../lib/avatarCatalog";
 import type { AvatarProfile } from "../../lib/avatarProfile";
 
 describe("resolveMenuAvatarSelection", () => {
@@ -32,8 +37,8 @@ describe("resolveMenuAvatarSelection", () => {
     } satisfies AvatarProfile;
 
     expect(resolveMenuAvatarSelection(profile)).toMatchObject({
-      avatarId: 3,
-      code: "RED_CAT",
+      avatarId: 4,
+      code: "VIOLET_OWL",
     });
   });
 
@@ -41,6 +46,31 @@ describe("resolveMenuAvatarSelection", () => {
     expect(resolveMenuAvatarSelection(null)).toMatchObject({
       avatarId: 1,
       code: "BLUE_AMPHIBIAN",
+    });
+  });
+
+  it("resolves menu theme tokens from selected avatar identity", () => {
+    const staleThemeProfile = {
+      avatarId: 4,
+      avatarCode: "VIOLET_OWL",
+      avatarName: "Violet Owl",
+      theme: { accent: "#00C2FF", chip: "aqua" },
+      isLegacyFallback: false,
+      fallbackReason: "none",
+      assetPayload: null,
+    } satisfies AvatarProfile;
+
+    expect(resolveMenuAvatarTheme(staleThemeProfile)).toEqual({
+      accent: "#A855F7",
+      chip: "violet",
+    });
+  });
+
+  it("uses GMO preview images for change-avatar cards without /avatars/v1 fallback", () => {
+    const previewImages = AVATAR_OPTIONS.map((option) => resolveMenuAvatarPreviewImage(option));
+    expect(previewImages).toEqual(["/flowGMO.png", "/chillGMO.png", "/lowGMO.png", "/evolveGMO.png"]);
+    previewImages.forEach((imagePath) => {
+      expect(imagePath).not.toContain("/avatars/v1/");
     });
   });
 });

--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -32,7 +32,7 @@ import {
   type ModerationTrackerConfig,
   type ModerationTrackerType,
 } from "../../lib/api";
-import { resolveAvatarMedia, resolveAvatarTheme, type AvatarProfile } from "../../lib/avatarProfile";
+import type { AvatarProfile } from "../../lib/avatarProfile";
 import { normalizeGameModeValue, type GameMode } from "../../lib/gameMode";
 import { GAME_MODE_META, GAME_MODE_ORDER, type LocalizedLanguage } from "../../lib/gameModeMeta";
 import { AVATAR_OPTIONS, resolveAvatarOption, resolveTemporaryLegacyAvatarPreviewImage } from "../../lib/avatarCatalog";
@@ -74,6 +74,18 @@ export function resolveMenuAvatarSelection(
   avatarProfile: AvatarProfile | null,
 ): MenuAvatarOption {
   return resolveAvatarOption(avatarProfile);
+}
+
+export function resolveMenuAvatarTheme(avatarProfile: AvatarProfile | null): { accent: string; chip: MenuAvatarOption["chip"] } {
+  const selectedAvatar = resolveMenuAvatarSelection(avatarProfile);
+  return {
+    accent: selectedAvatar.accent,
+    chip: selectedAvatar.chip,
+  };
+}
+
+export function resolveMenuAvatarPreviewImage(avatarOption: MenuAvatarOption): string {
+  return resolveTemporaryLegacyAvatarPreviewImage(avatarOption) ?? "/FlowMood.jpg";
 }
 
 
@@ -383,7 +395,7 @@ export function DashboardMenu({
     () => isDemandingModeJump(normalizedCurrentMode, selectedOrCurrentMode),
     [normalizedCurrentMode, selectedOrCurrentMode],
   );
-  const currentAvatarTheme = useMemo(() => resolveAvatarTheme(currentAvatarProfile), [currentAvatarProfile]);
+  const currentAvatarTheme = useMemo(() => resolveMenuAvatarTheme(currentAvatarProfile), [currentAvatarProfile]);
 
   const menuRowClassName =
     "flex h-12 w-full items-center gap-3 rounded-xl px-3 text-left text-sm font-medium text-[color:var(--color-text-dim)] transition hover:bg-[color:var(--color-overlay-2)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/40";
@@ -1329,20 +1341,7 @@ export function DashboardMenu({
                             {MENU_AVATAR_OPTIONS.map((avatarOption) => {
                               const isSelected = selectedOrCurrentAvatarId === avatarOption.avatarId;
                               const isCurrent = currentAvatarSelection.avatarId === avatarOption.avatarId;
-                              const previewProfile: AvatarProfile = {
-                                avatarId: avatarOption.avatarId,
-                                avatarCode: avatarOption.code,
-                                avatarName: avatarOption.name,
-                                theme: { accent: avatarOption.accent, chip: "aqua" },
-                                isLegacyFallback: false,
-                                fallbackReason: "none",
-                                assetPayload: null,
-                              };
-                              const avatarMedia = resolveAvatarMedia(previewProfile, {
-                                rhythm: normalizedCurrentMode,
-                                surface: "dashboard-menu",
-                              });
-                              const previewImageUrl = resolveTemporaryLegacyAvatarPreviewImage(avatarOption) ?? avatarMedia.imageUrl ?? "/FlowMood.jpg";
+                              const previewImageUrl = resolveMenuAvatarPreviewImage(avatarOption);
                               return (
                                 <button
                                   key={avatarOption.avatarId}
@@ -1359,7 +1358,7 @@ export function DashboardMenu({
                                     </div>
                                     <img
                                       src={previewImageUrl}
-                                      alt={avatarMedia.alt}
+                                      alt={`${avatarOption.name} avatar preview`}
                                       className="h-20 w-full rounded-xl border border-white/10 object-cover"
                                       loading="lazy"
                                     />

--- a/apps/web/src/lib/avatarCatalog.identity-mapping.test.ts
+++ b/apps/web/src/lib/avatarCatalog.identity-mapping.test.ts
@@ -51,6 +51,6 @@ describe('avatar identity mapping catalog', () => {
       fallbackReason: 'missing-avatar-payload',
     });
 
-    expect(resolved).toMatchObject({ avatarId: 4, code: 'VIOLET_OWL' });
+    expect(resolved).toMatchObject({ avatarId: 1, code: 'BLUE_AMPHIBIAN' });
   });
 });

--- a/apps/web/src/lib/avatarCatalog.legacy-preview.test.ts
+++ b/apps/web/src/lib/avatarCatalog.legacy-preview.test.ts
@@ -8,10 +8,10 @@ describe('resolveTemporaryLegacyAvatarPreviewImage', () => {
     );
 
     expect(byCode).toEqual({
-      LEGACY_LOW: '/lowGMO.png',
-      LEGACY_CHILL: '/chillGMO.png',
-      LEGACY_FLOW: '/flowGMO.png',
-      LEGACY_EVOLVE: '/evolveGMO.png',
+      BLUE_AMPHIBIAN: '/flowGMO.png',
+      GREEN_BEAR: '/chillGMO.png',
+      RED_CAT: '/lowGMO.png',
+      VIOLET_OWL: '/evolveGMO.png',
     });
   });
 

--- a/apps/web/src/lib/avatarCatalog.ts
+++ b/apps/web/src/lib/avatarCatalog.ts
@@ -16,10 +16,10 @@ export const AVATAR_OPTIONS: AvatarOption[] = [
 ];
 
 const LEGACY_CODE_ALIASES: Record<string, AvatarOption['code']> = {
-  LEGACY_CHILL: 'BLUE_AMPHIBIAN',
-  LEGACY_LOW: 'GREEN_BEAR',
-  LEGACY_EVOLVE: 'RED_CAT',
-  LEGACY_FLOW: 'VIOLET_OWL',
+  LEGACY_LOW: 'RED_CAT',
+  LEGACY_CHILL: 'GREEN_BEAR',
+  LEGACY_FLOW: 'BLUE_AMPHIBIAN',
+  LEGACY_EVOLVE: 'VIOLET_OWL',
 };
 
 const DEFAULT_AVATAR_OPTION: AvatarOption = AVATAR_OPTIONS[0];
@@ -28,10 +28,10 @@ const DEFAULT_AVATAR_OPTION: AvatarOption = AVATAR_OPTIONS[0];
 // Temporary dashboard Change Avatar previews.
 // TODO(rhythm-avatar-decoupling): replace legacy GMO images with final per-avatar assets.
 const TEMP_LEGACY_AVATAR_PREVIEW_BY_CODE: Record<AvatarOption['code'], string> = {
-  LEGACY_LOW: '/lowGMO.png',
-  LEGACY_CHILL: '/chillGMO.png',
-  LEGACY_FLOW: '/flowGMO.png',
-  LEGACY_EVOLVE: '/evolveGMO.png',
+  BLUE_AMPHIBIAN: '/flowGMO.png',
+  GREEN_BEAR: '/chillGMO.png',
+  RED_CAT: '/lowGMO.png',
+  VIOLET_OWL: '/evolveGMO.png',
 };
 
 export function resolveTemporaryLegacyAvatarPreviewImage(option: AvatarOption): string {

--- a/apps/web/src/lib/avatarFallbackPolicy.test.ts
+++ b/apps/web/src/lib/avatarFallbackPolicy.test.ts
@@ -52,7 +52,7 @@ describe('avatar fallback policy', () => {
       fallbackReason: 'missing-avatar-payload',
     });
 
-    expect(resolved.avatarId).toBe(2);
-    expect(resolved.code).toBe('GREEN_BEAR');
+    expect(resolved.avatarId).toBe(3);
+    expect(resolved.code).toBe('RED_CAT');
   });
 });


### PR DESCRIPTION
### Motivation

- Fix a narrow bug where the dashboard Change Avatar picker showed broken preview images (falling through to `/avatars/v1/...`) because the temporary preview map used the wrong keys. 
- Correct legacy avatar aliasing so persisted legacy codes map to the intended avatar identity instead of producing the wrong avatar/theme. 
- Ensure the dashboard menu uses the selected avatar identity to derive accent/theme tokens for consistent visuals on that surface.

### Description

- Corrected legacy alias mapping in `apps/web/src/lib/avatarCatalog.ts` so `LEGACY_LOW -> RED_CAT`, `LEGACY_CHILL -> GREEN_BEAR`, `LEGACY_FLOW -> BLUE_AMPHIBIAN`, and `LEGACY_EVOLVE -> VIOLET_OWL` by updating `LEGACY_CODE_ALIASES`.
- Replaced the broken TEMP preview map keys with current avatar codes in `apps/web/src/lib/avatarCatalog.ts` and mapped them to existing GMO images: `BLUE_AMPHIBIAN -> /flowGMO.png`, `GREEN_BEAR -> /chillGMO.png`, `RED_CAT -> /lowGMO.png`, `VIOLET_OWL -> /evolveGMO.png` (used by `resolveTemporaryLegacyAvatarPreviewImage`).
- Updated `apps/web/src/components/dashboard-v3/DashboardMenu.tsx` to use a menu-level preview resolver `resolveMenuAvatarPreviewImage()` and a menu-level theme resolver `resolveMenuAvatarTheme()` so the Change Avatar picker loads the corrected GMO images and the menu derives `accent`/`chip` from the resolved avatar identity rather than stale profile theme tokens.
- Removed the fall-through to legacy `/avatars/v1/...` paths on the normal picker path and kept a single static fallback (`/FlowMood.jpg`) only as an absolute last resort.
- Updated and added focused tests to validate identity mapping, preview mapping, and menu theme/preview behavior in `apps/web/src/lib/*` and `apps/web/src/components/dashboard-v3/*` tests.

### Testing

- Ran the focused unit tests with `npm --workspace apps/web run test -- --run src/lib/avatarCatalog.identity-mapping.test.ts src/lib/avatarCatalog.legacy-preview.test.ts src/lib/avatarFallbackPolicy.test.ts src/components/dashboard-v3/DashboardMenu.avatar-selection.test.ts` and all tests passed.
- The test suite run reported: 4 test files, 13 tests, all passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd672c5fcc833291bfdb1ac53435c9)