### PR TITLE
style: align rhythm section cards with official landing containers

### DIFF
--- a/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
+++ b/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
@@ -129,7 +129,7 @@ export function LabsWeeklyRhythmSystemSection({
           {copy.cards.map((card) => (
             <article
               key={card.id}
-              className="group relative flex min-h-[20.5rem] h-full flex-col gap-5 rounded-3xl bg-[linear-gradient(168deg,rgba(255,255,255,0.09),rgba(15,12,34,0.26))] p-5 shadow-[0_16px_36px_rgba(17,10,37,0.24),inset_0_1px_0_rgba(255,255,255,0.12)] transition duration-200 hover:-translate-y-0.5 hover:shadow-[0_20px_42px_rgba(17,10,37,0.3),inset_0_1px_0_rgba(255,255,255,0.14)]"
+              className="card rhythm-system-card group relative flex min-h-[20.5rem] h-full flex-col gap-5 p-5 transition duration-200 hover:-translate-y-0.5"
             >
               <div className="space-y-3">
                 <p className="text-[0.62rem] font-semibold uppercase tracking-[0.2em] text-white/56">{copy.rhythmLabel}</p>


### PR DESCRIPTION
### Motivation
- Make the new "Ritmos" section use the same UX/UI container treatment as the official landing so visual containers are consistent across the page.

### Description
- Replaced the custom outer container classes for rhythm cards with the shared landing container class by updating `apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx` to use `className="card rhythm-system-card ..."` instead of the bespoke rounded/bg/shadow utilities.
- Removed only the container-level styling (background, radius, shadow) while keeping all internal content, copy and behavior unchanged.
- Change is scoped to the rhythm section container markup and does not alter copy, data, or component logic.

### Testing
- Ran `pnpm -C apps/web exec tsc --noEmit --pretty false` which failed due to pre-existing TypeScript errors elsewhere in the repository and not related to this change.
- No other automated tests were added or modified for this UX-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bdf769b883328690f16839d63891)