### PR TITLE
fix(web): color dashboard chips by selected avatar palette

### DIFF
--- a/apps/web/src/components/common/GameModeChip.test.ts
+++ b/apps/web/src/components/common/GameModeChip.test.ts
@@ -33,18 +33,18 @@ describe('buildGameModeChip', () => {
         avatar_id: 99,
         avatar_code: 'RED_CAT',
         avatar_name: 'Red Cat',
-        avatar_theme_tokens: { accent: '#ef4444', chip: 'ember' },
+        avatar_theme_tokens: { accent: '#F87171', chip: 'ember' },
       }),
     );
 
     const chip = buildGameModeChip('Flow', { avatarProfile });
 
     expect(chip.label).toBe('FLOW');
-    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#EF4444' });
+    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#F87171' });
   });
 
   it('uses safe legacy fallback accent when avatar is missing', () => {
     const chip = buildGameModeChip('Flow');
-    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#00C2FF' });
+    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#38BDF8' });
   });
 });

--- a/apps/web/src/components/common/GameModeChip.tsx
+++ b/apps/web/src/components/common/GameModeChip.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react';
-import { resolveAvatarTheme, type AvatarProfile } from '../../lib/avatarProfile';
+import { type AvatarProfile } from '../../lib/avatarProfile';
+import { resolveAvatarChipColor } from '../../lib/avatarChipPalette';
 import { normalizeGameModeValue, type GameMode } from '../../lib/gameMode';
 
 interface GameModeChipStyle {
@@ -25,9 +26,9 @@ export function buildGameModeChip(
   mode?: string | null,
   options?: { avatarProfile?: AvatarProfile | null },
 ): GameModeChipStyle {
-  const theme = resolveAvatarTheme(options?.avatarProfile ?? null);
+  const chipColor = resolveAvatarChipColor(options?.avatarProfile ?? null);
   const style = {
-    '--ib-chip-accent': theme.accent,
+    '--ib-chip-accent': chipColor,
   } as CSSProperties;
 
   if (!mode) {

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts
@@ -33,19 +33,19 @@ describe('buildStreakModeChipVisual', () => {
         avatar_id: 7,
         avatar_code: 'RED_CAT',
         avatar_name: 'Red Cat',
-        avatar_theme_tokens: { accent: '#ef4444', chip: 'ember' },
+        avatar_theme_tokens: { accent: '#F87171', chip: 'ember' },
       }),
     );
 
     const visual = buildStreakModeChipVisual(avatarProfile);
 
-    expect(visual.accent).toBe('#ef4444');
-    expect(visual.glowPrimary).toContain('239, 68, 68');
-    expect(visual.glowSecondary).toContain('239, 68, 68');
+    expect(visual.accent).toBe('#F87171');
+    expect(visual.glowPrimary).toContain('248, 113, 113');
+    expect(visual.glowSecondary).toContain('248, 113, 113');
   });
 
   it('falls back safely when avatar profile is unavailable', () => {
     const visual = buildStreakModeChipVisual(null);
-    expect(visual.accent).toBe('#00C2FF');
+    expect(visual.accent).toBe('#38BDF8');
   });
 });

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
@@ -19,7 +19,8 @@ import { TaskInsightsModal } from './StreakTaskInsightsModal';
 import { DashboardMeta, DashboardTitle } from './DashboardTypography';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
 import { HABIT_ACHIEVEMENT_UPDATED_EVENT } from '../../lib/habitAchievementEvents';
-import { resolveAvatarTheme, type AvatarProfile } from '../../lib/avatarProfile';
+import { type AvatarProfile } from '../../lib/avatarProfile';
+import { resolveAvatarChipColor } from '../../lib/avatarChipPalette';
 import {
   DASHBOARD_SEGMENTED_BUTTON_ACTIVE,
   DASHBOARD_SEGMENTED_BUTTON_BASE,
@@ -326,11 +327,11 @@ function hexToRgba(hex: string, alpha: number): string {
 }
 
 export function buildStreakModeChipVisual(avatarProfile?: AvatarProfile | null) {
-  const avatarTheme = resolveAvatarTheme(avatarProfile ?? null);
+  const chipColor = resolveAvatarChipColor(avatarProfile ?? null);
   return {
-    accent: avatarTheme.accent,
-    glowPrimary: hexToRgba(avatarTheme.accent, 0.66),
-    glowSecondary: hexToRgba(avatarTheme.accent, 0.36),
+    accent: chipColor,
+    glowPrimary: hexToRgba(chipColor, 0.66),
+    glowSecondary: hexToRgba(chipColor, 0.36),
   };
 }
 

--- a/apps/web/src/lib/avatarChipPalette.test.ts
+++ b/apps/web/src/lib/avatarChipPalette.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAvatarChipColor } from './avatarChipPalette';
+import { buildAvatarPreviewProfile } from './avatarCatalog';
+
+describe('resolveAvatarChipColor', () => {
+  it('maps each avatar code to the softened dashboard chip palette', () => {
+    expect(resolveAvatarChipColor(buildAvatarPreviewProfile({ avatarId: 3, code: 'RED_CAT', name: 'Red Cat', accent: '#EF4444', chip: 'ember' }))).toBe('#F87171');
+    expect(resolveAvatarChipColor(buildAvatarPreviewProfile({ avatarId: 2, code: 'GREEN_BEAR', name: 'Green Bear', accent: '#58CC02', chip: 'leaf' }))).toBe('#4ADE80');
+    expect(resolveAvatarChipColor(buildAvatarPreviewProfile({ avatarId: 1, code: 'BLUE_AMPHIBIAN', name: 'Blue Amphibian', accent: '#00C2FF', chip: 'aqua' }))).toBe('#38BDF8');
+    expect(resolveAvatarChipColor(buildAvatarPreviewProfile({ avatarId: 4, code: 'VIOLET_OWL', name: 'Violet Owl', accent: '#A855F7', chip: 'violet' }))).toBe('#A78BFA');
+  });
+
+  it('falls back to blue amphibian color when avatar profile is missing', () => {
+    expect(resolveAvatarChipColor(null)).toBe('#38BDF8');
+  });
+});

--- a/apps/web/src/lib/avatarChipPalette.ts
+++ b/apps/web/src/lib/avatarChipPalette.ts
@@ -1,0 +1,14 @@
+import { resolveAvatarOption, type AvatarOption } from './avatarCatalog';
+import type { AvatarProfile } from './avatarProfile';
+
+const AVATAR_CHIP_PALETTE: Record<AvatarOption['code'], string> = {
+  RED_CAT: '#F87171',
+  GREEN_BEAR: '#4ADE80',
+  BLUE_AMPHIBIAN: '#38BDF8',
+  VIOLET_OWL: '#A78BFA',
+};
+
+export function resolveAvatarChipColor(avatarProfile: AvatarProfile | null | undefined): string {
+  const avatarCode = resolveAvatarOption(avatarProfile ?? null).code;
+  return AVATAR_CHIP_PALETTE[avatarCode];
+}


### PR DESCRIPTION
### Motivation

- Restaurar la intención original: los chips del Dashboard deben colorearse según el avatar seleccionado y no por el ritmo activo. 
- Aplicar una paleta suavizada final específica por avatar para unificar la identidad visual de los chips sin cambiar la semántica del ritmo.

### Description

- Añadí un helper compartido `resolveAvatarChipColor` (`apps/web/src/lib/avatarChipPalette.ts`) que mapea cada avatar a la paleta final: `RED_CAT -> #F87171`, `GREEN_BEAR -> #4ADE80`, `BLUE_AMPHIBIAN -> #38BDF8`, `VIOLET_OWL -> #A78BFA`.
- Actualicé `buildGameModeChip` (`apps/web/src/components/common/GameModeChip.tsx`) para usar `resolveAvatarChipColor(...)` al fijar `--ib-chip-accent`, manteniendo el label del ritmo (`LOW/CHILL/FLOW/EVOLVE`) como texto.
- Actualicé `buildStreakModeChipVisual` en `StreaksPanel` (`apps/web/src/components/dashboard-v3/StreaksPanel.tsx`) para usar el mismo helper y calcular también los glows a partir del color de chip suavizado.
- Añadí tests y actualicé expectativas para validar el mapeo y fallback: `apps/web/src/lib/avatarChipPalette.test.ts`, y ajusté `GameModeChip.test.ts` y `StreaksPanel.theme.test.ts` para la nueva paleta; no se tocaron los colores/logic del onboarding.

### Testing

- Ejecuté los tests dirigidos con `npm --workspace apps/web run test -- --run GameModeChip.test.ts StreaksPanel.theme.test.ts avatarChipPalette.test.ts` y todos pasaron.
- Los archivos de prueba verificados son `GameModeChip.test.ts`, `StreaksPanel.theme.test.ts` y `avatarChipPalette.test.ts`, con resultados: 3 archivos, 6 tests, todos OK.
- No se detectó ni se eliminó ningún `rhythmTheme.ts` en el repositorio y la nueva lógica ya no utiliza color derivado del ritmo para chips; la colorimetría de chips ahora proviene exclusivamente de `resolveAvatarChipColor`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9d22e68083329f9938aa294bd76c)