### PR TITLE
Simplify profile modal identity hierarchy in dashboard menu

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -1212,7 +1212,7 @@ export function DashboardMenu({
 
                       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1 [-webkit-overflow-scrolling:touch]">
                         <div className="space-y-3">
-                          <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-2)] p-4 text-center">
+                          <div className="px-1 py-2 text-center">
                             <img
                               src={currentAvatarPreviewImage}
                               alt={t('dashboard.menu.avatarAlt')}


### PR DESCRIPTION
### Motivation
- The profile identity block in the dashboard profile modal felt visually heavy due to an extra rounded card/background wrapper around the avatar, name, and email, creating a nested "card inside card" look. 
- The goal is to make the avatar + name + email appear as direct modal content for a lighter, more premium mobile-first appearance.

### Description
- Removed the rounded card chrome by replacing the wrapper `className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-2)] p-4 text-center"` with a lightweight `className="px-1 py-2 text-center"` in `apps/web/src/components/dashboard-v3/DashboardMenu.tsx` so the identity block is visually transparent. 
- Kept the avatar element, user name fallback logic, and email rendering unchanged (only the wrapper classes were adjusted). 
- Preserved spacing, centering, and mobile-first readability by using minimal padding and existing avatar/text classes.

### Testing
- No automated tests were run because this is a visual-only Tailwind class adjustment with no behavioral changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb50e6b94833285cc60da7a1ddbfc)