### PR TITLE
Refine post-upgrade welcome banner text styling

### DIFF
--- a/apps/web/src/i18n/post-login/dashboard.ts
+++ b/apps/web/src/i18n/post-login/dashboard.ts
@@ -133,8 +133,8 @@ export const dashboardTranslations = {
   'dashboard.upgradeCta.success': { es: 'Nuevo ritmo activado: {{nextMode}}', en: 'New rhythm activated: {{nextMode}}' },
   'dashboard.upgradeCta.successSubtitle': { es: 'Tu intensidad semanal ya se actualizó.', en: 'Your weekly intensity has been updated.' },
   'dashboard.upgradeCta.welcomeToast': {
-    es: 'Bienvenido a tu nuevo ritmo de intensidad {{nextMode}}',
-    en: 'Welcome to your new {{nextMode}} intensity rhythm',
+    es: 'Te damos la bienvenida a tu nuevo ritmo {{nextMode}}',
+    en: 'Welcome to your new {{nextMode}} rhythm',
   },
   'dashboard.upgradeCta.finalAction': { es: 'Seguir con mi Journey', en: 'Continue my journey' },
   'dashboard.upgradeCta.close': { es: 'Cerrar', en: 'Close' },

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -981,7 +981,7 @@ export default function DashboardV3Page() {
               <ToastBanner
                 tone="success"
                 message={upgradeWelcomeBanner}
-                className="mb-4 border-black/15 bg-gradient-to-r from-[#a770ef] via-[#cf8bf3] to-[#fdb99b] text-black shadow-[0_14px_30px_rgba(167,112,239,0.35)]"
+                className="mb-4 border-black/15 bg-gradient-to-r from-[#a770ef] via-[#cf8bf3] to-[#fdb99b] font-display text-base font-semibold leading-[1.3] tracking-[-0.01em] text-[#121212] shadow-[0_14px_30px_rgba(167,112,239,0.35)]"
               />
             ) : null}
             {isLoadingProfile && <ProfileSkeleton />}


### PR DESCRIPTION
### Motivation

- Improve legibility and visual presence of the post-upgrade welcome banner text while leaving the existing banner background, gradient, glow, sizing and layout untouched.
- Make the toast copy sound more natural and premium in both English and Spanish.

### Description

- Touched only the banner text styles and copy used for the post-upgrade welcome toast in the dashboard; background/gradient/shadow/layout/logic were not changed.
- Updated styling on the banner wrapper to apply `font-display`, `text-base`, `font-semibold`, `leading-[1.3]`, `tracking-[-0.01em]` and a soft near-black color `#121212` by changing the `className` where the `ToastBanner` is rendered in `apps/web/src/pages/DashboardV3.tsx`.
- Polished the localized copy in `apps/web/src/i18n/post-login/dashboard.ts` for the welcome toast to these strings: `es: 'Te damos la bienvenida a tu nuevo ritmo {{nextMode}}'` and `en: 'Welcome to your new {{nextMode}} rhythm'`.
- Files changed: `apps/web/src/pages/DashboardV3.tsx`, `apps/web/src/i18n/post-login/dashboard.ts`.

### Testing

- Ran `npm --workspace apps/web run typecheck`; the typecheck run failed due to pre-existing unrelated TypeScript errors elsewhere in the codebase and not caused by these UI text/style changes.
- No automated visual tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb092a79c8332b09df7c8e99296bc)