### PR TITLE
Fix avatar-driven dashboard media and chip accent mapping

### DIFF
--- a/apps/web/src/components/common/GameModeChip.test.ts
+++ b/apps/web/src/components/common/GameModeChip.test.ts
@@ -40,7 +40,7 @@ describe('buildGameModeChip', () => {
     const chip = buildGameModeChip('Flow', { avatarProfile });
 
     expect(chip.label).toBe('FLOW');
-    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#ef4444' });
+    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#EF4444' });
   });
 
   it('uses safe legacy fallback accent when avatar is missing', () => {

--- a/apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx
+++ b/apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx
@@ -58,7 +58,10 @@ export function UpgradeRecommendationModal({
   const currentRhythm = useMemo(() => normalizeGameModeValue(currentMode), [currentMode]);
   const nextRhythm = useMemo(() => normalizeGameModeValue(nextMode), [nextMode]);
   const avatarTheme = useMemo(() => resolveAvatarTheme(avatarProfile), [avatarProfile]);
-  const nextModeChip = useMemo(() => buildGameModeChip(nextMode), [nextMode]);
+  const nextModeChip = useMemo(
+    () => buildGameModeChip(nextMode, { avatarProfile }),
+    [avatarProfile, nextMode],
+  );
   const currentRhythmLabel = useMemo(() => buildRhythmIntensityLabel(currentMode, language), [currentMode, language]);
   const nextRhythmLabel = useMemo(() => buildRhythmIntensityLabel(nextMode, language), [nextMode, language]);
 

--- a/apps/web/src/lib/avatarProfile.ts
+++ b/apps/web/src/lib/avatarProfile.ts
@@ -1,4 +1,5 @@
 import type { CurrentUserProfile } from './api';
+import { resolveAvatarOption } from './avatarCatalog';
 import {
   resolveAssetPathByTier,
   resolveSurfaceAssetTier,
@@ -36,32 +37,32 @@ type DefaultAvatarFallback = {
   avatarName: string;
   avatarId: number;
   theme: AvatarThemeTokens;
-  media: Record<AvatarRhythm, AvatarMedia>;
+  mediaByAvatarCode: Record<string, AvatarMedia>;
 };
 
-const LEGACY_MEDIA_BY_RHYTHM: Record<AvatarRhythm, AvatarMedia> = {
-  LOW: {
+const LEGACY_MEDIA_BY_AVATAR_CODE: Record<string, AvatarMedia> = {
+  RED_CAT: {
     videoUrl: '/avatars/low-basic.mp4',
     imageUrl: '/LowMood.jpg',
-    alt: 'Legacy avatar expression for Low rhythm.',
+    alt: 'Legacy Red Cat avatar expression.',
     isPlaceholder: true,
   },
-  CHILL: {
+  GREEN_BEAR: {
     videoUrl: '/avatars/chill-basic.mp4',
     imageUrl: '/Chill-Mood.jpg',
-    alt: 'Legacy avatar expression for Chill rhythm.',
+    alt: 'Legacy Green Bear avatar expression.',
     isPlaceholder: true,
   },
-  FLOW: {
+  BLUE_AMPHIBIAN: {
     videoUrl: '/avatars/flow-basic.mp4',
     imageUrl: '/FlowMood.jpg',
-    alt: 'Legacy avatar expression for Flow rhythm.',
+    alt: 'Legacy Blue Amphibian avatar expression.',
     isPlaceholder: true,
   },
-  EVOLVE: {
+  VIOLET_OWL: {
     videoUrl: '/avatars/evolve-basic.mp4',
     imageUrl: '/Evolve-Mood.jpg',
-    alt: 'Legacy avatar expression for Evolve rhythm.',
+    alt: 'Legacy Violet Owl avatar expression.',
     isPlaceholder: true,
   },
 };
@@ -71,7 +72,7 @@ const DEFAULT_AVATAR_FALLBACK: DefaultAvatarFallback = {
   avatarCode: 'BLUE_AMPHIBIAN',
   avatarName: 'Blue Amphibian',
   theme: { accent: '#00C2FF', chip: 'aqua' },
-  media: LEGACY_MEDIA_BY_RHYTHM,
+  mediaByAvatarCode: LEGACY_MEDIA_BY_AVATAR_CODE,
 };
 
 const DEFAULT_RHYTHM: AvatarRhythm = 'FLOW';
@@ -113,13 +114,25 @@ export function resolveAvatarProfile(profile: CurrentUserProfile | null): Avatar
   const hasAvatarName = typeof profile.avatar_name === 'string' && profile.avatar_name.trim().length > 0;
   const hasAvatarId = typeof profile.avatar_id === 'number';
   const shouldFallbackIdentity = !hasAvatarCode && !hasAvatarId;
+  const canonicalOption = resolveAvatarOption({
+    avatarId: hasAvatarId ? profile.avatar_id : null,
+    avatarCode: hasAvatarCode ? profile.avatar_code!.trim() : DEFAULT_AVATAR_FALLBACK.avatarCode,
+    avatarName: hasAvatarName ? profile.avatar_name!.trim() : DEFAULT_AVATAR_FALLBACK.avatarName,
+    theme: DEFAULT_AVATAR_FALLBACK.theme,
+    isLegacyFallback: false,
+    fallbackReason: 'none',
+    assetPayload: null,
+  });
   const apiTheme = normalizeThemeTokens(profile.avatar_theme_tokens);
 
   return {
     avatarId: hasAvatarId ? profile.avatar_id : DEFAULT_AVATAR_FALLBACK.avatarId,
     avatarCode: hasAvatarCode ? profile.avatar_code!.trim() : DEFAULT_AVATAR_FALLBACK.avatarCode,
     avatarName: hasAvatarName ? profile.avatar_name!.trim() : DEFAULT_AVATAR_FALLBACK.avatarName,
-    theme: apiTheme ?? DEFAULT_AVATAR_FALLBACK.theme,
+    theme: {
+      accent: canonicalOption.accent,
+      chip: apiTheme?.chip ?? canonicalOption.chip,
+    },
     isLegacyFallback: shouldFallbackIdentity,
     fallbackReason: shouldFallbackIdentity ? 'missing-avatar-payload' : 'none',
     assetPayload: resolveAssetPayload(profile),
@@ -127,7 +140,15 @@ export function resolveAvatarProfile(profile: CurrentUserProfile | null): Avatar
 }
 
 export function resolveAvatarTheme(profile: AvatarProfile | null): AvatarThemeTokens {
-  return profile?.theme ?? DEFAULT_AVATAR_FALLBACK.theme;
+  if (!profile) {
+    return DEFAULT_AVATAR_FALLBACK.theme;
+  }
+
+  const canonicalOption = resolveAvatarOption(profile);
+  return {
+    accent: canonicalOption.accent,
+    chip: profile.theme?.chip ?? canonicalOption.chip,
+  };
 }
 
 function resolveImageForSurface(profile: AvatarProfile | null, rhythm: AvatarRhythm): string | null {
@@ -152,7 +173,10 @@ export function resolveAvatarMedia(
   },
 ): AvatarMedia {
   const rhythm = normalizeRhythm(options?.rhythm);
-  const fallbackMedia = LEGACY_MEDIA_BY_RHYTHM[rhythm];
+  const selectedAvatarCode = resolveAvatarOption(profile).code;
+  const fallbackMedia =
+    DEFAULT_AVATAR_FALLBACK.mediaByAvatarCode[selectedAvatarCode] ??
+    DEFAULT_AVATAR_FALLBACK.mediaByAvatarCode.BLUE_AMPHIBIAN;
 
   if (!profile) {
     return fallbackMedia;


### PR DESCRIPTION
### Motivation
- The dashboard/menu visual identity was still being derived from rhythm data, causing avatar video/loop and chip accent mismatches with the selected avatar.
- Product rule: selected avatar must drive dashboard media and chip accent while rhythm/game mode only controls behavior/intensity.

### Description
- Replaced rhythm-based legacy media fallback with an avatar-code keyed mapping so avatar media follows the selected avatar (`RED_CAT`, `GREEN_BEAR`, `BLUE_AMPHIBIAN`, `VIOLET_OWL`) in `apps/web/src/lib/avatarProfile.ts`.
- Enforced canonical avatar accent selection by deriving accent from the avatar catalog via `resolveAvatarOption` inside `resolveAvatarProfile` and `resolveAvatarTheme` so chips use avatar-driven accent colors.
- Made `resolveAvatarMedia` pick fallback media by avatar code and retained the existing surface/tier asset resolution logic for real payloads.
- Ensured the upgrade modal builds its `GameModeChip` with the active `avatarProfile` and updated the `GameModeChip` test expectation to match the canonical Red Cat accent.

### Testing
- Ran `npm --workspace apps/web run test -- --run src/components/common/GameModeChip.test.ts` and the test file passed.
- Ran `npm --workspace apps/web run test -- --run src/lib/avatarCatalog.identity-mapping.test.ts src/lib/avatarFallbackPolicy.test.ts` and both test files passed.
- Ran `npm --workspace apps/web run typecheck` which failed due to unrelated, pre-existing TypeScript issues in the repo (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde1eddd408332a15b72dcd5e9a9c2)