### PR TITLE
Ajustes visuales: compactar ‘The Real Problem’ y refinar Rhythms

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -629,7 +629,7 @@
 }
 
 .landing .truth-problem-kicker {
-  margin: 0 auto 18px;
+  margin: 0 auto 10px;
   font-size: 0.72rem;
   font-weight: 700;
   line-height: 1;
@@ -650,7 +650,7 @@
 
 .landing .truth-problem-title--outside {
   max-width: 19ch;
-  margin-bottom: clamp(4px, 1vw, 12px);
+  margin-bottom: clamp(2px, 0.7vw, 8px);
   font-size: clamp(1.78rem, 1.35vw + 1.34rem, 2.36rem);
 }
 
@@ -1079,37 +1079,35 @@
 .landing .rhythm-frequency-chip {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   align-self: start;
   flex-shrink: 0;
   border-radius: 999px;
-  background: linear-gradient(140deg, rgba(208, 154, 255, 0.34), rgba(244, 192, 177, 0.26));
-  border: 1px solid rgba(241, 219, 255, 0.36);
-  padding: 6px 12px 5px;
-  font-size: 0.7rem;
-  font-weight: 600;
+  background: linear-gradient(140deg, rgba(210, 162, 255, 0.42), rgba(248, 203, 189, 0.34));
+  border: 1px solid rgba(246, 229, 255, 0.44);
+  padding: 7px 13px 6px;
+  font-size: 0.74rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.14em;
   line-height: 1;
-  color: rgba(255, 246, 255, 0.92);
+  color: rgba(255, 248, 255, 0.98);
+  box-shadow: 0 4px 12px rgba(48, 27, 82, 0.2);
 }
 
 .landing .rhythm-intensity-track {
   height: 1.25rem;
   overflow: hidden;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.14);
-  border: 1px solid rgba(240, 226, 255, 0.16);
-  box-shadow:
-    inset 0 1px 3px rgba(7, 10, 24, 0.42),
-    0 4px 12px rgba(21, 26, 45, 0.22);
+  background: rgba(243, 248, 255, 0.14);
+  border: 1px solid rgba(235, 222, 255, 0.2);
+  box-shadow: 0 4px 10px rgba(17, 20, 37, 0.18);
 }
 
 .landing .rhythm-intensity-fill {
   height: 100%;
   border-radius: 999px;
-  box-shadow:
-    0 0 0 1px rgba(255, 237, 255, 0.22) inset,
-    0 0 18px rgba(201, 150, 255, 0.3);
+  box-shadow: 0 0 14px rgba(201, 150, 255, 0.28);
 }
 
 .landing .rhythm-card-copy {


### PR DESCRIPTION
### Motivation
- Reducir un espacio visual excesivo entre el kicker y el título en el bloque “The Real Problem” para alinear esa sección con el sistema de espaciado del resto de la landing. 
- Simplificar la barra de intensidad en la sección Rhythms para que el gradiente sea el foco y eliminar efectos de cavidad/sombra interna que la sobrecargan. 
- Aumentar la jerarquía visual de los chips de frecuencia (`1× / week`, etc.) con cambios sutiles de tamaño, peso y contraste para que funcionen como métrica secundaria sin dominar el diseño.

### Description
- Modifiqué `apps/web/src/pages/Landing.css` y ajusté el espaciado del bloque de problema: ` .truth-problem-kicker` pasa de `margin: 0 auto 18px` a `margin: 0 auto 10px` y ` .truth-problem-title--outside` reduce su `margin-bottom` via `clamp(2px, 0.7vw, 8px)` para compactar visualmente el kicker y el título. 
- Simplifiqué la pista de intensidad (`.rhythm-intensity-track`) eliminando la sombra inset y reduciendo el borde y el contraste del fondo, dejando un `background` y `border` más suaves y una sombra exterior sutil (`box-shadow: 0 4px 10px rgba(...)`).
- Ajusté el relleno/halo del fill (`.rhythm-intensity-fill`) eliminando el borde inset y dejando un único brillo suave (`box-shadow: 0 0 14px rgba(...)`) para que el gradiente destaque sin efectos compuestos. 
- Elevé la jerarquía del chip de frecuencia (`.rhythm-frequency-chip`) añadiendo `justify-content: center`, incrementando `padding`, subiendo `font-size` y `font-weight`, ajustando `letter-spacing` y contraste de fondo/borde y añadiendo una sombra sutil para mayor presencia sin dominar la tarjeta.
- Archivo modificado: `apps/web/src/pages/Landing.css`.

### Testing
- Ejecuté la comprobación de tipos con `npm -C apps/web run typecheck`, la cual falló por errores TypeScript preexistentes que no están relacionados con este cambio puramente CSS, por lo que no afectan la corrección visual aplicada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50018dc208332a3079ac7d28aa486)