### PR TITLE
Fix rhythm upgrade suggestion visuals, accept UX, and forced CTA consistency

### DIFF
--- a/apps/api/src/services/__tests__/gameModeUpgradeSuggestionService.test.ts
+++ b/apps/api/src/services/__tests__/gameModeUpgradeSuggestionService.test.ts
@@ -186,13 +186,13 @@ describe('gameModeUpgradeSuggestionService', () => {
       },
       {
         match: (sql) => sql.includes('FROM user_game_mode_upgrade_cta_overrides') && sql.includes('enabled = TRUE'),
-        handle: () => ({ rows: [{ user_id: 'u1', enabled: true, forced_current_mode: 'CHILL', forced_next_mode: 'FLOW', expires_at: null, created_at: '2026-03-13T00:00:00.000Z', updated_at: '2026-03-13T00:00:00.000Z' }] }),
+        handle: () => ({ rows: [{ user_id: 'u1', enabled: true, forced_current_mode: 'CHILL', forced_next_mode: 'CHILL', expires_at: null, created_at: '2026-03-13T00:00:00.000Z', updated_at: '2026-03-13T00:00:00.000Z' }] }),
       },
       {
         match: (sql) => sql.includes('FROM cat_game_mode') && sql.includes('WHERE code = $1'),
         handle: (_sql, params) => {
-          expect(params).toEqual(['FLOW']);
-          return { rows: [{ game_mode_id: 13, code: 'FLOW' }] };
+          expect(params).toEqual(['CHILL']);
+          return { rows: [{ game_mode_id: 12, code: 'CHILL' }] };
         },
       },
       {
@@ -209,7 +209,7 @@ describe('gameModeUpgradeSuggestionService', () => {
     expect(result).toMatchObject({
       debug_forced_cta: true,
       current_mode: 'LOW',
-      suggested_mode: 'FLOW',
+      suggested_mode: 'CHILL',
       period_key: 'debug_forced',
       eligible_for_upgrade: true,
       cta_enabled: true,
@@ -217,7 +217,8 @@ describe('gameModeUpgradeSuggestionService', () => {
     expect(mockRollingAnalysis).not.toHaveBeenCalled();
   });
 
-  it('resets accepted_at and dismissed_at when debug forced CTA is reapplied', async () => {
+
+  it('disables forced CTA when override next mode is not sequential for the real user mode', async () => {
     queueExpectations([
       {
         match: (sql) => sql.includes('FROM users u'),
@@ -228,10 +229,37 @@ describe('gameModeUpgradeSuggestionService', () => {
         handle: () => ({ rows: [{ user_id: 'u1', enabled: true, forced_current_mode: 'CHILL', forced_next_mode: 'FLOW', expires_at: null, created_at: '2026-03-13T00:00:00.000Z', updated_at: '2026-03-13T00:00:00.000Z' }] }),
       },
       {
+        match: (sql) => sql.includes('INSERT INTO user_game_mode_upgrade_suggestions'),
+        handle: (_sql, params) => {
+          expect(params?.[3]).toBe(null);
+          expect(params?.[4]).toBe(false);
+          return { rows: [{ accepted_at: null, dismissed_at: null, created_at: null }] };
+        },
+      },
+    ]);
+
+    const result = await getGameModeUpgradeSuggestion('u1');
+    expect(result.debug_forced_cta).toBe(true);
+    expect(result.suggested_mode).toBeNull();
+    expect(result.eligible_for_upgrade).toBe(false);
+    expect(result.cta_enabled).toBe(false);
+  });
+
+  it('resets accepted_at and dismissed_at when debug forced CTA is reapplied', async () => {
+    queueExpectations([
+      {
+        match: (sql) => sql.includes('FROM users u'),
+        handle: () => ({ rows: [{ user_id: 'u1', game_mode_id: 11, current_mode: 'LOW' }] }),
+      },
+      {
+        match: (sql) => sql.includes('FROM user_game_mode_upgrade_cta_overrides') && sql.includes('enabled = TRUE'),
+        handle: () => ({ rows: [{ user_id: 'u1', enabled: true, forced_current_mode: 'CHILL', forced_next_mode: 'CHILL', expires_at: null, created_at: '2026-03-13T00:00:00.000Z', updated_at: '2026-03-13T00:00:00.000Z' }] }),
+      },
+      {
         match: (sql) => sql.includes('FROM cat_game_mode') && sql.includes('WHERE code = $1'),
         handle: (_sql, params) => {
-          expect(params).toEqual(['FLOW']);
-          return { rows: [{ game_mode_id: 13, code: 'FLOW' }] };
+          expect(params).toEqual(['CHILL']);
+          return { rows: [{ game_mode_id: 12, code: 'CHILL' }] };
         },
       },
       {
@@ -326,8 +354,8 @@ describe('gameModeUpgradeSuggestionService', () => {
         handle: () => ({ rows: [] }),
       },
       {
-        match: (sql) => sql.includes('FROM cat_game_mode') && sql.includes('WHERE code = $1'),
-        handle: (_sql, params) => ({ rows: [{ game_mode_id: params?.[0] === 'LOW' ? 11 : 12, code: String(params?.[0]) }] }),
+        match: (sql) => sql.includes('FROM users u'),
+        handle: () => ({ rows: [{ user_id: 'u1', game_mode_id: 11, current_mode: 'LOW' }] }),
       },
       {
         match: (sql) => sql.includes('SELECT accepted_at') && sql.includes('FOR UPDATE'),

--- a/apps/api/src/services/gameModeUpgradeCtaOverrideService.ts
+++ b/apps/api/src/services/gameModeUpgradeCtaOverrideService.ts
@@ -81,7 +81,13 @@ export async function upsertGameModeUpgradeCtaOverride(input: {
       expires_at = EXCLUDED.expires_at,
       updated_at = NOW()
     RETURNING user_id, enabled, forced_current_mode, forced_next_mode, expires_at, created_at, updated_at`,
-    [input.userId, input.enabled, input.forcedCurrentMode, input.forcedNextMode, input.expiresAt],
+    [
+      input.userId,
+      input.enabled,
+      null,
+      input.forcedNextMode ? input.forcedNextMode.trim().toUpperCase() : null,
+      input.expiresAt,
+    ],
   );
 
   return result.rows[0];

--- a/apps/api/src/services/gameModeUpgradeSuggestionService.ts
+++ b/apps/api/src/services/gameModeUpgradeSuggestionService.ts
@@ -156,8 +156,14 @@ export async function getGameModeUpgradeSuggestion(userId: string): Promise<Game
   }
 
   if (forcedOverride) {
-    const forcedNextModeCode = forcedOverride.forced_next_mode ?? resolveNextGameModeCode(user.current_mode);
-    const forcedNextMode = forcedNextModeCode ? await resolveGameModeByCode(pool, forcedNextModeCode) : null;
+    const expectedNextModeCode = resolveNextGameModeCode(user.current_mode);
+    const forcedNextModeCode = (forcedOverride.forced_next_mode ?? '').trim().toUpperCase();
+    const validForcedNextModeCode = expectedNextModeCode && forcedNextModeCode === expectedNextModeCode
+      ? forcedNextModeCode
+      : null;
+    const forcedNextMode = validForcedNextModeCode
+      ? await resolveGameModeByCode(pool, validForcedNextModeCode)
+      : null;
     const canSuggest = Boolean(forcedNextMode);
     const suggestionState = await upsertSuggestionState(pool, {
       userId,
@@ -298,11 +304,20 @@ export async function acceptGameModeUpgradeSuggestion(userId: string): Promise<G
       throw new HttpError(409, 'upgrade_suggestion_not_eligible', 'Upgrade suggestion is not eligible');
     }
 
-    const currentMode = await resolveGameModeByCode(pool, suggestion.current_mode);
+    const userCurrentMode = await getUserCurrentMode(pool, userId);
+    if (!userCurrentMode.game_mode_id || !userCurrentMode.current_mode) {
+      throw new HttpError(409, 'upgrade_suggestion_stale', 'Upgrade suggestion is stale');
+    }
+
+    const expectedSuggestedMode = resolveNextGameModeCode(userCurrentMode.current_mode);
+    if (!expectedSuggestedMode || expectedSuggestedMode !== suggestion.suggested_mode) {
+      throw new HttpError(409, 'upgrade_suggestion_stale', 'Upgrade suggestion is stale');
+    }
+
     const suggestionState = await getSuggestionStateForPeriod(pool, {
       userId,
       periodKey: suggestion.period_key,
-      currentGameModeId: currentMode.game_mode_id,
+      currentGameModeId: userCurrentMode.game_mode_id,
     });
 
     if (!suggestionState) {
@@ -321,7 +336,7 @@ export async function acceptGameModeUpgradeSuggestion(userId: string): Promise<G
         userId,
         nextGameModeId: nextMode.game_mode_id,
         nextModeCode: nextMode.code,
-        expectedCurrentGameModeId: currentMode.game_mode_id,
+        expectedCurrentGameModeId: userCurrentMode.game_mode_id,
       });
     } catch (error) {
       if (error instanceof HttpError && error.code === 'game_mode_change_conflict') {
@@ -340,7 +355,7 @@ export async function acceptGameModeUpgradeSuggestion(userId: string): Promise<G
           AND period_key = $2
           AND current_game_mode_id = $3
       RETURNING accepted_at`,
-      [userId, suggestion.period_key, currentMode.game_mode_id],
+      [userId, suggestion.period_key, userCurrentMode.game_mode_id],
     );
 
     await pool.query('COMMIT');

--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -523,16 +523,20 @@ export function DashboardMenu({
 
     setIsUpgradeSubmitting(true);
     try {
-      await acceptGameModeUpgradeSuggestion();
+      const response = await acceptGameModeUpgradeSuggestion();
       await onGameModeChanged();
       await modeUpgradeSuggestionRequest.reload();
+      setToast({
+        tone: 'success',
+        message: t('dashboard.upgradeCta.welcomeToast', { nextMode: (response.suggestion.suggested_mode ?? '').toUpperCase() || 'RHYTHM' }),
+      });
     } catch (error) {
       console.error('[dashboard-menu] failed to accept game mode upgrade', error);
       throw error;
     } finally {
       setIsUpgradeSubmitting(false);
     }
-  }, [isUpgradeSubmitting, modeUpgradeSuggestionRequest, onGameModeChanged]);
+  }, [isUpgradeSubmitting, modeUpgradeSuggestionRequest, onGameModeChanged, setToast, t]);
 
   const handleSignOut = useCallback(async () => {
     handleClose();
@@ -1619,7 +1623,6 @@ export function DashboardMenu({
                   open={isUpgradeModalOpen && hasActiveUpgradeCta}
                   currentMode={modeUpgradeSuggestion?.current_mode ?? null}
                   nextMode={modeUpgradeSuggestion?.suggested_mode ?? null}
-                  avatarProfile={currentAvatarProfile}
                   isSubmitting={isUpgradeSubmitting}
                   onConfirm={handleAcceptUpgrade}
                   onClose={() => setIsUpgradeModalOpen(false)}

--- a/apps/web/src/components/dashboard-v3/ModeUpgradeSuggestionCTA.tsx
+++ b/apps/web/src/components/dashboard-v3/ModeUpgradeSuggestionCTA.tsx
@@ -1,5 +1,5 @@
 import { Sparkles } from 'lucide-react';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   acceptGameModeUpgradeSuggestion,
   dismissGameModeUpgradeSuggestion,
@@ -7,12 +7,13 @@ import {
 } from '../../lib/api';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
 import { UpgradeRecommendationModal } from './UpgradeRecommendationModal';
+import { ToastBanner } from '../common/ToastBanner';
 
 interface ModeUpgradeSuggestionCTAProps {
   suggestion: GameModeUpgradeSuggestion | null;
   isLoading?: boolean;
   onSuggestionChange?: (next: GameModeUpgradeSuggestion) => void;
-  onUpgradeAccepted?: () => void;
+  onUpgradeAccepted?: (nextMode: string | null) => void;
 }
 
 function formatModeLabel(mode: string | null): string {
@@ -29,6 +30,8 @@ export function ModeUpgradeSuggestionCTA({
   const [isOpen, setIsOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const submitLockRef = useRef(false);
+  const [welcomeToast, setWelcomeToast] = useState<string | null>(null);
+  const toastTimeoutRef = useRef<number | null>(null);
   const { t } = usePostLoginLanguage();
 
   const isVisible = useMemo(() => {
@@ -42,6 +45,29 @@ export function ModeUpgradeSuggestionCTA({
         !suggestion.dismissed_at,
     );
   }, [suggestion]);
+
+
+  useEffect(() => {
+    if (!welcomeToast) {
+      return;
+    }
+
+    if (toastTimeoutRef.current) {
+      window.clearTimeout(toastTimeoutRef.current);
+    }
+
+    toastTimeoutRef.current = window.setTimeout(() => {
+      setWelcomeToast(null);
+      toastTimeoutRef.current = null;
+    }, 2500);
+
+    return () => {
+      if (toastTimeoutRef.current) {
+        window.clearTimeout(toastTimeoutRef.current);
+        toastTimeoutRef.current = null;
+      }
+    };
+  }, [welcomeToast]);
 
   if (isLoading || !isVisible || !suggestion) {
     return null;
@@ -57,7 +83,7 @@ export function ModeUpgradeSuggestionCTA({
     try {
       const response = await acceptGameModeUpgradeSuggestion();
       onSuggestionChange?.(response.suggestion);
-      onUpgradeAccepted?.();
+      onUpgradeAccepted?.(response.suggestion.suggested_mode ?? null);
     } catch (error) {
       console.error('Failed to accept mode upgrade suggestion', error);
       throw error;
@@ -128,14 +154,24 @@ export function ModeUpgradeSuggestionCTA({
           </div>
         </div>
       </div>
+      {welcomeToast ? (
+        <ToastBanner
+          tone="success"
+          message={welcomeToast}
+          className="mt-3 border-white/40 bg-white/18 text-black shadow-[0_12px_28px_rgba(15,23,42,0.18)]"
+        />
+      ) : null}
 
       <UpgradeRecommendationModal
         open={isOpen}
         currentMode={suggestion.current_mode}
         nextMode={suggestion.suggested_mode}
-        avatarProfile={null}
         isSubmitting={isSubmitting}
         onConfirm={handleAccept}
+        onAcceptedSuccess={(acceptedMode) => {
+          const modeLabel = formatModeLabel(acceptedMode ?? suggestion.suggested_mode);
+          setWelcomeToast(t('dashboard.upgradeCta.welcomeToast', { nextMode: modeLabel }));
+        }}
         onClose={() => setIsOpen(false)}
         onOpenAllModes={() => setIsOpen(false)}
       />

--- a/apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx
+++ b/apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx
@@ -1,49 +1,52 @@
 import { Sparkles } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
-import { resolveAvatarTheme, type AvatarProfile } from '../../lib/avatarProfile';
 import { normalizeGameModeValue } from '../../lib/gameMode';
-import { GAME_MODE_META, type LocalizedLanguage } from '../../lib/gameModeMeta';
-import { buildGameModeChip, GameModeChip } from '../common/GameModeChip';
+import { resolveRhythmUpgradeVisual } from '../../lib/rhythmUpgradeVisual';
 
 interface UpgradeRecommendationModalProps {
   open: boolean;
   currentMode: string | null;
   nextMode: string | null;
-  avatarProfile: AvatarProfile | null;
   isSubmitting: boolean;
   onConfirm: () => Promise<void>;
   onClose: () => void;
   onOpenAllModes: () => void;
+  onAcceptedSuccess?: (nextMode: string | null) => void;
 }
 
 const DRAG_COMPLETE_THRESHOLD = 0.9;
 const DRAG_HANDLE_SIZE = 56;
+const SUCCESS_AUTO_CLOSE_MS = 850;
 
 function formatMode(mode: string | null): string {
   if (!mode) return 'RHYTHM';
   return mode.trim().toUpperCase();
 }
 
-function buildRhythmIntensityLabel(mode: string | null, language: LocalizedLanguage): string {
-  const normalized = normalizeGameModeValue(mode);
-  if (!normalized) {
-    return language === 'es' ? 'Ritmo · —' : 'Rhythm · —';
+function RhythmVisualSlot({ alt, imageUrl }: { alt: string; imageUrl: string | null }) {
+  if (imageUrl) {
+    return <img src={imageUrl} alt={alt} className="h-10 w-10 rounded-lg object-cover" />;
   }
 
-  const frequency = GAME_MODE_META[normalized].frequency[language];
-  return `${normalized} · ${frequency}`;
+  return (
+    <div
+      className="h-10 w-10 rounded-lg border border-black/10 bg-white/55"
+      aria-label={alt}
+      role="img"
+    />
+  );
 }
 
 export function UpgradeRecommendationModal({
   open,
   currentMode,
   nextMode,
-  avatarProfile,
   isSubmitting,
   onConfirm,
   onClose,
   onOpenAllModes,
+  onAcceptedSuccess,
 }: UpgradeRecommendationModalProps) {
   const { t, language } = usePostLoginLanguage();
   const [dragProgress, setDragProgress] = useState(0);
@@ -52,18 +55,14 @@ export function UpgradeRecommendationModal({
   const [activePointerId, setActivePointerId] = useState<number | null>(null);
   const railRef = useRef<HTMLDivElement | null>(null);
   const handleRef = useRef<HTMLButtonElement | null>(null);
+  const successTimeoutRef = useRef<number | null>(null);
 
   const confirmInFlightRef = useRef(false);
 
   const currentRhythm = useMemo(() => normalizeGameModeValue(currentMode), [currentMode]);
   const nextRhythm = useMemo(() => normalizeGameModeValue(nextMode), [nextMode]);
-  const avatarTheme = useMemo(() => resolveAvatarTheme(avatarProfile), [avatarProfile]);
-  const nextModeChip = useMemo(
-    () => buildGameModeChip(nextMode, { avatarProfile }),
-    [avatarProfile, nextMode],
-  );
-  const currentRhythmLabel = useMemo(() => buildRhythmIntensityLabel(currentMode, language), [currentMode, language]);
-  const nextRhythmLabel = useMemo(() => buildRhythmIntensityLabel(nextMode, language), [nextMode, language]);
+  const currentVisual = useMemo(() => resolveRhythmUpgradeVisual(currentMode, language), [currentMode, language]);
+  const nextVisual = useMemo(() => resolveRhythmUpgradeVisual(nextMode, language), [nextMode, language]);
 
   useEffect(() => {
     if (!open) {
@@ -72,6 +71,10 @@ export function UpgradeRecommendationModal({
       setIsDragging(false);
       setActivePointerId(null);
       confirmInFlightRef.current = false;
+      if (successTimeoutRef.current) {
+        window.clearTimeout(successTimeoutRef.current);
+        successTimeoutRef.current = null;
+      }
     }
   }, [open]);
 
@@ -84,10 +87,17 @@ export function UpgradeRecommendationModal({
     try {
       await onConfirm();
       setIsSuccess(true);
+      if (successTimeoutRef.current) {
+        window.clearTimeout(successTimeoutRef.current);
+      }
+      successTimeoutRef.current = window.setTimeout(() => {
+        onAcceptedSuccess?.(nextRhythm ?? null);
+        onClose();
+      }, SUCCESS_AUTO_CLOSE_MS);
     } finally {
       confirmInFlightRef.current = false;
     }
-  }, [isSubmitting, isSuccess, onConfirm]);
+  }, [isSubmitting, isSuccess, onConfirm, onAcceptedSuccess, onClose, nextRhythm]);
 
   const resolveProgressFromClientX = (clientX: number) => {
     if (!railRef.current) {
@@ -136,22 +146,10 @@ export function UpgradeRecommendationModal({
             <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-r from-[#a770ef] via-[#cf8bf3] to-[#fdb99b] text-black shadow-[0_12px_30px_rgba(167,112,239,0.5)]">
               <Sparkles className="h-7 w-7" />
             </div>
-            {nextMode ? (
-              <div className="flex justify-center">
-                <GameModeChip {...nextModeChip} />
-              </div>
-            ) : null}
             <p className="text-lg font-semibold">
               {t('dashboard.upgradeCta.success', { nextMode: formatMode(nextMode) })}
             </p>
             <p className="text-sm text-[color:var(--color-text-muted)]">{t('dashboard.upgradeCta.successSubtitle')}</p>
-            <button
-              type="button"
-              onClick={onClose}
-              className="w-full rounded-2xl bg-[color:var(--color-text)] px-4 py-3 text-sm font-semibold text-[color:var(--color-surface)] transition hover:opacity-90"
-            >
-              {t('dashboard.upgradeCta.finalAction')}
-            </button>
           </div>
         ) : (
           <>
@@ -202,7 +200,8 @@ export function UpgradeRecommendationModal({
                     >
                       {t('dashboard.upgradeCta.nextTag')}
                     </div>
-                    <p className="text-center text-[11px] font-semibold tracking-[0.02em]">{nextRhythmLabel}</p>
+                    <RhythmVisualSlot alt={nextVisual.alt} imageUrl={nextVisual.imageUrl} />
+                    <p className="text-center text-[11px] font-semibold tracking-[0.02em]">{nextVisual.label}</p>
                   </div>
                 ) : null}
 
@@ -235,13 +234,13 @@ export function UpgradeRecommendationModal({
                     aria-label={t('dashboard.upgradeCta.dragHint')}
                   >
                     <div
-                      className="flex h-14 w-14 items-center justify-center rounded-xl border border-black/10 text-[10px] font-bold uppercase tracking-[0.14em] text-white shadow-[0_10px_22px_rgba(15,23,42,0.28)]"
-                      style={{ backgroundColor: avatarTheme.accent }}
+                      className="flex h-14 w-14 items-center justify-center rounded-xl border border-black/10 bg-black/65 text-[10px] font-bold uppercase tracking-[0.14em] text-white shadow-[0_10px_22px_rgba(15,23,42,0.28)]"
                       aria-hidden="true"
                     >
                       {t('dashboard.upgradeCta.nowTag')}
                     </div>
-                    <p className="text-center text-[11px] font-semibold tracking-[0.02em]">{currentRhythmLabel}</p>
+                    <RhythmVisualSlot alt={currentVisual.alt} imageUrl={currentVisual.imageUrl} />
+                    <p className="text-center text-[11px] font-semibold tracking-[0.02em]">{currentVisual.label}</p>
                   </button>
                 ) : null}
               </div>
@@ -259,11 +258,11 @@ export function UpgradeRecommendationModal({
               {t('dashboard.upgradeCta.viewAllModes')}
             </button>
 
-            <div className="mt-4 flex items-center justify-end gap-2">
+            <div className="mt-5 flex items-center justify-between gap-3">
               <button
                 type="button"
                 onClick={onClose}
-                className="rounded-full border border-[color:var(--color-border-strong)] px-4 py-2 text-sm font-medium text-[color:var(--color-text)]"
+                className="inline-flex items-center rounded-full border border-[color:var(--color-border-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--color-text)] transition hover:bg-[color:var(--color-overlay-1)]"
               >
                 {t('dashboard.upgradeCta.close')}
               </button>

--- a/apps/web/src/components/dashboard-v3/__tests__/ModeUpgradeSuggestionCTA.test.tsx
+++ b/apps/web/src/components/dashboard-v3/__tests__/ModeUpgradeSuggestionCTA.test.tsx
@@ -16,13 +16,14 @@ vi.mock('../../../lib/api', async () => {
 
 vi.mock('../../../i18n/postLoginLanguage', () => ({
   usePostLoginLanguage: () => ({
-    t: (key: string) => {
+    t: (key: string, params?: Record<string, string>) => {
       const dict: Record<string, string> = {
         'dashboard.upgradeCta.closeAria': 'Cerrar upgrade',
         'dashboard.menu.upgradeAvailable': 'Upgrade disponible',
         'dashboard.upgradeCta.bannerTitle': 'Estás listo para el siguiente nivel',
         'dashboard.upgradeCta.bannerBody': 'Texto banner',
         'dashboard.upgradeCta.bannerAction': 'Continuar',
+        'dashboard.upgradeCta.welcomeToast': `Bienvenido a tu nuevo ritmo ${params?.nextMode ?? ''}`,
       };
       return dict[key] ?? key;
     },
@@ -30,7 +31,7 @@ vi.mock('../../../i18n/postLoginLanguage', () => ({
 }));
 
 vi.mock('../UpgradeRecommendationModal', () => ({
-  UpgradeRecommendationModal: ({ open, onConfirm }: { open: boolean; onConfirm: () => Promise<void> }) => {
+  UpgradeRecommendationModal: ({ open, onConfirm, onAcceptedSuccess }: { open: boolean; onConfirm: () => Promise<void>; onAcceptedSuccess?: (nextMode: string | null) => void }) => {
     if (!open) return null;
     return (
       <button
@@ -38,6 +39,7 @@ vi.mock('../UpgradeRecommendationModal', () => ({
         onClick={() => {
           void onConfirm();
           void onConfirm();
+          onAcceptedSuccess?.('EVOLVE');
         }}
       >
         Trigger confirm
@@ -62,7 +64,7 @@ const baseSuggestion = {
 };
 
 describe('ModeUpgradeSuggestionCTA', () => {
-  it('prevents duplicate accept submissions fired by repeated confirm callbacks', async () => {
+  it('prevents duplicate accept submissions and shows welcome toast', async () => {
     acceptMock.mockResolvedValue({ ok: true, suggestion: { ...baseSuggestion, accepted_at: '2026-01-01T00:00:00Z' } });
     const onUpgradeAccepted = vi.fn();
     const onSuggestionChange = vi.fn();
@@ -79,7 +81,8 @@ describe('ModeUpgradeSuggestionCTA', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Trigger confirm' }));
 
     await waitFor(() => expect(acceptMock).toHaveBeenCalledTimes(1));
-    expect(onUpgradeAccepted).toHaveBeenCalledTimes(1);
+    expect(onUpgradeAccepted).toHaveBeenCalledWith('evolve');
     expect(onSuggestionChange).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Bienvenido a tu nuevo ritmo EVOLVE')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/dashboard-v3/__tests__/UpgradeRecommendationModal.test.tsx
+++ b/apps/web/src/components/dashboard-v3/__tests__/UpgradeRecommendationModal.test.tsx
@@ -22,13 +22,12 @@ vi.mock('../../../i18n/postLoginLanguage', () => ({
 }));
 
 describe('UpgradeRecommendationModal', () => {
-  it('renders rhythm-first current and next intensity labels', () => {
+  it('renders rhythm visuals with neutral placeholders and no avatar accent style', () => {
     render(
       <UpgradeRecommendationModal
         open
         currentMode="flow"
         nextMode="evolve"
-        avatarProfile={null}
         isSubmitting={false}
         onConfirm={async () => {}}
         onClose={() => {}}
@@ -40,5 +39,9 @@ describe('UpgradeRecommendationModal', () => {
     expect(screen.getByText('NEXT')).toBeInTheDocument();
     expect(screen.getByText('Flow · 3x/week')).toBeInTheDocument();
     expect(screen.getByText('Evolve · 4x/week')).toBeInTheDocument();
+    expect(screen.getAllByRole('img', { name: /Rhythm/i })).toHaveLength(2);
+
+    const nowTag = screen.getByText('NOW').closest('div');
+    expect(nowTag?.getAttribute('style')).toBeNull();
   });
 });

--- a/apps/web/src/i18n/post-login/dashboard.ts
+++ b/apps/web/src/i18n/post-login/dashboard.ts
@@ -132,6 +132,7 @@ export const dashboardTranslations = {
   'dashboard.upgradeCta.viewAllModes': { es: 'Ver todos los ritmos', en: 'View all rhythms' },
   'dashboard.upgradeCta.success': { es: 'Nuevo ritmo activado: {{nextMode}}', en: 'New rhythm activated: {{nextMode}}' },
   'dashboard.upgradeCta.successSubtitle': { es: 'Tu intensidad semanal ya se actualizó.', en: 'Your weekly intensity has been updated.' },
+  'dashboard.upgradeCta.welcomeToast': { es: 'Bienvenido a tu nuevo ritmo {{nextMode}}', en: 'Welcome to your new rhythm {{nextMode}}' },
   'dashboard.upgradeCta.finalAction': { es: 'Seguir con mi Journey', en: 'Continue my journey' },
   'dashboard.upgradeCta.close': { es: 'Cerrar', en: 'Close' },
   'dashboard.upgradeCta.updating': { es: 'Actualizando...', en: 'Updating...' },

--- a/apps/web/src/lib/rhythmUpgradeVisual.ts
+++ b/apps/web/src/lib/rhythmUpgradeVisual.ts
@@ -1,0 +1,32 @@
+import { normalizeGameModeValue } from './gameMode';
+import { GAME_MODE_META, type LocalizedLanguage } from './gameModeMeta';
+
+export type RhythmUpgradeVisual = {
+  label: string;
+  imageUrl: string | null;
+  alt: string;
+};
+
+export function resolveRhythmUpgradeVisual(
+  mode: string | null,
+  language: LocalizedLanguage = 'en',
+): RhythmUpgradeVisual {
+  const normalized = normalizeGameModeValue(mode);
+
+  if (!normalized) {
+    return {
+      label: language === 'es' ? 'Ritmo · —' : 'Rhythm · —',
+      imageUrl: null,
+      alt: language === 'es' ? 'Visual de ritmo pendiente' : 'Pending rhythm visual',
+    };
+  }
+
+  const frequency = GAME_MODE_META[normalized].frequency[language];
+  const rhythmWord = language === 'es' ? 'Ritmo' : 'Rhythm';
+
+  return {
+    label: `${normalized} · ${frequency}`,
+    imageUrl: null,
+    alt: `${rhythmWord} ${normalized}`,
+  };
+}

--- a/docs/accept-game-mode-upgrade-audit.md
+++ b/docs/accept-game-mode-upgrade-audit.md
@@ -7,8 +7,8 @@
 - **History is persisted automatically by DB trigger**: when `users.game_mode_id` changes, trigger `trg_users_game_mode_history` inserts a row in `user_game_mode_history` with `effective_at = NOW()`.
 - There are currently **two write paths that change mode**:
   1) onboarding intro service (`submitOnboardingIntro`) updates `users.game_mode_id` **and** `image_url`/`avatar_url`.
-  2) upgrade-accept service (`acceptGameModeUpgradeSuggestion`) updates only `users.game_mode_id` (plus `updated_at`) and marks suggestion `accepted_at`.
-- **Upgrade accept already preserves history** (via trigger), but currently **does not synchronize avatar/image URL fields** as onboarding does.
+  2) upgrade-accept service (`acceptGameModeUpgradeSuggestion`) updates only `users.game_mode_id` (plus `updated_at`) and marks suggestion `accepted_at` (avatar fields unchanged by design).
+- **Upgrade accept already preserves history** (via trigger) and intentionally **only mutates `users.game_mode_id`** (plus suggestion acceptance state).
 - **XP/GP/Level are unchanged on accept** in current code (accept path only updates mode + suggestion state). Onboarding is different and can insert onboarding XP bonuses.
 - **Task difficulty is unchanged on accept** in current code (no task updates in accept path).
 
@@ -68,7 +68,7 @@ Within one DB transaction (`BEGIN ... COMMIT`), onboarding:
 
 ### Implication for Accept Upgrade
 - Reusing onboarding wholesale is **not safe** (it would drag unrelated onboarding side effects).
-- But the **mode+avatar write shape** used by onboarding is the visual-consistency baseline.
+- Accept upgrade is intentionally rhythm-only: it must not mutate avatar/image_url/avatar_url.
 
 ---
 

--- a/docs/rhythm-avatar-decoupling-frontend-drift-audit-2026-04-13-phase2-followup.md
+++ b/docs/rhythm-avatar-decoupling-frontend-drift-audit-2026-04-13-phase2-followup.md
@@ -135,3 +135,11 @@ High risk = user-facing drift likely, broad blast radius, or inconsistent identi
 ## Quick conclusion
 
 Decoupling foundation exists, but **mode-derived visual assumptions remain widespread in frontend render paths**. The next safest sequence is dashboard controls/chips → missions → onboarding primary flows → cross-platform callback identity → metadata/demo cleanup.
+
+
+## Update 2026-04-14 (resolved in this phase)
+
+- ✅ `UpgradeRecommendationModal.tsx` no longer uses avatar-driven accents/chips for rhythm upgrade visuals.
+- ✅ `DashboardMenu.tsx` and banner CTA now open the same rhythm-only modal contract and share the same neutral placeholder model for current/next rhythm visuals.
+- ✅ Forced CTA rule was hardened: admin override controls CTA visibility and only allows the next sequential valid rhythm from the user's real current mode (LOW→CHILL, CHILL→FLOW, FLOW→EVOLVE, EVOLVE→none).
+- ✅ Accept path now validates against the user's real current mode to avoid stale/invalid forced combinations and prevent 409 conflicts caused by fake forced current state.


### PR DESCRIPTION
### Motivation
- Remove avatar-driven styling from the rhythm upgrade flow so visuals are rhythm-first and consistent across entry points (banner CTA and dashboard menu). 
- Keep the upgrade accept flow purely about changing rhythm (`game_mode_id`) and avoid touching avatar/color/image state while preventing stale/invalid forced CTAs that caused accept conflicts. 

### Description
- Introduced a rhythm visual model helper `resolveRhythmUpgradeVisual` in `apps/web/src/lib/rhythmUpgradeVisual.ts` that returns `{ label, imageUrl, alt }` and renders neutral placeholders until rhythm images exist. 
- Reworked the upgrade modal `apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx` to remove `avatarProfile`/avatar accent usage, use the new rhythm visuals, keep drag-to-accept, show an in-modal success state, auto-close the modal, and call an optional `onAcceptedSuccess` callback. 
- Updated banner CTA and menu wiring in `apps/web/src/components/dashboard-v3/ModeUpgradeSuggestionCTA.tsx` and `apps/web/src/components/dashboard-v3/DashboardMenu.tsx` to open the same rhythm-only modal contract and show a welcome toast after a successful accept; added i18n copy `dashboard.upgradeCta.welcomeToast`. 
- Hardened backend logic in `apps/api/src/services/gameModeUpgradeSuggestionService.ts` to validate accept against the user’s real current mode (avoid stale/fake forced state) and to only honor forced CTAs when `forced_next_mode` matches the sequential next mode; normalized override persistence in `apps/api/src/services/gameModeUpgradeCtaOverrideService.ts`. 
- Updated and added tests to cover visual/modal consistency and accept/forced-CTA behavior: `apps/web/src/components/dashboard-v3/__tests__/UpgradeRecommendationModal.test.tsx`, `apps/web/src/components/dashboard-v3/__tests__/ModeUpgradeSuggestionCTA.test.tsx`, and `apps/api/src/services/__tests__/gameModeUpgradeSuggestionService.test.ts`; and updated docs `docs/accept-game-mode-upgrade-audit.md` and `docs/rhythm-avatar-decoupling-frontend-drift-audit-2026-04-13-phase2-followup.md`. 

### Testing
- Ran frontend unit tests with `pnpm vitest run src/components/dashboard-v3/__tests__/UpgradeRecommendationModal.test.tsx src/components/dashboard-v3/__tests__/ModeUpgradeSuggestionCTA.test.tsx` and they passed. 
- Ran backend unit tests with `pnpm vitest run src/services/__tests__/gameModeUpgradeSuggestionService.test.ts` and they passed. 
- All adjusted/added tests for modal visuals, accept success flow, and forced-CTA rules succeeded in the CI test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea2443bf88332b4c25c03ff519cd1)