### PR TITLE
Bump Android version code to 2

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "org.innerbloom.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.


### PR DESCRIPTION
## Summary

- Bumps Android `versionCode` from 1 to 2.
- Updates `versionName` from `1.0` to `1.0.1`.

## Why

Google Play rejected the internal testing AAB because version code 1 had already been used.

## Validation

- Confirmed the Play Console error references version code 1 already used.
- Rebuilding and signing a new AAB from this source change.