### PR TITLE
Refactor labs rhythm section: replace generic bar with weekly ticks and simplify cards

### DIFF
--- a/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
+++ b/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
@@ -1,42 +1,44 @@
 const INNERBLOOM_PREMIUM_GRADIENT =
   'linear-gradient(90deg, rgba(164, 109, 255, 0.98) 0%, rgba(204, 141, 255, 0.97) 52%, rgba(246, 187, 164, 0.96) 100%)';
 
+const WEEK_TICKS = 7;
+
 const RHYTHM_CARDS = [
   {
     id: 'low',
     name: 'LOW',
     frequency: '1× / week',
     micro: 'Lower load',
-    pills: ['Core habits', 'Recovery', 'Simple wins'],
-    intensity: 24,
-    density: 'Minimal structure',
+    support: 'Keeps the system alive when capacity is limited.',
+    activeDays: 1,
+    chips: ['3 core actions', 'Low structure'],
   },
   {
     id: 'chill',
     name: 'CHILL',
     frequency: '2× / week',
     micro: 'Steady pace',
-    pills: ['Balanced', 'Light momentum', 'No overload'],
-    intensity: 46,
-    density: 'Balanced cadence',
+    support: 'Balanced rhythm for consistency without overload.',
+    activeDays: 2,
+    chips: ['5 core actions', 'Light structure'],
   },
   {
     id: 'flow',
     name: 'FLOW',
     frequency: '3× / week',
     micro: 'Focused push',
-    pills: ['Priority blocks', 'Execution', 'Momentum'],
-    intensity: 72,
-    density: 'Higher cadence',
+    support: 'Higher cadence with room to recover and adapt.',
+    activeDays: 3,
+    chips: ['7 core actions', 'Guided structure'],
   },
   {
     id: 'evolve',
     name: 'EVOLVE',
     frequency: '4× / week',
     micro: 'More structure',
-    pills: ['Higher load', 'Guardrails', 'Progression'],
-    intensity: 93,
-    density: 'Structured intensity',
+    support: 'More committed weekly load with tighter planning.',
+    activeDays: 4,
+    chips: ['9 core actions', 'High structure'],
   },
 ] as const;
 
@@ -46,8 +48,7 @@ export function LabsWeeklyRhythmSystemSection() {
       aria-labelledby="labs-weekly-rhythm-title"
       className="relative overflow-hidden rounded-[2rem] border border-white/15 bg-[linear-gradient(152deg,rgba(255,255,255,0.11),rgba(167,123,245,0.09)_52%,rgba(72,43,126,0.08))] px-6 py-8 shadow-[0_28px_72px_rgba(24,12,52,0.26),inset_0_1px_0_rgba(255,255,255,0.22)] backdrop-blur-xl md:px-9 md:py-10"
     >
-      <div className="pointer-events-none absolute -top-16 left-1/2 h-40 w-[82%] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(176,122,255,0.28),rgba(176,122,255,0.09)_52%,transparent_78%)] blur-2xl" />
-      <div className="pointer-events-none absolute inset-0 rounded-[2rem] bg-[radial-gradient(circle_at_14%_20%,rgba(255,255,255,0.16),transparent_58%),radial-gradient(circle_at_84%_82%,rgba(186,161,255,0.1),transparent_58%)]" />
+      <div className="pointer-events-none absolute -top-16 left-1/2 h-40 w-[82%] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(176,122,255,0.24),rgba(176,122,255,0.06)_52%,transparent_78%)] blur-2xl" />
 
       <div className="relative space-y-7">
         <header className="max-w-3xl space-y-3">
@@ -56,65 +57,76 @@ export function LabsWeeklyRhythmSystemSection() {
             Pick the intensity you can sustain this week
           </h2>
           <p className="max-w-2xl text-sm leading-relaxed text-white/80 md:text-base">
-            Four weekly rhythm levels. Fast scan. Low to high load.
+            Four rhythms, one weekly logic: the more active days you can sustain, the higher your intensity.
           </p>
         </header>
 
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {RHYTHM_CARDS.map((card) => (
-            <article
-              key={card.id}
-              className="group relative flex h-full flex-col gap-4 overflow-hidden rounded-3xl border border-white/14 bg-[linear-gradient(168deg,rgba(255,255,255,0.085),rgba(15,12,34,0.26))] p-4 shadow-[0_14px_34px_rgba(17,10,37,0.22),inset_0_1px_0_rgba(255,255,255,0.14)] transition duration-200 hover:-translate-y-0.5 hover:border-white/20 md:p-5"
-            >
-              <div className="pointer-events-none absolute inset-x-4 top-0 h-px bg-[linear-gradient(90deg,rgba(255,255,255,0),rgba(255,255,255,0.56),rgba(255,255,255,0))] opacity-70" />
+          {RHYTHM_CARDS.map((card) => {
+            const progress = (card.activeDays / WEEK_TICKS) * 100;
 
-              <div className="space-y-1">
-                <p className="text-[0.62rem] font-semibold uppercase tracking-[0.2em] text-white/56">Rhythm</p>
-                <h3 className="text-[1.55rem] font-semibold tracking-[-0.03em] text-white">{card.name}</h3>
-                <p className="text-[0.73rem] font-semibold uppercase tracking-[0.16em] text-white/78">{card.frequency}</p>
-              </div>
+            return (
+              <article
+                key={card.id}
+                className="group relative flex h-full flex-col gap-4 rounded-3xl border border-white/14 bg-[linear-gradient(168deg,rgba(255,255,255,0.08),rgba(15,12,34,0.22))] p-5 shadow-[0_14px_34px_rgba(17,10,37,0.2),inset_0_1px_0_rgba(255,255,255,0.14)] transition duration-200 hover:-translate-y-0.5 hover:border-white/20"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-[0.62rem] font-semibold uppercase tracking-[0.2em] text-white/56">Rhythm</p>
+                    <h3 className="text-[1.55rem] font-semibold tracking-[-0.03em] text-white">{card.name}</h3>
+                  </div>
+                  <span className="inline-flex items-center rounded-full border border-white/16 bg-white/[0.08] px-2.5 py-1 text-[0.62rem] font-semibold uppercase tracking-[0.15em] text-white/90">
+                    {card.frequency}
+                  </span>
+                </div>
 
-              <div className="space-y-2">
-                <div className="overflow-hidden rounded-full border border-white/12 bg-[linear-gradient(180deg,rgba(255,255,255,0.12),rgba(255,255,255,0.05))] p-[3px] shadow-[inset_0_1px_1px_rgba(255,255,255,0.28)]">
-                  <div className="relative h-[0.68rem] rounded-full bg-[linear-gradient(180deg,rgba(18,22,59,0.8),rgba(13,16,42,0.85))] shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]">
+                <div className="space-y-2.5">
+                  <div className="h-[0.38rem] overflow-hidden rounded-full bg-white/[0.08]">
                     <div
-                      className="absolute inset-y-[1px] left-[1px] rounded-full shadow-[0_0_0_1px_rgba(255,255,255,0.18),0_0_14px_rgba(201,150,255,0.42),0_0_26px_rgba(246,187,164,0.24)]"
-                      style={{
-                        width: `calc(${card.intensity}% - 2px)`,
-                        backgroundImage: INNERBLOOM_PREMIUM_GRADIENT,
-                      }}
-                    >
-                      <div className="h-full rounded-full bg-[linear-gradient(180deg,rgba(255,255,255,0.42),rgba(255,255,255,0)_75%)]" />
-                    </div>
+                      className="h-full rounded-full shadow-[0_0_12px_rgba(201,150,255,0.34)]"
+                      style={{ width: `${progress}%`, backgroundImage: INNERBLOOM_PREMIUM_GRADIENT }}
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-7 gap-1.5" aria-label={`${card.activeDays} active days out of 7`}>
+                    {Array.from({ length: WEEK_TICKS }).map((_, index) => {
+                      const isActive = index < card.activeDays;
+                      return (
+                        <span
+                          key={`${card.id}-tick-${index}`}
+                          className={`h-1.5 rounded-full ${
+                            isActive ? 'shadow-[0_0_8px_rgba(201,150,255,0.38)]' : 'bg-white/[0.14]'
+                          }`}
+                          style={isActive ? { backgroundImage: INNERBLOOM_PREMIUM_GRADIENT } : undefined}
+                          aria-hidden
+                        />
+                      );
+                    })}
                   </div>
                 </div>
-                <div className="flex items-center justify-between text-[0.62rem] uppercase tracking-[0.16em] text-white/52">
-                  <span>Low</span>
-                  <span>High</span>
+
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-white/90">{card.micro}</p>
+                  <p className="text-xs leading-relaxed text-white/66">{card.support}</p>
                 </div>
-              </div>
 
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-white/88">{card.micro}</p>
-                <p className="text-[0.67rem] font-medium uppercase tracking-[0.14em] text-white/58">{card.density}</p>
-              </div>
-
-              <ul className="mt-auto flex flex-wrap gap-1.5">
-                {card.pills.map((pill) => (
-                  <li
-                    key={pill}
-                    className="rounded-full border border-white/12 bg-white/[0.09] px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.05em] text-white/86"
-                  >
-                    {pill}
-                  </li>
-                ))}
-              </ul>
-            </article>
-          ))}
+                <ul className="mt-auto flex flex-wrap gap-1.5">
+                  {card.chips.map((chip) => (
+                    <li
+                      key={chip}
+                      className="rounded-full border border-white/12 bg-white/[0.08] px-2.5 py-1 text-[0.64rem] font-medium uppercase tracking-[0.05em] text-white/86"
+                    >
+                      {chip}
+                    </li>
+                  ))}
+                </ul>
+              </article>
+            );
+          })}
         </div>
 
         <p className="text-xs leading-relaxed text-white/66 md:text-sm">
-          Rhythm = weekly intensity. No avatars, no mood storytelling.
+          Rhythm = weekly intensity linked to sustainable frequency.
         </p>
       </div>
     </section>


### PR DESCRIPTION
### Motivation

- Limpiar y premiumizar el módulo experimental de ritmo para que comunique intensidad semanal con menos ruido y más intención visual.
- Sustituir la barra genérica y sus decoraciones por una señal más minimalista, semántica y alineada al sistema weekly-rhythm (1–4 niveles).
- Reducir elementos anidados y chips arbitrarios para que cada elemento dentro de la card justifique su existencia.

### Description

- Cambié `apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx` para rehacer las cards y la señal de intensidad como protagonista en lugar de múltiples capas decorativas.  
- Eliminé la cápsula gruesa y el indicador `Low/High` y retiré chips arbitrarios de 3 items, manteniendo solo un `frequency` chip visible y hasta 2 chips funcionales por card (carga de acciones y nivel de estructura).  
- Reemplacé la barra previa por una lógica semanal concreta usando `WEEK_TICKS = 7` y `activeDays` por ritmo (LOW=1, CHILL=2, FLOW=3, EVOLVE=4) y calculando `progress` para el fill con el gradiente premium `INNERBLOOM_PREMIUM_GRADIENT`.  
- Afiné copy y jerarquía (pequeña label `Rhythm`, nombre grande, `frequency` chip, micro-copy y 0–2 supporting chips), y quité overlays/decoraciones innecesarias para un aspecto más product-native.

### Testing

- Ejecuté `pnpm -C apps/web exec tsc --noEmit` y la comprobación falló por errores TypeScript preexistentes en el repo (Clerk typings y contratos de `PreviewAchievementCard`) no relacionados con este cambio.  
- Intenté `pnpm -C apps/web exec eslint src/components/labs/LabsWeeklyRhythmSystemSection.tsx` y la verificación no pudo completarse por la falta de `eslint.config.js` en el workspace (ESLint v9 flat config), por lo que no se pudo validar con ESLint aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d1b90c208332a532032a61e6385d)