### PR TITLE
Improve dashboard menu contrast in light mode and reduce rhythm chip size

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -404,7 +404,7 @@ export function DashboardMenu({
   const menuRowClassName =
     "flex h-12 w-full items-center gap-3 rounded-xl px-3 text-left text-sm font-medium text-[color:var(--color-text-dim)] transition hover:bg-[color:var(--color-overlay-2)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/40";
   const menuCardClassName =
-    "ib-card-contour-shadow relative z-10 rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-2)]";
+    "ib-card-contour-shadow relative z-10 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)]";
 
   const handleOpenProfile = useCallback(() => {
     setIsProfileOpen(true);
@@ -829,7 +829,7 @@ export function DashboardMenu({
                       <div
                         role="radiogroup"
                         aria-label={t('dashboard.language.title')}
-                        className="inline-flex items-center rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-slate-900-15)] p-1"
+                        className="inline-flex items-center rounded-full border border-[color:var(--color-border-strong)] bg-[color:var(--color-overlay-2)] p-1 dark:border-[color:var(--color-border-soft)] dark:bg-[color:var(--color-slate-900-15)]"
                       >
                         {([
                           { value: "es", label: "ES" },
@@ -847,8 +847,8 @@ export function DashboardMenu({
                               onClick={() => setManualLanguage(option.value)}
                               className={`min-w-[3rem] rounded-full px-3 py-1.5 text-xs font-semibold tracking-[0.18em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/40 ${
                                 isActive
-                                  ? "border border-white/35 bg-[color:var(--color-surface)] text-[color:var(--color-text-strong)]"
-                                  : "border border-transparent text-[color:var(--color-text-faint)] hover:text-[color:var(--color-text)]"
+                                  ? "border border-[color:var(--color-border-strong)] bg-[color:var(--color-surface)] text-[color:var(--color-text-strong)] dark:border-white/35"
+                                  : "border border-[color:var(--color-border-subtle)]/70 text-[color:var(--color-text-dim)] hover:border-[color:var(--color-border-soft)] hover:text-[color:var(--color-text)] dark:border-transparent dark:text-[color:var(--color-text-faint)]"
                               }`}
                             >
                               {option.label}
@@ -861,7 +861,7 @@ export function DashboardMenu({
                         type="button"
                         onClick={handleThemeCycle}
                         aria-label={`${t('dashboard.theme.appearance')}: ${themeToggleLabel}`}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-slate-900-15)] text-[color:var(--color-text-dim)] transition hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/40"
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--color-border-strong)] bg-[color:var(--color-overlay-2)] text-[color:var(--color-text-dim)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-3)] hover:text-[color:var(--color-text)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/40 dark:border-[color:var(--color-border-soft)] dark:bg-[color:var(--color-slate-900-15)] dark:hover:bg-[color:var(--color-overlay-2)]"
                       >
                         {theme === "dark" ? (
                           <svg
@@ -906,7 +906,7 @@ export function DashboardMenu({
                           {user?.fullName || user?.username || t('dashboard.menu.profileFallback')}
                         </p>
                         {user?.primaryEmailAddress?.emailAddress ? (
-                          <p className="truncate text-xs text-text-muted">
+                          <p className="truncate text-xs text-[color:var(--color-text-dim)] dark:text-text-muted">
                             {user.primaryEmailAddress.emailAddress}
                           </p>
                         ) : null}
@@ -929,7 +929,7 @@ export function DashboardMenu({
                         <span>{hasActiveUpgradeCta ? t('dashboard.menu.upgradeAvailable') : t('dashboard.menu.changeGameMode')}</span>
                         {hasActiveUpgradeCta ? <span className="rounded-full border border-black/20 bg-white/35 px-2 py-0.5 text-[10px] font-bold uppercase text-black shadow-[0_8px_20px_rgba(167,112,239,0.35)] backdrop-blur-sm">7d</span> : null}
                       </div>
-                      <span className="[&_.ib-game-mode-chip__glow]:opacity-10 [&_.ib-game-mode-chip__glow]:blur-[3px] [&_.ib-game-mode-chip__inner]:gap-1 [&_.ib-game-mode-chip__inner]:px-[0.56rem] [&_.ib-game-mode-chip__inner]:py-[0.18rem] [&_.ib-game-mode-chip__inner]:text-[8px] [&_.ib-game-mode-chip__inner]:tracking-[0.16em] [&_.ib-game-mode-chip__inner_span:first-child]:h-1 [&_.ib-game-mode-chip__inner_span:first-child]:w-1">
+                      <span className="[&_.ib-game-mode-chip__glow]:opacity-10 [&_.ib-game-mode-chip__glow]:blur-[3px] [&_.ib-game-mode-chip__inner]:gap-0.5 [&_.ib-game-mode-chip__inner]:px-[0.4rem] [&_.ib-game-mode-chip__inner]:py-[0.12rem] [&_.ib-game-mode-chip__inner]:text-[7px] [&_.ib-game-mode-chip__inner]:tracking-[0.12em] [&_.ib-game-mode-chip__inner_span:first-child]:h-0.5 [&_.ib-game-mode-chip__inner_span:first-child]:w-0.5">
                         <GameModeChip {...buildGameModeChip(normalizedCurrentMode ?? 'Flow', { avatarProfile: currentAvatarProfile })} />
                       </span>
                     </button>


### PR DESCRIPTION
### Motivation
- Several elements in the dashboard menu in light mode (profile email, language switch, theme toggle, and card surfaces) looked too washed-out and lacked visual separation, reducing readability and making the menu feel like one flat surface. 
- The change/rhythm chip felt oversized and visually heavy inside its row, so it needed a proportional reduction for better balance without altering behavior.

### Description
- Strengthened the menu card contour by switching the card border token to `--color-border-soft` for clearer but still subtle surface separation in light mode in `DashboardMenu.tsx`.
- Improved the ES/EN segmented control in light mode by making the container `border-[color:var(--color-border-strong)]` with a light `bg-[color:var(--color-overlay-2)]`, and updated active/inactive segment classes to use stronger borders and clearer text colors while preserving `dark:` overrides. 
- Increased contrast/visibility for the theme appearance toggle in light mode by switching to `border-[color:var(--color-border-strong)]` and `bg-[color:var(--color-overlay-2)]`, added improved hover behavior, and preserved dark-mode styling via `dark:` utilities. 
- Raised the profile email's light-mode color to `text-[color:var(--color-text-dim)]` (keeping `dark:text-text-muted`) so the email reads as a clearly legible secondary text while remaining subordinate to the username. 
- Reduced the visual footprint of the GameMode/Rhythm chip by scaling inner gap, padding, label size, tracking, and the small indicator sizes (approximately 30% smaller) via adjusted utility classes; chip behavior and logic remain unchanged. 
- All edits are contained to `apps/web/src/components/dashboard-v3/DashboardMenu.tsx` and are visual-only class changes.

### Testing
- Ran the project typecheck with `npm --prefix apps/web run typecheck`; the run failed due to pre-existing unrelated TypeScript errors elsewhere in the repo and not from this visual-only change. 
- No unit or integration tests were modified; this PR is intentionally low-risk and limited to CSS/class updates in the single component file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb7b1d46883328387d6443d929b93)