### PR TITLE
Unify onboarding rhythm theming and avatar preview sources

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -35,7 +35,7 @@ import {
 import type { AvatarProfile } from "../../lib/avatarProfile";
 import { normalizeGameModeValue, type GameMode } from "../../lib/gameMode";
 import { GAME_MODE_META, GAME_MODE_ORDER, type LocalizedLanguage } from "../../lib/gameModeMeta";
-import { AVATAR_OPTIONS, resolveAvatarOption, resolveTemporaryLegacyAvatarPreviewImage } from "../../lib/avatarCatalog";
+import { AVATAR_OPTIONS, resolveAvatarOption, resolveAvatarPickerPreviewImage } from "../../lib/avatarCatalog";
 import type { ResolvedTheme } from "../../theme/themePreference";
 import {
   forwardRef,
@@ -85,7 +85,7 @@ export function resolveMenuAvatarTheme(avatarProfile: AvatarProfile | null): { a
 }
 
 export function resolveMenuAvatarPreviewImage(avatarOption: MenuAvatarOption): string {
-  return resolveTemporaryLegacyAvatarPreviewImage(avatarOption) ?? "/FlowMood.jpg";
+  return resolveAvatarPickerPreviewImage(avatarOption) ?? "/FlowMood.jpg";
 }
 
 

--- a/apps/web/src/lib/avatarCatalog.ts
+++ b/apps/web/src/lib/avatarCatalog.ts
@@ -38,6 +38,10 @@ export function resolveTemporaryLegacyAvatarPreviewImage(option: AvatarOption): 
   return TEMP_LEGACY_AVATAR_PREVIEW_BY_CODE[option.code];
 }
 
+export function resolveAvatarPickerPreviewImage(option: AvatarOption): string {
+  return resolveTemporaryLegacyAvatarPreviewImage(option);
+}
+
 export function getAvatarOptionById(avatarId: number | null | undefined): AvatarOption | null {
   if (typeof avatarId !== 'number') return null;
   return AVATAR_OPTIONS.find((option) => option.avatarId === avatarId) ?? null;

--- a/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
+++ b/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
@@ -11,8 +11,8 @@ import { GpExplainerOverlay } from './ui/GpExplainerOverlay';
 import { HUD } from './ui/HUD';
 import { NavButtons } from './ui/NavButtons';
 import { GameModeChip as SharedGameModeChip, buildGameModeChip } from '../components/common/GameModeChip';
-import { buildAvatarPreviewProfile, getAvatarOptionById } from '../lib/avatarCatalog';
-import { resolveAvatarMedia, resolveAvatarTheme, type AvatarThemeTokens } from '../lib/avatarProfile';
+import { buildAvatarPreviewProfile, getAvatarOptionById, resolveAvatarPickerPreviewImage } from '../lib/avatarCatalog';
+import { getOnboardingRhythmTheme } from './utils/onboardingRhythmTheme';
 
 type Pillar = 'Body' | 'Mind' | 'Soul';
 type Step = 'body' | 'mind' | 'soul' | 'moderation' | 'summary' | 'setup';
@@ -551,22 +551,6 @@ const GAME_MODE_META_KEY: Record<GameMode, keyof typeof GAME_MODE_META> = {
   EVOLVE: 'Evolve',
 };
 
-const MODE_SOFT_STYLES: Record<GameMode, { tint: string; border: string; glow: string }> = {
-  LOW: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
-  CHILL: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
-  FLOW: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
-  EVOLVE: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
-};
-
-function buildAvatarSoftStyles(theme: AvatarThemeTokens | null): { tint: string; border: string; glow: string } {
-  const accent = theme?.accent ?? 'var(--color-accent-secondary)';
-  return {
-    tint: `color-mix(in srgb, ${accent} 20%, transparent)`,
-    border: `color-mix(in srgb, ${accent} 40%, transparent)`,
-    glow: `color-mix(in srgb, ${accent} 22%, transparent)`,
-  };
-}
-
 function buildVisibleRoute(includeModeration: boolean): Step[] {
   return includeModeration ? STEP_ORDER : STEP_ORDER.filter((step) => step !== 'moderation');
 }
@@ -739,8 +723,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
   const copy = COPY[language];
   const selectedAvatarOption = getAvatarOptionById(avatarId);
   const selectedAvatarProfile = selectedAvatarOption ? buildAvatarPreviewProfile(selectedAvatarOption) : null;
-  const selectedAvatarTheme = resolveAvatarTheme(selectedAvatarProfile);
-  const selectedAvatarMedia = resolveAvatarMedia(selectedAvatarProfile, { rhythm: gameMode, surface: 'onboarding' });
+  const selectedAvatarPreviewImage = selectedAvatarOption ? resolveAvatarPickerPreviewImage(selectedAvatarOption) : null;
 
   const minimum = MODE_MINIMUMS[gameMode];
   const setupSteps = useMemo(
@@ -1037,7 +1020,8 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
     }
 
     const tasks = copy.tasks[currentPillar];
-    const modeStyle = selectedAvatarProfile ? buildAvatarSoftStyles(selectedAvatarTheme) : MODE_SOFT_STYLES[gameMode];
+    const rhythmTheme = getOnboardingRhythmTheme(gameMode);
+    const modeStyle = { tint: rhythmTheme.softTint, border: rhythmTheme.border, glow: rhythmTheme.glow };
 
     return (
       <section className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">
@@ -1176,7 +1160,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
                       <p className="text-xs uppercase tracking-wide text-white/50">Avatar</p>
                       <p className="mt-1 inline-flex items-center gap-2 text-sm text-white/80">
                         <span>{selectedAvatarOption?.name ?? '—'}</span>
-                        {selectedAvatarOption ? <img src={selectedAvatarMedia.imageUrl ?? '/FlowMood.jpg'} alt={selectedAvatarMedia.alt} className="h-7 w-7 rounded-full border border-white/20 object-cover" /> : null}
+                        {selectedAvatarOption ? <img src={selectedAvatarPreviewImage ?? '/FlowMood.jpg'} alt={selectedAvatarOption.name} className="h-7 w-7 rounded-full border border-white/20 object-cover" /> : null}
                       </p>
                     </div>
                     <div>

--- a/apps/web/src/onboarding/quickStart.ts
+++ b/apps/web/src/onboarding/quickStart.ts
@@ -1,5 +1,6 @@
 import type { OnboardingLanguage } from './constants';
 import type { GameMode, Pillar } from './state';
+import { ONBOARDING_RHYTHM_THEME } from './utils/onboardingRhythmTheme';
 
 export type ModerationOption = 'sugar' | 'tobacco' | 'alcohol';
 
@@ -215,10 +216,10 @@ export interface QuickStartManualTaskCandidate {
 }
 
 export const QUICK_START_MODE_SOFT_STYLES: Record<GameMode, { tint: string; border: string; glow: string }> = {
-  LOW: { tint: 'rgba(125, 211, 252, 0.34)', border: 'rgba(125, 211, 252, 0.56)', glow: 'rgba(56, 189, 248, 0.18)' },
-  CHILL: { tint: 'rgba(167, 139, 250, 0.32)', border: 'rgba(196, 181, 253, 0.55)', glow: 'rgba(139, 92, 246, 0.2)' },
-  FLOW: { tint: 'rgba(244, 114, 182, 0.3)', border: 'rgba(251, 182, 206, 0.58)', glow: 'rgba(236, 72, 153, 0.2)' },
-  EVOLVE: { tint: 'rgba(52, 211, 153, 0.28)', border: 'rgba(167, 243, 208, 0.55)', glow: 'rgba(16, 185, 129, 0.2)' },
+  LOW: { tint: ONBOARDING_RHYTHM_THEME.LOW.softTint, border: ONBOARDING_RHYTHM_THEME.LOW.border, glow: ONBOARDING_RHYTHM_THEME.LOW.glow },
+  CHILL: { tint: ONBOARDING_RHYTHM_THEME.CHILL.softTint, border: ONBOARDING_RHYTHM_THEME.CHILL.border, glow: ONBOARDING_RHYTHM_THEME.CHILL.glow },
+  FLOW: { tint: ONBOARDING_RHYTHM_THEME.FLOW.softTint, border: ONBOARDING_RHYTHM_THEME.FLOW.border, glow: ONBOARDING_RHYTHM_THEME.FLOW.glow },
+  EVOLVE: { tint: ONBOARDING_RHYTHM_THEME.EVOLVE.softTint, border: ONBOARDING_RHYTHM_THEME.EVOLVE.border, glow: ONBOARDING_RHYTHM_THEME.EVOLVE.glow },
 };
 
 export function buildQuickStartManualCandidates(args: {

--- a/apps/web/src/onboarding/steps/AvatarStep.tsx
+++ b/apps/web/src/onboarding/steps/AvatarStep.tsx
@@ -2,9 +2,7 @@ import { motion } from 'framer-motion';
 import type { OnboardingLanguage } from '../constants';
 import type { GameMode } from '../state';
 import { NavButtons } from '../ui/NavButtons';
-import { AVATAR_OPTIONS } from '../../lib/avatarCatalog';
-import { resolveAvatarMedia } from '../../lib/avatarProfile';
-import { buildAvatarPreviewProfile } from '../../lib/avatarCatalog';
+import { AVATAR_OPTIONS, resolveAvatarPickerPreviewImage } from '../../lib/avatarCatalog';
 
 interface AvatarStepProps {
   language?: OnboardingLanguage;
@@ -17,7 +15,6 @@ interface AvatarStepProps {
 
 export function AvatarStep({
   language = 'es',
-  rhythm,
   selectedAvatarId,
   onSelectAvatar,
   onConfirm,
@@ -52,8 +49,7 @@ export function AvatarStep({
         <div className="mt-6 grid gap-4 md:grid-cols-2">
           {AVATAR_OPTIONS.map((option) => {
             const isActive = selectedAvatarId === option.avatarId;
-            const previewProfile = buildAvatarPreviewProfile(option);
-            const media = resolveAvatarMedia(previewProfile, { rhythm, surface: 'onboarding' });
+            const previewImageUrl = resolveAvatarPickerPreviewImage(option);
             return (
               <button
                 key={option.avatarId}
@@ -71,7 +67,7 @@ export function AvatarStep({
                   ) : null}
                 </div>
                 <div className="mt-3 overflow-hidden rounded-xl border border-white/10 bg-white/5">
-                  <img src={media.imageUrl ?? '/FlowMood.jpg'} alt={media.alt} className="h-28 w-full object-cover" loading="lazy" />
+                  <img src={previewImageUrl ?? '/FlowMood.jpg'} alt={option.name} className="h-28 w-full object-cover" loading="lazy" />
                 </div>
               </button>
             );

--- a/apps/web/src/onboarding/steps/GameModeStep.tsx
+++ b/apps/web/src/onboarding/steps/GameModeStep.tsx
@@ -3,6 +3,7 @@ import type { GameMode } from '../state';
 import type { OnboardingLanguage } from '../constants';
 import { NavButtons } from '../ui/NavButtons';
 import { GAME_MODE_META } from '../../lib/gameModeMeta';
+import { getOnboardingRhythmTheme } from '../utils/onboardingRhythmTheme';
 
 interface GameModeStepProps {
   language?: OnboardingLanguage;
@@ -57,6 +58,7 @@ export function GameModeStep({ language = 'es', selected, onSelect, onConfirm, o
           {MODE_ORDER.map((mode) => {
             const content = MODE_CARD_CONTENT[mode];
             const isActive = selected === mode;
+            const modeTheme = getOnboardingRhythmTheme(mode);
 
             return (
               <motion.button
@@ -70,19 +72,27 @@ export function GameModeStep({ language = 'es', selected, onSelect, onConfirm, o
                 className={[
                   'glass-card onboarding-surface-inner onboarding-glass-border-soft relative flex h-full overflow-hidden rounded-3xl border px-5 py-[1.35rem] text-left transition-all duration-250 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950/80',
                   isActive
-                    ? 'border-white/80 bg-white/[0.11] ring-2 ring-sky-300/85 shadow-[0_0_0_1px_rgba(255,255,255,0.28),0_0_28px_rgba(34,211,238,0.38),0_0_52px_rgba(139,92,246,0.34)] -translate-y-0.5 scale-[1.01] focus-visible:ring-4 focus-visible:ring-cyan-200/95'
+                    ? 'border-white/80 bg-white/[0.11] ring-2 -translate-y-0.5 scale-[1.01] focus-visible:ring-4'
                     : 'hover:border-white/30 hover:bg-white/[0.07] focus-visible:border-white/45 focus-visible:ring-sky-300/70',
                 ]
                   .filter(Boolean)
                   .join(' ')}
+                style={isActive ? {
+                  boxShadow: `0 0 0 1px rgba(255,255,255,0.28),0 0 28px ${modeTheme.glow},0 0 52px ${modeTheme.softTint}`,
+                  borderColor: modeTheme.border,
+                  background: `color-mix(in srgb, ${modeTheme.softTint} 48%, rgba(255,255,255,0.11))`,
+                } : undefined}
               >
                 <span
                   className={[
-                    'pointer-events-none absolute inset-0 rounded-3xl bg-[radial-gradient(circle_at_25%_15%,rgba(34,211,238,0.22)_0%,rgba(59,130,246,0.12)_35%,rgba(139,92,246,0.22)_70%,transparent_100%)] transition-all duration-250 ease-out',
+                    'pointer-events-none absolute inset-0 rounded-3xl transition-all duration-250 ease-out',
                     isActive ? 'opacity-100' : 'opacity-0',
                   ]
                     .filter(Boolean)
                     .join(' ')}
+                  style={{
+                    background: `radial-gradient(circle at 25% 15%, color-mix(in srgb, ${modeTheme.accent} 32%, transparent) 0%, color-mix(in srgb, ${modeTheme.accent} 20%, transparent) 35%, color-mix(in srgb, ${modeTheme.accent} 28%, transparent) 70%, transparent 100%)`,
+                  }}
                   aria-hidden
                 />
                 <span className="relative z-10 flex h-full w-full flex-col gap-3">

--- a/apps/web/src/onboarding/steps/QuickStartSummaryStep.tsx
+++ b/apps/web/src/onboarding/steps/QuickStartSummaryStep.tsx
@@ -4,8 +4,7 @@ import type { GameMode, Pillar } from '../state';
 import type { QuickStartTask } from '../quickStart';
 import { GAME_MODE_META } from '../../lib/gameModeMeta';
 import { buildGameModeChip, GameModeChip } from '../../components/common/GameModeChip';
-import { buildAvatarPreviewProfile, getAvatarOptionById } from '../../lib/avatarCatalog';
-import { resolveAvatarMedia } from '../../lib/avatarProfile';
+import { buildAvatarPreviewProfile, getAvatarOptionById, resolveAvatarPickerPreviewImage } from '../../lib/avatarCatalog';
 
 interface QuickStartSummaryStepProps {
   language?: OnboardingLanguage;
@@ -80,7 +79,7 @@ export function QuickStartSummaryStep({
   }, { Body: [], Mind: [], Soul: [] });
   const avatarOption = getAvatarOptionById(selectedAvatarId);
   const avatarProfile = avatarOption ? buildAvatarPreviewProfile(avatarOption) : null;
-  const avatarMedia = resolveAvatarMedia(avatarProfile, { rhythm: gameMode, surface: 'onboarding' });
+  const avatarPreviewImage = avatarOption ? resolveAvatarPickerPreviewImage(avatarOption) : null;
 
   return (
     <section className="glass-card onboarding-surface-base mx-auto w-full max-w-5xl rounded-3xl p-6 sm:p-8">
@@ -106,7 +105,7 @@ export function QuickStartSummaryStep({
                 <p className="text-xs uppercase tracking-wide text-white/50">Avatar</p>
                 <p className="mt-1 inline-flex items-center gap-2 text-sm text-white/80">
                   <span>{avatarOption?.name ?? '—'}</span>
-                  {avatarOption ? <img src={avatarMedia.imageUrl ?? '/FlowMood.jpg'} alt={avatarMedia.alt} className="h-7 w-7 rounded-full border border-white/20 object-cover" /> : null}
+                  {avatarOption ? <img src={avatarPreviewImage ?? '/FlowMood.jpg'} alt={avatarOption.name} className="h-7 w-7 rounded-full border border-white/20 object-cover" /> : null}
                 </p>
               </div>
               <div>

--- a/apps/web/src/onboarding/steps/SummaryStep.tsx
+++ b/apps/web/src/onboarding/steps/SummaryStep.tsx
@@ -5,8 +5,7 @@ import type { Answers, GameMode, XP } from '../state';
 import { MODE_CARD_CONTENT } from './GameModeStep';
 import { NavButtons } from '../ui/NavButtons';
 import { GameModeChip as SharedGameModeChip, buildGameModeChip } from '../../components/common/GameModeChip';
-import { buildAvatarPreviewProfile, getAvatarOptionById } from '../../lib/avatarCatalog';
-import { resolveAvatarMedia } from '../../lib/avatarProfile';
+import { buildAvatarPreviewProfile, getAvatarOptionById, resolveAvatarPickerPreviewImage } from '../../lib/avatarCatalog';
 
 interface SummaryStepProps {
   language?: OnboardingLanguage;
@@ -249,7 +248,7 @@ export function SummaryStep({
   const { mode } = answers;
   const avatarOption = getAvatarOptionById(selectedAvatarId);
   const avatarProfile = avatarOption ? buildAvatarPreviewProfile(avatarOption) : null;
-  const avatarMedia = resolveAvatarMedia(avatarProfile, { rhythm: mode, surface: 'onboarding' });
+  const avatarPreviewImage = avatarOption ? resolveAvatarPickerPreviewImage(avatarOption) : null;
   const isDisabled = isSubmitting;
 
   const bodyTraits = answers.foundations.body.map(extractTrait);
@@ -274,7 +273,7 @@ export function SummaryStep({
                 value={avatarOption ? (
                   <span className="inline-flex items-center gap-2">
                     <span>{avatarOption.name}</span>
-                    <img src={avatarMedia.imageUrl ?? '/FlowMood.jpg'} alt={avatarMedia.alt} className="h-7 w-7 rounded-full border border-white/20 object-cover" />
+                    <img src={avatarPreviewImage ?? '/FlowMood.jpg'} alt={avatarOption.name} className="h-7 w-7 rounded-full border border-white/20 object-cover" />
                   </span>
                 ) : '—'}
               />

--- a/apps/web/src/onboarding/ui/HUD.tsx
+++ b/apps/web/src/onboarding/ui/HUD.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from 'react';
 import type { OnboardingLanguage } from '../constants';
 import type { GameMode, XP } from '../state';
 import { GpProgressBar } from './GpProgressBar';
+import { getOnboardingRhythmTheme } from '../utils/onboardingRhythmTheme';
 
 interface HUDProps {
   language?: OnboardingLanguage;
@@ -16,27 +17,11 @@ interface HUDProps {
   onBrandClick?: () => void;
 }
 
-const MODE_BADGE_META: Record<GameMode, { label: string; accent: string; dot: string }> = {
-  LOW: {
-    label: 'Low Mood',
-    accent: 'rgba(248, 113, 113, 0.45)',
-    dot: 'rgba(248, 113, 113, 0.96)',
-  },
-  CHILL: {
-    label: 'Chill Mood',
-    accent: 'rgba(74, 222, 128, 0.4)',
-    dot: 'rgba(74, 222, 128, 0.95)',
-  },
-  FLOW: {
-    label: 'Flow Mood',
-    accent: 'rgba(56, 189, 248, 0.42)',
-    dot: 'rgba(56, 189, 248, 0.95)',
-  },
-  EVOLVE: {
-    label: 'Evolve Mood',
-    accent: 'rgba(167, 139, 250, 0.44)',
-    dot: 'rgba(167, 139, 250, 0.96)',
-  },
+const MODE_BADGE_LABELS: Record<GameMode, string> = {
+  LOW: 'Low Mood',
+  CHILL: 'Chill Mood',
+  FLOW: 'Flow Mood',
+  EVOLVE: 'Evolve Mood',
 };
 
 type PillarKey = 'Body' | 'Mind' | 'Soul';
@@ -52,16 +37,16 @@ function ModeBadge({ mode }: { mode: GameMode | null }) {
     return null;
   }
 
-  const meta = MODE_BADGE_META[mode];
-  const style = { '--chip-accent': meta.accent } as CSSProperties;
+  const theme = getOnboardingRhythmTheme(mode);
+  const style = { '--chip-accent': theme.badgeAccent } as CSSProperties;
 
   return (
     <span
       className="onboarding-mode-chip inline-flex items-center gap-2 px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white/85 shadow-[0_0_18px_rgba(8,12,24,0.5)] ring-1 ring-white/10"
       style={style}
     >
-      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: meta.dot }} />
-      {meta.label}
+      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: theme.badgeDot }} />
+      {MODE_BADGE_LABELS[mode]}
     </span>
   );
 }

--- a/apps/web/src/onboarding/utils/onboardingRhythmTheme.ts
+++ b/apps/web/src/onboarding/utils/onboardingRhythmTheme.ts
@@ -1,0 +1,49 @@
+import type { GameMode } from '../state';
+
+export type OnboardingRhythmTheme = {
+  accent: string;
+  border: string;
+  glow: string;
+  softTint: string;
+  badgeDot: string;
+  badgeAccent: string;
+};
+
+export const ONBOARDING_RHYTHM_THEME: Record<GameMode, OnboardingRhythmTheme> = {
+  LOW: {
+    accent: 'rgb(248, 113, 113)',
+    border: 'rgba(248, 113, 113, 0.45)',
+    glow: 'rgba(248, 113, 113, 0.32)',
+    softTint: 'rgba(248, 113, 113, 0.2)',
+    badgeDot: 'rgba(248, 113, 113, 0.96)',
+    badgeAccent: 'rgba(248, 113, 113, 0.45)',
+  },
+  CHILL: {
+    accent: 'rgb(74, 222, 128)',
+    border: 'rgba(74, 222, 128, 0.4)',
+    glow: 'rgba(74, 222, 128, 0.3)',
+    softTint: 'rgba(74, 222, 128, 0.2)',
+    badgeDot: 'rgba(74, 222, 128, 0.95)',
+    badgeAccent: 'rgba(74, 222, 128, 0.4)',
+  },
+  FLOW: {
+    accent: 'rgb(56, 189, 248)',
+    border: 'rgba(56, 189, 248, 0.42)',
+    glow: 'rgba(56, 189, 248, 0.32)',
+    softTint: 'rgba(56, 189, 248, 0.2)',
+    badgeDot: 'rgba(56, 189, 248, 0.95)',
+    badgeAccent: 'rgba(56, 189, 248, 0.42)',
+  },
+  EVOLVE: {
+    accent: 'rgb(167, 139, 250)',
+    border: 'rgba(167, 139, 250, 0.44)',
+    glow: 'rgba(167, 139, 250, 0.34)',
+    softTint: 'rgba(167, 139, 250, 0.2)',
+    badgeDot: 'rgba(167, 139, 250, 0.96)',
+    badgeAccent: 'rgba(167, 139, 250, 0.44)',
+  },
+};
+
+export function getOnboardingRhythmTheme(mode: GameMode): OnboardingRhythmTheme {
+  return ONBOARDING_RHYTHM_THEME[mode];
+}

--- a/apps/web/src/pages/QuickStartPreview.tsx
+++ b/apps/web/src/pages/QuickStartPreview.tsx
@@ -14,8 +14,8 @@ import { GpExplainerOverlay } from '../onboarding/ui/GpExplainerOverlay';
 import { HUD } from '../onboarding/ui/HUD';
 import { NavButtons } from '../onboarding/ui/NavButtons';
 import { GameModeChip as SharedGameModeChip, buildGameModeChip } from '../components/common/GameModeChip';
-import { buildAvatarPreviewProfile, getAvatarOptionById } from '../lib/avatarCatalog';
-import { resolveAvatarMedia, resolveAvatarTheme, type AvatarThemeTokens } from '../lib/avatarProfile';
+import { buildAvatarPreviewProfile, getAvatarOptionById, resolveAvatarPickerPreviewImage } from '../lib/avatarCatalog';
+import { getOnboardingRhythmTheme } from '../onboarding/utils/onboardingRhythmTheme';
 
 type Pillar = 'Body' | 'Mind' | 'Soul';
 type Step = 'game-mode' | 'avatar' | 'branch' | 'body' | 'mind' | 'soul' | 'moderation' | 'summary' | 'setup';
@@ -554,22 +554,6 @@ const GAME_MODE_META_KEY: Record<GameMode, keyof typeof GAME_MODE_META> = {
   EVOLVE: 'Evolve',
 };
 
-const MODE_SOFT_STYLES: Record<GameMode, { tint: string; border: string; glow: string }> = {
-  LOW: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
-  CHILL: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
-  FLOW: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
-  EVOLVE: { tint: 'color-mix(in srgb, var(--color-accent-secondary) 20%, transparent)', border: 'color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)', glow: 'color-mix(in srgb, var(--color-accent-secondary) 22%, transparent)' },
-};
-
-function buildAvatarSoftStyles(theme: AvatarThemeTokens | null): { tint: string; border: string; glow: string } {
-  const accent = theme?.accent ?? 'var(--color-accent-secondary)';
-  return {
-    tint: `color-mix(in srgb, ${accent} 20%, transparent)`,
-    border: `color-mix(in srgb, ${accent} 40%, transparent)`,
-    glow: `color-mix(in srgb, ${accent} 22%, transparent)`,
-  };
-}
-
 function getDefaultLanguage(searchParams: URLSearchParams): OnboardingLanguage {
   const lang = searchParams.get('lang');
   if (lang === 'es' || lang === 'en') {
@@ -744,8 +728,7 @@ export default function QuickStartPreviewPage() {
   const copy = COPY[language];
   const selectedAvatarOption = getAvatarOptionById(avatarId);
   const selectedAvatarProfile = selectedAvatarOption ? buildAvatarPreviewProfile(selectedAvatarOption) : null;
-  const selectedAvatarTheme = resolveAvatarTheme(selectedAvatarProfile);
-  const selectedAvatarMedia = resolveAvatarMedia(selectedAvatarProfile, { rhythm: gameMode, surface: 'onboarding' });
+  const selectedAvatarPreviewImage = selectedAvatarOption ? resolveAvatarPickerPreviewImage(selectedAvatarOption) : null;
 
   const minimum = MODE_MINIMUMS[gameMode];
   const setupSteps = useMemo(
@@ -1052,7 +1035,8 @@ export default function QuickStartPreviewPage() {
     }
 
     const tasks = copy.tasks[currentPillar];
-    const modeStyle = selectedAvatarProfile ? buildAvatarSoftStyles(selectedAvatarTheme) : MODE_SOFT_STYLES[gameMode];
+    const rhythmTheme = getOnboardingRhythmTheme(gameMode);
+    const modeStyle = { tint: rhythmTheme.softTint, border: rhythmTheme.border, glow: rhythmTheme.glow };
 
     return (
       <section className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">
@@ -1287,7 +1271,7 @@ export default function QuickStartPreviewPage() {
                       <p className="text-xs uppercase tracking-wide text-white/50">Avatar</p>
                       <p className="mt-1 inline-flex items-center gap-2 text-sm text-white/80">
                         <span>{selectedAvatarOption?.name ?? '—'}</span>
-                        {selectedAvatarOption ? <img src={selectedAvatarMedia.imageUrl ?? '/FlowMood.jpg'} alt={selectedAvatarMedia.alt} className="h-7 w-7 rounded-full border border-white/20 object-cover" /> : null}
+                        {selectedAvatarOption ? <img src={selectedAvatarPreviewImage ?? '/FlowMood.jpg'} alt={selectedAvatarOption.name} className="h-7 w-7 rounded-full border border-white/20 object-cover" /> : null}
                       </p>
                     </div>
                     <div>


### PR DESCRIPTION
### Motivation
- Onboarding visuals were drifting because rhythm colors were fragmented across components while avatar preview images were resolved via a rhythm-driven media resolver, causing inconsistent identity and color behavior.
- The onboarding quick-start flows incorrectly used selected avatar themes to style the flow, which violated the product rule that flow color must always come from rhythm.
- Avatar picker previews and summary thumbnails were not aligned with Dashboard > Change Avatar, producing different animal preview images across surfaces.

### Description
- Added a canonical rhythm theme helper `apps/web/src/onboarding/utils/onboardingRhythmTheme.ts` that maps `LOW/CHILL/FLOW/EVOLVE` to stable tokens (`accent`, `border`, `glow`, `softTint`, `badgeDot`, `badgeAccent`).
- Switched HUD to read badge dot/accent from the new helper in `apps/web/src/onboarding/ui/HUD.tsx` so the HUD and theme source are unified.
- Updated rhythm cards in `apps/web/src/onboarding/steps/GameModeStep.tsx` to render per-rhythm visual skins using the new theme instead of a generic cyan/violet highlight.
- Removed avatar-driven color branching in quick-start flows and aligned flow accents to rhythm tokens in `apps/web/src/onboarding/IntegratedQuickStartFlow.tsx`, `apps/web/src/pages/QuickStartPreview.tsx`, and `apps/web/src/onboarding/quickStart.ts` so the onboarding flow is rhythm-first.
- Centralized avatar picker preview logic by adding `resolveAvatarPickerPreviewImage` in `apps/web/src/lib/avatarCatalog.ts` and reused it from `apps/web/src/components/dashboard-v3/DashboardMenu.tsx` and `apps/web/src/onboarding/steps/AvatarStep.tsx` so onboarding picker previews match Dashboard Change Avatar.
- Stabilized avatar thumbnails in summary surfaces by switching summary/avatar preview code to use the shared picker preview image in `apps/web/src/onboarding/steps/SummaryStep.tsx`, `apps/web/src/onboarding/steps/QuickStartSummaryStep.tsx`, `apps/web/src/onboarding/IntegratedQuickStartFlow.tsx`, and `apps/web/src/pages/QuickStartPreview.tsx` to prevent rhythm-dependent avatar swaps.

### Testing
- Ran the repository type check with `npm run typecheck:web`, which failed due to pre-existing, unrelated TypeScript errors in auth/dashboard/mobile/test areas and did not introduce new errors scoped to the modified onboarding/avatar files.
- No UI screenshot or end-to-end tests were executed in this environment, so visual verification will be needed in a browser to confirm color mappings and avatar preview alignment across HUD, GameModeStep, AvatarStep, SummaryStep, Integrated Quick Start, and Quick Start Preview.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf0981f7c833289e33801706b9b20)