### PR TITLE
Align dashboard menu selected-state accents with Innerbloom violet language

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -1355,7 +1355,7 @@ export function DashboardMenu({
                                   key={mode}
                                   type="button"
                                   onClick={() => handleSelectGameMode(mode)}
-                                  className={`relative overflow-hidden rounded-2xl border px-3 py-3 text-left transition ${isSelected ? 'border-[color:var(--color-accent-primary)] bg-[color:var(--color-overlay-3)] shadow-[0_0_0_1px_rgba(125,211,252,0.65),0_0_20px_rgba(56,189,248,0.2)]' : 'border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:bg-[color:var(--color-overlay-2)]'}`}
+                                  className={`relative overflow-hidden rounded-2xl border px-3 py-3 text-left transition ${isSelected ? 'border-[color:var(--color-accent-primary)] bg-[color:var(--color-overlay-3)] shadow-[0_0_0_1px_rgba(167,112,239,0.58),0_0_20px_rgba(139,92,246,0.22)]' : 'border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:bg-[color:var(--color-overlay-2)]'}`}
                                 >
                                   <div className="ml-2 space-y-2">
                                     <div className="flex items-center justify-between gap-2">
@@ -1474,7 +1474,7 @@ export function DashboardMenu({
                                   key={avatarOption.avatarId}
                                   type="button"
                                   onClick={() => setSelectedAvatarId(avatarOption.avatarId)}
-                                  className={`relative overflow-hidden rounded-2xl border px-3 py-3 text-left transition ${isSelected ? 'border-[color:var(--color-accent-primary)] bg-[color:var(--color-overlay-3)] shadow-[0_0_0_1px_rgba(125,211,252,0.65),0_0_20px_rgba(56,189,248,0.2)]' : 'border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:bg-[color:var(--color-overlay-2)]'}`}
+                                  className={`relative overflow-hidden rounded-2xl border px-3 py-3 text-left transition ${isSelected ? 'border-[color:var(--color-accent-primary)] bg-[color:var(--color-overlay-3)] shadow-[0_0_0_1px_rgba(167,112,239,0.58),0_0_20px_rgba(139,92,246,0.22)]' : 'border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:bg-[color:var(--color-overlay-2)]'}`}
                                 >
                                   <div className="ml-2 space-y-2">
                                     <div className="flex items-center justify-between gap-2">


### PR DESCRIPTION
### Motivation
- Align selected-state border/glow treatments in the dashboard menu selection UIs to Innerbloom’s violet accent language instead of the current cyan/light-blue, while keeping all behavior unchanged.

### Description
- Replaced the cyan/light-blue selected-card shadow values with violet tones in `apps/web/src/components/dashboard-v3/DashboardMenu.tsx` for the selected card treatments in the Change Rhythm modal and Change Avatar modal.
- The visual update only changes the shadow/glow colors to `rgba(167,112,239,0.58)` and `rgba(139,92,246,0.22)` while preserving `border-[color:var(--color-accent-primary)]`, the selection classes, and all selection logic.

### Testing
- Ran `rg` against the file to confirm the prior cyan glow tokens (`rgba(125,211,252..., rgba(56,189,248...)`) are no longer present and the new violet RGBA values are in place.
- Attempted `pnpm --dir apps/web exec eslint src/components/dashboard-v3/DashboardMenu.tsx`, which failed in this environment due to a missing `eslint.config.*` file and did not block this small visual-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb96b4b008332b900cb07624f44a1)