### PR TITLE
fix(onboarding): restore vertical scroll in IntroJourney root container

### DIFF
--- a/apps/web/src/onboarding/IntroJourney.tsx
+++ b/apps/web/src/onboarding/IntroJourney.tsx
@@ -597,7 +597,7 @@ export function IntroJourney({ language = 'es', onFinish, isSubmitting = false, 
   }
 
   return (
-    <div className="onboarding-force-white relative flex min-h-screen min-h-dvh flex-col overflow-hidden bg-[#000c40] pb-16">
+    <div className="onboarding-force-white relative flex min-h-screen min-h-dvh flex-col overflow-x-hidden bg-[#000c40] pb-16">
       <HUD
         language={language}
         mode={answers.mode}


### PR DESCRIPTION
### Motivation
- Corregir una regresión donde el contenedor raíz del onboarding (`overflow-hidden`) impedía el scroll vertical en pasos largos como `mode-select` y `avatar-select`.

### Description
- Reemplacé `overflow-hidden` por `overflow-x-hidden` en `apps/web/src/onboarding/IntroJourney.tsx` para restaurar el scroll vertical mientras se evita overflow horizontal y sin modificar la lógica del overlay.

### Testing
- Ejecuté el chequeo de tipos con `pnpm -C apps/web exec tsc --noEmit`, que falló por errores de TypeScript preexistentes en otros módulos y no relacionados con este cambio, y revisé el archivo `apps/web/src/onboarding/IntroJourney.tsx` para confirmar que la lógica de bloqueo de scroll del overlay (`document.body.style.overflow = 'hidden'` cuando `isGpExplainerOpen`) permanece intacta.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8aead8f48332b4b13113ca89a065)