### PR TITLE
Apply Inner Bloom gradient to dashboard accents

### DIFF
--- a/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
@@ -607,10 +607,10 @@ function TaskItem({
               )}
             />
             <div className="min-w-0 flex-1">
-              <div className="h-2.5 overflow-hidden rounded-full bg-violet-400/20">
+              <div className="h-2.5 overflow-hidden rounded-full" style={{ background: 'var(--gradient-innerbloom-soft)' }}>
                 <div
-                  className="h-2.5 rounded-full bg-gradient-to-r from-violet-400 via-fuchsia-400 to-sky-300 transition-all"
-                  style={{ width: `${pct}%` }}
+                  className="h-2.5 rounded-full transition-all"
+                  style={{ width: `${pct}%`, background: 'var(--gradient-innerbloom)' }}
                 />
               </div>
             </div>

--- a/apps/web/src/content/officialDesignTokens.ts
+++ b/apps/web/src/content/officialDesignTokens.ts
@@ -40,6 +40,12 @@ export const OFFICIAL_DESIGN_TOKENS = {
   },
   gradients: [
     {
+      name: 'innerbloom',
+      type: 'linear',
+      angle: '90deg',
+      stops: ['#a770ef 0%', '#cf8bf3 52%', '#fdb99b 100%']
+    },
+    {
       name: 'landing_background_core',
       type: 'multi-layer',
       angle: '140deg',

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -48,6 +48,22 @@
     --color-slate-400: #94a3b8;
     --color-slate-900-95: rgba(15, 23, 42, 0.95);
     --color-slate-950-80: rgba(2, 6, 23, 0.8);
+    --color-innerbloom-gradient-start: #a770ef;
+    --color-innerbloom-gradient-mid: #cf8bf3;
+    --color-innerbloom-gradient-end: #fdb99b;
+    --gradient-innerbloom: linear-gradient(
+      90deg,
+      var(--color-innerbloom-gradient-start) 0%,
+      var(--color-innerbloom-gradient-mid) 52%,
+      var(--color-innerbloom-gradient-end) 100%
+    );
+    --gradient-innerbloom-soft: linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--color-innerbloom-gradient-start) 22%, transparent) 0%,
+      color-mix(in srgb, var(--color-innerbloom-gradient-mid) 24%, transparent) 52%,
+      color-mix(in srgb, var(--color-innerbloom-gradient-end) 20%, transparent) 100%
+    );
+    --shadow-innerbloom-cta: 0 12px 28px rgba(207, 139, 243, 0.28);
     --color-widget-menu-heading: var(--color-text);
     --color-widget-menu-label: var(--color-text-muted);
     --color-widget-menu-item-title: var(--color-text);

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -1374,7 +1374,8 @@ function DailyQuestView({
             <button
               type="button"
               onClick={onOpenDailyQuest}
-              className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-sky-400 via-indigo-400 to-fuchsia-500 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-white shadow-[0_12px_28px_rgba(99,102,241,0.28)] transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+              className="inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-white transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+              style={{ background: 'var(--gradient-innerbloom)', boxShadow: 'var(--shadow-innerbloom-cta)' }}
             >
               Abrir Daily Quest
             </button>
@@ -1393,7 +1394,8 @@ function DailyQuestView({
               ].map((tip) => (
                 <li key={tip} className="flex items-start gap-2 text-[color:var(--color-text-muted)]">
                   <span
-                    className="mt-1 inline-block h-2 w-2 rounded-full bg-gradient-to-br from-sky-300 via-indigo-300 to-fuchsia-300 shadow-[0_0_12px_rgba(99,102,241,0.45)]"
+                    className="mt-1 inline-block h-2 w-2 rounded-full shadow-[0_0_12px_rgba(207,139,243,0.45)]"
+                    style={{ background: 'var(--gradient-innerbloom)' }}
                     aria-hidden
                   />
                   <span>{tip}</span>

--- a/docs/innerbloom-ui-system.md
+++ b/docs/innerbloom-ui-system.md
@@ -71,6 +71,18 @@ Primary color is used for emphasis, interactive focus, active controls, and key 
 
 Accent color is used for secondary gradients, celebratory states, and mixed accent surfaces.
 
+### Inner Bloom gradient
+
+The **Inner Bloom gradient** is the canonical brand progress/CTA gradient taken from the onboarding GP bar.
+
+- CSS token: `--gradient-innerbloom`
+- Stops: `#a770ef 0%` -> `#cf8bf3 52%` -> `#fdb99b 100%`
+- Direction: `90deg`
+- Soft track token: `--gradient-innerbloom-soft`
+- CTA shadow token: `--shadow-innerbloom-cta`
+
+Use this gradient for primary brand progress bars, GP/onboarding-aligned progress fills, and primary Daily Quest CTAs. Avoid replacing it with cyan/sky/indigo gradients in core product progress surfaces unless the component is intentionally representing a separate metric color system.
+
 ### Neutral surfaces
 
 Use neutral stacks per theme:
@@ -362,4 +374,3 @@ If an implementation requires a new visual pattern, Codex must update this UI Sy
 - [ ] Uses existing token categories (surface, border, text, accent, overlay).
 - [ ] Reuses existing Dashboard-v3 card/chip/button/input structure.
 - [ ] No undocumented one-off style introduced.
-


### PR DESCRIPTION
## Summary
- Adds the canonical `--gradient-innerbloom` token from the onboarding GP bar, plus soft track and CTA shadow tokens.
- Replaces Streaks weekly progress fills/tracks with the Inner Bloom gradient instead of the violet/fuchsia/sky gradient.
- Replaces the Daily Quest section CTA and bullet accent dots with the Inner Bloom gradient.
- Documents the gradient in the tracked UI system docs and official design token list.

## Validation
- `pnpm --filter @innerbloom/web build`

## Notes
- Existing local unrelated changes were left unstaged and are not included in this PR.