### PR TITLE
Refine GameModeChip glow behavior in dark mode

### DIFF
--- a/apps/web/src/components/common/GameModeChip.tsx
+++ b/apps/web/src/components/common/GameModeChip.tsx
@@ -49,9 +49,12 @@ export function buildGameModeChip(
 
 export function GameModeChip({ label, animate, style }: GameModeChipStyle) {
   return (
-    <span className="ib-game-mode-chip relative inline-flex items-center" style={style}>
+    <span
+      className={`ib-game-mode-chip relative inline-flex items-center ${animate ? 'ib-game-mode-chip--animated' : ''}`}
+      style={style}
+    >
       <span
-        className={`ib-game-mode-chip__glow absolute -inset-[2px] rounded-full blur-md ${animate ? 'animate-pulse' : ''}`}
+        className="ib-game-mode-chip__glow absolute rounded-full"
         aria-hidden
       />
       <span className="ib-game-mode-chip__inner relative inline-flex items-center gap-2 rounded-full border px-3 py-[0.26rem] text-[10px] font-semibold uppercase tracking-[0.2em] backdrop-blur">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5133,7 +5133,10 @@
   }
 
   .ib-game-mode-chip__glow {
+    inset: -2px;
     background: color-mix(in srgb, var(--ib-chip-accent) 45%, transparent);
+    filter: blur(10px);
+    opacity: 0.6;
   }
 
   .ib-game-mode-chip__inner {
@@ -5149,8 +5152,47 @@
       inset 0 0 0 1px color-mix(in srgb, var(--ib-chip-accent) 28%, rgba(255, 255, 255, 0.32));
   }
 
+  .ib-game-mode-chip--animated .ib-game-mode-chip__glow {
+    animation: ib-game-mode-chip-pulse 2.8s ease-in-out infinite;
+  }
+
   :root[data-theme='light'] .ib-game-mode-chip__inner {
     color: color-mix(in srgb, var(--ib-chip-accent) 72%, #0f172a);
+  }
+
+  :root[data-theme='dark'] .ib-game-mode-chip__glow {
+    inset: -1px;
+    background: color-mix(in srgb, var(--ib-chip-accent) 28%, transparent);
+    filter: blur(5px);
+    opacity: 0.32;
+  }
+
+  :root[data-theme='dark'] .ib-game-mode-chip__inner {
+    box-shadow:
+      0 0 7px color-mix(in srgb, var(--ib-chip-accent) 12%, transparent),
+      inset 0 0 0 1px color-mix(in srgb, var(--ib-chip-accent) 22%, rgba(255, 255, 255, 0.24));
+  }
+
+  :root[data-theme='dark'] .ib-game-mode-chip--animated .ib-game-mode-chip__glow {
+    animation: ib-game-mode-chip-pulse 5.2s ease-out infinite;
+  }
+
+  @keyframes ib-game-mode-chip-pulse {
+    0%,
+    100% {
+      opacity: var(--ib-chip-glow-opacity-start, 0.55);
+      transform: scale(1);
+    }
+    50% {
+      opacity: var(--ib-chip-glow-opacity-end, 0.7);
+      transform: scale(var(--ib-chip-glow-scale, 1.035));
+    }
+  }
+
+  :root[data-theme='dark'] .ib-game-mode-chip {
+    --ib-chip-glow-opacity-start: 0.28;
+    --ib-chip-glow-opacity-end: 0.36;
+    --ib-chip-glow-scale: 1.01;
   }
 
   .ib-streak-mode-chip {


### PR DESCRIPTION
### Motivation
- En modo oscuro el halo alrededor del `GameModeChip` (glow exterior + blur + `box-shadow` interior + `animate-pulse`) provocaba un bloom excesivo que reducía la legibilidad del texto y hacía que el label pareciera “envuelto” en una nube.

### Description
- Cambios en `apps/web/src/components/common/GameModeChip.tsx`: reemplacé el uso directo de Tailwind `animate-pulse` y `blur-md` por una clase específica `ib-game-mode-chip--animated` para poder controlar la animación por tema sin tocar la estructura del componente.
- Cambios en `apps/web/src/index.css`: moví y afiné el control del glow a CSS y añadí reglas por tema (`:root[data-theme='dark']`) para reducir el bloom en dark mode.
- Ajustes concretos aplicados: la mezcla del glow bajó de `45%` a `28%`, el `blur` exterior pasó a `5px` en dark (base `10px`), el `inset` se redujo de `-2px` a `-1px`, y la `opacity` del glow pasó de `0.6` a `0.32` en dark; la sombra externa del interior (`box-shadow`) se redujo de `0 0 14px (≈24%)` a `0 0 7px (≈12%)` y el `inset` interno de borde de `28%` a `22%` para mantener la identidad del chip sin lavar el texto.
- Reemplacé `animate-pulse` por `@keyframes ib-game-mode-chip-pulse` y variables CSS tematizables, con una versión más lenta y sutil en dark (`5.2s`, `--ib-chip-glow-opacity-start: 0.28`, `--ib-chip-glow-opacity-end: 0.36`, `--ib-chip-glow-scale: 1.01`).

### Testing
- Ejecuté `pnpm -C apps/web exec tsc --noEmit` y la verificación falló por errores TypeScript preexistentes en otras partes del repositorio no relacionados con este cambio, por lo que no se pudo completar un `tsc` limpio; resultado: *failed*.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea1ac86e48332902469bbaeb47c7a)