### PR TITLE
fix(web): lock manual scroll while guided demo overlay is active

### DIFF
--- a/apps/web/src/components/demo/GuidedDemoOverlay.tsx
+++ b/apps/web/src/components/demo/GuidedDemoOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { DEMO_GUIDED_STEPS, type DemoLanguage, type GuidedStep } from '../../config/demoGuidedTour';
 
 type Props = {
@@ -154,6 +154,7 @@ export function GuidedDemoOverlay({
   onFinalPrimaryAction,
   onFinalSecondaryAction,
 }: Props) {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
   const [stepIndex, setStepIndex] = useState(0);
   const [targetRect, setTargetRect] = useState<Rect | null>(null);
   const [viewport, setViewport] = useState({ width: window.innerWidth, height: window.innerHeight });
@@ -163,6 +164,90 @@ export function GuidedDemoOverlay({
   const isDailyQuestStep = walkthroughMode === 'daily-quest-modal';
   const isLogrosModalStep = LABS_LOGROS_MODAL_STEP_IDS.has(step.id);
   const isCompactMobile = viewport.width <= 390 || viewport.height <= 740;
+
+  useEffect(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const dailyQuestScroller = getDailyQuestScrollContainer();
+    const scrollY = window.scrollY;
+
+    const previousHtmlOverflow = html.style.overflow;
+    const previousHtmlOverscrollBehavior = html.style.overscrollBehavior;
+    const previousBodyOverflow = body.style.overflow;
+    const previousBodyOverscrollBehavior = body.style.overscrollBehavior;
+    const previousBodyPosition = body.style.position;
+    const previousBodyTop = body.style.top;
+    const previousBodyLeft = body.style.left;
+    const previousBodyRight = body.style.right;
+    const previousBodyWidth = body.style.width;
+    const previousBodyTouchAction = body.style.touchAction;
+
+    const previousDailyQuestOverflow = dailyQuestScroller?.style.overflow;
+    const previousDailyQuestOverscrollBehavior = dailyQuestScroller?.style.overscrollBehavior;
+    const previousDailyQuestTouchAction = dailyQuestScroller?.style.touchAction;
+    const previousDailyQuestWebkitOverflowScrolling = dailyQuestScroller?.style.getPropertyValue('-webkit-overflow-scrolling');
+
+    html.style.overflow = 'hidden';
+    html.style.overscrollBehavior = 'none';
+
+    body.style.overflow = 'hidden';
+    body.style.overscrollBehavior = 'none';
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
+    body.style.left = '0';
+    body.style.right = '0';
+    body.style.width = '100%';
+    body.style.touchAction = 'none';
+
+    if (dailyQuestScroller) {
+      dailyQuestScroller.style.overflow = 'hidden';
+      dailyQuestScroller.style.overscrollBehavior = 'none';
+      dailyQuestScroller.style.touchAction = 'none';
+      dailyQuestScroller.style.setProperty('-webkit-overflow-scrolling', 'auto');
+    }
+
+    const preventManualScroll = (event: WheelEvent | TouchEvent) => {
+      event.preventDefault();
+    };
+
+    const overlayNode = overlayRef.current;
+    overlayNode?.addEventListener('wheel', preventManualScroll, { passive: false });
+    overlayNode?.addEventListener('touchmove', preventManualScroll, { passive: false });
+    window.addEventListener('wheel', preventManualScroll, { passive: false });
+    window.addEventListener('touchmove', preventManualScroll, { passive: false });
+
+    return () => {
+      overlayNode?.removeEventListener('wheel', preventManualScroll);
+      overlayNode?.removeEventListener('touchmove', preventManualScroll);
+      window.removeEventListener('wheel', preventManualScroll);
+      window.removeEventListener('touchmove', preventManualScroll);
+
+      html.style.overflow = previousHtmlOverflow;
+      html.style.overscrollBehavior = previousHtmlOverscrollBehavior;
+
+      body.style.overflow = previousBodyOverflow;
+      body.style.overscrollBehavior = previousBodyOverscrollBehavior;
+      body.style.position = previousBodyPosition;
+      body.style.top = previousBodyTop;
+      body.style.left = previousBodyLeft;
+      body.style.right = previousBodyRight;
+      body.style.width = previousBodyWidth;
+      body.style.touchAction = previousBodyTouchAction;
+
+      if (dailyQuestScroller) {
+        dailyQuestScroller.style.overflow = previousDailyQuestOverflow ?? '';
+        dailyQuestScroller.style.overscrollBehavior = previousDailyQuestOverscrollBehavior ?? '';
+        dailyQuestScroller.style.touchAction = previousDailyQuestTouchAction ?? '';
+        if (previousDailyQuestWebkitOverflowScrolling != null && previousDailyQuestWebkitOverflowScrolling.length > 0) {
+          dailyQuestScroller.style.setProperty('-webkit-overflow-scrolling', previousDailyQuestWebkitOverflowScrolling);
+        } else {
+          dailyQuestScroller.style.removeProperty('-webkit-overflow-scrolling');
+        }
+      }
+
+      window.scrollTo({ top: scrollY, behavior: 'auto' });
+    };
+  }, []);
 
   useEffect(() => {
     if (isDailyQuestStep) {
@@ -446,7 +531,12 @@ export function GuidedDemoOverlay({
   const overlayMaskClass = 'bg-slate-950/80 backdrop-blur-[7px]';
 
   return (
-    <div className={`pointer-events-none fixed inset-0 ${overlayZClass}`}>
+    <div
+      ref={overlayRef}
+      className={`pointer-events-auto fixed inset-0 ${overlayZClass}`}
+      onWheel={(event) => event.preventDefault()}
+      onTouchMove={(event) => event.preventDefault()}
+    >
       {targetRect ? (
         <>
           <div className={`absolute left-0 right-0 top-0 ${overlayMaskClass}`} style={{ height: targetRect.top }} />


### PR DESCRIPTION
### Motivation
- The guided demo overlay allowed pointer/scroll events to pass through on mobile, letting users scroll the dashboard or Daily Quest modal while a walkthrough attention window was visible, which breaks UX focus. 
- The fix centralizes scroll capture in the shared overlay component so the tour can reliably block manual gestures without per-page patches.

### Description
- Updated `apps/web/src/components/demo/GuidedDemoOverlay.tsx` to make the overlay root capture interactions (`pointer-events-auto`) and added an `overlayRef` to attach gesture handlers. 
- Added a mount `useEffect` that applies a robust scroll lock: sets `html`/`body` `overflow: hidden` and `overscrollBehavior: none`, freezes `body` with `position: fixed` while preserving/restoring scroll position, and sets `touch-action: none`. 
- Locks the Daily Quest scroller (`[data-daily-quest-scroll-container="true"]`) by mutating its inline styles (including `-webkit-overflow-scrolling`) and fully restores prior styles on unmount. 
- Prevents manual scroll leakage by registering non-passive `wheel`/`touchmove` handlers on the overlay root and `window`, while keeping the tooltip `aside` interactive so walkthrough buttons still work; programmatic auto-scroll (`scrollTo`/`scrollIntoView`) and the existing `alignForStep` flow were left intact.

### Testing
- Ran `npm run typecheck:web`; the run failed due to pre-existing repository-wide TypeScript issues unrelated to this change, and not caused by the overlay edits. 
- Confirmed the change compiles locally enough to commit the patch and that the `GuidedDemoOverlay` file was updated and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b6b34e348332851491f8502c3a3e)