### PR TITLE
Refine Achievements carousel hierarchy and Wrapped section titles

### DIFF
--- a/apps/web/src/components/dashboard-v3/RewardsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/RewardsSection.tsx
@@ -339,7 +339,7 @@ function MonthlyWrapupShelf({ items, language, anchor }: { items: MonthlyWrapped
   return (
     <div data-demo-anchor={anchor} className="ib-card-contour-shadow ib-light-elevated-surface ib-light-elevated-surface--indigo rounded-2xl p-4">
       <div className="flex items-start justify-between gap-4">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--color-text-dim)]">{language === 'es' ? 'Monthly Wrap-Up' : 'Monthly Wrap-Up'}</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--color-text-dim)]">{language === 'es' ? 'Monthly Wrapped' : 'Monthly Wrapped'}</p>
         <InlineCountdown days={monthlyCountdownDays} language={language} />
       </div>
       {latest ? (
@@ -373,7 +373,7 @@ function WeeklyWrapupShelf({ items, onOpen, language, anchor }: { items: WeeklyW
   return (
     <div data-demo-anchor={anchor} className="ib-card-contour-shadow ib-light-elevated-surface ib-light-elevated-surface--emerald rounded-2xl p-4">
       <div className="flex items-start justify-between gap-4">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--color-text-dim)]">{language === 'es' ? 'Weekly Wrap-Up' : 'Weekly Wrap-Up'}</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--color-text-dim)]">{language === 'es' ? 'Weekly Wrapped' : 'Weekly Wrapped'}</p>
         <InlineCountdown days={weeklyCountdownDays} language={language} />
       </div>
       {compactItems.length ? (
@@ -1164,10 +1164,10 @@ function AchievedShelf({
                           </div>
                           <div className="mt-auto space-y-1 pb-2">
                             <p className="text-lg font-semibold text-[color:var(--color-text-strong)]">{habit.taskName}</p>
-                            <p className="line-clamp-1 text-xs text-[color:var(--color-text-muted)]/90">
+                            <p className="line-clamp-1 text-sm font-medium text-[color:var(--color-text)]/95">
                               {habit.trait?.name ?? (language === 'es' ? 'Rasgo en progreso' : 'Trait in progress')}
                             </p>
-                            <p className="text-sm text-[color:var(--color-text-muted)]">
+                            <p className="text-[11px] text-[color:var(--color-text-muted)]/75">
                               {language === 'es'
                                 ? 'Toca para ver más'
                                 : 'Tap to see more'}


### PR DESCRIPTION
### Motivation
- Improve the visual hierarchy of the Achievements carousel front card so the trait reads as a clearer secondary data point while the helper “Tap to see more” becomes subtler, and update the visible Wrap-Up section titles to the requested wording.

### Description
- Promoted the trait line and de-emphasized the helper copy on the carousel front card by changing classes to `text-sm font-medium text-[color:var(--color-text)]/95` for the trait and `text-[11px] text-[color:var(--color-text-muted)]/75` for the helper, and renamed `Weekly Wrap-Up` → `Weekly Wrapped` and `Monthly Wrap-Up` → `Monthly Wrapped`; all edits are surgical and confined to `apps/web/src/components/dashboard-v3/RewardsSection.tsx` with no business logic, API, hook, carousel, or growth-calibration changes.

### Testing
- Ran the repository typecheck with `npm run typecheck:web` which failed due to unrelated repository-wide TypeScript errors outside this change, and attempted to run ESLint but workspace invocation failed; no runtime or visual test failures introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8bb93a3c83328e304b10ccde07d6)