### PR TITLE
Improve native mobile auth UX

### DIFF
--- a/apps/mobile/capacitor.config.ts
+++ b/apps/mobile/capacitor.config.ts
@@ -8,6 +8,8 @@ const config: CapacitorConfig = {
     scheme: 'innerbloom',
   },
   server: {
+    hostname: 'innerbloomjourney.org',
+    androidScheme: 'https',
     iosScheme: 'capacitor',
   },
 };

--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -14,11 +14,9 @@ import { useRequest } from "../../hooks/useRequest";
 import { useThemePreference } from "../../theme/ThemePreferenceProvider";
 import { isNativeCapacitorPlatform } from "../../mobile/capacitor";
 import {
-  buildNativeMobileAuthUrl,
   clearMobileAuthSession,
   setForceNativeWelcome,
 } from "../../mobile/mobileAuthSession";
-import { openUrlInCapacitorBrowser } from "../../mobile/capacitor";
 import { cancelNativeDailyReminderNotification } from "../../mobile/localNotifications";
 import { SHOW_BILLING_UI } from "../../config/releaseFlags";
 import {
@@ -559,12 +557,21 @@ export function DashboardMenu({
   const handleSignOut = useCallback(async () => {
     handleClose();
     if (isNativeCapacitorPlatform()) {
-      await openUrlInCapacitorBrowser(buildNativeMobileAuthUrl('logout'));
+      await cancelNativeDailyReminderNotification();
+      clearMobileAuthSession("manual-sign-out");
+      setForceNativeWelcome(true);
+      setApiAuthTokenProvider(null);
+      try {
+        await signOut();
+      } catch (error) {
+        console.warn("[dashboard-menu] Clerk signOut failed during native logout", error);
+      }
+      navigate("/", { replace: true });
       return;
     }
 
     await signOut({ redirectUrl: "/" });
-  }, [signOut, handleClose]);
+  }, [signOut, handleClose, navigate]);
 
   const deleteAccountKeyword = language === "en" ? "DELETE" : "ELIMINAR";
   const canConfirmAccountDeletion =

--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -31,19 +31,20 @@ export function AuthLayout({
         <div className="absolute inset-x-0 top-0 h-44 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent)]" />
       </div>
 
+      {secondaryActionLabel && secondaryActionHref ? (
+        <a
+          href={secondaryActionHref}
+          className="absolute left-4 top-[calc(env(safe-area-inset-top,0px)+0.45rem)] z-20 inline-flex items-center justify-center gap-2 rounded-full px-1 py-1 text-sm font-semibold text-white/62 transition-colors duration-200 hover:text-white sm:left-6 lg:left-8"
+        >
+          <span aria-hidden="true" className="text-base leading-none">←</span>
+          {secondaryActionLabel}
+        </a>
+      ) : null}
+
       <div className="relative z-10 mx-auto flex w-full min-w-0 max-w-md flex-col items-center gap-6 pt-5 text-center sm:gap-7">
         <div className="flex items-center justify-center text-[17px] font-semibold uppercase tracking-[0.42em] text-white/66">
           <BrandWordmark className="gap-3.5" textClassName="tracking-[0.42em]" iconClassName="h-[3.2em]" />
         </div>
-
-        {secondaryActionLabel && secondaryActionHref ? (
-          <a
-            href={secondaryActionHref}
-            className="inline-flex w-full items-center justify-center rounded-full border border-white/12 bg-white/[0.045] px-4 py-2.5 text-sm font-semibold text-white/72 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition-colors duration-200 hover:border-white/25 hover:bg-white/[0.08] hover:text-white sm:px-5"
-          >
-            {secondaryActionLabel}
-          </a>
-        ) : null}
 
         <div className="w-full space-y-3 text-balance text-center">
           {typeof title === 'string' ? (

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -53,7 +53,7 @@ function LocalizedClerkProvider({ children }: { children: React.ReactNode }) {
   const authLanguage = resolveAuthLanguage(location.search);
   const clerkLocalization = getClerkLocalization(authLanguage);
   const isMobileBridgeRoute = location.pathname === '/mobile-auth';
-  const clerkEnabled = !isNativeApp || isMobileBridgeRoute;
+  const clerkEnabled = true;
   const mobileBridgeSearch = new URLSearchParams(location.search);
   const mobileBridgeMode = mobileBridgeSearch.get('mode') === 'sign-up' ? 'sign-up' : 'sign-in';
   const mobileBridgeReturnTo = mobileBridgeSearch.get('return_to');
@@ -77,7 +77,7 @@ function LocalizedClerkProvider({ children }: { children: React.ReactNode }) {
       publishableKey={publishableKey}
       localization={clerkLocalization}
       standardBrowser={!isNativeApp}
-      touchSession={!isNativeApp}
+      touchSession
       signInUrl={signInUrl}
       signUpUrl={signUpUrl}
       signInForceRedirectUrl={authBridgeRedirectUrl}

--- a/apps/web/src/mobile/MobileAppEntry.tsx
+++ b/apps/web/src/mobile/MobileAppEntry.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import { BrandWordmark } from '../components/layout/BrandWordmark';
 import { useAuth } from '../auth/runtimeAuth';
 import { DASHBOARD_PATH, DEFAULT_DASHBOARD_PATH } from '../config/auth';
@@ -74,6 +74,7 @@ function MobileEntryError({
 }
 
 function MobileWelcome() {
+  const navigate = useNavigate();
   const language = resolveAuthLanguage(typeof window !== 'undefined' ? window.location.search : '');
   const copy = language === 'en'
     ? {
@@ -89,10 +90,9 @@ function MobileWelcome() {
         signUp: 'Crear cuenta',
       };
 
-  const openNativeAuth = async (mode: 'sign-in' | 'sign-up') => {
+  const openEmbeddedAuth = (mode: 'sign-in' | 'sign-up') => {
     setForceNativeWelcome(false);
-    const mobileAuthUrl = buildNativeMobileAuthUrl(mode, language);
-    await openUrlInCapacitorBrowser(mobileAuthUrl);
+    navigate(mode === 'sign-up' ? `/sign-up?lang=${language}` : `/login?lang=${language}`);
   };
 
   const openNativeGoogleAuth = async () => {
@@ -102,33 +102,40 @@ function MobileWelcome() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-5 pb-[calc(env(safe-area-inset-bottom,0px)+1.75rem)] pt-[calc(env(safe-area-inset-top,0px)+1rem)] text-white">
-      <div className="flex min-h-[82vh] w-full max-w-md flex-col">
-        <div className="pt-3 text-center">
-          <div className="flex items-center justify-center text-[17px] font-semibold uppercase tracking-[0.42em] text-white/66">
+    <div className="flex h-dvh max-h-dvh min-h-dvh items-center justify-center overflow-hidden px-5 pb-[calc(env(safe-area-inset-bottom,0px)+0.85rem)] pt-[calc(env(safe-area-inset-top,0px)+0.65rem)] text-white">
+      <div className="flex h-full w-full max-w-md flex-col">
+        <div className="shrink-0 pt-[clamp(0.25rem,1.1dvh,0.75rem)] text-center">
+          <div className="flex items-center justify-center text-[clamp(0.82rem,2.1dvh,1.06rem)] font-semibold uppercase tracking-[0.42em] text-white/66">
             <BrandWordmark className="gap-3.5" textClassName="tracking-[0.42em]" iconClassName="h-[3.2em]" />
           </div>
         </div>
 
-        <div className="flex flex-1 flex-col px-1 pb-3 pt-6">
-          <div className="px-2">
+        <div className="flex min-h-0 flex-1 flex-col px-1 pb-[clamp(0.25rem,1.2dvh,0.75rem)] pt-[clamp(1rem,3dvh,1.5rem)]">
+          <div className="min-h-0 shrink px-2">
             <img
               src="/og/neneOG4.jpg"
               alt="Innerbloom hero"
-              className="h-[37vh] min-h-[300px] w-full rounded-[1.75rem] object-cover object-center shadow-[0_24px_70px_rgba(15,23,42,0.38)]"
+              className="h-[min(34dvh,300px)] min-h-[210px] w-full rounded-[1.65rem] object-cover object-center shadow-[0_24px_70px_rgba(15,23,42,0.38)]"
             />
           </div>
 
-          <div className="flex flex-1 flex-col pt-7">
-            <div className="mt-10 text-center">
-              <h1 className="text-[2.4rem] font-semibold tracking-tight text-white">{copy.title}</h1>
+          <div className="flex min-h-0 flex-1 flex-col pt-[clamp(1rem,3.2dvh,1.75rem)]">
+            <div className="text-center">
+              <h1 className="text-[clamp(2rem,5.2dvh,2.4rem)] font-semibold tracking-tight text-white">{copy.title}</h1>
             </div>
 
-            <div className="mt-auto space-y-3 px-2 pt-10">
+            <div className="mt-auto space-y-[clamp(0.55rem,1.5dvh,0.75rem)] px-2 pt-[clamp(1rem,4dvh,2.5rem)]">
+              <button
+                type="button"
+                onClick={() => openEmbeddedAuth('sign-up')}
+                className="inline-flex w-full items-center justify-center rounded-full bg-[#7c3aed] px-5 py-[clamp(0.75rem,1.8dvh,0.875rem)] text-sm font-semibold text-white shadow-[0_20px_44px_rgba(124,58,237,0.35)] transition hover:bg-[#8b5cf6]"
+              >
+                {copy.signUp}
+              </button>
               <button
                 type="button"
                 onClick={() => void openNativeGoogleAuth()}
-                className="inline-flex w-full items-center justify-center gap-3 rounded-full border border-slate-200/90 bg-white px-5 py-3.5 text-sm font-semibold text-slate-900 shadow-[0_20px_44px_rgba(15,23,42,0.22)] transition hover:bg-slate-50"
+                className="inline-flex w-full items-center justify-center gap-3 rounded-full border border-slate-200/90 bg-white px-5 py-[clamp(0.75rem,1.8dvh,0.875rem)] text-sm font-semibold text-slate-900 shadow-[0_20px_44px_rgba(15,23,42,0.22)] transition hover:bg-slate-50"
               >
                 <svg
                   viewBox="0 0 48 48"
@@ -146,17 +153,10 @@ function MobileWelcome() {
               </button>
               <button
                 type="button"
-                onClick={() => void openNativeAuth('sign-in')}
-                className="inline-flex w-full items-center justify-center rounded-full bg-[#7c3aed] px-5 py-3.5 text-sm font-semibold text-white shadow-[0_20px_44px_rgba(124,58,237,0.35)] transition hover:bg-[#8b5cf6]"
+                onClick={() => openEmbeddedAuth('sign-in')}
+                className="inline-flex w-full items-center justify-center rounded-full border border-white/18 bg-white/8 px-5 py-[clamp(0.75rem,1.8dvh,0.875rem)] text-sm font-semibold text-white transition hover:bg-white/12"
               >
                 {copy.signIn}
-              </button>
-              <button
-                type="button"
-                onClick={() => void openNativeAuth('sign-up')}
-                className="inline-flex w-full items-center justify-center rounded-full border border-white/18 bg-white/8 px-5 py-3.5 text-sm font-semibold text-white transition hover:bg-white/12"
-              >
-                {copy.signUp}
               </button>
             </div>
           </div>

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -2,7 +2,6 @@ import { SignIn } from '@clerk/clerk-react';
 import { useLocation } from 'react-router-dom';
 import { GoogleOAuthButton } from '../components/auth/GoogleOAuthButton';
 import { AuthLayout } from '../components/layout/AuthLayout';
-import { BrandWordmark } from '../components/layout/BrandWordmark';
 import { DASHBOARD_PATH } from '../config/auth';
 import { buildLocalizedAuthPath, resolveAuthLanguage } from '../lib/authLanguage';
 import {
@@ -14,9 +13,7 @@ import {
 import { usePageMeta } from '../lib/seo';
 import {
   isNativeCapacitorPlatform,
-  openUrlInCapacitorBrowser,
 } from '../mobile/capacitor';
-import { buildNativeMobileAuthUrl } from '../mobile/mobileAuthSession';
 
 export default function LoginPage() {
   const location = useLocation();
@@ -40,30 +37,27 @@ export default function LoginPage() {
   });
 
   if (isNativeApp) {
-    const mobileAuthUrl = buildNativeMobileAuthUrl('sign-in', language);
-
     return (
       <AuthLayout
         title={language === 'en' ? 'Sign in' : 'Iniciar sesión'}
         secondaryActionLabel={language === 'en' ? 'Back to app' : 'Volver a la app'}
         secondaryActionHref="/"
       >
-        <div className="mx-auto max-w-xl rounded-[2rem] border border-white/12 bg-[linear-gradient(180deg,rgba(255,255,255,0.12),rgba(255,255,255,0.06))] p-8 text-center text-white shadow-[0_24px_70px_rgba(15,23,42,0.28)] backdrop-blur-2xl">
-          <div className="flex items-center justify-center text-[11px] font-semibold uppercase tracking-[0.38em] text-white/56">
-            <BrandWordmark className="gap-2.5" textClassName="tracking-[0.38em]" iconClassName="h-[1.85em]" />
+        <div className={AUTH_STACK_CLASS}>
+          <div className={AUTH_CLERK_FORM_SHELL_CLASS}>
+            <SignIn
+              appearance={createAuthAppearance({
+                elements: {
+                  footerActionText: 'text-white/50',
+                  footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4'
+                }
+              })}
+              routing="path"
+              path="/login"
+              signUpUrl={buildLocalizedAuthPath('/sign-up', language)}
+              fallbackRedirectUrl="/"
+            />
           </div>
-          <p className="mt-6 text-sm leading-7 text-white/76">
-            {language === 'en'
-              ? 'Continue in the secure browser and return to Innerbloom with your active session.'
-              : 'Continúa en el navegador seguro y vuelve a Innerbloom con tu sesión activa.'}
-          </p>
-          <button
-            type="button"
-            onClick={() => void openUrlInCapacitorBrowser(mobileAuthUrl)}
-            className="mt-7 inline-flex w-full items-center justify-center rounded-full bg-[#7c3aed] px-5 py-3.5 text-sm font-semibold text-white shadow-[0_18px_42px_rgba(124,58,237,0.34)] transition hover:bg-[#8b5cf6]"
-          >
-            {language === 'en' ? 'Open secure login' : 'Abrir login seguro'}
-          </button>
         </div>
       </AuthLayout>
     );

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -3,7 +3,6 @@ import { useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { GoogleOAuthButton } from '../components/auth/GoogleOAuthButton';
 import { AuthLayout } from '../components/layout/AuthLayout';
-import { BrandWordmark } from '../components/layout/BrandWordmark';
 import { buildLocalizedAuthPath, resolveAuthLanguage } from '../lib/authLanguage';
 import {
   AUTH_CLERK_FORM_SHELL_CLASS,
@@ -35,7 +34,7 @@ export default function SignUpPage() {
   });
 
   if (isNativeApp) {
-    const mobileAuthUrl = buildNativeMobileAuthUrl('sign-up', language);
+    const googleAuthUrl = buildNativeMobileAuthUrl('sign-up', language, { provider: 'google' });
 
     return (
       <AuthLayout
@@ -43,22 +42,43 @@ export default function SignUpPage() {
         secondaryActionLabel={language === 'en' ? 'Back to app' : 'Volver a la app'}
         secondaryActionHref="/"
       >
-        <div className="mx-auto max-w-xl rounded-[2rem] border border-white/12 bg-[linear-gradient(180deg,rgba(255,255,255,0.12),rgba(255,255,255,0.06))] p-8 text-center text-white shadow-[0_24px_70px_rgba(15,23,42,0.28)] backdrop-blur-2xl">
-          <div className="flex items-center justify-center text-[11px] font-semibold uppercase tracking-[0.38em] text-white/56">
-            <BrandWordmark className="gap-2.5" textClassName="tracking-[0.38em]" iconClassName="h-[1.85em]" />
-          </div>
-          <p className="mt-6 text-sm leading-7 text-white/76">
-            {language === 'en'
-              ? 'Create your account in the secure browser and return to the app to continue onboarding.'
-              : 'Crea tu cuenta en el navegador seguro y vuelve a la app para continuar el onboarding.'}
-          </p>
+        <div className={AUTH_STACK_CLASS}>
           <button
             type="button"
-            onClick={() => void openUrlInCapacitorBrowser(mobileAuthUrl)}
-            className="mt-7 inline-flex w-full items-center justify-center rounded-full bg-[#7c3aed] px-5 py-3.5 text-sm font-semibold text-white shadow-[0_18px_42px_rgba(124,58,237,0.34)] transition hover:bg-[#8b5cf6]"
+            onClick={() => void openUrlInCapacitorBrowser(googleAuthUrl)}
+            className="inline-flex h-12 w-full items-center justify-center gap-3 rounded-full border border-slate-200/90 bg-white px-4 text-sm font-semibold leading-none text-slate-900 shadow-[0_14px_34px_rgba(15,23,42,0.2)] transition hover:bg-slate-50"
           >
-            {language === 'en' ? 'Open secure sign up' : 'Abrir registro seguro'}
+            <svg
+              viewBox="0 0 48 48"
+              aria-hidden="true"
+              role="img"
+              className="h-[18px] w-[18px] shrink-0"
+              focusable="false"
+            >
+              <path fill="#FFC107" d="M43.611 20.083H42V20H24v8h11.303C33.655 32.657 29.239 36 24 36c-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.842 1.153 7.959 3.041l5.657-5.657C34.053 6.053 29.281 4 24 4 12.954 4 4 12.954 4 24s8.954 20 20 20 20-8.954 20-20c0-1.341-.138-2.65-.389-3.917Z" />
+              <path fill="#FF3D00" d="M6.306 14.691l6.571 4.819C14.655 15.108 18.961 12 24 12c3.059 0 5.842 1.153 7.959 3.041l5.657-5.657C34.053 6.053 29.281 4 24 4 16.318 4 9.656 8.337 6.306 14.691Z" />
+              <path fill="#4CAF50" d="M24 44c5.179 0 9.868-1.977 13.409-5.192l-6.19-5.238C29.146 35.091 26.715 36 24 36c-5.218 0-9.621-3.317-11.283-7.946l-6.522 5.025C9.505 39.556 16.227 44 24 44Z" />
+              <path fill="#1976D2" d="M43.611 20.083H42V20H24v8h11.303c-.792 2.237-2.231 4.166-4.091 5.571l.003-.002 6.19 5.238C36.971 39.202 44 34 44 24c0-1.341-.138-2.65-.389-3.917Z" />
+            </svg>
+            {language === 'en' ? 'Sign up with Google' : 'Crear cuenta con Google'}
           </button>
+          <div className={AUTH_DIVIDER_CLASS}>
+            <span className="h-px flex-1 bg-white/12" aria-hidden />
+            <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
+            <span className="h-px flex-1 bg-white/12" aria-hidden />
+          </div>
+          <div
+            ref={signUpContainerRef}
+            className={AUTH_CLERK_FORM_SHELL_CLASS}
+          >
+            <SignUp
+              appearance={appearance}
+              routing="path"
+              path="/sign-up"
+              signInUrl={buildLocalizedAuthPath('/login', language)}
+              fallbackRedirectUrl="/intro-journey"
+            />
+          </div>
         </div>
       </AuthLayout>
     );


### PR DESCRIPTION
## Summary

- Keeps Clerk enabled in the native mobile shell so the embedded session survives the browser handoff.
- Updates the native welcome auth hierarchy: Create account first, Google second, email login third.
- Removes duplicate Google from native email login, keeps Google available in sign up, and moves Back to app to a low-hierarchy top-left link.
- Avoids opening the browser during native logout and returns directly to the welcome screen.
- Uses the production hostname for Capacitor Android so Clerk accepts the WebView origin.

## Validation

- `git diff --check`
- `pnpm --dir apps/mobile run build:web`
- `pnpm --dir apps/mobile run sync`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:installDebug --console=plain`
- Manual Android emulator check for welcome/login/logout visual flow.

## Notes

Existing unrelated local changes were intentionally left out of this PR.