### PR TITLE
Fix production mobile env

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "org.innerbloom.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
-        versionName "1.0.1"
+        versionCode 3
+        versionName "1.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -1,2 +1,8 @@
 VITE_API_BASE_URL=https://apiv2.innerbloomjourney.org
 VITE_SHOW_STREAKS_PANEL=true
+
+VITE_API_URL=https://apiv2.innerbloomjourney.org
+VITE_CLERK_PUBLISHABLE_KEY=pk_live_Y2xlcmsuaW5uZXJibG9vbWpvdXJuZXkub3JnJA
+VITE_CLERK_TOKEN_TEMPLATE=
+VITE_DASHBOARD_PATH=/dashboard-v3
+VITE_WEB_BASE_URL=https://innerbloomjourney.org


### PR DESCRIPTION
## Summary

- Adds the production Vite runtime values required by the mobile bundle, including the Clerk publishable key and dashboard/web URLs.
- Bumps Android `versionCode` to 3 and `versionName` to `1.0.2` for the next Play Console internal testing upload.

## Why

The v2 AAB rendered only the background because the production bundle was built without `VITE_CLERK_PUBLISHABLE_KEY`, causing startup to throw before React rendered.

## Validation

- Reproduced the blank release screen in the Android emulator.
- Rebuilt the native web bundle and verified the missing-key throw is no longer emitted.
- Preparing a new signed AAB after merge.