### PR TITLE
Insert approved Rhythms section into official landing (centered, bilingual)

### DIFF
--- a/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
+++ b/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
@@ -1,5 +1,7 @@
 import type { PostLoginLanguage } from '../../i18n/postLoginLanguage';
 
+type RhythmSectionLanguage = Extract<PostLoginLanguage, 'en' | 'es'>;
+
 const INNERBLOOM_PREMIUM_GRADIENT =
   'linear-gradient(90deg, rgba(164, 109, 255, 0.98) 0%, rgba(204, 141, 255, 0.97) 52%, rgba(246, 187, 164, 0.96) 100%)';
 
@@ -99,18 +101,23 @@ const RHYTHM_SECTION_COPY = {
 } as const;
 
 interface LabsWeeklyRhythmSystemSectionProps {
-  language?: PostLoginLanguage;
+  language?: RhythmSectionLanguage;
+  headingAlignment?: 'left' | 'center';
 }
 
-export function LabsWeeklyRhythmSystemSection({ language = 'en' }: LabsWeeklyRhythmSystemSectionProps) {
+export function LabsWeeklyRhythmSystemSection({
+  language = 'en',
+  headingAlignment = 'left',
+}: LabsWeeklyRhythmSystemSectionProps) {
   const copy = RHYTHM_SECTION_COPY[language];
+  const isCentered = headingAlignment === 'center';
 
   return (
     <section aria-labelledby="labs-weekly-rhythm-title" className="relative py-2">
       <div className="pointer-events-none absolute -top-12 left-1/2 h-36 w-[80%] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(176,122,255,0.24),rgba(176,122,255,0.06)_52%,transparent_78%)] blur-2xl" />
 
       <div className="relative space-y-8">
-        <header className="max-w-3xl space-y-3">
+        <header className={`max-w-3xl space-y-3 ${isCentered ? 'mx-auto text-center' : ''}`}>
           <p className="text-xs font-semibold uppercase tracking-[0.22em] text-white/70">{copy.kicker}</p>
           <h2 id="labs-weekly-rhythm-title" className="text-3xl font-semibold tracking-[-0.03em] text-white md:text-4xl">
             {copy.title}

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -9,6 +9,7 @@ import PremiumTimeline from '../components/PremiumTimeline';
 import { AdaptiveText } from '../components/landing/AdaptiveText';
 import { CookieConsentBanner } from '../components/landing/CookieConsentBanner';
 import { useLandingAnalytics } from '../components/landing/useLandingAnalytics';
+import { LabsWeeklyRhythmSystemSection } from '../components/labs/LabsWeeklyRhythmSystemSection';
 import { buildOnboardingPath } from '../onboarding/i18n';
 import { usePostLoginLanguage } from '../i18n/postLoginLanguage';
 import { persistCookieConsentState, readCookieConsentState } from '../lib/cookieConsent';
@@ -862,6 +863,12 @@ export default function LandingPage() {
               })}
             </div>
             <AdaptiveText as="p" className="section-sub highlight">{copy.pillars.highlight}</AdaptiveText>
+          </div>
+        </section>
+
+        <section className="section-pad reveal-on-scroll" id="rhythms">
+          <div className="container">
+            <LabsWeeklyRhythmSystemSection language={language} headingAlignment="center" />
           </div>
         </section>
 


### PR DESCRIPTION
### Motivation
- Surface the approved “Rhythms” marketing block on the official landing immediately before the avatar/modes content so weekly rhythm messaging appears higher in the page hierarchy.
- Reuse the existing labs rhythm module to preserve the approved card structure, bilingual copy, and visual direction while enabling a centered heading for the official landing.

### Description
- Imported and inserted `LabsWeeklyRhythmSystemSection` into `apps/web/src/pages/Landing.tsx` as a new `<section id="rhythms">` immediately before the existing `section id="modes"` (lines ~869–873). 
- Extended `apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx` with a `headingAlignment?: 'left' | 'center'` prop and narrowed the `language` prop type, and used `headingAlignment="center"` when rendering from the landing.
- Kept the original avatar/modes block unchanged below the new Rhythms section, preserved the approved card layout (RHYTHM label, title + frequency chip, branded gradient bar, state line, microphrase, and two chips), and reused the component’s English/Spanish copy by passing the landing `language` state.
- Files changed: `apps/web/src/pages/Landing.tsx` and `apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx`; insertion point: the new `section id="rhythms"` is placed immediately before the existing modes/avatar section; i18n is handled by passing the landing `language` to the reused component; a minimal refactor was done to support centered headings; remaining cleanup is to remove or reconcile the legacy `modes` section in a future rollout to avoid duplicated rhythm messaging.

### Testing
- Ran `npm run typecheck:web`; the typecheck failed due to pre-existing unrelated TypeScript errors in the repository (Clerk typings, preview-achievement types, and lib target issues), and those failures are not caused by the changes in this PR.
- No additional automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4271d4d588332ae6607c936f22cf8)