### PR TITLE
Polish scheduler, new task, and avatar modal UI

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -1514,14 +1514,11 @@ export function DashboardMenu({
                           ) : null}
 
                           <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-2)] p-3">
-                            <p className="text-sm text-[color:var(--color-text)]">
-                              {t("dashboard.menu.avatarConfirmPrompt")}
-                            </p>
-                            <div className="mt-3 flex gap-2">
+                            <div className="flex flex-col gap-3">
                               <button
                                 type="button"
                                 onClick={handleCloseAvatar}
-                                className="flex-1 rounded-xl border border-[color:var(--color-border-subtle)] px-3 py-2 text-sm text-[color:var(--color-text-dim)]"
+                                className="inline-flex w-full items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] px-5 py-2 text-sm font-semibold uppercase tracking-[0.18em] text-[color:var(--color-slate-200)] transition hover:border-[color:var(--color-border-soft)] hover:text-[color:var(--color-text)] disabled:cursor-not-allowed disabled:opacity-60"
                                 disabled={isSavingAvatar}
                               >
                                 {t('dashboard.menu.cancel')}
@@ -1529,7 +1526,8 @@ export function DashboardMenu({
                               <button
                                 type="button"
                                 onClick={() => void handleConfirmAvatar()}
-                                className="flex-1 rounded-xl border border-[color:var(--color-accent-primary)] bg-[color:var(--color-accent-primary)]/20 px-3 py-2 text-sm font-semibold text-[color:var(--color-text)] disabled:opacity-60"
+                                className="inline-flex w-full items-center justify-center rounded-full px-5 py-2 text-sm font-semibold uppercase tracking-[0.18em] text-[#121212] transition disabled:cursor-not-allowed disabled:opacity-60"
+                                style={{ background: 'var(--gradient-innerbloom)', boxShadow: 'var(--shadow-innerbloom-cta)' }}
                                 disabled={isSavingAvatar}
                               >
                                 {isSavingAvatar ? t("dashboard.menu.avatarSaving") : t("dashboard.menu.confirmChange")}

--- a/apps/web/src/components/dashboard-v3/ReminderSchedulerDialog.tsx
+++ b/apps/web/src/components/dashboard-v3/ReminderSchedulerDialog.tsx
@@ -127,7 +127,7 @@ export const ReminderSchedulerDialog = forwardRef<
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 64 }}
           >
-            <div className="mb-4 flex items-start justify-between gap-4">
+            <div className="mb-3 flex items-start justify-between gap-4">
               <div>
                 <h2
                   id={titleId}
@@ -135,10 +135,7 @@ export const ReminderSchedulerDialog = forwardRef<
                 >
                   {t("dashboard.reminderScheduler.eyebrow")}
                 </h2>
-                <p className="reminder-scheduler-dialog__title mt-1 font-display text-2xl font-semibold text-text">
-                  {t("dashboard.reminderScheduler.title")}
-                </p>
-                <p className="reminder-scheduler-dialog__description mt-1 text-sm text-text-muted">
+                <p className="reminder-scheduler-dialog__description mt-2 text-sm text-text-muted">
                   {t("dashboard.reminderScheduler.description")}
                 </p>
               </div>

--- a/apps/web/src/components/settings/DailyReminderSettings.tsx
+++ b/apps/web/src/components/settings/DailyReminderSettings.tsx
@@ -516,10 +516,14 @@ export function DailyReminderSettings({
               }))
             }
             disabled={isSaving}
-            className="reminder-scheduler-form__control w-full rounded-2xl border border-white/10 bg-surface px-4 py-3 text-base text-white outline-none transition focus:border-white/40"
+            className="reminder-scheduler-form__control reminder-scheduler-form__time-select w-full rounded-2xl border border-white/10 bg-surface px-4 py-3 text-base text-white outline-none transition focus:border-white/40"
           >
             {TIME_OPTIONS.map((time) => (
-              <option key={time} value={time}>
+              <option
+                key={time}
+                value={time}
+                className="reminder-scheduler-form__time-option"
+              >
                 {time}
               </option>
             ))}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5068,6 +5068,36 @@
     background: #eef2f7;
     color: var(--scheduler-text);
   }
+
+  :root[data-theme='dark'] [data-light-scope='reminder-scheduler'] .reminder-scheduler-form__time-select {
+    color: #f8fafc;
+    background-color: #16213b;
+    -webkit-text-fill-color: #f8fafc;
+    color-scheme: dark;
+  }
+
+  :root[data-theme='dark'] [data-light-scope='reminder-scheduler'] .reminder-scheduler-form__time-select option,
+  :root[data-theme='dark'] [data-light-scope='reminder-scheduler'] .reminder-scheduler-form__time-option {
+    color: #f8fafc;
+    background-color: #111c33;
+    -webkit-text-fill-color: #f8fafc;
+  }
+
+  @supports (-webkit-touch-callout: none) {
+    :root[data-theme='dark'] [data-light-scope='reminder-scheduler'] .reminder-scheduler-form__time-select {
+      color: #ffffff;
+      background-color: #0f1b33;
+      -webkit-text-fill-color: #ffffff;
+      color-scheme: dark;
+    }
+
+    :root[data-theme='dark'] [data-light-scope='reminder-scheduler'] .reminder-scheduler-form__time-select option,
+    :root[data-theme='dark'] [data-light-scope='reminder-scheduler'] .reminder-scheduler-form__time-option {
+      color: #ffffff;
+      background-color: #101a2f;
+      -webkit-text-fill-color: #ffffff;
+    }
+  }
   :root[data-theme='light'] [data-light-scope='daily-quest'] {
     color: var(--color-text);
     box-shadow: 0 24px 52px rgba(15, 23, 42, 0.12);

--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -1696,10 +1696,9 @@ function CreateTaskModal({
             </header>
 
             <section className="space-y-4">
-              <div className="space-y-2">
+              <div className="space-y-1.5">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">{t('editor.modal.create.step1')}</p>
-                <label className="flex flex-col gap-2">
-                  <span className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">{t('editor.modal.create.selectPillarLabel')}</span>
+                <div className="flex flex-col gap-2">
                   <select
                     value={selectedPillarId}
                     onChange={(event) => {
@@ -1718,7 +1717,7 @@ function CreateTaskModal({
                       </option>
                     ))}
                   </select>
-                </label>
+                </div>
                 {isLoadingPillars && (
                   <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500">{t('editor.loading.pillars')}</p>
                 )}
@@ -1740,10 +1739,9 @@ function CreateTaskModal({
                 )}
               </div>
 
-              <div className="space-y-2">
+              <div className="space-y-1.5">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">{t('editor.modal.create.step2')}</p>
-                <label className="flex flex-col gap-2">
-                  <span className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">{t('editor.modal.create.selectTraitLabel')}</span>
+                <div className="flex flex-col gap-2">
                   <select
                     value={selectedTraitId}
                     onChange={(event) => {
@@ -1762,7 +1760,7 @@ function CreateTaskModal({
                       </option>
                     ))}
                   </select>
-                </label>
+                </div>
                 {isLoadingTraits && (
                   <p className="text-[11px] uppercase tracking-[0.2em] text-slate-500">{t('editor.loading.traits')}</p>
                 )}


### PR DESCRIPTION
### Motivation
- Limpiar y alinear visualmente tres modales clave (Reminder Scheduler, New Task, Avatar) sin tocar lógica ni flujos, manteniendo el sistema visual premium de Innerbloom.
- Mejorar legibilidad en Android dark mode para el selector de hora del scheduler sin afectar light mode ni otros selects globales.
- Eliminar redundancias textuales y armonizar el footer de confirmación del avatar con el patrón de CTA gradiente ya usado en New Task.

### Description
- Reminder Scheduler: quité la línea grande del título `dashboard.reminderScheduler.title` y ajusté el spacing del header para dejar eyebrow + descripción + botón close equilibrados; archivo modificado: `apps/web/src/components/dashboard-v3/ReminderSchedulerDialog.tsx`.
- Time picker contrast (scoped): añadí clases específicas al `<select>`/`<option>` de hora y reglas CSS dark-mode scoped al scheduler con `-webkit-text-fill-color`, `color`, `background-color` y `color-scheme` para reforzar contraste en Android/WebView; archivos modificados: `apps/web/src/components/settings/DailyReminderSettings.tsx` y `apps/web/src/index.css`.
- New Task modal: eliminé los labels duplicados encima de los selects (`selectPillarLabel` y `selectTraitLabel`) manteniendo los step headers, placeholders, validaciones y estados; archivo modificado: `apps/web/src/pages/editor/index.tsx`.
- Avatar modal footer: reemplacé la pregunta de confirmación por un bloque vertical (botón secundario “Cancelar” y CTA primario con `var(--gradient-innerbloom)` y `var(--shadow-innerbloom-cta)`), preservando `handleCloseAvatar`, `handleConfirmAvatar` y estados de loading; archivo modificado: `apps/web/src/components/dashboard-v3/DashboardMenu.tsx`.
- I18n: no borré keys por seguridad; quedaron potencialmente sin uso `dashboard.reminderScheduler.title`, `dashboard.menu.avatarConfirmPrompt`, `editor.modal.create.selectPillarLabel` y `editor.modal.create.selectTraitLabel` (se dejaron intactas en `apps/web/src/i18n/post-login/dashboard.ts` y `apps/web/src/i18n/post-login/editor.ts`).

### Testing
- Ejecuté `npm run typecheck:web` y la verificación de TypeScript falló; la falla proviene de errores TypeScript preexistentes en otros módulos no tocados por este PR, por lo que el fallo no fue introducido por estos cambios.
- No se ejecutaron tests de integración/visual automáticos adicionales en este entorno; los cambios son sólo de UI/estilos y se recomienda validar en dispositivos Android (WebView) en dark mode para confirmar contraste y en mobile para revisar spacing del footer del avatar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e42914488332a93e7cfc0cb653ee)