### PR TITLE
Refine official landing hierarchy and convert mode carousel to avatars

### DIFF
--- a/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
+++ b/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
@@ -118,11 +118,11 @@ export function LabsWeeklyRhythmSystemSection({
 
       <div className="relative space-y-8">
         <header className={`max-w-3xl space-y-3 ${isCentered ? 'mx-auto text-center' : ''}`}>
-          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-white/70">{copy.kicker}</p>
-          <h2 id="labs-weekly-rhythm-title" className="text-3xl font-semibold tracking-[-0.03em] text-white md:text-4xl">
+          <p className="section-kicker">{copy.kicker}</p>
+          <h2 id="labs-weekly-rhythm-title" className="rhythm-heading-title text-3xl font-semibold tracking-[-0.03em] text-white md:text-4xl">
             {copy.title}
           </h2>
-          <p className="text-sm leading-relaxed text-white/84 md:text-base">{copy.description}</p>
+          <p className="rhythm-heading-sub text-sm leading-relaxed text-white/84 md:text-base">{copy.description}</p>
         </header>
 
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -161,7 +161,7 @@ export function LabsWeeklyRhythmSystemSection({
                 {card.chips.map((chip) => (
                   <li
                     key={chip}
-                    className="rounded-full bg-[linear-gradient(140deg,rgba(177,121,255,0.24),rgba(255,255,255,0.08))] px-2.5 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.08em] text-[#f2e4ff]"
+                    className="rhythm-lower-chip rounded-full px-2.5 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.08em]"
                   >
                     {chip}
                   </li>

--- a/apps/web/src/content/officialLandingContent.ts
+++ b/apps/web/src/content/officialLandingContent.ts
@@ -25,8 +25,8 @@ export type LandingCopy = {
     alt: string;
   };
   problem: { title: string; body: string };
-  pillars: { title: string; intro: string; highlightLeadIn: string; highlight: string; items: Pillar[] };
-  modes: { title: string; intro: string; items: Mode[] };
+  pillars: { kicker: string; title: string; intro: string; highlightLeadIn: string; highlight: string; items: Pillar[] };
+  modes: { kicker: string; title: string; intro: string; items: Mode[] };
   how: { kicker: string; title: string; intro: string; closingLine: string; steps: HowTimelineStep[] };
   featureShowcase: { kicker: string; title: string; intro: string; items: FeatureShowcaseItem[] };
   demo: { title: string; text: string; banner: string; cta: string };
@@ -62,6 +62,7 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
         'La mayoría de las apps de hábitos están diseñadas para una versión de vos que no existe: siempre con la misma energía, el mismo foco y la misma disciplina.\n\nPero la vida cambia. Y cuando el sistema no cambia con vos, no parece que falló el sistema: parece que fallaste vos.'
     },
     pillars: {
+      kicker: 'PILARES DE INNERBLOOM',
       title: 'Crecer en una sola dirección desequilibra.',
       intro:
         'Innerbloom organiza tus hábitos en Body, Mind y Soul para que tu progreso no dependa solo de una parte de vos.',
@@ -86,32 +87,33 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
       ]
     },
     modes: {
-      title: 'Elige el ritmo que hoy puedes sostener',
-      intro: 'No todas las personas pueden sostener la misma frecuencia. Innerbloom ajusta la intensidad semanal de tu plan según tu capacidad actual: desde reconstruir tu base hasta avanzar con más carga y constancia.',
+      kicker: 'AVATARES DE INNERBLOOM',
+      title: 'Elige tu avatar dentro de Innerbloom',
+      intro: 'Tu avatar representa cómo te ves y te expresas dentro del sistema de Innerbloom. Elige el que mejor conecte con tu identidad hoy.',
       items: [
         {
           id: 'low',
-          title: '🪫 LOW MOOD',
-          state: 'sin energía, sobrecargado.',
-          goal: 'reconstruir tu base con la menor carga posible y hábitos fáciles de sostener.'
+          title: '🐈 RED CAT',
+          state: '',
+          goal: 'Un avatar vibrante para quienes quieren mostrarse con presencia y personalidad.'
         },
         {
           id: 'chill',
-          title: '🍃 CHILL MOOD',
-          state: 'relajado y estable.',
-          goal: 'mantener una constancia ligera y estable con una frecuencia que se sienta posible.'
+          title: '🐻 GREEN BEAR',
+          state: '',
+          goal: 'Un avatar sereno y cercano para quienes priorizan calidez y estabilidad.'
         },
         {
           id: 'flow',
-          title: '🌊 FLOW MOOD',
-          state: 'enfocado y en movimiento.',
-          goal: 'aprovechar tu impulso con una intensidad sostenible y dirección clara.'
+          title: '🦎 BLUE AMPHIBIAN',
+          state: '',
+          goal: 'Un avatar adaptable para quienes disfrutan explorar y moverse entre contextos.'
         },
         {
           id: 'evolve',
-          title: '🧬 EVOLVE MOOD',
-          state: 'ambicioso y determinado.',
-          goal: 'subir la intensidad con más estructura sin romper la consistencia que ya construiste.'
+          title: '🦉 VIOLET OWL',
+          state: '',
+          goal: 'Un avatar con carácter y visión para quienes quieren proyectar claridad y criterio.'
         }
       ]
     },
@@ -297,6 +299,7 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
         'Most habit apps are designed for a version of you that doesn’t exist: always with the same energy, the same focus, and the same discipline.\n\nBut life changes. And when the system doesn’t change with you, it doesn’t feel like the system failed — it feels like you did.'
     },
     pillars: {
+      kicker: 'INNERBLOOM PILLARS',
       title: 'Growing in only one direction creates imbalance.',
       intro:
         'Innerbloom organizes your habits across Body, Mind, and Soul so your progress doesn’t depend on only one part of you.',
@@ -321,32 +324,33 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
       ]
     },
     modes: {
-      title: 'Choose the pace you can sustain today',
-      intro: 'Not everyone can sustain the same frequency. Innerbloom adjusts your plan’s weekly intensity based on your current capacity: from rebuilding your base to moving forward with more load and consistency.',
+      kicker: 'INNERBLOOM AVATARS',
+      title: 'Choose your Innerbloom avatar',
+      intro: 'Your avatar represents how you show up inside the Innerbloom system. Pick the one that best reflects your identity right now.',
       items: [
         {
           id: 'low',
-          title: '🪫 LOW MOOD',
-          state: 'low energy, overwhelmed.',
-          goal: 'rebuild your base with the lightest possible load and habits you can actually sustain.'
+          title: '🐈 RED CAT',
+          state: '',
+          goal: 'A vibrant avatar for people who want to show up with presence and personality.'
         },
         {
           id: 'chill',
-          title: '🍃 CHILL MOOD',
-          state: 'relaxed and stable.',
-          goal: 'maintain light, steady consistency with a frequency that feels realistic.'
+          title: '🐻 GREEN BEAR',
+          state: '',
+          goal: 'A calm, friendly avatar for people who value warmth and steadiness.'
         },
         {
           id: 'flow',
-          title: '🌊 FLOW MOOD',
-          state: 'focused and moving.',
-          goal: 'use your momentum with sustainable intensity and clear direction.'
+          title: '🦎 BLUE AMPHIBIAN',
+          state: '',
+          goal: 'An adaptable avatar for people who like moving across contexts with ease.'
         },
         {
           id: 'evolve',
-          title: '🧬 EVOLVE MOOD',
-          state: 'ambitious and determined.',
-          goal: 'increase intensity with more structure without breaking the consistency you already built.'
+          title: '🦉 VIOLET OWL',
+          state: '',
+          goal: 'A thoughtful avatar for people who want to project clarity and perspective.'
         }
       ]
     },

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -540,6 +540,16 @@
   margin: 0 0 24px;
 }
 
+.landing .section-kicker {
+  margin: 0 0 6px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(186, 201, 229, 0.88);
+  text-align: center;
+}
+
 .landing .truth-problem {
   position: relative;
   padding: clamp(78px, 8.8vw, 116px) 0 clamp(58px, 6.9vw, 90px);
@@ -657,13 +667,14 @@
 }
 
 .landing .pillars-title {
-  font-size: clamp(2.2rem, 1.8vw + 1.5rem, 3rem);
+  font-size: clamp(2rem, 1.2vw + 1.5rem, 2.5rem);
   font-weight: 600;
 }
 
 .landing .pillars-intro {
-  font-size: clamp(1rem, 0.4vw + 0.95rem, 1.2rem);
-  color: rgba(215, 231, 255, 0.88);
+  font-size: clamp(0.96rem, 0.35vw + 0.92rem, 1.06rem);
+  color: rgba(214, 229, 255, 0.88);
+  margin: 0 auto 24px;
 }
 
 .landing .grid-3 {
@@ -742,6 +753,8 @@
   min-height: 390px;
   border-radius: var(--landing-glass-radius-lg);
   padding: 18.15px;
+  display: flex;
+  flex-direction: column;
 }
 
 .landing .pillar-heading {
@@ -774,10 +787,11 @@
   line-height: 1.55;
   text-align: left;
   color: rgba(232, 242, 255, 0.97);
+  flex: 1;
 }
 
 .landing .pillar-examples {
-  margin-top: 14px;
+  margin-top: auto;
   padding-top: 14px;
   display: grid;
   gap: 10px;
@@ -828,6 +842,14 @@
   margin: 8px auto 0;
 }
 
+.landing .modes-title {
+  font-size: clamp(2rem, 1.2vw + 1.5rem, 2.5rem);
+}
+
+.landing .modes-intro {
+  font-size: clamp(0.96rem, 0.35vw + 0.92rem, 1.06rem);
+}
+
 .landing .mode-main {
   border-radius: var(--landing-glass-radius-lg);
   border-left-width: 4px;
@@ -846,36 +868,7 @@
 
 .landing .mode-header {
   display: grid;
-  gap: 10px;
-}
-
-.landing .mode-meta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: 10px;
-}
-
-.landing .mode-meta-item {
-  margin: 0;
-  display: grid;
-  gap: 2px;
-}
-
-.landing .mode-meta-label {
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: #9aa9c8;
-  font-size: 0.64rem;
-  font-weight: 700;
-}
-
-.landing .mode-meta-copy {
-  margin: 0;
-  color: #e8f1ff;
-  font-size: 0.85rem;
-  line-height: 1.3;
+  gap: 4px;
 }
 
 .landing .mode-media {
@@ -946,77 +939,31 @@
   transform: scale(1.03);
 }
 
-.landing .mode-frequency-chip {
-  display: inline-flex;
-  align-items: center;
-  width: fit-content;
-  margin-left: auto;
-  border-radius: 999px;
-  border: 1px solid rgba(125, 211, 252, 0.42);
-  background: rgba(56, 189, 248, 0.14);
-  color: #dff4ff;
-  font-size: 0.78rem;
-  font-weight: 700;
-  padding: 5px 10px;
-}
-
-.landing .mode-goal-block {
-  border-top: 1px solid rgba(191, 219, 254, 0.14);
-  padding-top: 12px;
-  display: grid;
-  gap: 6px;
-}
-
-.landing .mode-goal-label {
+.landing .mode-avatar-copy {
   margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: #b7bfd4;
-  font-size: 0.7rem;
-  font-weight: 700;
-}
-
-.landing .mode-goal-copy {
-  margin: 0;
-  color: #e8f1ff;
-  line-height: 1.45;
+  color: rgba(226, 236, 252, 0.94);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  text-wrap: pretty;
 }
 
 .landing .mode-low {
   border-left: 3px solid var(--low);
 }
 
-.landing .mode-low .mode-frequency-chip {
-  border-color: color-mix(in oklab, var(--low) 72%, #ffffff 28%);
-  background: color-mix(in oklab, var(--low) 22%, transparent);
-}
-
 .landing .mode-chill {
   border-left: 3px solid var(--chill);
-}
-
-.landing .mode-chill .mode-frequency-chip {
-  border-color: color-mix(in oklab, var(--chill) 72%, #ffffff 28%);
-  background: color-mix(in oklab, var(--chill) 22%, transparent);
 }
 
 .landing .mode-flow {
   border-left: 3px solid var(--flow);
 }
 
-.landing .mode-flow .mode-frequency-chip {
-  border-color: color-mix(in oklab, var(--flow) 72%, #ffffff 28%);
-  background: color-mix(in oklab, var(--flow) 22%, transparent);
-}
 
 .landing .mode-evolve {
   border-left: 3px solid var(--evolve);
 }
 
-.landing .mode-evolve .mode-frequency-chip {
-  border-color: color-mix(in oklab, var(--evolve) 72%, #ffffff 28%);
-  background: color-mix(in oklab, var(--evolve) 22%, transparent);
-}
 .landing .mode-title {
   font-weight: 900;
   display: flex;
@@ -1049,6 +996,25 @@
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: rgba(186, 201, 229, 0.88);
+}
+
+.landing .rhythm-lower-chip {
+  border: 1px solid rgba(211, 226, 255, 0.28);
+  background: rgba(186, 206, 255, 0.12);
+  color: rgba(235, 245, 255, 0.94);
+  font-size: 0.68rem;
+  line-height: 1.2;
+}
+
+.landing .rhythm-heading-title {
+  margin: 0 0 8px;
+  font-size: clamp(2rem, 1.2vw + 1.5rem, 2.5rem);
+}
+
+.landing .rhythm-heading-sub {
+  margin: 0 0 24px;
+  font-size: clamp(0.96rem, 0.35vw + 0.92rem, 1.06rem);
+  color: rgba(214, 229, 255, 0.88);
 }
 
 .landing .how-intro {
@@ -2634,6 +2600,31 @@
   .landing .grid-2,
   .landing .pricing-grid {
     grid-template-columns: 1fr;
+  }
+
+  .landing .pillar-card {
+    min-height: 0;
+    padding: 20px 18px;
+    gap: 8px;
+  }
+
+  .landing .pillar-heading {
+    font-size: clamp(1.48rem, 2.6vw + 0.95rem, 1.7rem);
+  }
+
+  .landing .pillar-definition {
+    font-size: clamp(1rem, 1.8vw + 0.8rem, 1.1rem);
+    line-height: 1.58;
+  }
+
+  .landing .pillar-examples-label {
+    font-size: 0.78rem;
+    letter-spacing: 0.13em;
+  }
+
+  .landing .pillar-chip {
+    font-size: 0.84rem;
+    padding: 5px 12px;
   }
 
   .landing .modes-carousel {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -70,28 +70,28 @@ const MODE_VISUALS: Record<Language, Record<'low' | 'chill' | 'flow' | 'evolve',
       avatarVideo: '/avatars/low-basic.mp4',
       avatarImage: '/LowMood.jpg',
       thumbImage: '/LowVertical.png',
-      avatarAlt: 'Low mode avatar with a resting facial expression.',
+      avatarAlt: 'Red Cat avatar in Innerbloom.',
       avatarLabel: 'Aligned with your energy'
     },
     chill: {
       avatarVideo: '/avatars/chill-basic.mp4',
       avatarImage: '/Chill-Mood.jpg',
       thumbImage: '/ChillVertical.png',
-      avatarAlt: 'Chill mode avatar with a calm expression.',
+      avatarAlt: 'Green Bear avatar in Innerbloom.',
       avatarLabel: 'Aligned with your energy'
     },
     flow: {
       avatarVideo: '/avatars/flow-basic.mp4',
       avatarImage: '/FlowMood.jpg',
       thumbImage: '/FlowVertical.png',
-      avatarAlt: 'Flow mode avatar in action with a focused expression.',
+      avatarAlt: 'Blue Amphibian avatar in Innerbloom.',
       avatarLabel: 'Aligned with your energy'
     },
     evolve: {
       avatarVideo: '/avatars/evolve-basic.mp4',
       avatarImage: '/Evolve-Mood.jpg',
       thumbImage: '/EvolveVertical.png',
-      avatarAlt: 'Evolve mode avatar with a determined expression.',
+      avatarAlt: 'Violet Owl avatar in Innerbloom.',
       avatarLabel: 'Aligned with your energy'
     }
   },
@@ -100,28 +100,28 @@ const MODE_VISUALS: Record<Language, Record<'low' | 'chill' | 'flow' | 'evolve',
       avatarVideo: '/avatars/low-basic.mp4',
       avatarImage: '/LowMood.jpg',
       thumbImage: '/LowVertical.png',
-      avatarAlt: 'Avatar del modo Low con expresión de descanso.',
+      avatarAlt: 'Avatar Red Cat dentro de Innerbloom.',
       avatarLabel: 'Alineado a tu energía'
     },
     chill: {
       avatarVideo: '/avatars/chill-basic.mp4',
       avatarImage: '/Chill-Mood.jpg',
       thumbImage: '/ChillVertical.png',
-      avatarAlt: 'Avatar del modo Chill con expresión de calma.',
+      avatarAlt: 'Avatar Green Bear dentro de Innerbloom.',
       avatarLabel: 'Alineado a tu energía'
     },
     flow: {
       avatarVideo: '/avatars/flow-basic.mp4',
       avatarImage: '/FlowMood.jpg',
       thumbImage: '/FlowVertical.png',
-      avatarAlt: 'Avatar del modo Flow en movimiento y enfocado.',
+      avatarAlt: 'Avatar Blue Amphibian dentro de Innerbloom.',
       avatarLabel: 'Alineado a tu energía'
     },
     evolve: {
       avatarVideo: '/avatars/evolve-basic.mp4',
       avatarImage: '/Evolve-Mood.jpg',
       thumbImage: '/EvolveVertical.png',
-      avatarAlt: 'Avatar del modo Evolve con expresión determinada.',
+      avatarAlt: 'Avatar Violet Owl dentro de Innerbloom.',
       avatarLabel: 'Alineado a tu energía'
     }
   }
@@ -283,24 +283,6 @@ export default function LandingPage() {
   const modeCount = copy.modes.items.length;
   const activeMode = copy.modes.items[activeModeIndex] ?? copy.modes.items[0];
   const activeVisual = MODE_VISUALS[language][activeMode.id];
-  const frequencyByMode: Record<Language, Record<typeof activeMode.id, string>> = {
-    es: {
-      low: '1×/semana',
-      chill: '2×/semana',
-      flow: '3×/semana',
-      evolve: '4×/semana'
-    },
-    en: {
-      low: '1×/week',
-      chill: '2×/week',
-      flow: '3×/week',
-      evolve: '4×/week'
-    }
-  };
-  const modeFrequency = frequencyByMode[language][activeMode.id];
-  const modeStateLabel = language === 'es' ? 'Estado' : 'State';
-  const modeObjectiveLabel = language === 'es' ? 'Objetivo' : 'Objective';
-
   useEffect(() => {
     console.info('[landing][ga4-debug] cookie consent read on load', initialCookieConsentStateRef.current);
   }, []);
@@ -830,6 +812,7 @@ export default function LandingPage() {
 
         <section className="why section-pad reveal-on-scroll" id="pillars">
           <div className="container narrow">
+            <p className="section-kicker">{copy.pillars.kicker}</p>
             <AdaptiveText as="h2" className="pillars-title">{copy.pillars.title}</AdaptiveText>
             <AdaptiveText as="p" className="section-sub pillars-intro">{copy.pillars.intro}</AdaptiveText>
             <div className="cards grid-3">
@@ -874,8 +857,9 @@ export default function LandingPage() {
 
         <section ref={modesSectionRef} className="modes section-pad reveal-on-scroll" id="modes">
           <div className="container">
-            <AdaptiveText as="h2">{copy.modes.title}</AdaptiveText>
-            <AdaptiveText as="p" className="section-sub">{copy.modes.intro}</AdaptiveText>
+            <p className="section-kicker">{copy.modes.kicker}</p>
+            <AdaptiveText as="h2" className="modes-title">{copy.modes.title}</AdaptiveText>
+            <AdaptiveText as="p" className="section-sub modes-intro">{copy.modes.intro}</AdaptiveText>
             <div
               className="modes-carousel"
               aria-live="polite"
@@ -884,7 +868,7 @@ export default function LandingPage() {
               <div
                 className="mode-thumbs"
                 role="listbox"
-                aria-label={language === 'es' ? 'Elegir modo' : 'Choose mode'}
+                aria-label={language === 'es' ? 'Elegir avatar' : 'Choose avatar'}
                 onTouchStart={handleModeThumbTouchStart}
                 onTouchEnd={handleModeThumbTouchEnd}
               >
@@ -911,13 +895,6 @@ export default function LandingPage() {
               <article className={`card mode mode-main mode-${activeMode.id} fade-item`}>
                 <header className="mode-header">
                   <div className="mode-title">{activeMode.title}</div>
-                  <div className="mode-meta">
-                    <p className="mode-meta-item">
-                      <span className="mode-meta-label">{modeStateLabel}</span>
-                      <span className="mode-meta-copy">{activeMode.state}</span>
-                    </p>
-                    <span className="mode-frequency-chip">{modeFrequency}</span>
-                  </div>
                 </header>
                 <figure className="mode-media">
                   <video
@@ -932,10 +909,7 @@ export default function LandingPage() {
                   />
                   <figcaption className="mode-media-caption">{activeVisual.avatarLabel}</figcaption>
                 </figure>
-                <div className="mode-goal-block">
-                  <p className="mode-goal-label">{modeObjectiveLabel}</p>
-                  <p className="mode-goal-copy">{activeMode.goal}</p>
-                </div>
+                <p className="mode-avatar-copy">{activeMode.goal}</p>
               </article>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Unify visible product hierarchy and visual scale across the Pillars, New Rhythms, and the old mode carousel while keeping risk minimal and preserving the Innerbloom visual language. 
- Convert the mode/mood carousel into an avatars-focused presentation to remove weekly/intensity semantics from the visible UX. 
- Improve pillars cards so suggested-task chips align consistently across cards and mobile typography reads better without redesigning core structure.

### Description
- Added bilingual kicker fields to `OFFICIAL_LANDING_CONTENT` and updated copy to include `PILARES DE INNERBLOOM` / `INNERBLOOM PILLARS` and `AVATARES DE INNERBLOOM` / `INNERBLOOM AVATARS`, and replaced mood labels with avatar labels (`RED CAT`, `GREEN BEAR`, `BLUE AMPHIBIAN`, `VIOLET OWL`) in `apps/web/src/content/officialLandingContent.ts`. 
- Rendered the new `section-kicker` above the pillars and avatars headings in `apps/web/src/pages/Landing.tsx` and changed the modes area to avatar-focused headings and subtitle while keeping internal `modes` keys intact. 
- Removed visible `STATE`, `OBJECTIVE`, and frequency chip UI from the carousel card and replaced the goal block with a single avatar description (`mode-avatar-copy`), and updated thumbnail `aria-label` to refer to avatars. 
- Restructured pillar cards to use column flex so the title is top, definition expands in the middle, and the suggested-tasks block is pinned to the bottom; adjusted mobile typography and chip sizes in `apps/web/src/pages/Landing.css` and added a shared `section-kicker`/heading style. 
- Kept the New Rhythms component structure as the source of truth, but restyled only the lower chips to a softer `rhythm-lower-chip` look in `apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx` to visually align with pillar chips while leaving the frequency chip unchanged. 
- Updated avatar `alt` copy in `Landing.tsx` to match the new visible avatar labels and preserved carousel behavior, thumbnails, desktop/mobile ordering, and autoplay logic.

### Testing
- Ran repository checks: `git status --short` to confirm staged changes and files modified, and `rg` searches to verify no remaining visible old mood/frequency labels; those checks succeeded. 
- Verified `LandingV2` was not modified by checking `apps/web/src/pages/LandingV2.tsx` and diffs; this check succeeded. 
- Executed the project typecheck with `npm --prefix apps/web run -s typecheck`, which failed due to pre-existing, unrelated TypeScript errors elsewhere in the repo (Clerk typings and dashboard preview types), so typecheck failures are not caused by these landing changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d240add48332ad913eeed7dc922e)