### PR TITLE
Onboarding: decouple rhythm colors, apply CTA gradient, and auto-advance mode/avatar

### DIFF
--- a/apps/web/src/onboarding/IntroJourney.tsx
+++ b/apps/web/src/onboarding/IntroJourney.tsx
@@ -282,9 +282,8 @@ export function IntroJourney({ language = 'es', onFinish, isSubmitting = false, 
           <GameModeStep
             language={language}
             selected={answers.mode}
-            onSelect={(mode: GameMode) => setMode(mode)}
-            onConfirm={() => {
-              if (!answers.mode) return;
+            onSelect={(mode: GameMode) => {
+              setMode(mode);
               goNext();
             }}
             onBack={() => goToStep('clerk-gate')}
@@ -312,19 +311,15 @@ export function IntroJourney({ language = 'es', onFinish, isSubmitting = false, 
               language={language}
               rhythm={answers.mode}
               selectedAvatarId={answers.avatarId}
+              isSaving={isSavingAvatar}
               onSelectAvatar={(avatarId) => {
+                if (isSavingAvatar) return;
                 setAvatarId(avatarId);
                 setAvatarStepError(null);
-              }}
-              onBack={() => goToStep('mode-select')}
-              onConfirm={() => {
-                if (!answers.avatarId || isSavingAvatar) return;
-                const selectedAvatarId = answers.avatarId;
                 void (async () => {
                   try {
                     setIsSavingAvatar(true);
-                    setAvatarStepError(null);
-                    await changeCurrentUserAvatar(selectedAvatarId);
+                    await changeCurrentUserAvatar(avatarId);
                     await markOnboardingProgress('avatar_selected', { trigger: 'intro_journey' });
                     goNext();
                   } catch (error) {
@@ -335,6 +330,7 @@ export function IntroJourney({ language = 'es', onFinish, isSubmitting = false, 
                   }
                 })();
               }}
+              onBack={() => goToStep('mode-select')}
             />
             {avatarStepError ? <p className="text-center text-sm text-rose-200">{avatarStepError}</p> : null}
           </>

--- a/apps/web/src/onboarding/steps/AvatarStep.tsx
+++ b/apps/web/src/onboarding/steps/AvatarStep.tsx
@@ -1,7 +1,6 @@
 import { motion } from 'framer-motion';
 import type { OnboardingLanguage } from '../constants';
 import type { GameMode } from '../state';
-import { NavButtons } from '../ui/NavButtons';
 import { AVATAR_OPTIONS, resolveAvatarPickerPreviewImage } from '../../lib/avatarCatalog';
 
 interface AvatarStepProps {
@@ -9,16 +8,16 @@ interface AvatarStepProps {
   rhythm: GameMode | null;
   selectedAvatarId: number | null;
   onSelectAvatar: (avatarId: number) => void;
-  onConfirm: () => void;
   onBack?: () => void;
+  isSaving?: boolean;
 }
 
 export function AvatarStep({
   language = 'es',
   selectedAvatarId,
   onSelectAvatar,
-  onConfirm,
   onBack,
+  isSaving = false,
 }: AvatarStepProps) {
   const copy = language === 'en'
     ? {
@@ -26,16 +25,16 @@ export function AvatarStep({
         title: 'Which avatar feels like your space?',
         subtitle: 'Avatar controls visuals. Rhythm keeps controlling your journey behavior.',
         selected: 'Selected',
-        continue: 'Continue',
-        select: 'Select an avatar',
+        back: 'Back',
+        saving: 'Saving…',
       }
     : {
         step: 'Paso 2 · Elegí tu avatar',
         title: '¿Qué avatar representa tu espacio?',
         subtitle: 'El avatar define lo visual. Tu ritmo sigue definiendo el comportamiento del Journey.',
         selected: 'Seleccionado',
-        continue: 'Continuar',
-        select: 'Seleccioná un avatar',
+        back: 'Volver',
+        saving: 'Guardando…',
       };
 
   return (
@@ -55,13 +54,15 @@ export function AvatarStep({
                 key={option.avatarId}
                 type="button"
                 onClick={() => onSelectAvatar(option.avatarId)}
+                disabled={isSaving}
                 aria-pressed={isActive}
-                className={`onboarding-surface-inner rounded-2xl border px-4 py-3 text-left transition ${isActive ? 'border-white/80 bg-white/12' : 'border-white/20 bg-white/6 hover:border-white/35'}`}
+                aria-busy={isSaving}
+                className={`onboarding-surface-inner rounded-2xl border px-4 py-3 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cf8bf3]/60 ${isActive ? 'border-white/80 bg-white/12' : 'border-white/20 bg-white/6 hover:border-white/35'} ${isSaving ? 'cursor-wait opacity-70' : ''}`}
               >
                 <div className="flex items-center justify-between">
                   <p className="text-sm font-semibold text-white">{option.name}</p>
                   {isActive ? (
-                    <span className="rounded-full border border-emerald-200/70 bg-emerald-300/90 px-2 py-0.5 text-[10px] font-semibold uppercase text-slate-950">
+                    <span className="rounded-full border border-[#eed9ff]/80 bg-[#e9d5ff]/90 px-2 py-0.5 text-[10px] font-semibold uppercase text-[#240f43]">
                       {copy.selected}
                     </span>
                   ) : null}
@@ -73,14 +74,22 @@ export function AvatarStep({
             );
           })}
         </div>
-        <NavButtons
-          language={language}
-          showBack={Boolean(onBack)}
-          onBack={onBack}
-          onConfirm={onConfirm}
-          confirmLabel={selectedAvatarId ? copy.continue : copy.select}
-          disabled={!selectedAvatarId}
-        />
+
+        <div className="mt-8 flex items-center justify-between gap-3">
+          {onBack ? (
+            <button
+              type="button"
+              onClick={onBack}
+              disabled={isSaving}
+              className="inline-flex items-center gap-2 rounded-full border border-white/10 px-5 py-2 text-sm font-medium text-white/80 transition hover:border-white/30 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cf8bf3]/60 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              ← {copy.back}
+            </button>
+          ) : (
+            <span />
+          )}
+          {isSaving ? <span className="text-xs font-medium uppercase tracking-[0.2em] text-white/60">{copy.saving}</span> : null}
+        </div>
       </div>
     </motion.div>
   );

--- a/apps/web/src/onboarding/steps/GameModeStep.tsx
+++ b/apps/web/src/onboarding/steps/GameModeStep.tsx
@@ -1,7 +1,6 @@
 import { motion } from 'framer-motion';
 import type { GameMode } from '../state';
 import type { OnboardingLanguage } from '../constants';
-import { NavButtons } from '../ui/NavButtons';
 import { GAME_MODE_META } from '../../lib/gameModeMeta';
 import { getOnboardingRhythmTheme } from '../utils/onboardingRhythmTheme';
 
@@ -9,7 +8,6 @@ interface GameModeStepProps {
   language?: OnboardingLanguage;
   selected: GameMode | null;
   onSelect: (mode: GameMode) => void;
-  onConfirm: () => void;
   onBack?: () => void;
 }
 
@@ -22,7 +20,7 @@ export const MODE_CARD_CONTENT = {
 
 const MODE_ORDER: GameMode[] = ['LOW', 'CHILL', 'FLOW', 'EVOLVE'];
 
-export function GameModeStep({ language = 'es', selected, onSelect, onConfirm, onBack }: GameModeStepProps) {
+export function GameModeStep({ language = 'es', selected, onSelect, onBack }: GameModeStepProps) {
   const copy = language === 'en'
     ? {
         step: 'Step 1 · Choose your rhythm',
@@ -31,8 +29,7 @@ export function GameModeStep({ language = 'es', selected, onSelect, onConfirm, o
         selected: 'Selected',
         state: 'State',
         objective: 'Objective',
-        enterMode: 'Enter mode',
-        selectMode: 'Select a mode',
+        back: 'Back',
         selectedSuffix: ' selected',
       }
     : {
@@ -42,10 +39,10 @@ export function GameModeStep({ language = 'es', selected, onSelect, onConfirm, o
         selected: 'Seleccionado',
         state: 'Estado',
         objective: 'Objetivo',
-        enterMode: 'Entrar al modo',
-        selectMode: 'Seleccioná un modo',
+        back: 'Volver',
         selectedSuffix: ' seleccionado',
       };
+
   return (
     <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2 }}>
       <div className="glass-card onboarding-surface-base mx-auto max-w-4xl rounded-3xl p-4 sm:p-6">
@@ -73,7 +70,7 @@ export function GameModeStep({ language = 'es', selected, onSelect, onConfirm, o
                   'glass-card onboarding-surface-inner onboarding-glass-border-soft relative flex h-full overflow-hidden rounded-3xl border px-5 py-[1.35rem] text-left transition-all duration-250 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950/80',
                   isActive
                     ? 'border-white/80 bg-white/[0.11] ring-2 -translate-y-0.5 scale-[1.01] focus-visible:ring-4'
-                    : 'hover:border-white/30 hover:bg-white/[0.07] focus-visible:border-white/45 focus-visible:ring-sky-300/70',
+                    : 'hover:border-white/30 hover:bg-white/[0.07] focus-visible:border-white/45 focus-visible:ring-[#cf8bf3]/70',
                 ]
                   .filter(Boolean)
                   .join(' ')}
@@ -100,7 +97,7 @@ export function GameModeStep({ language = 'es', selected, onSelect, onConfirm, o
                     <span className="flex items-center gap-2">
                       <span className="text-xs font-semibold tracking-[0.12em] text-white/95 sm:text-sm">{content.title}</span>
                       {isActive ? (
-                        <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200/80 bg-emerald-300/95 px-2 py-0.5 text-[0.58rem] font-semibold uppercase tracking-[0.08em] text-slate-950 shadow-[0_0_14px_rgba(110,231,183,0.42)] sm:text-[0.62rem]">
+                        <span className="inline-flex items-center gap-1 rounded-full border border-[#eed9ff]/80 bg-[#e9d5ff]/90 px-2 py-0.5 text-[0.58rem] font-semibold uppercase tracking-[0.08em] text-[#240f43] shadow-[0_0_14px_rgba(207,139,243,0.42)] sm:text-[0.62rem]">
                           <span aria-hidden>✓</span>
                           {copy.selected}
                         </span>
@@ -131,14 +128,18 @@ export function GameModeStep({ language = 'es', selected, onSelect, onConfirm, o
             );
           })}
         </div>
-        <NavButtons
-          language={language}
-          showBack={Boolean(onBack)}
-          onBack={onBack}
-          onConfirm={onConfirm}
-          confirmLabel={selected ? copy.enterMode : copy.selectMode}
-          disabled={!selected}
-        />
+
+        {onBack ? (
+          <div className="mt-8 flex justify-start">
+            <button
+              type="button"
+              onClick={onBack}
+              className="inline-flex items-center gap-2 rounded-full border border-white/10 px-5 py-2 text-sm font-medium text-white/80 transition hover:border-white/30 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cf8bf3]/60"
+            >
+              ← {copy.back}
+            </button>
+          </div>
+        ) : null}
       </div>
     </motion.div>
   );

--- a/apps/web/src/onboarding/ui/GpProgressBar.tsx
+++ b/apps/web/src/onboarding/ui/GpProgressBar.tsx
@@ -12,7 +12,7 @@ export function GpProgressBar({ progress, totalGp, className }: GpProgressBarPro
     <div className={className ? `flex items-center gap-3 ${className}` : 'flex items-center gap-3'}>
       <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-white/10">
         <div
-          className="h-full rounded-full bg-gradient-to-r from-emerald-400 via-sky-400 to-violet-500 progress-fill--typing"
+          className="h-full rounded-full bg-gradient-to-r from-[#a770ef] via-[#cf8bf3] to-[#fdb99b] progress-fill--typing"
           style={{ width: `${safeProgress}%` }}
         />
       </div>

--- a/apps/web/src/onboarding/ui/HUD.tsx
+++ b/apps/web/src/onboarding/ui/HUD.tsx
@@ -42,10 +42,9 @@ function ModeBadge({ mode }: { mode: GameMode | null }) {
 
   return (
     <span
-      className="onboarding-mode-chip inline-flex items-center gap-2 px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white/85 shadow-[0_0_18px_rgba(8,12,24,0.5)] ring-1 ring-white/10"
+      className="onboarding-mode-chip inline-flex items-center px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white/85 shadow-[0_0_18px_rgba(8,12,24,0.5)] ring-1 ring-white/10"
       style={style}
     >
-      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: theme.badgeDot }} />
       {MODE_BADGE_LABELS[mode]}
     </span>
   );
@@ -63,7 +62,7 @@ function MiniPillarBar({ icon, value }: { icon: string; value: number }) {
             initial={{ width: 0 }}
             animate={{ width: `${pct}%` }}
             transition={{ duration: 0.24, ease: 'easeOut' }}
-            className="h-full rounded-full bg-gradient-to-r from-sky-400 via-violet-400 to-fuchsia-400"
+            className="h-full rounded-full bg-gradient-to-r from-[#a770ef] via-[#cf8bf3] to-[#fdb99b]"
           />
         </div>
         <span className="shrink-0 font-semibold text-white/80">{Math.round(value)} GP</span>

--- a/apps/web/src/onboarding/ui/ModeQuestionTitle.tsx
+++ b/apps/web/src/onboarding/ui/ModeQuestionTitle.tsx
@@ -1,50 +1,25 @@
 const MODE_TITLE_REGEX = /^(LOW|CHILL|FLOW|EVOLVE)\s*·\s*(.+)$/i;
 
-const MODE_DOT_CLASSNAME: Record<string, string> = {
-  LOW: 'bg-red-400 shadow-[0_0_16px_rgba(248,113,113,0.78)]',
-  CHILL: 'bg-emerald-400 shadow-[0_0_16px_rgba(74,222,128,0.75)]',
-  FLOW: 'bg-sky-400 shadow-[0_0_16px_rgba(56,189,248,0.75)]',
-  EVOLVE: 'bg-violet-400 shadow-[0_0_16px_rgba(167,139,250,0.78)]',
-};
-
 type ModeQuestionTitleProps = {
   title: string;
   className?: string;
 };
 
-function parseModeTitle(title: string): { mode: string; text: string } | null {
+function parseModeTitle(title: string): string | null {
   const match = title.trim().match(MODE_TITLE_REGEX);
   if (!match) {
     return null;
   }
 
-  const mode = match[1].toUpperCase();
   const text = match[2].trim();
   if (!text) {
     return null;
   }
 
-  return { mode, text };
+  return text;
 }
 
 export function ModeQuestionTitle({ title, className = 'text-2xl font-semibold text-white' }: ModeQuestionTitleProps) {
-  const parsed = parseModeTitle(title);
-
-  if (!parsed) {
-    return <h2 className={className}>{title}</h2>;
-  }
-
-  const dotClassName = MODE_DOT_CLASSNAME[parsed.mode] ?? 'bg-white/80';
-
-  return (
-    <h2 className={className}>
-      <span className="inline-flex items-center gap-3">
-        <span
-          aria-hidden="true"
-          className={`inline-block h-[0.9em] w-[0.9em] shrink-0 rounded-full align-middle ${dotClassName}`}
-        />
-        <span>{parsed.text}</span>
-      </span>
-    </h2>
-  );
+  const parsedText = parseModeTitle(title);
+  return <h2 className={className}>{parsedText ?? title}</h2>;
 }

--- a/apps/web/src/onboarding/utils/onboardingRhythmTheme.ts
+++ b/apps/web/src/onboarding/utils/onboardingRhythmTheme.ts
@@ -5,43 +5,22 @@ export type OnboardingRhythmTheme = {
   border: string;
   glow: string;
   softTint: string;
-  badgeDot: string;
   badgeAccent: string;
 };
 
+const SHARED_ONBOARDING_RHYTHM_THEME: OnboardingRhythmTheme = {
+  accent: 'rgb(199, 139, 243)',
+  border: 'rgba(207, 139, 243, 0.44)',
+  glow: 'rgba(167, 112, 239, 0.34)',
+  softTint: 'rgba(191, 143, 239, 0.2)',
+  badgeAccent: 'rgba(207, 139, 243, 0.28)',
+};
+
 export const ONBOARDING_RHYTHM_THEME: Record<GameMode, OnboardingRhythmTheme> = {
-  LOW: {
-    accent: 'rgb(248, 113, 113)',
-    border: 'rgba(248, 113, 113, 0.45)',
-    glow: 'rgba(248, 113, 113, 0.32)',
-    softTint: 'rgba(248, 113, 113, 0.2)',
-    badgeDot: 'rgba(248, 113, 113, 0.96)',
-    badgeAccent: 'rgba(248, 113, 113, 0.45)',
-  },
-  CHILL: {
-    accent: 'rgb(74, 222, 128)',
-    border: 'rgba(74, 222, 128, 0.4)',
-    glow: 'rgba(74, 222, 128, 0.3)',
-    softTint: 'rgba(74, 222, 128, 0.2)',
-    badgeDot: 'rgba(74, 222, 128, 0.95)',
-    badgeAccent: 'rgba(74, 222, 128, 0.4)',
-  },
-  FLOW: {
-    accent: 'rgb(56, 189, 248)',
-    border: 'rgba(56, 189, 248, 0.42)',
-    glow: 'rgba(56, 189, 248, 0.32)',
-    softTint: 'rgba(56, 189, 248, 0.2)',
-    badgeDot: 'rgba(56, 189, 248, 0.95)',
-    badgeAccent: 'rgba(56, 189, 248, 0.42)',
-  },
-  EVOLVE: {
-    accent: 'rgb(167, 139, 250)',
-    border: 'rgba(167, 139, 250, 0.44)',
-    glow: 'rgba(167, 139, 250, 0.34)',
-    softTint: 'rgba(167, 139, 250, 0.2)',
-    badgeDot: 'rgba(167, 139, 250, 0.96)',
-    badgeAccent: 'rgba(167, 139, 250, 0.44)',
-  },
+  LOW: SHARED_ONBOARDING_RHYTHM_THEME,
+  CHILL: SHARED_ONBOARDING_RHYTHM_THEME,
+  FLOW: SHARED_ONBOARDING_RHYTHM_THEME,
+  EVOLVE: SHARED_ONBOARDING_RHYTHM_THEME,
 };
 
 export function getOnboardingRhythmTheme(mode: GameMode): OnboardingRhythmTheme {

--- a/apps/web/src/pages/QuickStartPreview.tsx
+++ b/apps/web/src/pages/QuickStartPreview.tsx
@@ -712,6 +712,7 @@ export default function QuickStartPreviewPage() {
   const [gameMode, setGameMode] = useState<GameMode>('CHILL');
   const [avatarId, setAvatarId] = useState<number | null>(null);
   const [avatarStepError, setAvatarStepError] = useState<string | null>(null);
+  const [isSavingAvatar, setIsSavingAvatar] = useState(false);
   const [selectedByPillar, setSelectedByPillar] = useState<Record<Pillar, string[]>>({ Body: [], Mind: [], Soul: [] });
   const [inputsByTask, setInputsByTask] = useState<Record<string, string>>({});
   const [moderationPrefs, setModerationPrefs] = useState<Record<ModerationOption, boolean>>({
@@ -1139,8 +1140,10 @@ export default function QuickStartPreviewPage() {
             <GameModeStep
               language={language}
               selected={gameMode}
-              onSelect={setGameMode}
-              onConfirm={goNext}
+              onSelect={(mode) => {
+                setGameMode(mode);
+                goNext();
+              }}
             />
           </section>
         ) : null}
@@ -1150,24 +1153,26 @@ export default function QuickStartPreviewPage() {
               language={language}
               rhythm={gameMode}
               selectedAvatarId={avatarId}
+              isSaving={isSavingAvatar}
               onSelectAvatar={(value) => {
+                if (isSavingAvatar) return;
                 setAvatarId(value);
                 setAvatarStepError(null);
-              }}
-              onBack={goBack}
-              onConfirm={() => {
-                if (!avatarId) return;
                 void (async () => {
                   try {
-                    await changeCurrentUserAvatar(avatarId);
+                    setIsSavingAvatar(true);
+                    await changeCurrentUserAvatar(value);
                     await markOnboardingProgress('avatar_selected', { trigger: 'quick_start_preview' });
                     goNext();
                   } catch (error) {
                     console.error('[quick_start_preview] avatar select failed', error);
                     setAvatarStepError(language === 'en' ? 'Could not save avatar. Try again.' : 'No pudimos guardar tu avatar. Intentá de nuevo.');
+                  } finally {
+                    setIsSavingAvatar(false);
                   }
                 })();
               }}
+              onBack={goBack}
             />
             {avatarStepError ? <p className="mt-2 text-center text-sm text-rose-200">{avatarStepError}</p> : null}
           </section>

--- a/docs/onboarding-rhythm-visual-decoupling-2026-04-15.md
+++ b/docs/onboarding-rhythm-visual-decoupling-2026-04-15.md
@@ -1,0 +1,74 @@
+# Onboarding rhythm visual decoupling (2026-04-15)
+
+## Scope
+
+This update applies to the shared onboarding segment before `path-select`, so it impacts both:
+
+- traditional onboarding
+- quick start onboarding
+
+No downstream behavior logic was changed for `game_mode`, calibration, generation, summary, missions, or behavior engines.
+
+## Changes implemented
+
+### 1) Unified rhythm visual identity in onboarding
+
+- Removed per-rhythm color coding from onboarding rhythm selection visuals.
+- `LOW`, `CHILL`, `FLOW`, and `EVOLVE` now share the same premium soft-violet selection glow/tint.
+- Kept all existing mode-specific content (title, state, objective, frequency) unchanged.
+
+## 2) HUD rhythm badge cleanup
+
+- Removed the colored status dot from the selected rhythm chip.
+- The badge now shows text only (`LOW MOOD`, `CHILL MOOD`, `FLOW MOOD`, `EVOLVE MOOD`) with a neutral/violet-soft treatment.
+
+## 3) Traditional question titles cleanup
+
+- Removed colored dots from mode-prefixed question titles.
+- `ModeQuestionTitle` still supports parsing `LOW · ...`, `CHILL · ...`, etc.
+- When parsed, it renders only the post-prefix question text.
+- Titles that do not match the mode-prefix pattern continue to render unchanged.
+
+## 4) Progress gradient refresh
+
+Applied CTA gradient across onboarding progress UI:
+
+- `from-[#a770ef] via-[#cf8bf3] to-[#fdb99b]`
+
+Updated in:
+
+- top progress bar
+- HUD mini bars (`Body`, `Mind`, `Soul`)
+
+## 5) Rhythm auto-advance
+
+In `mode-select`:
+
+- selecting a rhythm now persists onboarding state as before
+- onboarding auto-advances immediately to `avatar-select`
+
+## 6) Avatar auto-advance with safe persistence order
+
+In `avatar-select` click flow:
+
+1. set local avatar selection
+2. persist avatar via existing `changeCurrentUserAvatar`
+3. mark progress via existing `markOnboardingProgress('avatar_selected')`
+4. only then advance to the next step
+
+Error handling remains in place; advance does **not** happen on failure.
+
+## 7) CTA removal for rhythm + avatar steps
+
+Because selection now auto-advances:
+
+- removed redundant confirm CTA from rhythm step
+- removed redundant confirm CTA from avatar step
+- kept back navigation on both steps
+
+## UX outcome
+
+- click rhythm → advances automatically
+- click avatar → saves + marks progress + advances automatically
+- onboarding visuals are no longer rhythm-color-coded before path split
+- both onboarding branches inherit this behavior because changes occur before `path-select`


### PR DESCRIPTION
### Motivation
- Unificar la identidad visual y mejorar la experiencia inicial del onboarding eliminando la colorimetría por modo y acelerando la navegación en los pasos previos a la bifurcación (`path-select`).
- Mantener la lógica de negocio intacta y aplicar un tratamiento visual premium Innerbloom (soft-violet) y el gradiente CTA consistente.

### Description
- Reemplazado el theme por uno compartido violeta suave en `apps/web/src/onboarding/utils/onboardingRhythmTheme.ts` para que `LOW/CHILL/FLOW/EVOLVE` usen el mismo set visual sin colorimetría por modo.  
- Actualizada la selección de ritmo en `apps/web/src/onboarding/steps/GameModeStep.tsx` para aplicar glow violeta unificado, remover el botón de confirmación y mantener solo el botón `Volver` cuando aplica.  
- Eliminado el puntito cromático del chip de ritmo en `apps/web/src/onboarding/ui/HUD.tsx` y aplicado el gradiente CTA `from-[#a770ef] via-[#cf8bf3] to-[#fdb99b]` en las mini barras Body/Mind/Soul.  
- Reemplazada la barra superior de progreso en `apps/web/src/onboarding/ui/GpProgressBar.tsx` por el mismo gradiente CTA.  
- `ModeQuestionTitle` (`apps/web/src/onboarding/ui/ModeQuestionTitle.tsx`) ahora parsea títulos con prefijo de modo pero no renderiza ningún dot cromático, mostrando solo el texto posterior al prefijo.  
- Implementado auto-advance en `apps/web/src/onboarding/IntroJourney.tsx`: seleccionar ritmo ejecuta `setMode` y avanza a `avatar-select`, y seleccionar avatar persiste con `changeCurrentUserAvatar` + `markOnboardingProgress('avatar_selected')` y solo avanza tras guardar correctamente (con guardas `isSavingAvatar` para evitar doble submit).  
- Retocado `AvatarStep` (`apps/web/src/onboarding/steps/AvatarStep.tsx`) para eliminar confirm CTA redundante, exponer estado `isSaving` y mostrar estado de guardado/back; también se actualizó `apps/web/src/pages/QuickStartPreview.tsx` para reflejar el nuevo patrón de auto-advance y guardado.  
- Añadido documento explicativo `docs/onboarding-rhythm-visual-decoupling-2026-04-15.md` que resume alcance y decisiones.

### Testing
- Ejecuté `npm run typecheck:web`; el comando falló por errores TypeScript preexistentes en otras áreas del repo que no fueron modificadas por este cambio, por lo que la suite de typecheck global no quedó verde.  
- Revisé la salida de `tsc` y no se detectaron errores nuevos originados por los cambios de onboarding; los fallos reportados son ajenos al scope de esta PR.  
- No se ejecutaron tests E2E ni capturas de UI automáticas en este entorno; se recomienda una verificación manual rápida en desktop y mobile para validar transiciones y foco/acc18.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df826e9364833293d5dd83574bbb14)