### PR TITLE
feat(web): add Labs MVP for decoupled weekly rhythm landing narrative

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,6 +25,8 @@ import QuickStartPreviewPage from './pages/QuickStartPreview';
 import LabsDemoModeSelectPage from './pages/LabsDemoModeSelect';
 import DemoModeSelectPage from './pages/DemoModeSelect';
 import LabsLogrosDemoPage from './pages/labs/LogrosDemoPage';
+import LabsIndexPage from './pages/labs/LabsIndexPage';
+import LandingRhythmSectionMvpPage from './pages/labs/LandingRhythmSectionMvpPage';
 import { useGa4FunnelTracking } from './hooks/useGa4FunnelTracking';
 import { isNativeCapacitorPlatform } from './mobile/capacitor';
 import { writeMobileDebug } from './mobile/mobileDebug';
@@ -261,8 +263,10 @@ export default function App() {
         <Route path="/premium-timeline" element={<PremiumTimelineDemoPage />} />
         <Route path="/demo" element={<DemoDashboardPage />} />
         <Route path="/demo-mode-select" element={<DemoModeSelectPage />} />
+        <Route path="/labs" element={<LabsIndexPage />} />
         <Route path="/labs/demo-mode-select" element={<LabsDemoModeSelectPage legacyLabsPath />} />
         <Route path="/labs/logros" element={<LabsLogrosDemoPage />} />
+        <Route path="/labs/landing-rhythm-section" element={<LandingRhythmSectionMvpPage />} />
         <Route path="/onboarding" element={<OnboardingIntroPage />} />
         <Route path="/intro-journey" element={<OnboardingIntroPage />} />
         <Route

--- a/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
+++ b/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
@@ -1,0 +1,113 @@
+const RHYTHM_CARDS = [
+  {
+    id: 'low',
+    name: 'LOW',
+    frequency: '1× / week',
+    state: 'Low energy, overloaded, or returning after a break.',
+    purpose: 'Rebuild your base with minimum load and protect consistency.',
+    examples: ['2 core habits', 'Recovery priority', 'Simple wins'],
+    intensity: 25,
+  },
+  {
+    id: 'chill',
+    name: 'CHILL',
+    frequency: '2× / week',
+    state: 'Stable enough to move, but still protecting bandwidth.',
+    purpose: 'Keep momentum light with a realistic and steady pace.',
+    examples: ['3–4 weekly actions', 'Balanced focus', 'No pressure spikes'],
+    intensity: 45,
+  },
+  {
+    id: 'flow',
+    name: 'FLOW',
+    frequency: '3× / week',
+    state: 'Focused and ready for a sustainable push.',
+    purpose: 'Drive meaningful progress while keeping your rhythm sustainable.',
+    examples: ['Priority blocks', 'Focused execution', 'Weekly review'],
+    intensity: 70,
+  },
+  {
+    id: 'evolve',
+    name: 'EVOLVE',
+    frequency: '4× / week',
+    state: 'High intent and ready for more structure this week.',
+    purpose: 'Increase load with more structure while protecting balance.',
+    examples: ['Structured plan', 'Higher load', 'Consistency guardrails'],
+    intensity: 90,
+  },
+] as const;
+
+export function LabsWeeklyRhythmSystemSection() {
+  return (
+    <section
+      aria-labelledby="labs-weekly-rhythm-title"
+      className="relative overflow-hidden rounded-[2rem] border border-white/15 bg-[linear-gradient(152deg,rgba(255,255,255,0.11),rgba(167,123,245,0.09)_52%,rgba(72,43,126,0.08))] px-6 py-8 shadow-[0_28px_72px_rgba(24,12,52,0.26),inset_0_1px_0_rgba(255,255,255,0.22)] backdrop-blur-xl md:px-9 md:py-10"
+    >
+      <div className="pointer-events-none absolute -top-16 left-1/2 h-40 w-[82%] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(176,122,255,0.28),rgba(176,122,255,0.09)_52%,transparent_78%)] blur-2xl" />
+      <div className="pointer-events-none absolute inset-0 rounded-[2rem] bg-[radial-gradient(circle_at_14%_20%,rgba(255,255,255,0.16),transparent_58%),radial-gradient(circle_at_84%_82%,rgba(186,161,255,0.1),transparent_58%)]" />
+
+      <div className="relative space-y-7">
+        <header className="max-w-3xl space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-white/70">Weekly rhythm system</p>
+          <h2 id="labs-weekly-rhythm-title" className="text-3xl font-semibold tracking-[-0.03em] text-white md:text-4xl">
+            Choose the weekly rhythm you can sustain today
+          </h2>
+          <p className="max-w-2xl text-sm leading-relaxed text-white/80 md:text-base">
+            Your rhythm defines how intense your plan should feel this week — from rebuilding your base to moving forward with
+            more structure and consistency.
+          </p>
+        </header>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {RHYTHM_CARDS.map((card) => (
+            <article
+              key={card.id}
+              className="group flex h-full flex-col rounded-3xl border border-white/14 bg-[linear-gradient(168deg,rgba(255,255,255,0.08),rgba(15,12,34,0.22))] p-4 shadow-[0_14px_34px_rgba(17,10,37,0.22),inset_0_1px_0_rgba(255,255,255,0.14)] transition duration-200 hover:-translate-y-0.5 hover:border-white/20 md:p-5"
+            >
+              <div className="mb-4 flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-white/65">Rhythm</p>
+                  <h3 className="mt-1 text-xl font-semibold tracking-[-0.02em] text-white">{card.name}</h3>
+                </div>
+                <span className="rounded-full border border-white/16 bg-white/8 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-white/86">
+                  {card.frequency}
+                </span>
+              </div>
+
+              <div className="mb-4 rounded-2xl border border-white/10 bg-white/6 p-3">
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-white/60">Weekly load</p>
+                <div className="mt-2 h-2 rounded-full bg-white/12">
+                  <div className="h-full rounded-full bg-[linear-gradient(90deg,rgba(191,146,255,0.9),rgba(118,209,255,0.95))]" style={{ width: `${card.intensity}%` }} />
+                </div>
+              </div>
+
+              <div className="space-y-3 text-sm text-white/84">
+                <p>
+                  <span className="font-medium text-white">State:</span> {card.state}
+                </p>
+                <p>
+                  <span className="font-medium text-white">This week is for:</span> {card.purpose}
+                </p>
+              </div>
+
+              <ul className="mt-4 flex flex-wrap gap-2">
+                {card.examples.map((example) => (
+                  <li
+                    key={example}
+                    className="rounded-full border border-white/12 bg-white/[0.08] px-2.5 py-1 text-[0.68rem] font-medium tracking-[0.01em] text-white/86"
+                  >
+                    {example}
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+
+        <p className="text-xs leading-relaxed text-white/68 md:text-sm">
+          Rhythm shapes your weekly plan intensity. Avatar identity belongs to a separate product layer.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/pages/labs/LabsIndexPage.tsx
+++ b/apps/web/src/pages/labs/LabsIndexPage.tsx
@@ -1,0 +1,62 @@
+import { Link } from 'react-router-dom';
+import { BrandWordmark } from '../../components/layout/BrandWordmark';
+import { OFFICIAL_DESIGN_TOKENS } from '../../content/officialDesignTokens';
+
+const LAB_EXPERIMENTS = [
+  {
+    title: 'Landing Rhythm Section MVP',
+    description: 'Experimental landing section focused on weekly rhythm intensity (decoupled from avatar identity).',
+    href: '/labs/landing-rhythm-section',
+  },
+  {
+    title: 'Demo Mode Select',
+    description: 'Legacy labs route for selecting LOW / CHILL / FLOW / EVOLVE before opening demo.',
+    href: '/labs/demo-mode-select',
+  },
+  {
+    title: 'Logros Demo',
+    description: 'Guided preview of the Achievements module for dashboard exploration.',
+    href: '/labs/logros',
+  },
+];
+
+export default function LabsIndexPage() {
+  const purpleAfternoon = OFFICIAL_DESIGN_TOKENS.gradients.find((gradient) => gradient.name === 'purple_afternoon');
+  const landingBackground = purpleAfternoon
+    ? {
+        backgroundImage: `linear-gradient(${purpleAfternoon.angle}, ${purpleAfternoon.stops[0]}, ${purpleAfternoon.stops[1]})`,
+      }
+    : undefined;
+
+  return (
+    <main className="min-h-screen text-[color:var(--color-text)]" style={landingBackground}>
+      <div className="mx-auto w-full max-w-5xl px-4 py-8 md:px-6 md:py-10">
+        <header className="mb-6 rounded-[1.8rem] border border-white/14 bg-white/10 p-6 shadow-[0_20px_44px_rgba(21,11,45,0.22)] backdrop-blur-xl md:mb-8 md:p-7">
+          <BrandWordmark
+            className="text-white/88"
+            textClassName="text-[0.72rem] font-semibold tracking-[0.34em] text-white/72 md:text-xs"
+            iconClassName="h-[1.65em]"
+          />
+          <h1 className="mt-4 text-3xl font-semibold tracking-[-0.03em] text-white md:text-[2.2rem]">Innerbloom Labs</h1>
+          <p className="mt-2 max-w-3xl text-sm leading-relaxed text-white/78 md:text-base">
+            Internal experiments and concept validations. Use these routes to evaluate messaging, layout, and product narratives before official rollout.
+          </p>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2">
+          {LAB_EXPERIMENTS.map((experiment) => (
+            <Link
+              key={experiment.href}
+              to={experiment.href}
+              className="group rounded-[1.35rem] border border-white/12 bg-[linear-gradient(158deg,rgba(255,255,255,0.09),rgba(15,12,34,0.22))] p-5 shadow-[0_14px_32px_rgba(18,10,39,0.2)] transition hover:-translate-y-0.5 hover:border-white/20 hover:bg-[linear-gradient(158deg,rgba(255,255,255,0.12),rgba(15,12,34,0.24))]"
+            >
+              <p className="text-[0.66rem] uppercase tracking-[0.18em] text-white/62">Experiment</p>
+              <h2 className="mt-2 text-xl font-semibold tracking-[-0.02em] text-white group-hover:text-white">{experiment.title}</h2>
+              <p className="mt-2 text-sm leading-relaxed text-white/78">{experiment.description}</p>
+            </Link>
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/pages/labs/LandingRhythmSectionMvpPage.tsx
+++ b/apps/web/src/pages/labs/LandingRhythmSectionMvpPage.tsx
@@ -1,0 +1,79 @@
+import { Link } from 'react-router-dom';
+import { BrandWordmark } from '../../components/layout/BrandWordmark';
+import { LabsWeeklyRhythmSystemSection } from '../../components/labs/LabsWeeklyRhythmSystemSection';
+import { OFFICIAL_DESIGN_TOKENS } from '../../content/officialDesignTokens';
+
+const CONTEXT_BLOCKS = {
+  before: {
+    kicker: 'Context before',
+    title: 'Why adaptive planning matters',
+    body: 'Most people do not fail because they lack discipline. They fail because their plan ignores weekly fluctuations in energy, time, and mental bandwidth.',
+  },
+  after: {
+    kicker: 'Context after',
+    title: 'How rhythm turns into execution',
+    body: 'Once your rhythm is defined, Innerbloom translates weekly intensity into realistic tasks, reminders, and progression checks that can evolve over time.',
+  },
+};
+
+function ContextPreviewCard({ kicker, title, body }: { kicker: string; title: string; body: string }) {
+  return (
+    <section className="rounded-[1.75rem] border border-white/12 bg-[linear-gradient(148deg,rgba(255,255,255,0.085),rgba(167,123,245,0.065)_52%,rgba(72,43,126,0.05))] p-6 shadow-[0_18px_40px_rgba(24,12,52,0.2),inset_0_1px_0_rgba(255,255,255,0.16)] backdrop-blur-lg md:p-7">
+      <p className="text-[0.65rem] font-semibold uppercase tracking-[0.24em] text-white/64">{kicker}</p>
+      <h2 className="mt-2 text-2xl font-semibold tracking-[-0.025em] text-white md:text-[1.75rem]">{title}</h2>
+      <p className="mt-3 max-w-3xl text-sm leading-relaxed text-white/80 md:text-base">{body}</p>
+    </section>
+  );
+}
+
+export default function LandingRhythmSectionMvpPage() {
+  const purpleAfternoon = OFFICIAL_DESIGN_TOKENS.gradients.find((gradient) => gradient.name === 'purple_afternoon');
+  const landingBackground = purpleAfternoon
+    ? {
+        backgroundImage: `linear-gradient(${purpleAfternoon.angle}, ${purpleAfternoon.stops[0]}, ${purpleAfternoon.stops[1]})`,
+      }
+    : undefined;
+
+  return (
+    <main className="min-h-screen text-[color:var(--color-text)]" style={landingBackground}>
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-8 md:gap-10 md:px-6 md:py-10 lg:px-8 lg:py-12">
+        <header className="flex flex-wrap items-center justify-between gap-3">
+          <BrandWordmark
+            className="text-white/88"
+            textClassName="text-[0.72rem] font-semibold tracking-[0.34em] text-white/72 md:text-xs"
+            iconClassName="h-[1.65em]"
+          />
+          <div className="flex items-center gap-2">
+            <Link
+              to="/labs"
+              className="rounded-full border border-white/16 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-white/88 transition hover:bg-white/14"
+            >
+              Labs index
+            </Link>
+            <Link
+              to="/"
+              className="rounded-full border border-white/16 bg-white/8 px-4 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-white/80 transition hover:bg-white/12"
+            >
+              Back to landing
+            </Link>
+          </div>
+        </header>
+
+        <section className="rounded-[1.75rem] border border-white/12 bg-black/10 p-5 shadow-[0_14px_32px_rgba(19,10,41,0.2)] backdrop-blur-md md:p-6">
+          <p className="text-xs uppercase tracking-[0.22em] text-white/66">Landing section MVP · Experiment</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-[-0.03em] text-white md:text-[2.3rem]">
+            Rhythm Section Narrative Test (Decoupled from Avatar Identity)
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-white/80 md:text-base">
+            This lab page recreates a realistic landing flow: a short section before, the experimental rhythm module in-context,
+            and a short section after. The goal is to evaluate clarity, hierarchy, and message continuity.
+          </p>
+        </section>
+
+        <ContextPreviewCard {...CONTEXT_BLOCKS.before} />
+        <LabsWeeklyRhythmSystemSection />
+        <ContextPreviewCard {...CONTEXT_BLOCKS.after} />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- The landing currently mixes `rhythm` (weekly intensity) with avatar identity, which obscures the product message; this change creates an isolated experiment to test a rhythm-first narrative decoupled from avatars. 
- The goal is a quick, iteration-friendly MVP inside `/labs` that can be reviewed in context without touching the official landing page.

### Description
- Add a reusable 4-card grid rhythm component `LabsWeeklyRhythmSystemSection` that presents `LOW`, `CHILL`, `FLOW`, and `EVOLVE` with frequency, state, purpose, example pills and a weekly-load indicator. 
- Add a lab page `LandingRhythmSectionMvpPage` that renders a short context-before block, the experimental rhythm section in-place, and a context-after block to simulate landing flow. 
- Add a labs index page `LabsIndexPage` with a discoverable entry to the new experiment and wire routes so the experiment is reachable at `/labs/landing-rhythm-section`. 
- Wire imports and routes in the main router so the pages are navigable; files added/modified: `apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx`, `apps/web/src/pages/labs/LandingRhythmSectionMvpPage.tsx`, `apps/web/src/pages/labs/LabsIndexPage.tsx`, and `apps/web/src/App.tsx`.

### Testing
- Ran `npm run typecheck:web`; the command failed due to pre-existing TypeScript errors unrelated to the new Labs files (Clerk types and existing preview/achievement typing/tests), and no new TypeScript errors attributable to the added Labs files were observed. 
- The new routes were sanity-checked in the router (`/labs` and `/labs/landing-rhythm-section`) to ensure navigation is wired correctly; no runtime build/server verification was performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c01ac5788332aa094d3db4e4c41b)