### PR TITLE
Admin forced CTA: derive next from real current mode and fix accept staleness

### DIFF
--- a/apps/api/src/modules/admin/admin.handlers.ts
+++ b/apps/api/src/modules/admin/admin.handlers.ts
@@ -355,8 +355,6 @@ export const putAdminUserModeUpgradeCtaOverride = asyncHandler(async (req: Reque
   const item = await setUserModeUpgradeCtaOverride({
     userId,
     enabled: body.enabled,
-    forcedCurrentMode: body.forcedCurrentMode,
-    forcedNextMode: body.forcedNextMode,
     expiresAt: body.expiresAt ?? null,
   });
   res.json({ ok: true, item });

--- a/apps/api/src/modules/admin/admin.schemas.ts
+++ b/apps/api/src/modules/admin/admin.schemas.ts
@@ -155,12 +155,8 @@ export const taskDifficultyCalibrationRunBodySchema = z.object({
 
 
 
-const modeCodeSchema = z.enum(['LOW', 'CHILL', 'FLOW', 'EVOLVE']);
-
 export const adminModeUpgradeCtaOverrideUpsertBodySchema = z.object({
   enabled: z.boolean().default(true),
-  forcedCurrentMode: modeCodeSchema,
-  forcedNextMode: modeCodeSchema,
   expiresAt: z.string().datetime().nullable().optional(),
 });
 

--- a/apps/api/src/modules/admin/admin.service.ts
+++ b/apps/api/src/modules/admin/admin.service.ts
@@ -1501,15 +1501,39 @@ export async function getUserModeUpgradeCtaOverride(userId: string): Promise<Adm
 export async function setUserModeUpgradeCtaOverride(input: {
   userId: string;
   enabled: boolean;
-  forcedCurrentMode: 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE';
-  forcedNextMode: 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE';
   expiresAt: string | null;
 }): Promise<AdminModeUpgradeCtaOverride> {
+  const currentModeResult = await pool.query<{ code: string | null }>(
+    `SELECT gm.code
+       FROM users u
+  LEFT JOIN cat_game_mode gm ON gm.game_mode_id = u.game_mode_id
+      WHERE u.user_id = $1::uuid
+      LIMIT 1`,
+    [input.userId],
+  );
+
+  if (!currentModeResult.rows.length) {
+    throw new HttpError(404, 'user_not_found', 'User not found');
+  }
+
+  const currentMode = (currentModeResult.rows[0]?.code ?? '').trim().toUpperCase();
+  const forcedNextMode = currentMode === 'LOW'
+    ? 'CHILL'
+    : currentMode === 'CHILL'
+      ? 'FLOW'
+      : currentMode === 'FLOW'
+        ? 'EVOLVE'
+        : null;
+
+  if (!forcedNextMode) {
+    throw new HttpError(409, 'mode_upgrade_override_unavailable', 'No forced upgrade CTA is available for current mode');
+  }
+
   return upsertGameModeUpgradeCtaOverride({
     userId: input.userId,
     enabled: input.enabled,
-    forcedCurrentMode: input.forcedCurrentMode,
-    forcedNextMode: input.forcedNextMode,
+    forcedCurrentMode: null,
+    forcedNextMode,
     expiresAt: input.expiresAt,
   });
 }

--- a/apps/api/src/services/__tests__/gameModeUpgradeSuggestionService.test.ts
+++ b/apps/api/src/services/__tests__/gameModeUpgradeSuggestionService.test.ts
@@ -208,7 +208,7 @@ describe('gameModeUpgradeSuggestionService', () => {
 
     expect(result).toMatchObject({
       debug_forced_cta: true,
-      current_mode: 'CHILL',
+      current_mode: 'LOW',
       suggested_mode: 'FLOW',
       period_key: 'debug_forced',
       eligible_for_upgrade: true,
@@ -326,14 +326,15 @@ describe('gameModeUpgradeSuggestionService', () => {
         handle: () => ({ rows: [] }),
       },
       {
-        match: (sql) => sql.includes('FROM user_game_mode_upgrade_suggestions s'),
-        handle: () => ({
-          rows: [{ period_key: 'rolling_2025-01-31', eligible_for_upgrade: true, accepted_at: null, dismissed_at: null, current_mode: 'LOW', suggested_mode: 'CHILL' }],
-        }),
+        match: (sql) => sql.includes('FROM cat_game_mode') && sql.includes('WHERE code = $1'),
+        handle: (_sql, params) => ({ rows: [{ game_mode_id: params?.[0] === 'LOW' ? 11 : 12, code: String(params?.[0]) }] }),
       },
       {
-        match: (sql) => sql.includes('FROM cat_game_mode') && sql.includes('WHERE code = $1'),
-        handle: (_sql, params) => ({ rows: [{ game_mode_id: params?.[0] === 'CHILL' ? 12 : 11, code: String(params?.[0]) }] }),
+        match: (sql) => sql.includes('SELECT accepted_at') && sql.includes('FOR UPDATE'),
+        handle: (_sql, params) => {
+          expect(params).toEqual(['u1', 'rolling_2025-01-31', 11]);
+          return { rows: [{ accepted_at: null }] };
+        },
       },
       {
         match: (sql) => sql.includes('FROM cat_game_mode') && sql.includes('WHERE code = $1'),

--- a/apps/api/src/services/gameModeUpgradeSuggestionService.ts
+++ b/apps/api/src/services/gameModeUpgradeSuggestionService.ts
@@ -18,14 +18,6 @@ type UserModeRow = {
 };
 
 
-type SuggestionRow = {
-  period_key: string;
-  eligible_for_upgrade: boolean;
-  accepted_at: string | null;
-  dismissed_at: string | null;
-  current_mode: string;
-  suggested_mode: string | null;
-};
 
 const CTA_ACTIVE_WINDOW_DAYS = 7;
 
@@ -164,8 +156,7 @@ export async function getGameModeUpgradeSuggestion(userId: string): Promise<Game
   }
 
   if (forcedOverride) {
-    const forcedCurrentMode = forcedOverride.forced_current_mode ?? user.current_mode;
-    const forcedNextModeCode = forcedOverride.forced_next_mode ?? resolveNextGameModeCode(forcedCurrentMode);
+    const forcedNextModeCode = forcedOverride.forced_next_mode ?? resolveNextGameModeCode(user.current_mode);
     const forcedNextMode = forcedNextModeCode ? await resolveGameModeByCode(pool, forcedNextModeCode) : null;
     const canSuggest = Boolean(forcedNextMode);
     const suggestionState = await upsertSuggestionState(pool, {
@@ -180,7 +171,7 @@ export async function getGameModeUpgradeSuggestion(userId: string): Promise<Game
     const ctaEnabled = Boolean(canSuggest) && (!ctaActiveUntil || Date.parse(ctaActiveUntil) > Date.now());
 
     return {
-      current_mode: forcedCurrentMode,
+      current_mode: user.current_mode,
       suggested_mode: canSuggest ? (forcedNextMode?.code ?? null) : null,
       period_key: 'debug_forced',
       eligible_for_upgrade: canSuggest,
@@ -255,26 +246,20 @@ export async function getGameModeUpgradeSuggestion(userId: string): Promise<Game
   };
 }
 
-async function getLatestSuggestionForCurrentMode(client: typeof pool, userId: string): Promise<SuggestionRow | null> {
-  const result = await client.query<SuggestionRow>(
-    `SELECT s.period_key,
-            s.eligible_for_upgrade,
-            s.accepted_at,
-            s.dismissed_at,
-            gm_current.code AS current_mode,
-            gm_suggested.code AS suggested_mode
-       FROM user_game_mode_upgrade_suggestions s
- INNER JOIN cat_game_mode gm_current ON gm_current.game_mode_id = s.current_game_mode_id
-  LEFT JOIN cat_game_mode gm_suggested ON gm_suggested.game_mode_id = s.suggested_game_mode_id
-      WHERE s.user_id = $1::uuid
-        AND s.current_game_mode_id = (
-          SELECT game_mode_id
-            FROM users
-           WHERE user_id = $1::uuid
-        )
-      ORDER BY s.period_key DESC, s.created_at DESC
-      LIMIT 1`,
-    [userId],
+async function getSuggestionStateForPeriod(client: typeof pool, params: {
+  userId: string;
+  periodKey: string;
+  currentGameModeId: number;
+}): Promise<{ accepted_at: string | null } | null> {
+  const result = await client.query<{ accepted_at: string | null }>(
+    `SELECT accepted_at
+       FROM user_game_mode_upgrade_suggestions
+      WHERE user_id = $1::uuid
+        AND period_key = $2
+        AND current_game_mode_id = $3
+      LIMIT 1
+      FOR UPDATE`,
+    [params.userId, params.periodKey, params.currentGameModeId],
   );
 
   return result.rows[0] ?? null;
@@ -313,19 +298,23 @@ export async function acceptGameModeUpgradeSuggestion(userId: string): Promise<G
       throw new HttpError(409, 'upgrade_suggestion_not_eligible', 'Upgrade suggestion is not eligible');
     }
 
-    const latestSuggestion = await getLatestSuggestionForCurrentMode(pool, userId);
+    const currentMode = await resolveGameModeByCode(pool, suggestion.current_mode);
+    const suggestionState = await getSuggestionStateForPeriod(pool, {
+      userId,
+      periodKey: suggestion.period_key,
+      currentGameModeId: currentMode.game_mode_id,
+    });
 
-    if (!latestSuggestion || latestSuggestion.period_key !== suggestion.period_key) {
+    if (!suggestionState) {
       throw new HttpError(409, 'upgrade_suggestion_stale', 'Upgrade suggestion is stale');
     }
 
-    if (latestSuggestion.accepted_at) {
+    if (suggestionState.accepted_at) {
       await pool.query('COMMIT');
       return suggestion;
     }
 
     const nextMode = await resolveGameModeByCode(pool, suggestion.suggested_mode);
-    const currentMode = await resolveGameModeByCode(pool, suggestion.current_mode);
 
     try {
       await changeUserGameMode(pool, {

--- a/apps/web/src/components/admin/AdminLayout.tsx
+++ b/apps/web/src/components/admin/AdminLayout.tsx
@@ -55,6 +55,21 @@ const SUBSCRIPTION_STATUS_LABELS: Record<SubscriptionStatus, string> = {
   expired: 'Expirada',
 };
 
+const NEXT_MODE_BY_CODE: Record<'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE', 'CHILL' | 'FLOW' | 'EVOLVE' | null> = {
+  LOW: 'CHILL',
+  CHILL: 'FLOW',
+  FLOW: 'EVOLVE',
+  EVOLVE: null,
+};
+
+function normalizeMode(value: string | null | undefined): 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE' | null {
+  const normalized = (value ?? '').trim().toUpperCase();
+  if (normalized === 'LOW' || normalized === 'CHILL' || normalized === 'FLOW' || normalized === 'EVOLVE') {
+    return normalized;
+  }
+  return null;
+}
+
 type LogsState = {
   items: AdminLogRow[];
   page: number;
@@ -92,8 +107,6 @@ export function AdminLayout() {
   const [modeUpgradeAnalysisError, setModeUpgradeAnalysisError] = useState<string | null>(null);
   const [modeUpgradeCtaOverride, setModeUpgradeCtaOverride] = useState<AdminModeUpgradeCtaOverride | null>(null);
   const [modeUpgradeCtaOverrideEnabled, setModeUpgradeCtaOverrideEnabled] = useState(false);
-  const [modeUpgradeCtaOverrideCurrentMode, setModeUpgradeCtaOverrideCurrentMode] = useState<'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE'>('LOW');
-  const [modeUpgradeCtaOverrideNextMode, setModeUpgradeCtaOverrideNextMode] = useState<'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE'>('CHILL');
   const [modeUpgradeCtaOverrideExpiresAt, setModeUpgradeCtaOverrideExpiresAt] = useState('');
   const [modeUpgradeCtaOverrideLoading, setModeUpgradeCtaOverrideLoading] = useState(false);
   const [modeUpgradeCtaOverrideSaving, setModeUpgradeCtaOverrideSaving] = useState(false);
@@ -277,8 +290,6 @@ export function AdminLayout() {
     setModeUpgradeAnalysisError(null);
     setModeUpgradeCtaOverride(null);
     setModeUpgradeCtaOverrideEnabled(false);
-    setModeUpgradeCtaOverrideCurrentMode('LOW');
-    setModeUpgradeCtaOverrideNextMode('CHILL');
     setModeUpgradeCtaOverrideExpiresAt('');
     setModeUpgradeCtaOverrideMessage(null);
     setModeUpgradeCtaOverrideError(null);
@@ -379,8 +390,6 @@ export function AdminLayout() {
         }
         setModeUpgradeCtaOverride(data.item);
         setModeUpgradeCtaOverrideEnabled(Boolean(data.item?.enabled));
-        setModeUpgradeCtaOverrideCurrentMode(((data.item?.forced_current_mode ?? 'LOW') as 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE'));
-        setModeUpgradeCtaOverrideNextMode(((data.item?.forced_next_mode ?? 'CHILL') as 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE'));
         setModeUpgradeCtaOverrideExpiresAt(data.item?.expires_at ? data.item.expires_at.slice(0, 16) : '');
       })
       .catch((error: unknown) => {
@@ -400,6 +409,10 @@ export function AdminLayout() {
       cancelled = true;
     };
   }, [selectedUser]);
+
+  const modeUpgradeCurrentMode = normalizeMode(modeUpgradeAnalysis?.current_mode ?? selectedUser?.gameMode ?? null);
+  const modeUpgradeNextMode = modeUpgradeCurrentMode ? NEXT_MODE_BY_CODE[modeUpgradeCurrentMode] : null;
+  const canApplyModeUpgradeCta = Boolean(selectedUser && modeUpgradeCurrentMode && modeUpgradeNextMode);
 
   const handleUpdateSubscription = useCallback(
     async (payload: { planCode: string; status?: SubscriptionStatus; successMessage: string }) => {
@@ -488,8 +501,6 @@ export function AdminLayout() {
     try {
       const response = await upsertAdminModeUpgradeCtaOverride(selectedUser.id, {
         enabled: modeUpgradeCtaOverrideEnabled,
-        forcedCurrentMode: modeUpgradeCtaOverrideCurrentMode,
-        forcedNextMode: modeUpgradeCtaOverrideNextMode,
         expiresAt: modeUpgradeCtaOverrideExpiresAt ? new Date(modeUpgradeCtaOverrideExpiresAt).toISOString() : null,
       });
       setModeUpgradeCtaOverride(response.item);
@@ -500,7 +511,7 @@ export function AdminLayout() {
     } finally {
       setModeUpgradeCtaOverrideSaving(false);
     }
-  }, [selectedUser, modeUpgradeCtaOverrideEnabled, modeUpgradeCtaOverrideCurrentMode, modeUpgradeCtaOverrideNextMode, modeUpgradeCtaOverrideExpiresAt]);
+  }, [selectedUser, modeUpgradeCtaOverrideEnabled, modeUpgradeCtaOverrideExpiresAt]);
 
   const handleClearModeUpgradeCtaOverride = useCallback(async () => {
     if (!selectedUser) {
@@ -515,8 +526,6 @@ export function AdminLayout() {
       await clearAdminModeUpgradeCtaOverride(selectedUser.id);
       setModeUpgradeCtaOverride(null);
       setModeUpgradeCtaOverrideEnabled(false);
-      setModeUpgradeCtaOverrideCurrentMode('LOW');
-      setModeUpgradeCtaOverrideNextMode('CHILL');
       setModeUpgradeCtaOverrideExpiresAt('');
       setModeUpgradeCtaOverrideMessage('Forced CTA limpiado.');
     } catch (error) {
@@ -1256,31 +1265,26 @@ export function AdminLayout() {
                     />
                     Force Upgrade CTA
                   </label>
-                  <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.12em] text-cyan-300">
-                    Current
-                    <select value={modeUpgradeCtaOverrideCurrentMode} onChange={(event) => setModeUpgradeCtaOverrideCurrentMode(event.target.value as 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE')} className="rounded-md border border-cyan-700/50 bg-slate-900/70 px-2 py-1 text-xs normal-case tracking-normal text-slate-100">
-                      <option value="LOW">LOW</option><option value="CHILL">CHILL</option><option value="FLOW">FLOW</option><option value="EVOLVE">EVOLVE</option>
-                    </select>
-                  </label>
-                  <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.12em] text-cyan-300">
-                    Next
-                    <select value={modeUpgradeCtaOverrideNextMode} onChange={(event) => setModeUpgradeCtaOverrideNextMode(event.target.value as 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE')} className="rounded-md border border-cyan-700/50 bg-slate-900/70 px-2 py-1 text-xs normal-case tracking-normal text-slate-100">
-                      <option value="LOW">LOW</option><option value="CHILL">CHILL</option><option value="FLOW">FLOW</option><option value="EVOLVE">EVOLVE</option>
-                    </select>
-                  </label>
+                  <p className="rounded-md border border-cyan-700/50 bg-slate-900/70 px-2 py-1 text-xs normal-case tracking-normal text-slate-100">
+                    Current real: <strong>{modeUpgradeCurrentMode ?? '—'}</strong>
+                  </p>
+                  <p className="rounded-md border border-cyan-700/50 bg-slate-900/70 px-2 py-1 text-xs normal-case tracking-normal text-slate-100">
+                    Next valid: <strong>{modeUpgradeNextMode ?? 'No upgrade'}</strong>
+                  </p>
                   <label className="flex flex-col gap-1 text-[11px] uppercase tracking-[0.12em] text-cyan-300">
                     Expires (optional)
                     <input type="datetime-local" value={modeUpgradeCtaOverrideExpiresAt} onChange={(event) => setModeUpgradeCtaOverrideExpiresAt(event.target.value)} className="rounded-md border border-cyan-700/50 bg-slate-900/70 px-2 py-1 text-xs normal-case tracking-normal text-slate-100" />
                   </label>
                 </div>
                 <div className="mt-2 flex flex-wrap items-center gap-2">
-                  <button type="button" onClick={handleApplyModeUpgradeCtaOverride} disabled={modeUpgradeCtaOverrideSaving || !selectedUser} className="inline-flex items-center justify-center rounded-md border border-cyan-700/60 bg-cyan-900/30 px-3 py-1.5 text-xs font-semibold text-cyan-100 hover:border-cyan-400/60 disabled:cursor-not-allowed disabled:opacity-60">
+                  <button type="button" onClick={handleApplyModeUpgradeCtaOverride} disabled={modeUpgradeCtaOverrideSaving || !canApplyModeUpgradeCta} className="inline-flex items-center justify-center rounded-md border border-cyan-700/60 bg-cyan-900/30 px-3 py-1.5 text-xs font-semibold text-cyan-100 hover:border-cyan-400/60 disabled:cursor-not-allowed disabled:opacity-60">
                     {modeUpgradeCtaOverrideSaving ? 'Applying…' : 'Apply Forced CTA'}
                   </button>
                   <button type="button" onClick={handleClearModeUpgradeCtaOverride} disabled={modeUpgradeCtaOverrideClearing || !selectedUser} className="inline-flex items-center justify-center rounded-md border border-cyan-700/60 bg-slate-900/40 px-3 py-1.5 text-xs font-semibold text-cyan-100 hover:border-cyan-400/60 disabled:cursor-not-allowed disabled:opacity-60">
                     {modeUpgradeCtaOverrideClearing ? 'Clearing…' : 'Clear Forced CTA'}
                   </button>
                   {modeUpgradeCtaOverride?.enabled ? <span className="text-[11px] text-emerald-300">Active</span> : <span className="text-[11px] text-cyan-300/80">Inactive</span>}
+                  {!modeUpgradeNextMode ? <span className="text-[11px] text-amber-300">Current mode is EVOLVE: forced CTA is disabled.</span> : null}
                 </div>
                 {modeUpgradeCtaOverrideMessage ? <p className="mt-1 text-xs font-semibold text-emerald-300">{modeUpgradeCtaOverrideMessage}</p> : null}
                 {modeUpgradeCtaOverrideError ? <p className="mt-1 text-xs font-semibold text-rose-300">{modeUpgradeCtaOverrideError}</p> : null}

--- a/apps/web/src/lib/adminApi.ts
+++ b/apps/web/src/lib/adminApi.ts
@@ -192,8 +192,6 @@ export async function upsertAdminModeUpgradeCtaOverride(
   userId: string,
   payload: {
     enabled: boolean;
-    forcedCurrentMode: 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE';
-    forcedNextMode: 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE';
     expiresAt?: string | null;
   },
 ) {

--- a/apps/web/src/pages/admin2/CoreEnginePage.tsx
+++ b/apps/web/src/pages/admin2/CoreEnginePage.tsx
@@ -23,6 +23,20 @@ const BTN_PRIMARY = 'admin2-btn admin2-btn--primary';
 const BTN_SECONDARY = 'admin2-btn admin2-btn--secondary';
 const BTN_GHOST = 'admin2-btn admin2-btn--ghost';
 const BTN_DANGER = 'admin2-btn admin2-btn--danger';
+const NEXT_MODE_BY_CODE: Record<'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE', 'CHILL' | 'FLOW' | 'EVOLVE' | null> = {
+  LOW: 'CHILL',
+  CHILL: 'FLOW',
+  FLOW: 'EVOLVE',
+  EVOLVE: null,
+};
+
+function normalizeMode(value: string | null | undefined): 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE' | null {
+  const normalized = (value ?? '').trim().toUpperCase();
+  if (normalized === 'LOW' || normalized === 'CHILL' || normalized === 'FLOW' || normalized === 'EVOLVE') {
+    return normalized;
+  }
+  return null;
+}
 
 export function CoreEnginePage() {
   const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
@@ -54,8 +68,6 @@ export function CoreEnginePage() {
 
   const [ctaOverride, setCtaOverride] = useState<AdminModeUpgradeCtaOverride | null>(null);
   const [ctaEnabled, setCtaEnabled] = useState(false);
-  const [ctaCurrentMode, setCtaCurrentMode] = useState<'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE'>('LOW');
-  const [ctaNextMode, setCtaNextMode] = useState<'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE'>('CHILL');
   const [ctaExpiresAt, setCtaExpiresAt] = useState('');
   const [ctaLoading, setCtaLoading] = useState(false);
   const [ctaSaving, setCtaSaving] = useState(false);
@@ -82,8 +94,6 @@ export function CoreEnginePage() {
       setAnalysis(analysisRes);
       setCtaOverride(ctaRes.item);
       setCtaEnabled(Boolean(ctaRes.item?.enabled));
-      setCtaCurrentMode((ctaRes.item?.forced_current_mode as 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE') ?? 'LOW');
-      setCtaNextMode((ctaRes.item?.forced_next_mode as 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE') ?? 'CHILL');
       setCtaExpiresAt(ctaRes.item?.expires_at ? ctaRes.item.expires_at.slice(0, 16) : '');
     } catch (error) {
       console.error('[admin2][core-engine] failed to load mode data', error);
@@ -215,15 +225,17 @@ export function CoreEnginePage() {
     }
   }, [loadModeData, manualModeReason, manualModeTarget, selectedUser]);
 
+  const resolvedCurrentMode = normalizeMode(analysis?.current_mode ?? selectedUser?.gameMode ?? null);
+  const resolvedNextMode = resolvedCurrentMode ? NEXT_MODE_BY_CODE[resolvedCurrentMode] : null;
+  const canApplyForcedCta = Boolean(selectedUser && resolvedCurrentMode && resolvedNextMode);
+
   const applyCta = useCallback(async () => {
-    if (!selectedUser) return;
+    if (!selectedUser || !resolvedNextMode) return;
     try {
       setCtaSaving(true);
       setCtaMessage(null);
       const response = await upsertAdminModeUpgradeCtaOverride(selectedUser.id, {
         enabled: ctaEnabled,
-        forcedCurrentMode: ctaCurrentMode,
-        forcedNextMode: ctaNextMode,
         expiresAt: ctaExpiresAt ? new Date(ctaExpiresAt).toISOString() : null,
       });
       setCtaOverride(response.item);
@@ -234,7 +246,7 @@ export function CoreEnginePage() {
     } finally {
       setCtaSaving(false);
     }
-  }, [ctaCurrentMode, ctaEnabled, ctaExpiresAt, ctaNextMode, selectedUser]);
+  }, [ctaEnabled, ctaExpiresAt, resolvedNextMode, selectedUser]);
 
   const clearCta = useCallback(async () => {
     if (!selectedUser) return;
@@ -382,16 +394,17 @@ export function CoreEnginePage() {
 
           <div className="mt-3 grid gap-2 rounded-lg border border-[color:var(--admin-border)] p-2 text-xs md:grid-cols-4">
             <label className="flex items-center gap-2"><input type="checkbox" checked={ctaEnabled} onChange={(e) => setCtaEnabled(e.target.checked)} /> Forced CTA</label>
-            <select value={ctaCurrentMode} onChange={(e) => setCtaCurrentMode(e.target.value as 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE')} className="rounded border border-[color:var(--admin-border)] bg-transparent px-2 py-1"><option>LOW</option><option>CHILL</option><option>FLOW</option><option>EVOLVE</option></select>
-            <select value={ctaNextMode} onChange={(e) => setCtaNextMode(e.target.value as 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE')} className="rounded border border-[color:var(--admin-border)] bg-transparent px-2 py-1"><option>LOW</option><option>CHILL</option><option>FLOW</option><option>EVOLVE</option></select>
+            <p className="rounded border border-[color:var(--admin-border)] px-2 py-1">Current real: <strong>{resolvedCurrentMode ?? '—'}</strong></p>
+            <p className="rounded border border-[color:var(--admin-border)] px-2 py-1">Next valid: <strong>{resolvedNextMode ?? 'No upgrade'}</strong></p>
             <input type="datetime-local" value={ctaExpiresAt} onChange={(e) => setCtaExpiresAt(e.target.value)} className="rounded border border-[color:var(--admin-border)] bg-transparent px-2 py-1" />
             <div className="md:col-span-4 flex flex-wrap gap-2">
               <button type="button" onClick={() => void applyManualMode()} disabled={!selectedUser || changingMode} className={BTN_SECONDARY}>{changingMode ? 'Changing…' : 'Apply Manual Mode Change'}</button>
               <select value={manualModeTarget} onChange={(e) => setManualModeTarget(e.target.value as 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE')} className="rounded border border-[color:var(--admin-border)] bg-transparent px-2 py-1"><option>LOW</option><option>CHILL</option><option>FLOW</option><option>EVOLVE</option></select>
               <input value={manualModeReason} onChange={(e) => setManualModeReason(e.target.value)} className="min-w-52 flex-1 rounded border border-[color:var(--admin-border)] bg-transparent px-2 py-1" />
-              <button type="button" onClick={() => void applyCta()} disabled={!selectedUser || ctaSaving} className={BTN_PRIMARY}>{ctaSaving ? 'Applying…' : 'Apply Forced CTA'}</button>
+              <button type="button" onClick={() => void applyCta()} disabled={!canApplyForcedCta || ctaSaving} className={BTN_PRIMARY}>{ctaSaving ? 'Applying…' : 'Apply Forced CTA'}</button>
               <button type="button" onClick={() => void clearCta()} disabled={!selectedUser || ctaClearing} className={BTN_DANGER}>{ctaClearing ? 'Clearing…' : 'Clear Forced CTA'}</button>
               <span className="text-[11px]">override actual: <strong>{ctaLoading ? 'cargando…' : ctaOverride?.enabled ? 'enabled' : 'disabled'}</strong></span>
+              {!resolvedNextMode ? <span className="text-[11px] text-amber-300">Current mode is EVOLVE: forced CTA is disabled.</span> : null}
             </div>
           </div>
           {analysisError ? <p className="mt-2 text-xs text-red-300">{analysisError}</p> : null}


### PR DESCRIPTION
### Motivation

- Hacer que el forced CTA del admin sea operativo y compatible con el endpoint real de `accept` sin permitir combinaciones inválidas entre current/next. 
- Evitar conflictos `409` por mezcla de filas `debug_forced` y `rolling_*` usando una resolución determinista y bloqueada de la sugerencia aplicable. 

### Description

- Cambié el contrato admin para que la PUT de override acepte sólo `enabled` y `expiresAt` y eliminé campos editables `forcedCurrentMode`/`forcedNextMode` en `admin.schemas`, `admin.handlers` y cliente `adminApi`. 
- En `admin.service` (`setUserModeUpgradeCtaOverride`) se resuelve el `current_mode` real del usuario desde la tabla `users` y se calcula el `forcedNextMode` secuencialmente (`LOW→CHILL`, `CHILL→FLOW`, `FLOW→EVOLVE`), devolviendo `409` cuando no hay next válido (p.ej. `EVOLVE`) y guardando `forcedCurrentMode: null` para no falsificar el current operativo. 
- En `gameModeUpgradeSuggestionService` el forced CTA ahora usa el `current_mode` real para operar y deriva `forcedNextMode` desde ese current; añadí `getSuggestionStateForPeriod` que selecciona y hace `FOR UPDATE` la fila específica `(user_id, period_key, current_game_mode_id)` y adapté `acceptGameModeUpgradeSuggestion` para validar/lockear esa fila en lugar de basarse en orden por `period_key`. 
- UI admin (CoreEnginePage y AdminLayout) ahora muestra `Current real` y `Next valid`, elimina selects editables de current/next y desactiva el botón de aplicar cuando no hay upgrade posible. 
- Actualicé tests relacionados en `gameModeUpgradeSuggestionService.test.ts` para reflejar el uso del `current` real y la nueva validación bloqueante en `accept`.

Files changed: `apps/api/src/modules/admin/admin.schemas.ts`, `apps/api/src/modules/admin/admin.handlers.ts`, `apps/api/src/modules/admin/admin.service.ts`, `apps/api/src/services/gameModeUpgradeSuggestionService.ts`, `apps/api/src/services/__tests__/gameModeUpgradeSuggestionService.test.ts`, `apps/web/src/lib/adminApi.ts`, `apps/web/src/pages/admin2/CoreEnginePage.tsx`, `apps/web/src/components/admin/AdminLayout.tsx`.

### Testing

- Ejecuté `npm --workspace apps/api run typecheck` y la comprobación de tipos en la API pasó correctamente. 
- Ejecuté `npm --workspace apps/api run test -- src/services/__tests__/gameModeUpgradeSuggestionService.test.ts` y los 11 tests del fichero pasaron exitosamente. 
- Ejecuté `npm --workspace apps/web run typecheck` y falló por errores de tipos preexistentes en el workspace web no relacionados con este cambio, por lo que la verificación tipada del front no se completó aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9f80261c833289a7e913c23f77c4)