### PR TITLE
Unify Dashboard rhythm chip colors with onboarding palette

### DIFF
--- a/apps/web/src/components/common/GameModeChip.test.ts
+++ b/apps/web/src/components/common/GameModeChip.test.ts
@@ -26,7 +26,7 @@ function makeProfile(overrides: Partial<CurrentUserProfile>): CurrentUserProfile
 }
 
 describe('buildGameModeChip', () => {
-  it('keeps rhythm label content while using avatar accent styling', () => {
+  it('keeps rhythm label content and uses onboarding rhythm color mapping even when avatar differs', () => {
     const avatarProfile = resolveAvatarProfile(
       makeProfile({
         game_mode: 'Flow',
@@ -40,11 +40,18 @@ describe('buildGameModeChip', () => {
     const chip = buildGameModeChip('Flow', { avatarProfile });
 
     expect(chip.label).toBe('FLOW');
-    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#EF4444' });
+    expect(chip.style).toMatchObject({ '--ib-chip-accent': 'rgb(56, 189, 248)' });
   });
 
-  it('uses safe legacy fallback accent when avatar is missing', () => {
-    const chip = buildGameModeChip('Flow');
-    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#00C2FF' });
+  it('falls back safely to FLOW rhythm accent when mode is missing', () => {
+    const chip = buildGameModeChip('');
+    expect(chip.style).toMatchObject({ '--ib-chip-accent': 'rgb(56, 189, 248)' });
+  });
+
+  it('maps every rhythm to the onboarding source-of-truth palette', () => {
+    expect(buildGameModeChip('Low').style).toMatchObject({ '--ib-chip-accent': 'rgb(248, 113, 113)' });
+    expect(buildGameModeChip('Chill').style).toMatchObject({ '--ib-chip-accent': 'rgb(74, 222, 128)' });
+    expect(buildGameModeChip('Flow').style).toMatchObject({ '--ib-chip-accent': 'rgb(56, 189, 248)' });
+    expect(buildGameModeChip('Evolve').style).toMatchObject({ '--ib-chip-accent': 'rgb(167, 139, 250)' });
   });
 });

--- a/apps/web/src/components/common/GameModeChip.tsx
+++ b/apps/web/src/components/common/GameModeChip.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from 'react';
-import { resolveAvatarTheme, type AvatarProfile } from '../../lib/avatarProfile';
 import { normalizeGameModeValue, type GameMode } from '../../lib/gameMode';
+import { resolveRhythmTheme } from '../../lib/rhythmTheme';
 
 interface GameModeChipStyle {
   label: string;
@@ -23,11 +23,11 @@ const DEFAULT_CHIP_STYLE: GameModeChipStyle = {
 
 export function buildGameModeChip(
   mode?: string | null,
-  options?: { avatarProfile?: AvatarProfile | null },
+  _options?: { avatarProfile?: unknown | null },
 ): GameModeChipStyle {
-  const theme = resolveAvatarTheme(options?.avatarProfile ?? null);
+  const rhythmTheme = resolveRhythmTheme(mode);
   const style = {
-    '--ib-chip-accent': theme.accent,
+    '--ib-chip-accent': rhythmTheme.accent,
   } as CSSProperties;
 
   if (!mode) {

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts
@@ -1,51 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import { buildStreakModeChipVisual } from './StreaksPanel';
-import { resolveAvatarProfile } from '../../lib/avatarProfile';
-import type { CurrentUserProfile } from '../../lib/api';
-
-function makeProfile(overrides: Partial<CurrentUserProfile>): CurrentUserProfile {
-  return {
-    user_id: 'user-1',
-    clerk_user_id: 'clerk-1',
-    email_primary: 'test@example.com',
-    full_name: 'Test User',
-    image_url: null,
-    game_mode: 'Flow',
-    weekly_target: 3,
-    avatar_id: null,
-    avatar_code: null,
-    avatar_name: null,
-    avatar_theme_tokens: null,
-    timezone: 'UTC',
-    locale: 'en',
-    created_at: '2026-04-13T00:00:00.000Z',
-    updated_at: '2026-04-13T00:00:00.000Z',
-    deleted_at: null,
-    ...overrides,
-  };
-}
 
 describe('buildStreakModeChipVisual', () => {
-  it('uses avatar theme accent regardless of rhythm content', () => {
-    const avatarProfile = resolveAvatarProfile(
-      makeProfile({
-        game_mode: 'Flow',
-        avatar_id: 7,
-        avatar_code: 'RED_CAT',
-        avatar_name: 'Red Cat',
-        avatar_theme_tokens: { accent: '#ef4444', chip: 'ember' },
-      }),
-    );
+  it('uses onboarding rhythm accent for FLOW', () => {
+    const visual = buildStreakModeChipVisual('Flow');
 
-    const visual = buildStreakModeChipVisual(avatarProfile);
-
-    expect(visual.accent).toBe('#ef4444');
-    expect(visual.glowPrimary).toContain('239, 68, 68');
-    expect(visual.glowSecondary).toContain('239, 68, 68');
+    expect(visual.accent).toBe('rgb(56, 189, 248)');
+    expect(visual.glowPrimary).toBe('rgba(56, 189, 248, 0.32)');
+    expect(visual.glowSecondary).toBe('rgba(56, 189, 248, 0.2)');
   });
 
-  it('falls back safely when avatar profile is unavailable', () => {
+  it('maps all rhythm modes to onboarding source-of-truth accents', () => {
+    expect(buildStreakModeChipVisual('Low').accent).toBe('rgb(248, 113, 113)');
+    expect(buildStreakModeChipVisual('Chill').accent).toBe('rgb(74, 222, 128)');
+    expect(buildStreakModeChipVisual('Flow').accent).toBe('rgb(56, 189, 248)');
+    expect(buildStreakModeChipVisual('Evolve').accent).toBe('rgb(167, 139, 250)');
+  });
+
+  it('falls back safely to FLOW rhythm when mode is unavailable', () => {
     const visual = buildStreakModeChipVisual(null);
-    expect(visual.accent).toBe('#00C2FF');
+    expect(visual.accent).toBe('rgb(56, 189, 248)');
   });
 });

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
@@ -19,13 +19,14 @@ import { TaskInsightsModal } from './StreakTaskInsightsModal';
 import { DashboardMeta, DashboardTitle } from './DashboardTypography';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
 import { HABIT_ACHIEVEMENT_UPDATED_EVENT } from '../../lib/habitAchievementEvents';
-import { resolveAvatarTheme, type AvatarProfile } from '../../lib/avatarProfile';
+import type { AvatarProfile } from '../../lib/avatarProfile';
 import {
   DASHBOARD_SEGMENTED_BUTTON_ACTIVE,
   DASHBOARD_SEGMENTED_BUTTON_BASE,
   DASHBOARD_SEGMENTED_BUTTON_INACTIVE,
   DASHBOARD_SEGMENTED_GROUP_BASE,
 } from './segmentedControlStyles';
+import { resolveRhythmTheme } from '../../lib/rhythmTheme';
 
 export const FEATURE_STREAKS_PANEL_V1 = false;
 
@@ -310,27 +311,12 @@ function GlowChip({ glowPrimary, glowSecondary, children, className, innerClassN
   );
 }
 
-function hexToRgba(hex: string, alpha: number): string {
-  const normalized = hex.replace('#', '').trim();
-  const expanded = normalized.length === 3
-    ? normalized.split('').map((chunk) => `${chunk}${chunk}`).join('')
-    : normalized;
-  if (!/^[0-9a-fA-F]{6}$/.test(expanded)) {
-    return `rgba(139, 92, 246, ${alpha})`;
-  }
-  const int = Number.parseInt(expanded, 16);
-  const r = (int >> 16) & 255;
-  const g = (int >> 8) & 255;
-  const b = int & 255;
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-export function buildStreakModeChipVisual(avatarProfile?: AvatarProfile | null) {
-  const avatarTheme = resolveAvatarTheme(avatarProfile ?? null);
+export function buildStreakModeChipVisual(mode?: string | null) {
+  const rhythmTheme = resolveRhythmTheme(mode);
   return {
-    accent: avatarTheme.accent,
-    glowPrimary: hexToRgba(avatarTheme.accent, 0.66),
-    glowSecondary: hexToRgba(avatarTheme.accent, 0.36),
+    accent: rhythmTheme.accent,
+    glowPrimary: rhythmTheme.glow,
+    glowSecondary: rhythmTheme.softTint,
   };
 }
 
@@ -665,7 +651,7 @@ function TaskItem({
   );
 }
 
-export function StreaksPanel({ userId, gameMode, weeklyTarget, avatarProfile, forceLoadingTasks = false }: StreaksPanelProps) {
+export function StreaksPanel({ userId, gameMode, weeklyTarget, avatarProfile: _avatarProfile, forceLoadingTasks = false }: StreaksPanelProps) {
   const { t, language } = usePostLoginLanguage();
   const [pillar, setPillar] = useState<Pillar>('Body');
   const [range, setRange] = useState<StreakPanelRange>('month');
@@ -877,7 +863,7 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, avatarProfile, fo
           : tab.label,
   }));
   const daysConsecutiveText = (days: string) => t('dashboard.streaks.daysConsecutiveSr', { days });
-  const modeChipVisual = buildStreakModeChipVisual(avatarProfile);
+  const modeChipVisual = buildStreakModeChipVisual(normalizedMode);
   const modeChip = {
     className: 'ib-streak-mode-chip',
     glowPrimary: modeChipVisual.glowPrimary,

--- a/apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx
+++ b/apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx
@@ -1,9 +1,10 @@
 import { Sparkles } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
-import { resolveAvatarTheme, type AvatarProfile } from '../../lib/avatarProfile';
+import type { AvatarProfile } from '../../lib/avatarProfile';
 import { normalizeGameModeValue } from '../../lib/gameMode';
 import { GAME_MODE_META, type LocalizedLanguage } from '../../lib/gameModeMeta';
+import { resolveRhythmTheme } from '../../lib/rhythmTheme';
 import { buildGameModeChip, GameModeChip } from '../common/GameModeChip';
 
 interface UpgradeRecommendationModalProps {
@@ -57,7 +58,7 @@ export function UpgradeRecommendationModal({
 
   const currentRhythm = useMemo(() => normalizeGameModeValue(currentMode), [currentMode]);
   const nextRhythm = useMemo(() => normalizeGameModeValue(nextMode), [nextMode]);
-  const avatarTheme = useMemo(() => resolveAvatarTheme(avatarProfile), [avatarProfile]);
+  const currentRhythmTheme = useMemo(() => resolveRhythmTheme(currentMode), [currentMode]);
   const nextModeChip = useMemo(
     () => buildGameModeChip(nextMode, { avatarProfile }),
     [avatarProfile, nextMode],
@@ -236,7 +237,7 @@ export function UpgradeRecommendationModal({
                   >
                     <div
                       className="flex h-14 w-14 items-center justify-center rounded-xl border border-black/10 text-[10px] font-bold uppercase tracking-[0.14em] text-white shadow-[0_10px_22px_rgba(15,23,42,0.28)]"
-                      style={{ backgroundColor: avatarTheme.accent }}
+                      style={{ backgroundColor: currentRhythmTheme.accent }}
                       aria-hidden="true"
                     >
                       {t('dashboard.upgradeCta.nowTag')}

--- a/apps/web/src/lib/rhythmTheme.ts
+++ b/apps/web/src/lib/rhythmTheme.ts
@@ -1,0 +1,17 @@
+import { getOnboardingRhythmTheme } from '../onboarding/utils/onboardingRhythmTheme';
+import { normalizeGameModeValue, type GameMode } from './gameMode';
+
+type OnboardingRhythmMode = 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE';
+
+const ONBOARDING_RHYTHM_BY_GAME_MODE: Record<GameMode, OnboardingRhythmMode> = {
+  Low: 'LOW',
+  Chill: 'CHILL',
+  Flow: 'FLOW',
+  Evolve: 'EVOLVE',
+};
+
+export function resolveRhythmTheme(mode?: string | null) {
+  const normalizedMode = normalizeGameModeValue(mode) ?? 'Flow';
+  const onboardingMode = ONBOARDING_RHYTHM_BY_GAME_MODE[normalizedMode];
+  return getOnboardingRhythmTheme(onboardingMode);
+}


### PR DESCRIPTION
### Motivation
- The Dashboard used avatar-derived/legacy accent colors for rhythm/mode chips, causing visual desync with the onboarding experience. The goal is to make all rhythm/mode chips use the onboarding source-of-truth colors. 
- Keep the existing premium look (dark translucent background, glow, subtle border, inner dot, white/85 text) while replacing color tokens so FLOW is clearly blue (`#38BDF8`) and not purple.

### Description
- Add a shared resolver `resolveRhythmTheme` that consumes the onboarding source-of-truth `getOnboardingRhythmTheme` and normalizes game mode inputs into onboarding keys (`apps/web/src/lib/rhythmTheme.ts`).
- Update `buildGameModeChip` so chips are styled from the rhythm theme (mode) instead of avatar accent, preserving existing structure and effects (`apps/web/src/components/common/GameModeChip.tsx`).
- Update streaks chip derivation to use rhythm tokens (`accent`, `glow`, `softTint`) so glow/border/fills come from onboarding palette (`apps/web/src/components/dashboard-v3/StreaksPanel.tsx`).
- Use the rhythm theme accent for the draggable NOW badge in the upgrade modal instead of avatar accent (`apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx`).
- Update tests to assert the exact onboarding palette mapping and fallback behavior (`apps/web/src/components/common/GameModeChip.test.ts`, `apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts`).
- Files changed: `apps/web/src/lib/rhythmTheme.ts`, `apps/web/src/components/common/GameModeChip.tsx`, `apps/web/src/components/common/GameModeChip.test.ts`, `apps/web/src/components/dashboard-v3/StreaksPanel.tsx`, `apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts`, `apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx`.
- Explicit final palette applied (sourced from onboarding): LOW → `#F87171`, CHILL → `#4ADE80`, FLOW → `#38BDF8`, EVOLVE → `#A78BFA`.

### Testing
- Ran unit tests for the modified areas: `npm --workspace apps/web run test -- src/components/common/GameModeChip.test.ts src/components/dashboard-v3/StreaksPanel.theme.test.ts`, and both test files passed (all tests green).
- Ran typecheck `npm --workspace apps/web run typecheck`, which failed due to pre-existing unrelated TypeScript errors elsewhere in the codebase; these type errors are not introduced by this change and are out of scope for this visual refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de879368f48332b0963548517a7477)