### PR TITLE
Hacer transparente el contenedor de acciones en modal Cambiar Avatar

### DIFF
--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -1526,7 +1526,7 @@ export function DashboardMenu({
                             </p>
                           ) : null}
 
-                          <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-2)] p-3">
+                          <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-transparent p-3">
                             <div className="flex flex-col gap-3">
                               <button
                                 type="button"


### PR DESCRIPTION
### Motivation
- Quitar el relleno sólido del área de acciones en el modal de `Change Avatar` para permitir que se vea el contenido de fondo y ajustar la estética sin alterar la funcionalidad.

### Description
- En `apps/web/src/components/dashboard-v3/DashboardMenu.tsx` se reemplazó la clase `bg-[color:var(--color-overlay-2)]` por `bg-transparent` en el contenedor que envuelve los botones `Cancel` y `Confirm Change` del modal.

### Testing
- Ejecuté `cd apps/web && pnpm typecheck`, que falla debido a errores de TypeScript preexistentes en el proyecto que no están relacionados con este cambio de estilo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42542f4148332a1f5570103c2243f)