### PR TITLE
Fix outside-click dismissal consistency for dashboard menu modal layers

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -296,7 +296,7 @@ export function DashboardMenu({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        setIsOpen(false);
+        handleEscapeDismiss();
       }
     };
     document.addEventListener("keydown", handleKeyDown);
@@ -304,7 +304,7 @@ export function DashboardMenu({
       document.body.style.overflow = previousOverflow;
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isOpen]);
+  }, [handleEscapeDismiss, isOpen]);
 
 
   useEffect(() => {
@@ -646,6 +646,44 @@ export function DashboardMenu({
     },
     [handleClose],
   );
+
+  const handleLayerOverlayClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>, onClose: () => void) => {
+      if (event.target === event.currentTarget) {
+        onClose();
+      }
+    },
+    [],
+  );
+
+  function handleEscapeDismiss() {
+    if (isDeleteAccountOpen) {
+      handleCloseDeleteAccount();
+      return;
+    }
+
+    if (isAvatarOpen) {
+      handleCloseAvatar();
+      return;
+    }
+
+    if (isGameModeOpen) {
+      handleCloseGameMode();
+      return;
+    }
+
+    if (isProfileOpen) {
+      handleCloseProfile();
+      return;
+    }
+
+    if (isUpgradeModalOpen) {
+      setIsUpgradeModalOpen(false);
+      return;
+    }
+
+    handleClose();
+  }
 
   const currentAvatarPreviewImage = useMemo(
     () => resolveMenuAvatarPreviewImage(currentAvatarSelection),
@@ -1188,7 +1226,10 @@ export function DashboardMenu({
                 </div>
 
                 {isProfileOpen ? (
-                  <div className="absolute inset-0 z-20 flex items-end bg-black/40 p-2 pb-[calc(env(safe-area-inset-bottom,0px)+0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+0.5rem)] md:items-center">
+                  <div
+                    className="absolute inset-0 z-20 flex items-end bg-black/40 p-2 pb-[calc(env(safe-area-inset-bottom,0px)+0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+0.5rem)] md:items-center"
+                    onClick={(event) => handleLayerOverlayClick(event, handleCloseProfile)}
+                  >
                     <div
                       className="flex w-full min-h-0 max-h-[92vh] flex-col overflow-hidden rounded-3xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-slate-900-95)] p-4 shadow-2xl"
                       style={{ maxHeight: 'calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 1rem)' }}
@@ -1277,7 +1318,10 @@ export function DashboardMenu({
                 ) : null}
 
                 {isGameModeOpen ? (
-                  <div className="absolute inset-0 z-20 flex items-end bg-black/40 p-2 pb-[calc(env(safe-area-inset-bottom,0px)+0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+0.5rem)] md:items-center">
+                  <div
+                    className="absolute inset-0 z-20 flex items-end bg-black/40 p-2 pb-[calc(env(safe-area-inset-bottom,0px)+0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+0.5rem)] md:items-center"
+                    onClick={(event) => handleLayerOverlayClick(event, handleCloseGameMode)}
+                  >
                     <div
                       className="flex w-full min-h-0 max-h-[92vh] flex-col overflow-hidden rounded-3xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-slate-900-95)] p-4 shadow-2xl"
                       style={{ maxHeight: 'calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 1rem)' }}
@@ -1393,7 +1437,10 @@ export function DashboardMenu({
                 ) : null}
 
                 {isAvatarOpen ? (
-                  <div className="absolute inset-0 z-30 flex items-end bg-black/40 p-2 pb-[calc(env(safe-area-inset-bottom,0px)+0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+0.5rem)] md:items-center">
+                  <div
+                    className="absolute inset-0 z-30 flex items-end bg-black/40 p-2 pb-[calc(env(safe-area-inset-bottom,0px)+0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+0.5rem)] md:items-center"
+                    onClick={(event) => handleLayerOverlayClick(event, handleCloseAvatar)}
+                  >
                     <div
                       className="flex w-full min-h-0 max-h-[92vh] flex-col overflow-hidden rounded-3xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-slate-900-95)] p-4 shadow-2xl"
                       style={{ maxHeight: 'calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 1rem)' }}
@@ -1490,7 +1537,10 @@ export function DashboardMenu({
 
 
                 {isDeleteAccountOpen ? (
-                  <div className="absolute inset-0 z-40 flex items-end bg-black/55 p-2 pb-[calc(env(safe-area-inset-bottom,0px)+0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+0.5rem)] backdrop-blur-sm md:items-center">
+                  <div
+                    className="absolute inset-0 z-40 flex items-end bg-black/55 p-2 pb-[calc(env(safe-area-inset-bottom,0px)+0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+0.5rem)] backdrop-blur-sm md:items-center"
+                    onClick={(event) => handleLayerOverlayClick(event, handleCloseDeleteAccount)}
+                  >
                     <div
                       role="alertdialog"
                       aria-modal="true"


### PR DESCRIPTION
### Motivation
- Make outside-click dismissal consistent and predictable across all menu-owned modal/sheet layers so clicking the dark overlay closes only the active/topmost layer and clicks inside a modal never close it.

### Description
- Add a shared `handleLayerOverlayClick` helper that uses `event.target === event.currentTarget` and wire it to the overlays for `profile`, `game mode` (rhythm), `avatar`, and `delete account` layers so only outside clicks close those layers.
- Introduce `handleEscapeDismiss()` to ensure the Escape key dismisses the topmost active layer first in this order: delete account → avatar → game mode → profile → upgrade modal → main menu.
- Preserve the existing outer `handleOverlayClick` (main menu) and reuse existing close handlers and guarded logic (saving/deleting protections and close buttons) without changing business logic or modal content.

### Testing
- Ran `npm run typecheck:web`; the typecheck failed due to pre-existing, repository-wide TypeScript errors unrelated to this change so no type errors attributable to the new overlay logic were introduced.
- No other automated tests were added or changed for this focused dismissal fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb66aec3c8332a20e7341bbabb9ef)