### PR TITLE
Ajustes de jerarquía y capa tipográfica conceptual en la landing

### DIFF
--- a/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
+++ b/apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx
@@ -129,32 +129,32 @@ export function LabsWeeklyRhythmSystemSection({
           {copy.cards.map((card) => (
             <article
               key={card.id}
-              className="card rhythm-system-card group relative flex min-h-[20.5rem] h-full flex-col gap-5 p-5 transition duration-200 hover:-translate-y-0.5"
+              className="card card--hero-glass rhythm-system-card group relative flex min-h-[20.5rem] h-full flex-col gap-5 p-5 transition duration-200 hover:-translate-y-0.5"
             >
               <div className="space-y-3">
-                <p className="text-[0.62rem] font-semibold uppercase tracking-[0.2em] text-white/56">{copy.rhythmLabel}</p>
+                <p className="rhythm-card-label">{copy.rhythmLabel}</p>
 
                 <div className="flex items-start justify-between gap-3">
-                  <h3 className="text-[1.65rem] leading-none font-semibold tracking-[-0.03em] text-white">{card.name}</h3>
-                  <span className="inline-flex shrink-0 items-center self-start rounded-full bg-[linear-gradient(140deg,rgba(208,154,255,0.42),rgba(244,192,177,0.3))] px-3.5 py-1.5 text-[0.74rem] font-semibold uppercase tracking-[0.14em] leading-none text-[#fff6ff] shadow-[0_8px_20px_rgba(176,108,255,0.32)]">
+                  <h3 className="rhythm-card-title concept-term concept-term--rhythm">{card.name}</h3>
+                  <span className="rhythm-frequency-chip">
                     {card.frequency}
                   </span>
                 </div>
 
                 <div
-                  className="h-[1.2rem] overflow-hidden rounded-full bg-white/[0.08]"
+                  className="rhythm-intensity-track"
                   aria-label={`${card.name} ${copy.intensityAria} ${card.intensity}%`}
                 >
                   <div
-                    className="h-full rounded-full shadow-[0_0_16px_rgba(201,150,255,0.36)]"
+                    className="rhythm-intensity-fill"
                     style={{ width: `${card.intensity}%`, backgroundImage: INNERBLOOM_PREMIUM_GRADIENT }}
                   />
                 </div>
               </div>
 
-              <div className="space-y-1.5">
-                <p className="text-sm text-white/74">{card.state}</p>
-                <p className="text-base font-medium text-white/94">{card.micro}</p>
+              <div className="rhythm-card-copy">
+                <p className="rhythm-card-state">{card.state}</p>
+                <p className="rhythm-card-micro">{card.micro}</p>
               </div>
 
               <ul className="mt-auto flex flex-wrap gap-1.5">

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -5,6 +5,9 @@
   --font-body:
     "Manrope", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
     "Helvetica Neue", sans-serif;
+  --font-concept:
+    "Value Sans", "Sora", "Avenir Next", "Inter", "Manrope", "Segoe UI",
+    system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   --bg: #0b1220;
   --bg-2: #0f1a2e;
   --card: #111f35;
@@ -530,24 +533,48 @@
 
 .landing section h2 {
   font-size: clamp(2rem, 1.2vw + 1.5rem, 2.5rem);
-  margin: 0 0 8px;
+  margin: 0 0 10px;
   text-align: center;
+  line-height: 1.12;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
 }
 
 .landing .section-sub {
   text-align: center;
-  color: var(--muted);
-  margin: 0 0 24px;
+  color: color-mix(in srgb, var(--muted) 82%, #c4d8ff 18%);
+  margin: 0 auto 28px;
+  max-width: 66ch;
+  font-size: clamp(0.96rem, 0.3vw + 0.9rem, 1.05rem);
+  line-height: 1.62;
+  text-wrap: pretty;
 }
 
 .landing .section-kicker {
-  margin: 0 0 6px;
+  margin: 0 0 8px;
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: rgba(186, 201, 229, 0.88);
   text-align: center;
+}
+
+
+.landing .concept-term {
+  font-family: var(--font-concept);
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-variation-settings: "opsz" 28;
+}
+
+.landing .concept-term--pillar {
+  letter-spacing: 0.048em;
+}
+
+.landing .concept-term--rhythm {
+  letter-spacing: 0.08em;
 }
 
 .landing .truth-problem {
@@ -673,8 +700,8 @@
 
 .landing .pillars-intro {
   font-size: clamp(0.96rem, 0.35vw + 0.92rem, 1.06rem);
-  color: rgba(214, 229, 255, 0.88);
-  margin: 0 auto 24px;
+  color: rgba(214, 229, 255, 0.82);
+  margin: 0 auto 30px;
 }
 
 .landing .grid-3 {
@@ -694,6 +721,16 @@
   padding: 18px;
   backdrop-filter: blur(var(--landing-glass-blur));
   box-shadow: var(--landing-glass-shadow);
+}
+
+.landing .card--hero-glass {
+  border-color: rgba(235, 244, 255, 0.5);
+  background:
+    radial-gradient(130% 124% at 14% 12%, rgba(255, 255, 255, 0.2), transparent 58%),
+    linear-gradient(135deg, rgba(248, 236, 255, 0.17), rgba(214, 233, 255, 0.13));
+  box-shadow:
+    0 22px 48px rgba(42, 24, 84, 0.24),
+    inset 0 1px 0 rgba(255, 255, 255, 0.62);
 }
 
 .landing .card::before {
@@ -752,58 +789,60 @@
   z-index: 1;
   min-height: 390px;
   border-radius: var(--landing-glass-radius-lg);
-  padding: 18.15px;
+  padding: 20px 20px 18px;
   display: flex;
   flex-direction: column;
+  gap: 8px;
 }
 
 .landing .pillar-heading {
   margin: 0;
   display: flex;
-  align-items: baseline;
-  gap: 10px;
-  font-size: clamp(1.42rem, 0.82vw + 1.16rem, 1.74rem);
-  font-weight: 800;
-  line-height: 1.18;
+  align-items: center;
+  gap: 12px;
+  font-size: clamp(1.36rem, 0.74vw + 1.12rem, 1.64rem);
+  font-weight: 700;
+  line-height: 1.12;
 }
 
 .landing .pillar-emoji {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.1rem;
-  height: 2.1rem;
+  width: 2rem;
+  height: 2rem;
   border-radius: 999px;
-  font-size: 1.72rem;
+  font-size: 1.56rem;
   line-height: 1;
   background: transparent;
   border: 1px solid transparent;
 }
 
 .landing .pillar-definition {
-  margin-top: 9px;
-  max-width: 32ch;
-  font-size: clamp(1.08rem, 0.4vw + 1rem, 1.32rem);
-  line-height: 1.55;
+  margin-top: 4px;
+  max-width: 34ch;
+  font-size: clamp(1rem, 0.22vw + 0.96rem, 1.08rem);
+  line-height: 1.6;
   text-align: left;
-  color: rgba(232, 242, 255, 0.97);
+  color: rgba(220, 233, 252, 0.9);
   flex: 1;
 }
 
 .landing .pillar-examples {
   margin-top: auto;
-  padding-top: 14px;
+  padding-top: 16px;
   display: grid;
-  gap: 10px;
-  border-top: 1px solid rgba(191, 219, 254, 0.16);
+  gap: 12px;
+  border-top: 1px solid rgba(191, 219, 254, 0.22);
+  opacity: 0.94;
 }
 
 .landing .pillar-examples-label {
   font-size: 0.72rem;
   font-weight: 600;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(198, 218, 246, 0.78);
+  color: rgba(198, 218, 246, 0.66);
 }
 
 .landing .pillar-chips {
@@ -941,8 +980,8 @@
 
 .landing .mode-avatar-copy {
   margin: 0;
-  color: rgba(226, 236, 252, 0.94);
-  font-size: 0.95rem;
+  color: rgba(222, 234, 252, 0.9);
+  font-size: 0.93rem;
   line-height: 1.5;
   text-wrap: pretty;
 }
@@ -983,10 +1022,11 @@
 }
 
 .landing .how-heading {
-  margin: 0 auto 28px;
+  margin: 0 auto 34px;
   text-align: center;
   display: grid;
-  gap: 8px;
+  gap: 10px;
+  max-width: 62ch;
 }
 
 .landing .how-kicker {
@@ -999,10 +1039,10 @@
 }
 
 .landing .rhythm-lower-chip {
-  border: 1px solid rgba(211, 226, 255, 0.28);
-  background: rgba(186, 206, 255, 0.12);
-  color: rgba(235, 245, 255, 0.94);
-  font-size: 0.68rem;
+  border: 1px solid rgba(211, 226, 255, 0.24);
+  background: rgba(186, 206, 255, 0.08);
+  color: rgba(232, 243, 255, 0.85);
+  font-size: 0.66rem;
   line-height: 1.2;
 }
 
@@ -1014,7 +1054,81 @@
 .landing .rhythm-heading-sub {
   margin: 0 0 24px;
   font-size: clamp(0.96rem, 0.35vw + 0.92rem, 1.06rem);
-  color: rgba(214, 229, 255, 0.88);
+  color: rgba(214, 229, 255, 0.82);
+  max-width: 62ch;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.landing .rhythm-card-label {
+  margin: 0;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(213, 227, 255, 0.56);
+}
+
+.landing .rhythm-card-title {
+  margin: 0;
+  font-size: clamp(1.48rem, 0.56vw + 1.34rem, 1.72rem);
+  line-height: 0.98;
+  color: rgba(248, 250, 255, 0.98);
+}
+
+.landing .rhythm-frequency-chip {
+  display: inline-flex;
+  align-items: center;
+  align-self: start;
+  flex-shrink: 0;
+  border-radius: 999px;
+  background: linear-gradient(140deg, rgba(208, 154, 255, 0.34), rgba(244, 192, 177, 0.26));
+  border: 1px solid rgba(241, 219, 255, 0.36);
+  padding: 6px 12px 5px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  line-height: 1;
+  color: rgba(255, 246, 255, 0.92);
+}
+
+.landing .rhythm-intensity-track {
+  height: 1.25rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(240, 226, 255, 0.16);
+  box-shadow:
+    inset 0 1px 3px rgba(7, 10, 24, 0.42),
+    0 4px 12px rgba(21, 26, 45, 0.22);
+}
+
+.landing .rhythm-intensity-fill {
+  height: 100%;
+  border-radius: 999px;
+  box-shadow:
+    0 0 0 1px rgba(255, 237, 255, 0.22) inset,
+    0 0 18px rgba(201, 150, 255, 0.3);
+}
+
+.landing .rhythm-card-copy {
+  display: grid;
+  gap: 5px;
+}
+
+.landing .rhythm-card-state {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(223, 235, 255, 0.76);
+  line-height: 1.45;
+}
+
+.landing .rhythm-card-micro {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 520;
+  color: rgba(242, 247, 255, 0.94);
 }
 
 .landing .how-intro {
@@ -1119,16 +1233,17 @@
 .landing .timeline-card:hover,
 .landing .timeline-card:focus-visible,
 .landing .timeline-card.is-active {
-  border-color: rgba(222, 201, 255, 0.8);
+  border-color: rgba(222, 201, 255, 0.84);
   box-shadow:
-    0 0 0 2px rgba(184, 137, 255, 0.2),
+    0 0 0 2px rgba(184, 137, 255, 0.24),
     var(--landing-glass-shadow);
 }
 
 .landing .timeline-card h3 {
   margin: 0;
-  font-size: 1.125rem;
-  font-weight: 600;
+  font-size: 1.12rem;
+  font-weight: 620;
+  color: rgba(245, 249, 255, 0.96);
 }
 .landing .timeline-outcome-preview {
   margin: 0;
@@ -1810,23 +1925,27 @@
 }
 
 .landing .demo-title {
+  margin: 0;
   font-size: clamp(2.3rem, 3.2vw, 3.1rem);
   line-height: 1.03;
-  margin: 0;
+  max-width: 14ch;
+  text-wrap: balance;
 }
 
 .landing .demo-sub {
   margin: 0;
-  max-width: 34ch;
-  color: rgba(236, 242, 255, 0.94);
+  max-width: 38ch;
+  color: rgba(232, 241, 255, 0.9);
   text-align: center;
   font-size: clamp(1rem, 0.58vw + 0.82rem, 1.16rem);
+  line-height: 1.54;
 }
 
 .landing .demo-bridge-copy {
   margin: 0;
-  font-size: 0.93rem;
-  color: rgba(236, 243, 255, 0.95);
+  font-size: 0.91rem;
+  color: rgba(229, 239, 255, 0.86);
+  line-height: 1.5;
 }
 
 .landing .demo-actions {
@@ -1879,13 +1998,14 @@
   line-height: 1.1;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  opacity: 0.75;
+  opacity: 0.64;
 }
 
 .landing .timeline-copy {
   margin: 0;
   font-size: 0.92rem;
   line-height: 1.5;
+  color: rgba(223, 233, 250, 0.88);
 }
 
 .landing .slider {
@@ -2097,19 +2217,31 @@
   margin-bottom: 12px;
   backdrop-filter: blur(var(--landing-glass-blur));
   box-shadow: var(--landing-glass-shadow);
+  transition: border-color 170ms ease, background-color 170ms ease;
 }
 
 .landing .faq summary {
   cursor: pointer;
-  font-weight: 700;
+  font-weight: 650;
   font-family: var(--font-heading);
+  color: rgba(244, 248, 255, 0.96);
+  letter-spacing: -0.01em;
   overflow-wrap: anywhere;
 }
 
 .landing .faq p {
-  color: #d8def5;
+  color: rgba(216, 227, 245, 0.88);
   margin-bottom: 0;
+  margin-top: 9px;
+  line-height: 1.58;
   overflow-wrap: anywhere;
+}
+
+.landing .faq details[open] {
+  border-color: rgba(227, 209, 255, 0.48);
+  background:
+    radial-gradient(122% 112% at 14% 10%, rgba(255, 255, 255, 0.16), transparent 58%),
+    linear-gradient(136deg, rgba(242, 232, 255, 0.14), rgba(214, 231, 255, 0.12));
 }
 
 .landing .footer {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -820,13 +820,13 @@ export default function LandingPage() {
                 const { definition, examples } = splitPillarCopy(pillar.copy, language);
                 return (
                   <article
-                    className="card pillar-card fade-item"
+                    className="card card--hero-glass pillar-card fade-item"
                     key={pillar.title}
                     style={{ '--delay': `${index * 90}ms` } as CSSProperties}
                   >
                     <h3 className="pillar-heading">
                       <span className="pillar-emoji" aria-hidden>{pillar.emoji}</span>
-                      <span>{pillar.title}</span>
+                      <span className="concept-term concept-term--pillar">{pillar.title}</span>
                     </h3>
                     <p className="pillar-definition">{definition}</p>
                     {examples.length > 0 ? (
@@ -892,7 +892,7 @@ export default function LandingPage() {
                 })}
               </div>
 
-              <article className={`card mode mode-main mode-${activeMode.id} fade-item`}>
+              <article className={`card card--hero-glass mode mode-main mode-${activeMode.id} fade-item`}>
                 <header className="mode-header">
                   <div className="mode-title">{activeMode.title}</div>
                 </header>


### PR DESCRIPTION
### Motivation
- Mejorar la jerarquía visual, contraste y cohesión tipográfica de la landing sin alterar la arquitectura ni la identidad base. 
- Dar mayor presencia a la «vocabulario del sistema» (p. ej. `Body / Mind / Soul`, `LOW / CHILL / FLOW / EVOLVE`) con una capa tipográfica preparada para integrar una fuente editorial más premium. 

### Description
- Añadí una variable CSS `--font-concept` y utilidades `.concept-term` para una capa tipográfica conceptual con fallbacks seguros y ajustes de weight/tracking/opsz; no se reemplazó el sistema base (`Sora` para headings, `Manrope` para body). (files: `apps/web/src/pages/Landing.css`)
- Apliqué la capa conceptual y nuevas clases a los pilares (`.concept-term--pillar`) y a los ritmos (`.concept-term--rhythm`), además de ajustar espaciados y tamaños para reforzar su autoridad. (files: `apps/web/src/pages/Landing.tsx`, `apps/web/src/components/labs/LabsWeeklyRhythmSystemSection.tsx`)
- Reforcé la separación visual de las tarjetas importantes introduciendo `card--hero-glass` y reequilibré paddings, gaps y contrastes en cards, definiciones de pilares y zona de ejemplos para mejorar la lectura secuencial. (file: `apps/web/src/pages/Landing.css`) 
- Mejoré la barra de intensidad manteniendo el gradiente existente: mayor contraste del track, borde/inset para separación, y halo sutil en el fill `rhythm-intensity-fill` para mayor legibilidad funcional sin efecto neón. (files: `LabsWeeklyRhythmSystemSection.tsx`, `Landing.css`)

### Testing
- Ejecuté el linter del monorepo con `pnpm -w run lint` y la ejecución terminó correctamente. (✅)
- Construí la app web con `pnpm -C apps/web run build` y la build fue exitosa; se mantuvieron warnings no bloqueantes del pipeline/minificación CSS ya presentes en el repo. (✅)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f9fbd23883328e0e24e2c34c34d8)