### PR TITLE
Refine labs rhythm section to open landing composition and stronger card hierarchy

### DIFF
--- a/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
+++ b/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
@@ -6,6 +6,7 @@ const RHYTHM_CARDS = [
     id: 'low',
     name: 'LOW',
     frequency: '1× / week',
+    state: 'low energy, overwhelmed',
     micro: 'Lower load',
     intensity: 26,
     chips: ['BASE REBUILD', 'LIGHTEST LOAD'],
@@ -14,6 +15,7 @@ const RHYTHM_CARDS = [
     id: 'chill',
     name: 'CHILL',
     frequency: '2× / week',
+    state: 'relaxed and stable',
     micro: 'Steady pace',
     intensity: 48,
     chips: ['STEADY CONSISTENCY', 'LIGHT CADENCE'],
@@ -22,6 +24,7 @@ const RHYTHM_CARDS = [
     id: 'flow',
     name: 'FLOW',
     frequency: '3× / week',
+    state: 'focused and moving',
     micro: 'Focused push',
     intensity: 72,
     chips: ['CLEAR DIRECTION', 'SUSTAINABLE PUSH'],
@@ -30,6 +33,7 @@ const RHYTHM_CARDS = [
     id: 'evolve',
     name: 'EVOLVE',
     frequency: '4× / week',
+    state: 'ambitious and determined',
     micro: 'More structure',
     intensity: 92,
     chips: ['HIGHER STRUCTURE', 'MORE INTENSITY'],
@@ -38,20 +42,17 @@ const RHYTHM_CARDS = [
 
 export function LabsWeeklyRhythmSystemSection() {
   return (
-    <section
-      aria-labelledby="labs-weekly-rhythm-title"
-      className="relative overflow-hidden rounded-[2rem] border border-white/15 bg-[linear-gradient(152deg,rgba(255,255,255,0.11),rgba(167,123,245,0.09)_52%,rgba(72,43,126,0.08))] px-6 py-8 shadow-[0_28px_72px_rgba(24,12,52,0.26),inset_0_1px_0_rgba(255,255,255,0.22)] backdrop-blur-xl md:px-9 md:py-10"
-    >
-      <div className="pointer-events-none absolute -top-16 left-1/2 h-40 w-[82%] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(176,122,255,0.24),rgba(176,122,255,0.06)_52%,transparent_78%)] blur-2xl" />
+    <section aria-labelledby="labs-weekly-rhythm-title" className="relative py-2">
+      <div className="pointer-events-none absolute -top-12 left-1/2 h-36 w-[80%] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(176,122,255,0.24),rgba(176,122,255,0.06)_52%,transparent_78%)] blur-2xl" />
 
-      <div className="relative space-y-7">
+      <div className="relative space-y-8">
         <header className="max-w-3xl space-y-3">
           <p className="text-xs font-semibold uppercase tracking-[0.22em] text-white/70">Weekly rhythm system</p>
           <h2 id="labs-weekly-rhythm-title" className="text-3xl font-semibold tracking-[-0.03em] text-white md:text-4xl">
             Pick the intensity you can sustain
           </h2>
-          <p className="max-w-2xl text-sm leading-relaxed text-white/80 md:text-base">
-            Four rhythms, one weekly logic.
+          <p className="text-sm leading-relaxed text-white/84 md:text-base">
+            Four rhythms, one weekly logic. <span className="text-white/72">Rhythm = weekly intensity linked to sustainable frequency.</span>
           </p>
         </header>
 
@@ -59,35 +60,40 @@ export function LabsWeeklyRhythmSystemSection() {
           {RHYTHM_CARDS.map((card) => (
             <article
               key={card.id}
-              className="group relative flex h-full flex-col gap-5 rounded-3xl border border-white/14 bg-[linear-gradient(168deg,rgba(255,255,255,0.08),rgba(15,12,34,0.22))] p-5 shadow-[0_14px_34px_rgba(17,10,37,0.2),inset_0_1px_0_rgba(255,255,255,0.14)] transition duration-200 hover:-translate-y-0.5 hover:border-white/20"
+              className="group relative flex min-h-[20.5rem] h-full flex-col gap-5 rounded-3xl bg-[linear-gradient(168deg,rgba(255,255,255,0.09),rgba(15,12,34,0.26))] p-5 shadow-[0_16px_36px_rgba(17,10,37,0.24),inset_0_1px_0_rgba(255,255,255,0.12)] transition duration-200 hover:-translate-y-0.5 hover:shadow-[0_20px_42px_rgba(17,10,37,0.3),inset_0_1px_0_rgba(255,255,255,0.14)]"
             >
-              <div className="flex items-start justify-between gap-3">
+              <div className="space-y-3">
                 <div className="space-y-1">
                   <p className="text-[0.62rem] font-semibold uppercase tracking-[0.2em] text-white/56">Rhythm</p>
-                  <h3 className="text-[1.55rem] font-semibold tracking-[-0.03em] text-white">{card.name}</h3>
+                  <div className="flex flex-wrap items-end justify-between gap-x-3 gap-y-2">
+                    <h3 className="text-[1.65rem] font-semibold tracking-[-0.03em] text-white">{card.name}</h3>
+                    <span className="inline-flex items-center rounded-full bg-[linear-gradient(140deg,rgba(208,154,255,0.42),rgba(244,192,177,0.3))] px-3.5 py-1.5 text-[0.74rem] font-semibold uppercase tracking-[0.14em] text-[#fff6ff] shadow-[0_8px_20px_rgba(176,108,255,0.32)]">
+                      {card.frequency}
+                    </span>
+                  </div>
                 </div>
-                <span className="inline-flex items-center rounded-full border border-[#f0ddff]/28 bg-[linear-gradient(140deg,rgba(206,146,255,0.28),rgba(255,255,255,0.08))] px-2.5 py-1 text-[0.62rem] font-semibold uppercase tracking-[0.15em] text-[#f3e6ff] shadow-[0_6px_16px_rgba(162,96,245,0.24)]">
-                  {card.frequency}
-                </span>
-              </div>
 
-              <div
-                className="h-[1.14rem] overflow-hidden rounded-full bg-white/[0.07]"
-                aria-label={`${card.name} intensity ${card.intensity}%`}
-              >
                 <div
-                  className="h-full rounded-full shadow-[0_0_16px_rgba(201,150,255,0.36)]"
-                  style={{ width: `${card.intensity}%`, backgroundImage: INNERBLOOM_PREMIUM_GRADIENT }}
-                />
+                  className="h-[1.2rem] overflow-hidden rounded-full bg-white/[0.08]"
+                  aria-label={`${card.name} intensity ${card.intensity}%`}
+                >
+                  <div
+                    className="h-full rounded-full shadow-[0_0_16px_rgba(201,150,255,0.36)]"
+                    style={{ width: `${card.intensity}%`, backgroundImage: INNERBLOOM_PREMIUM_GRADIENT }}
+                  />
+                </div>
               </div>
 
-              <p className="text-sm font-medium text-white/90">{card.micro}</p>
+              <div className="space-y-1.5">
+                <p className="text-sm text-white/74">{card.state}</p>
+                <p className="text-base font-medium text-white/94">{card.micro}</p>
+              </div>
 
               <ul className="mt-auto flex flex-wrap gap-1.5">
                 {card.chips.map((chip) => (
                   <li
                     key={chip}
-                    className="rounded-full border border-[#f0ddff]/16 bg-[linear-gradient(140deg,rgba(177,121,255,0.2),rgba(255,255,255,0.06))] px-2.5 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.08em] text-[#f2e4ff]"
+                    className="rounded-full bg-[linear-gradient(140deg,rgba(177,121,255,0.24),rgba(255,255,255,0.08))] px-2.5 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.08em] text-[#f2e4ff]"
                   >
                     {chip}
                   </li>
@@ -96,8 +102,6 @@ export function LabsWeeklyRhythmSystemSection() {
             </article>
           ))}
         </div>
-
-        <p className="text-xs leading-relaxed text-white/66 md:text-sm">Rhythm = weekly intensity linked to sustainable frequency.</p>
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation
- Make the Labs rhythm section read as a native landing module rather than a "container inside container" by removing the heavy outer panel and opening the composition to the landing background.
- Improve visual hierarchy so frequency is instantly scannable and cards feel more premium and elongated.
- Reintroduce concise semantic state for each rhythm so the cards communicate meaningful intent, not decorative copy.
- Remove hard outlines and rely on softer tonal contrast, glow and a single premium gradient bar to keep the section clean and elegant.

### Description
- Removed the large rounded panel wrapper and heavy border/backdrop so the heading and cards sit directly on the landing background by replacing the section wrapper with a lighter `className="relative py-2"` and a subtle radial backdrop. 
- Strengthened frequency hierarchy by enlarging and re-styling the frequency chip, placing it beside the rhythm name, and increasing contrast and shadow so `1× / week` → `4× / week` are immediately scannable. 
- Removed card outlines/borders and swapped to tonal gradient surfaces with softer shadows, increased card vertical proportion via `min-h-[20.5rem]`, and kept a single thick premium gradient intensity bar per card. 
- Reintroduced compact per-rhythm `state` lines using repo semantics and kept the exact two chips per rhythm unchanged. (Changed file: `apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx`.)

### Testing
- Ran `pnpm -C apps/web exec tsc --noEmit`, which failed due to pre-existing unrelated TypeScript errors elsewhere in the repo and not because of the changes in `LabsWeeklyRhythmSystemSection.tsx`.
- Ran `pnpm -C apps/web exec eslint src/components/labs/LabsWeeklyRhythmSystemSection.tsx`, which could not run successfully in this environment because ESLint expects a flat config file that is not present here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41fb2ccf48332af8b62b8ade323ee)