### PR TITLE
Unify rhythm upgrade accept flow and show dashboard-level welcome banner

### DIFF
--- a/apps/web/src/components/admin/AdminLayout.tsx
+++ b/apps/web/src/components/admin/AdminLayout.tsx
@@ -359,7 +359,7 @@ export function AdminLayout() {
         console.error('[admin] failed to fetch mode upgrade analysis', error);
         if (!cancelled) {
           setModeUpgradeAnalysis(null);
-          setModeUpgradeAnalysisError('No se pudo cargar el análisis de mode upgrade.');
+          setModeUpgradeAnalysisError('No se pudo cargar el análisis de Rhythm Upgrade Suggestion.');
         }
       })
       .finally(() => {
@@ -396,7 +396,7 @@ export function AdminLayout() {
         console.error('[admin] failed to fetch mode upgrade CTA override', error);
         if (!cancelled) {
           setModeUpgradeCtaOverride(null);
-          setModeUpgradeCtaOverrideError('No se pudo cargar el override de Upgrade CTA.');
+          setModeUpgradeCtaOverrideError('No se pudo cargar el override de Rhythm Upgrade Suggestion CTA.');
         }
       })
       .finally(() => {
@@ -507,7 +507,7 @@ export function AdminLayout() {
       setModeUpgradeCtaOverrideMessage('Forced CTA aplicado.');
     } catch (error) {
       console.error('[admin] failed to save mode upgrade CTA override', error);
-      setModeUpgradeCtaOverrideError('No se pudo guardar el override de Upgrade CTA.');
+      setModeUpgradeCtaOverrideError('No se pudo guardar el override de Rhythm Upgrade Suggestion CTA.');
     } finally {
       setModeUpgradeCtaOverrideSaving(false);
     }
@@ -530,7 +530,7 @@ export function AdminLayout() {
       setModeUpgradeCtaOverrideMessage('Forced CTA limpiado.');
     } catch (error) {
       console.error('[admin] failed to clear mode upgrade CTA override', error);
-      setModeUpgradeCtaOverrideError('No se pudo limpiar el override de Upgrade CTA.');
+      setModeUpgradeCtaOverrideError('No se pudo limpiar el override de Rhythm Upgrade Suggestion CTA.');
     } finally {
       setModeUpgradeCtaOverrideClearing(false);
     }
@@ -1182,8 +1182,8 @@ export function AdminLayout() {
             <div className="flex flex-col gap-4 rounded-xl border border-cyan-700/40 bg-cyan-900/10 p-4 text-sm text-cyan-100">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="space-y-1">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-300">MODE UPGRADE ANALYSIS</p>
-                  <p className="text-sm text-cyan-100/90">Inspección read-only del review mensual y elegibilidad de upgrade.</p>
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-300">RHYTHM UPGRADE SUGGESTION ANALYSIS</p>
+                  <p className="text-sm text-cyan-100/90">Inspección read-only del review mensual y elegibilidad de la sugerencia de upgrade.</p>
                   {monthlyReviewMessage ? <p className="text-xs font-semibold text-emerald-300">{monthlyReviewMessage}</p> : null}
                   {monthlyReviewError ? <p className="text-xs font-semibold text-rose-300">{monthlyReviewError}</p> : null}
                   {modeUpgradeAnalysisError ? <p className="text-xs font-semibold text-rose-300">{modeUpgradeAnalysisError}</p> : null}
@@ -1200,7 +1200,7 @@ export function AdminLayout() {
                       : 'border border-cyan-700/60 bg-cyan-900/30 text-cyan-100 hover:border-cyan-400/60 hover:text-cyan-50'
                   }`}
                 >
-                  {runningMonthlyReview ? 'Running…' : 'Run Monthly Analysis'}
+                  {runningMonthlyReview ? 'Running…' : 'Run Monthly Rhythm Upgrade Suggestion Analysis'}
                 </button>
                 <button
                   type="button"
@@ -1212,7 +1212,7 @@ export function AdminLayout() {
                       : 'border border-cyan-700/60 bg-cyan-500/10 text-cyan-100 hover:border-cyan-500/80 hover:text-cyan-50'
                   }`}
                 >
-                  {runningRollingAnalysis ? 'Running…' : 'Recompute Rolling 30d Analysis'}
+                  {runningRollingAnalysis ? 'Running…' : 'Recompute Rolling Rhythm Upgrade Suggestion Analysis'}
                 </button>
               </div>
               <div className="grid grid-cols-1 gap-2 md:grid-cols-[minmax(0,220px)_1fr_auto] md:items-end">
@@ -1263,7 +1263,7 @@ export function AdminLayout() {
                       checked={modeUpgradeCtaOverrideEnabled}
                       onChange={(event) => setModeUpgradeCtaOverrideEnabled(event.target.checked)}
                     />
-                    Force Upgrade CTA
+                    Force Rhythm Upgrade Suggestion CTA
                   </label>
                   <p className="rounded-md border border-cyan-700/50 bg-slate-900/70 px-2 py-1 text-xs normal-case tracking-normal text-slate-100">
                     Current real: <strong>{modeUpgradeCurrentMode ?? '—'}</strong>

--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -54,6 +54,7 @@ interface DashboardMenuProps {
   currentGameMode: GameMode | string | null;
   currentAvatarProfile: AvatarProfile | null;
   onGameModeChanged: () => Promise<void> | void;
+  onUpgradeAccepted?: (nextMode: string | null) => void;
   onOpenScheduler?: () => void;
   moderation: {
     configs: Record<ModerationTrackerType, ModerationTrackerConfig> | null;
@@ -226,6 +227,7 @@ export function DashboardMenu({
   currentGameMode,
   currentAvatarProfile,
   onGameModeChanged,
+  onUpgradeAccepted,
   onOpenScheduler,
   moderation,
 }: DashboardMenuProps) {
@@ -532,20 +534,27 @@ export function DashboardMenu({
 
     setIsUpgradeSubmitting(true);
     try {
-      const response = await acceptGameModeUpgradeSuggestion();
+      await acceptGameModeUpgradeSuggestion();
       await onGameModeChanged();
       await modeUpgradeSuggestionRequest.reload();
-      setToast({
-        tone: 'success',
-        message: t('dashboard.upgradeCta.welcomeToast', { nextMode: (response.suggestion.suggested_mode ?? '').toUpperCase() || 'RHYTHM' }),
-      });
     } catch (error) {
       console.error('[dashboard-menu] failed to accept game mode upgrade', error);
       throw error;
     } finally {
       setIsUpgradeSubmitting(false);
     }
-  }, [isUpgradeSubmitting, modeUpgradeSuggestionRequest, onGameModeChanged, setToast, t]);
+  }, [isUpgradeSubmitting, modeUpgradeSuggestionRequest, onGameModeChanged]);
+
+  const handleUpgradeAcceptedSuccess = useCallback(
+    (acceptedMode: string | null) => {
+      const fallbackMode = modeUpgradeSuggestion?.suggested_mode ?? null;
+      const modeLabel = (acceptedMode ?? fallbackMode ?? "RHYTHM").trim().toUpperCase();
+      setIsUpgradeModalOpen(false);
+      handleClose();
+      onUpgradeAccepted?.(modeLabel);
+    },
+    [handleClose, modeUpgradeSuggestion?.suggested_mode, onUpgradeAccepted],
+  );
 
   const handleSignOut = useCallback(async () => {
     handleClose();
@@ -1683,6 +1692,7 @@ export function DashboardMenu({
                   nextMode={modeUpgradeSuggestion?.suggested_mode ?? null}
                   isSubmitting={isUpgradeSubmitting}
                   onConfirm={handleAcceptUpgrade}
+                  onAcceptedSuccess={handleUpgradeAcceptedSuccess}
                   onClose={() => setIsUpgradeModalOpen(false)}
                   onOpenAllModes={() => {
                     setIsUpgradeModalOpen(false);

--- a/apps/web/src/components/dashboard-v3/ModeUpgradeSuggestionCTA.tsx
+++ b/apps/web/src/components/dashboard-v3/ModeUpgradeSuggestionCTA.tsx
@@ -1,5 +1,5 @@
 import { Sparkles } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import {
   acceptGameModeUpgradeSuggestion,
   dismissGameModeUpgradeSuggestion,
@@ -7,7 +7,6 @@ import {
 } from '../../lib/api';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
 import { UpgradeRecommendationModal } from './UpgradeRecommendationModal';
-import { ToastBanner } from '../common/ToastBanner';
 
 interface ModeUpgradeSuggestionCTAProps {
   suggestion: GameModeUpgradeSuggestion | null;
@@ -30,8 +29,6 @@ export function ModeUpgradeSuggestionCTA({
   const [isOpen, setIsOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const submitLockRef = useRef(false);
-  const [welcomeToast, setWelcomeToast] = useState<string | null>(null);
-  const toastTimeoutRef = useRef<number | null>(null);
   const { t } = usePostLoginLanguage();
 
   const isVisible = useMemo(() => {
@@ -45,29 +42,6 @@ export function ModeUpgradeSuggestionCTA({
         !suggestion.dismissed_at,
     );
   }, [suggestion]);
-
-
-  useEffect(() => {
-    if (!welcomeToast) {
-      return;
-    }
-
-    if (toastTimeoutRef.current) {
-      window.clearTimeout(toastTimeoutRef.current);
-    }
-
-    toastTimeoutRef.current = window.setTimeout(() => {
-      setWelcomeToast(null);
-      toastTimeoutRef.current = null;
-    }, 2500);
-
-    return () => {
-      if (toastTimeoutRef.current) {
-        window.clearTimeout(toastTimeoutRef.current);
-        toastTimeoutRef.current = null;
-      }
-    };
-  }, [welcomeToast]);
 
   if (isLoading || !isVisible || !suggestion) {
     return null;
@@ -83,7 +57,6 @@ export function ModeUpgradeSuggestionCTA({
     try {
       const response = await acceptGameModeUpgradeSuggestion();
       onSuggestionChange?.(response.suggestion);
-      onUpgradeAccepted?.(response.suggestion.suggested_mode ?? null);
     } catch (error) {
       console.error('Failed to accept mode upgrade suggestion', error);
       throw error;
@@ -154,13 +127,6 @@ export function ModeUpgradeSuggestionCTA({
           </div>
         </div>
       </div>
-      {welcomeToast ? (
-        <ToastBanner
-          tone="success"
-          message={welcomeToast}
-          className="mt-3 border-white/40 bg-white/18 text-black shadow-[0_12px_28px_rgba(15,23,42,0.18)]"
-        />
-      ) : null}
 
       <UpgradeRecommendationModal
         open={isOpen}
@@ -170,7 +136,7 @@ export function ModeUpgradeSuggestionCTA({
         onConfirm={handleAccept}
         onAcceptedSuccess={(acceptedMode) => {
           const modeLabel = formatModeLabel(acceptedMode ?? suggestion.suggested_mode);
-          setWelcomeToast(t('dashboard.upgradeCta.welcomeToast', { nextMode: modeLabel }));
+          onUpgradeAccepted?.(modeLabel);
         }}
         onClose={() => setIsOpen(false)}
         onOpenAllModes={() => setIsOpen(false)}

--- a/apps/web/src/components/dashboard-v3/__tests__/ModeUpgradeSuggestionCTA.test.tsx
+++ b/apps/web/src/components/dashboard-v3/__tests__/ModeUpgradeSuggestionCTA.test.tsx
@@ -64,7 +64,7 @@ const baseSuggestion = {
 };
 
 describe('ModeUpgradeSuggestionCTA', () => {
-  it('prevents duplicate accept submissions and shows welcome toast', async () => {
+  it('prevents duplicate accept submissions and emits accepted mode once modal confirms success', async () => {
     acceptMock.mockResolvedValue({ ok: true, suggestion: { ...baseSuggestion, accepted_at: '2026-01-01T00:00:00Z' } });
     const onUpgradeAccepted = vi.fn();
     const onSuggestionChange = vi.fn();
@@ -81,8 +81,7 @@ describe('ModeUpgradeSuggestionCTA', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Trigger confirm' }));
 
     await waitFor(() => expect(acceptMock).toHaveBeenCalledTimes(1));
-    expect(onUpgradeAccepted).toHaveBeenCalledWith('evolve');
+    expect(onUpgradeAccepted).toHaveBeenCalledWith('EVOLVE');
     expect(onSuggestionChange).toHaveBeenCalledTimes(1);
-    expect(screen.getByText('Bienvenido a tu nuevo ritmo EVOLVE')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/i18n/post-login/dashboard.ts
+++ b/apps/web/src/i18n/post-login/dashboard.ts
@@ -132,7 +132,10 @@ export const dashboardTranslations = {
   'dashboard.upgradeCta.viewAllModes': { es: 'Ver todos los ritmos', en: 'View all rhythms' },
   'dashboard.upgradeCta.success': { es: 'Nuevo ritmo activado: {{nextMode}}', en: 'New rhythm activated: {{nextMode}}' },
   'dashboard.upgradeCta.successSubtitle': { es: 'Tu intensidad semanal ya se actualizó.', en: 'Your weekly intensity has been updated.' },
-  'dashboard.upgradeCta.welcomeToast': { es: 'Bienvenido a tu nuevo ritmo {{nextMode}}', en: 'Welcome to your new rhythm {{nextMode}}' },
+  'dashboard.upgradeCta.welcomeToast': {
+    es: 'Bienvenido a tu nuevo ritmo de intensidad {{nextMode}}',
+    en: 'Welcome to your new {{nextMode}} intensity rhythm',
+  },
   'dashboard.upgradeCta.finalAction': { es: 'Seguir con mi Journey', en: 'Continue my journey' },
   'dashboard.upgradeCta.close': { es: 'Cerrar', en: 'Close' },
   'dashboard.upgradeCta.updating': { es: 'Actualizando...', en: 'Updating...' },

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -102,6 +102,7 @@ import { ModerationWidget as ModerationStatusWidget } from "../components/modera
 import { ModerationEditSheet } from "../components/dashboard-v3/ModerationEditSheet";
 import { ModerationOnboardingSuggestion } from "../components/dashboard-v3/ModerationOnboardingSuggestion";
 import { ModeUpgradeSuggestionCTA } from "../components/dashboard-v3/ModeUpgradeSuggestionCTA";
+import { ToastBanner } from "../components/common/ToastBanner";
 import {
   readModerationOnboardingIntentFlag,
   writeModerationOnboardingIntentFlag,
@@ -170,7 +171,9 @@ export default function DashboardV3Page() {
   const { backendUserId, status, error, reload, clerkUserId, profile, avatarProfile } =
     useBackendUser();
   const location = useLocation();
-  const { language } = usePostLoginLanguage();
+  const { language, t } = usePostLoginLanguage();
+  const [upgradeWelcomeBanner, setUpgradeWelcomeBanner] = useState<string | null>(null);
+  const upgradeWelcomeTimeoutRef = useRef<number | null>(null);
   const sections = getDashboardSections(location.pathname, language);
   const activeSection = getActiveSection(location.pathname, sections, language);
   const overviewSection = getDashboardSectionConfig(
@@ -206,6 +209,34 @@ export default function DashboardV3Page() {
   const weeklyWrapped = useWeeklyWrapped(backendUserId);
   const isAppMode = useAppMode();
   const [isJourneyGenerating, setIsJourneyGenerating] = useState(false);
+
+  const handleUpgradeAccepted = useCallback((nextMode: string | null) => {
+    const modeLabel = (nextMode ?? "RHYTHM").trim().toUpperCase();
+    setUpgradeWelcomeBanner(t("dashboard.upgradeCta.welcomeToast", { nextMode: modeLabel }));
+    void reload();
+  }, [reload, t]);
+
+  useEffect(() => {
+    if (!upgradeWelcomeBanner) {
+      return;
+    }
+
+    if (upgradeWelcomeTimeoutRef.current) {
+      window.clearTimeout(upgradeWelcomeTimeoutRef.current);
+    }
+
+    upgradeWelcomeTimeoutRef.current = window.setTimeout(() => {
+      setUpgradeWelcomeBanner(null);
+      upgradeWelcomeTimeoutRef.current = null;
+    }, 8000);
+
+    return () => {
+      if (upgradeWelcomeTimeoutRef.current) {
+        window.clearTimeout(upgradeWelcomeTimeoutRef.current);
+        upgradeWelcomeTimeoutRef.current = null;
+      }
+    };
+  }, [upgradeWelcomeBanner]);
 
   useEffect(() => {
     console.info('[dashboard-v3] mounted', {
@@ -883,6 +914,7 @@ export default function DashboardV3Page() {
                 currentGameMode={gameMode}
                 currentAvatarProfile={avatarProfile}
                 onGameModeChanged={reload}
+                onUpgradeAccepted={handleUpgradeAccepted}
                 onOpenScheduler={handleOpenReminderScheduler}
                 moderation={{
                   configs: moderation.configs,
@@ -945,6 +977,13 @@ export default function DashboardV3Page() {
         />
         <main className="flex-1 pb-24 md:pb-0" data-light-scope="dashboard-v3">
           <div className="mx-auto w-full max-w-7xl px-3 py-4 md:px-5 md:py-6 lg:px-6 lg:py-8">
+            {upgradeWelcomeBanner ? (
+              <ToastBanner
+                tone="success"
+                message={upgradeWelcomeBanner}
+                className="mb-4 border-black/15 bg-gradient-to-r from-[#a770ef] via-[#cf8bf3] to-[#fdb99b] text-black shadow-[0_14px_30px_rgba(167,112,239,0.35)]"
+              />
+            ) : null}
             {isLoadingProfile && <ProfileSkeleton />}
 
             {failedToLoadProfile && !isLoadingProfile && (
@@ -973,10 +1012,10 @@ export default function DashboardV3Page() {
                       onOpenReminderScheduler={handleOpenReminderScheduler}
                       journeyReadyOpen={journeyReadyOpen}
                       onOpenModerationEdit={() => setIsModerationEditOpen(true)}
-                      onProfileRefresh={reload}
                       shouldShowFirstDailyQuestCta={shouldShowFirstDailyQuestCta}
                       onOpenDailyQuest={handleOpenDaily}
                       showOnboardingCompletionBanner={showOnboardingCompletionBanner}
+                      onUpgradeAccepted={handleUpgradeAccepted}
                     />
                   }
                 />
@@ -1118,10 +1157,10 @@ interface DashboardOverviewProps {
   onOpenReminderScheduler: () => void;
   journeyReadyOpen?: boolean;
   onOpenModerationEdit: () => void;
-  onProfileRefresh: () => void;
   shouldShowFirstDailyQuestCta: boolean;
   onOpenDailyQuest: () => void;
   showOnboardingCompletionBanner: boolean;
+  onUpgradeAccepted: (nextMode: string | null) => void;
 }
 
 export function DashboardOverview({
@@ -1136,10 +1175,10 @@ export function DashboardOverview({
   onOpenReminderScheduler,
   journeyReadyOpen = false,
   onOpenModerationEdit,
-  onProfileRefresh,
   shouldShowFirstDailyQuestCta,
   onOpenDailyQuest,
   showOnboardingCompletionBanner,
+  onUpgradeAccepted,
 }: DashboardOverviewProps) {
   const trackedPanelInteractionsRef = useRef<Set<"balance" | "streaks">>(
     new Set(),
@@ -1215,7 +1254,7 @@ export function DashboardOverview({
             suggestion={modeUpgradeSuggestion}
             isLoading={modeUpgradeSuggestionRequest.status === "loading"}
             onSuggestionChange={setModeUpgradeSuggestion}
-            onUpgradeAccepted={onProfileRefresh}
+            onUpgradeAccepted={onUpgradeAccepted}
           />
           <Alerts
             hasTasks={dailyQuestReadiness.hasTasks}

--- a/apps/web/src/pages/DemoDashboard.tsx
+++ b/apps/web/src/pages/DemoDashboard.tsx
@@ -252,10 +252,10 @@ export default function DemoDashboardPage() {
           section={overviewSection}
           onOpenReminderScheduler={() => undefined}
           onOpenModerationEdit={() => undefined}
-          onProfileRefresh={() => undefined}
           shouldShowFirstDailyQuestCta={false}
           onOpenDailyQuest={() => dailyQuestModalRef.current?.open()}
           showOnboardingCompletionBanner={false}
+          onUpgradeAccepted={() => undefined}
         />
       </main>
     </div>

--- a/apps/web/src/pages/admin2/CoreEnginePage.tsx
+++ b/apps/web/src/pages/admin2/CoreEnginePage.tsx
@@ -97,7 +97,7 @@ export function CoreEnginePage() {
       setCtaExpiresAt(ctaRes.item?.expires_at ? ctaRes.item.expires_at.slice(0, 16) : '');
     } catch (error) {
       console.error('[admin2][core-engine] failed to load mode data', error);
-      setAnalysisError('No se pudo cargar el análisis/override de mode upgrade.');
+      setAnalysisError('No se pudo cargar el análisis/override de Rhythm Upgrade Suggestion.');
     } finally {
       setAnalysisLoading(false);
       setCtaLoading(false);
@@ -268,7 +268,7 @@ export function CoreEnginePage() {
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-4">
       <header className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5">
         <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--admin-muted)]">Core Engine v2</p>
-        <h2 className="mt-1 text-2xl font-semibold tracking-tight">Growth Calibration · Mode Upgrade Analysis · Habit Achievement</h2>
+        <h2 className="mt-1 text-2xl font-semibold tracking-tight">Growth Calibration · Rhythm Upgrade Suggestion Analysis · Habit Achievement</h2>
       </header>
 
       <section className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4">
@@ -372,7 +372,7 @@ export function CoreEnginePage() {
         </article>
 
         <article className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4 text-sm">
-          <h3 className="font-semibold">Mode Upgrade Analysis</h3>
+          <h3 className="font-semibold">Rhythm Upgrade Suggestion Analysis</h3>
           <p className="text-xs text-[color:var(--admin-muted)]">Distingue análisis real vs forced/admin override y permite conmutar entre ambos.</p>
           <div className="mt-2 flex flex-wrap gap-2">
             <button type="button" onClick={() => void runMonthly()} disabled={!selectedUser || runningMonthly} className={BTN_SECONDARY}>{runningMonthly ? 'Running…' : 'Run Monthly Analysis'}</button>

--- a/apps/web/src/pages/admin2/OverviewPage.tsx
+++ b/apps/web/src/pages/admin2/OverviewPage.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 const SECTIONS = [
   {
     title: 'Core Engine',
-    description: 'Growth Calibration + Mode Upgrade Analysis + Habit Achievement en una sola operación.',
+    description: 'Growth Calibration + Rhythm Upgrade Suggestion Analysis + Habit Achievement en una sola operación.',
     to: '/admin/core-engine',
   },
   {


### PR DESCRIPTION
### Motivation
- Ensure the post-accept UX for the rhythm/upgrade suggestion is identical whether the user accepts from the dashboard CTA or from the menu modal, and make the final welcome feedback visible on desktop (it was previously trapped in a mobile-only menu area). 
- Also standardize admin copy that still referenced “Mode Upgrade / Upgrade Mode” to the new label “Rhythm Upgrade Suggestion Analysis”.

### Description
- Centralize the success path: `DashboardV3` now owns a single `handleUpgradeAccepted` callback and a dashboard-level welcome `ToastBanner` that auto-dismisses after `8000 ms`, and this callback is passed into both the menu and the dashboard CTA/modal so both entrypoints converge to the same final state. 
- `ModeUpgradeSuggestionCTA` no longer renders a local toast and instead emits `onUpgradeAccepted` when the modal reports a confirmed success. 
- `DashboardMenu` now accepts `onUpgradeAccepted`, stops rendering the mobile-only toast for accepts, closes the modal and the menu on success, and delegates the welcome banner display to the dashboard-level handler. 
- Update i18n copy for the welcome banner to: ES: `Bienvenido a tu nuevo ritmo de intensidad {{nextMode}}` and EN: `Welcome to your new {{nextMode}} intensity rhythm`, and rename admin UI strings to “Rhythm Upgrade Suggestion Analysis” across affected admin pages.
- Key files changed: `apps/web/src/pages/DashboardV3.tsx`, `apps/web/src/components/dashboard-v3/DashboardMenu.tsx`, `apps/web/src/components/dashboard-v3/ModeUpgradeSuggestionCTA.tsx`, `apps/web/src/i18n/post-login/dashboard.ts`, `apps/web/src/components/admin/AdminLayout.tsx`, `apps/web/src/pages/admin2/CoreEnginePage.tsx`, `apps/web/src/pages/admin2/OverviewPage.tsx`, `apps/web/src/pages/DemoDashboard.tsx`, and related test updates.

### Testing
- Ran the targeted unit test for the CTA flow with: `npm --workspace apps/web run test -- --run src/components/dashboard-v3/__tests__/ModeUpgradeSuggestionCTA.test.tsx`, which passed. 
- Attempted full web typecheck with `npm run typecheck:web`; this failed due to preexisting unrelated TypeScript errors elsewhere in the workspace and not caused by these changes. 
- Changes were smoke-validated by running the modified test and by inspecting the dashboard-level banner wiring and modal/menu closing logic in the updated components.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deacdce27c83328e44efd2e23a7e15)