### PR TITLE
Refine rhythms intensity bar visual cleanup

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -1099,15 +1099,15 @@
   height: 1.25rem;
   overflow: hidden;
   border-radius: 999px;
-  background: rgba(243, 248, 255, 0.14);
-  border: 1px solid rgba(235, 222, 255, 0.2);
-  box-shadow: 0 4px 10px rgba(17, 20, 37, 0.18);
+  background: rgba(228, 238, 255, 0.12);
+  clip-path: inset(0 round 999px);
+  box-shadow: 0 8px 18px rgba(16, 21, 38, 0.16);
 }
 
 .landing .rhythm-intensity-fill {
   height: 100%;
   border-radius: 999px;
-  box-shadow: 0 0 14px rgba(201, 150, 255, 0.28);
+  box-shadow: 0 2px 10px rgba(196, 146, 255, 0.2);
 }
 
 .landing .rhythm-card-copy {


### PR DESCRIPTION
### Motivation
- Reducir la sensación de contorno alrededor del fill de la barra de intensidad en la sección Rhythms manteniendo el gradiente y una sola sombra exterior sutil.
- Evitar bordes explícitos o efectos de cavidad que compiten visualmente con el fill y generan un borde óptico.

### Description
- Ajusté el track ` .landing .rhythm-intensity-track` para eliminar el `border`, suavizar el fondo a `rgba(228, 238, 255, 0.12)` y añadir `clip-path: inset(0 round 999px)` para asegurar un recorte redondeado limpio sin artefactos de contorno; la sombra del track quedó como `box-shadow: 0 8px 18px rgba(16, 21, 38, 0.16)`.
- Suavicé la sombra del fill en ` .landing .rhythm-intensity-fill` a `box-shadow: 0 2px 10px rgba(196, 146, 255, 0.2)` y mantuve el gradiente inline desde el componente (no modifiqué la imagen de fondo del fill en TSX).
- Confirmación explícita: el `fill` quedó sin `border`, sin `outline` y sin `ring`, solo con `height`, `border-radius` y `box-shadow` según la clase ` .landing .rhythm-intensity-fill`.

### Testing
- No se ejecutaron pruebas automatizadas visuales ya que es un cambio CSS de presentación (visual review recommended in-browser).
- Operaciones de control automatizadas: se verificó el diff y se creó el commit (`git diff` / `git commit`) con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e509619160833292d568332d06bc2b)