### PR TITLE
Polish labs editor visuals: guide overlay, wheel, and suggestions modal

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6248,6 +6248,35 @@
     border-color: var(--color-border-subtle);
   }
 
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-guide-overlay {
+    color: var(--color-text);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-guide-panel {
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(246, 242, 252, 0.94)
+    );
+    border-color: color-mix(in srgb, var(--color-border-strong) 65%, white);
+    color: var(--color-text);
+    box-shadow: 0 22px 56px rgba(76, 29, 149, 0.18);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-overlay {
+    background: rgba(36, 25, 62, 0.4);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-modal {
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.98),
+      rgba(244, 239, 251, 0.96)
+    );
+    border-color: color-mix(in srgb, var(--color-border-strong) 68%, white);
+    box-shadow: 0 28px 74px rgba(91, 33, 182, 0.22);
+  }
+
   :root[data-theme="light"]
     [data-light-scope="dashboard-v3"]
     [aria-label="Radar de GP por rasgo"]

--- a/apps/web/src/pages/labs/EditorLabPage.tsx
+++ b/apps/web/src/pages/labs/EditorLabPage.tsx
@@ -951,57 +951,60 @@ function TaskFilters({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="hidden items-center gap-2 md:flex">
+      <div className="hidden items-center justify-end gap-2 md:flex">
         <button
           type="button"
           onClick={onOpenGuide}
-          className="inline-flex items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-slate-200)] transition hover:border-white/30 hover:text-white"
+          aria-label="Abrir guía"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[linear-gradient(170deg,rgba(255,255,255,0.12),rgba(148,163,184,0.02))] text-[color:var(--color-slate-100)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_8px_18px_rgba(15,23,42,0.24)] transition hover:border-violet-200/40 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-200/60"
         >
-          Guía
+          <GuideCompassIcon className="h-3.5 w-3.5" />
         </button>
         <button
           type="button"
           onClick={onOpenSuggestions}
+          aria-label="Abrir sugerencias"
           data-editor-guide-target="suggestions"
-          className="inline-flex items-center justify-center rounded-full border border-violet-400/35 bg-violet-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-violet-100 transition hover:bg-violet-500/20"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-violet-300/40 bg-[linear-gradient(170deg,rgba(167,139,250,0.26),rgba(129,140,248,0.08))] text-violet-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.2),0_10px_18px_rgba(76,29,149,0.3)] transition hover:border-violet-200/70 hover:bg-violet-500/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-200/65"
         >
-          Sugerencias
+          <SuggestionsMagicIcon className="h-3.5 w-3.5" />
         </button>
       </div>
       <div className="md:hidden">
         <div className="editor-filters-mobile-panel sticky -mx-4 -mt-5 top-[4.5rem] z-30 space-y-3 rounded-t-2xl px-4 pt-5 pb-3 bg-[color:var(--color-slate-900-95)]">
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center justify-end gap-2">
             <button
               type="button"
               onClick={onOpenGuide}
-              className="inline-flex items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-3.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--color-slate-200)] transition hover:border-white/30 hover:text-white"
+              aria-label="Abrir guía"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[linear-gradient(170deg,rgba(255,255,255,0.12),rgba(148,163,184,0.02))] text-[color:var(--color-slate-100)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_8px_18px_rgba(15,23,42,0.24)] transition hover:border-violet-200/40 hover:text-white"
             >
-              Guía
+              <GuideCompassIcon className="h-3.5 w-3.5" />
             </button>
             <button
               type="button"
               onClick={onOpenSuggestions}
+              aria-label="Abrir sugerencias"
               data-editor-guide-target="suggestions"
-              className="inline-flex items-center justify-center rounded-full border border-violet-400/35 bg-violet-500/10 px-3.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-violet-100 transition hover:bg-violet-500/20"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-violet-300/40 bg-[linear-gradient(170deg,rgba(167,139,250,0.26),rgba(129,140,248,0.08))] text-violet-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.2),0_10px_18px_rgba(76,29,149,0.3)] transition hover:border-violet-200/70 hover:bg-violet-500/20"
             >
-              Sugerencias
+              <SuggestionsMagicIcon className="h-3.5 w-3.5" />
             </button>
           </div>
-          <label className="flex flex-col gap-1">
-            <input
-              type="search"
-              data-editor-guide-target="search"
-              value={searchTerm}
-              onChange={(event) => onSearchChange(event.target.value)}
-              placeholder={t("editor.filters.search.placeholder")}
-              className="w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-sm ios-touch-input text-[color:var(--color-slate-100)] placeholder:text-[color:var(--color-slate-400)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
-            />
-          </label>
-          <div className="space-y-2">
-            <div
-              data-editor-guide-target="pillars"
-              className="flex gap-2 overflow-x-auto pb-1 [mask-image:linear-gradient(to_right,transparent,black_12%,black_88%,transparent)]"
-            >
+          <div
+            data-editor-guide-target="search-pillar-zone"
+            className="space-y-2 rounded-2xl border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.48),rgba(30,41,59,0.28))] p-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+          >
+            <label className="flex flex-col gap-1">
+              <input
+                type="search"
+                value={searchTerm}
+                onChange={(event) => onSearchChange(event.target.value)}
+                placeholder={t("editor.filters.search.placeholder")}
+                className="w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-sm ios-touch-input text-[color:var(--color-slate-100)] placeholder:text-[color:var(--color-slate-400)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
+              />
+            </label>
+            <div className="flex gap-2 overflow-x-auto pb-1 [mask-image:linear-gradient(to_right,transparent,black_12%,black_88%,transparent)]">
               {pillars.map((pillar) => {
                 const isActive = pillar.value === selectedPillar;
                 return (
@@ -1035,7 +1038,10 @@ function TaskFilters({
           </button>
         )}
       </div>
-      <div className="hidden flex-col gap-3 md:flex md:flex-row md:items-end">
+      <div
+        data-editor-guide-target="search-pillar-zone"
+        className="hidden flex-col gap-3 rounded-2xl border border-white/10 bg-white/[0.02] p-3 md:flex md:flex-row md:items-end"
+      >
         <label className="flex w-full flex-col gap-2">
           <span className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">
             {t("editor.filters.search.label")}
@@ -1043,7 +1049,6 @@ function TaskFilters({
           <div className="relative flex items-center">
             <input
               type="search"
-              data-editor-guide-target="search"
               value={searchTerm}
               onChange={(event) => onSearchChange(event.target.value)}
               placeholder={t("editor.filters.search.placeholder")}
@@ -1056,7 +1061,6 @@ function TaskFilters({
             {t("editor.filters.pillar.label")}
           </span>
           <select
-            data-editor-guide-target="pillars"
             value={selectedPillar}
             onChange={(event) => onPillarChange(event.target.value)}
             className="w-full appearance-none rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2.5 text-sm ios-touch-input text-[color:var(--color-slate-100)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
@@ -2819,23 +2823,35 @@ function SuggestionsLabModal({
   }
 
   return (
-    <div className="fixed inset-0 z-[75] flex items-end justify-center bg-slate-950/75 backdrop-blur-sm md:items-center">
+    <div className="editor-suggestions-overlay fixed inset-0 z-[75] flex items-end justify-center bg-slate-950/80 backdrop-blur-md md:items-center">
       <button
         type="button"
         aria-label="Cerrar sugerencias"
         onClick={onClose}
         className="absolute inset-0 h-full w-full"
       />
-      <section className="relative z-10 w-full max-w-2xl rounded-t-3xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-slate-900-95)] p-4 md:rounded-3xl md:p-6">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-violet-200/80">
-          Sugerencias
-        </p>
-        <h2 className="mt-2 text-lg font-semibold text-white md:text-xl">
-          Sumá tareas base a tu sistema
-        </h2>
-        <p className="mt-2 max-w-xl text-sm leading-relaxed text-[color:var(--color-slate-300)]">
-          Elegí múltiples tareas del Quick Start por pilar para incorporarlas directamente a tu editor.
-        </p>
+      <section className="editor-suggestions-modal relative z-10 w-full max-w-3xl rounded-t-3xl border border-[color:var(--color-border-subtle)] bg-[linear-gradient(180deg,rgba(15,23,42,0.95),rgba(15,23,42,0.92))] p-4 shadow-[0_28px_80px_rgba(2,6,23,0.5)] md:rounded-3xl md:p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-violet-200/85">
+              Sugerencias
+            </p>
+            <h2 className="mt-2 text-lg font-semibold text-white md:text-xl">
+              Activá tareas recomendadas
+            </h2>
+            <p className="mt-2 max-w-xl text-sm leading-relaxed text-[color:var(--color-slate-300)]">
+              Seleccioná varias sugerencias por pilar y agregalas en lote a tu sistema.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Cerrar sugerencias"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-white/5 text-[color:var(--color-slate-200)] transition hover:border-white/35 hover:text-white"
+          >
+            <CloseTinyIcon className="h-4 w-4" />
+          </button>
+        </div>
         <div className="mt-4 flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-white/[0.02] px-3 py-2">
           <p className="text-xs text-[color:var(--color-slate-300)]">
             {selectedCount} de {totalAvailableSuggestions} seleccionadas
@@ -2856,7 +2872,7 @@ function SuggestionsLabModal({
             </button>
           </div>
         </div>
-        <div className="mt-4 max-h-[58vh] space-y-5 overflow-y-auto pr-1">
+        <div className="mt-4 max-h-[58vh] space-y-5 overflow-y-auto pr-1 pb-24 md:pb-20">
           {(
             Object.entries(grouped) as Array<
               [keyof typeof grouped, typeof EDITOR_LAB_QUICK_START_SEED]
@@ -2874,42 +2890,44 @@ function SuggestionsLabModal({
                   / {tasks.length}
                 </p>
               </div>
-              <div className="space-y-2">
+              <div className="grid gap-2 sm:grid-cols-2">
                 {tasks.map((task) => {
                   const checked = selectedSet.has(task.id);
                   return (
-                    <label
+                    <button
                       key={task.id}
-                      className={`flex cursor-pointer items-start gap-3 rounded-2xl border px-3 py-2.5 transition ${checked ? "border-violet-300/60 bg-violet-500/15 shadow-[0_10px_24px_rgba(139,92,246,0.2)]" : "border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:border-white/25"}`}
+                      type="button"
+                      onClick={() =>
+                        setSelectedIds((current) =>
+                          current.includes(task.id)
+                            ? current.filter((id) => id !== task.id)
+                            : [...current, task.id],
+                        )
+                      }
+                      aria-pressed={checked}
+                      className={`group flex items-start gap-3 rounded-2xl border px-3 py-3 text-left transition ${checked ? "border-violet-300/60 bg-[linear-gradient(155deg,rgba(167,139,250,0.25),rgba(129,140,248,0.12))] shadow-[0_10px_24px_rgba(139,92,246,0.24)]" : "border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:border-white/25"}`}
                     >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() =>
-                          setSelectedIds((current) =>
-                            current.includes(task.id)
-                              ? current.filter((id) => id !== task.id)
-                              : [...current, task.id],
-                          )
-                        }
-                        className="mt-1 h-4 w-4 rounded border-white/30 bg-transparent text-violet-400"
-                      />
+                      <span
+                        className={`mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] transition ${checked ? "border-violet-100 bg-violet-200/90 text-violet-700" : "border-white/25 text-transparent group-hover:border-white/40"}`}
+                      >
+                        ✓
+                      </span>
                       <span className="flex-1">
                         <span className="block text-sm font-medium text-[color:var(--color-slate-100)]">
                           {task.title}
                         </span>
-                        <span className="mt-1 inline-flex rounded-full border border-white/15 bg-white/5 px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-[color:var(--color-slate-400)]">
+                        <span className="mt-1 inline-flex rounded-full border border-violet-200/20 bg-violet-400/10 px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-violet-100/85">
                           {task.trait}
                         </span>
                       </span>
-                    </label>
+                    </button>
                   );
                 })}
               </div>
             </div>
           ))}
         </div>
-        <div className="mt-5 flex items-center justify-between gap-3 border-t border-white/10 pt-4">
+        <div className="absolute inset-x-0 bottom-0 flex items-center justify-between gap-3 border-t border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.05),rgba(15,23,42,0.96)_24%)] px-4 py-4 backdrop-blur-md md:px-6">
           <p className="text-xs text-[color:var(--color-slate-400)]">
             {hasSelectedSuggestions
               ? `Listo para sumar ${selectedCount} tarea(s) a tu sistema.`
@@ -2930,6 +2948,44 @@ function SuggestionsLabModal({
         </div>
       </section>
     </div>
+  );
+}
+
+function GuideCompassIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" className={className}>
+      <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.8" opacity="0.75" />
+      <path
+        d="M9.2 14.8 10.8 9.2 14.8 10.8 13.2 14.8 9.2 14.8Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+      <path d="M10.8 9.2 14.8 10.8" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function SuggestionsMagicIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" className={className}>
+      <path
+        d="M12 4.4 13.3 7.2 16.2 8.5 13.3 9.8 12 12.6 10.7 9.8 7.8 8.5 10.7 7.2 12 4.4Z"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinejoin="round"
+      />
+      <path d="m18.2 13.3.7 1.5 1.5.7-1.5.7-.7 1.5-.7-1.5-1.5-.7 1.5-.7.7-1.5Z" fill="currentColor" />
+      <path d="m5.8 14.6.55 1.1 1.1.55-1.1.55-.55 1.1-.55-1.1-1.1-.55 1.1-.55.55-1.1Z" fill="currentColor" />
+    </svg>
+  );
+}
+
+function CloseTinyIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" className={className}>
+      <path d="m7 7 10 10M17 7 7 17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
   );
 }
 

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
@@ -38,6 +38,7 @@ export function EditorGuideOverlay({
 
   const step = EDITOR_GUIDE_STEPS[stepIndex];
   const isWheelStep = step.id.startsWith("wheel");
+  const panelPlacement = step.panelPlacement ?? (isWheelStep ? "center" : "bottom");
 
   useEffect(() => {
     if (!isOpen) {
@@ -109,7 +110,7 @@ export function EditorGuideOverlay({
 
   return (
     <div
-      className="fixed inset-0 z-[90]"
+      className="editor-guide-overlay fixed inset-0 z-[90]"
       role="dialog"
       aria-modal="true"
       aria-label="Guía del editor"
@@ -117,15 +118,15 @@ export function EditorGuideOverlay({
       {frame && !isWheelStep ? (
         <>
           <div
-            className="absolute left-0 right-0 top-0 bg-slate-950/76 backdrop-blur-[1px] transition-all duration-500"
+            className="absolute left-0 right-0 top-0 bg-slate-950/82 backdrop-blur-[5px] transition-all duration-500"
             style={{ height: frame.top }}
           />
           <div
-            className="absolute left-0 bg-slate-950/76 transition-all duration-500"
+            className="absolute left-0 bg-slate-950/82 backdrop-blur-[5px] transition-all duration-500"
             style={{ top: frame.top, width: frame.left, height: frame.height }}
           />
           <div
-            className="absolute right-0 bg-slate-950/76 transition-all duration-500"
+            className="absolute right-0 bg-slate-950/82 backdrop-blur-[5px] transition-all duration-500"
             style={{
               top: frame.top,
               left: frame.left + frame.width,
@@ -133,11 +134,11 @@ export function EditorGuideOverlay({
             }}
           />
           <div
-            className="absolute left-0 right-0 bg-slate-950/76 transition-all duration-500"
+            className="absolute left-0 right-0 bg-slate-950/82 backdrop-blur-[5px] transition-all duration-500"
             style={{ top: frame.top + frame.height, bottom: 0 }}
           />
           <div
-            className="pointer-events-none absolute rounded-2xl border border-violet-300/70 shadow-[0_0_0_1px_rgba(255,255,255,0.18),0_0_42px_rgba(139,92,246,0.4)] transition-all duration-500"
+            className="pointer-events-none absolute rounded-2xl border border-violet-200/65 shadow-[0_0_0_1px_rgba(255,255,255,0.26),0_0_0_9999px_rgba(2,6,23,0.18),0_0_46px_rgba(139,92,246,0.38)] transition-all duration-500"
             style={{
               top: frame.top,
               left: frame.left,
@@ -147,10 +148,18 @@ export function EditorGuideOverlay({
           />
         </>
       ) : (
-        <div className="absolute inset-0 bg-slate-950/78 backdrop-blur-[1px]" />
+        <div className="absolute inset-0 bg-slate-950/82 backdrop-blur-[5px]" />
       )}
 
-      <section className="absolute inset-x-3 bottom-4 mx-auto flex w-full max-w-xl flex-col rounded-3xl border border-white/15 bg-[color:var(--color-slate-900-95)] px-5 py-4 text-white shadow-[0_20px_55px_rgba(15,23,42,0.6)] md:inset-x-0 md:bottom-6">
+      <section
+        className={`editor-guide-panel absolute inset-x-3 mx-auto flex w-full max-w-xl flex-col rounded-3xl border border-white/15 bg-[color:var(--color-slate-900-95)] px-5 py-4 text-white shadow-[0_20px_55px_rgba(15,23,42,0.6)] md:inset-x-0 ${
+          panelPlacement === "top"
+            ? "top-3 md:top-6"
+            : panelPlacement === "center"
+              ? "top-1/2 -translate-y-1/2"
+              : "bottom-4 md:bottom-6"
+        }`}
+      >
         {isWheelStep && (
           <div className="mb-3 rounded-2xl border border-white/10 bg-white/[0.02] px-2 py-3">
             <EditorGuideWheel stepId={step.id} />

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
@@ -49,6 +49,35 @@ const TRAIT_SEGMENTS = PILLARS.flatMap((pillar) =>
   })),
 );
 
+const PILLAR_ACCENTS: Record<
+  (typeof PILLARS)[number],
+  {
+    soft: string;
+    label: string;
+    chip: string;
+    icon: string;
+  }
+> = {
+  Body: {
+    soft: "rgba(126,145,255,0.44)",
+    label: "text-[color:var(--color-slate-100)]",
+    chip: "from-[#8FA2FF]/35 to-[#7DD6F3]/35",
+    icon: "✦",
+  },
+  Mind: {
+    soft: "rgba(180,116,255,0.43)",
+    label: "text-[color:var(--color-slate-100)]",
+    chip: "from-[#D580FF]/35 to-[#A58CFF]/35",
+    icon: "◈",
+  },
+  Soul: {
+    soft: "rgba(74,160,185,0.44)",
+    label: "text-[color:var(--color-slate-100)]",
+    chip: "from-[#63B9C4]/35 to-[#6C80CC]/35",
+    icon: "✧",
+  },
+};
+
 function levelFromStep(stepId: EditorGuideStepId): 1 | 2 | 3 {
   if (stepId === "wheel-core") {
     return 1;
@@ -64,17 +93,21 @@ export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
 
   return (
     <div className="relative mx-auto h-[21.5rem] w-[21.5rem] max-w-full">
-      <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle,_rgba(139,92,246,0.16),_transparent_72%)]" />
+      <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle,_rgba(139,92,246,0.2),_transparent_70%)]" />
 
       <div
-        className="absolute left-1/2 top-1/2 h-24 w-24 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/30 bg-violet-400/25 shadow-[0_0_30px_rgba(139,92,246,0.35)] transition-all duration-700"
+        className="absolute left-1/2 top-1/2 h-24 w-24 -translate-x-1/2 -translate-y-1/2 rounded-full border border-violet-100/35 bg-[radial-gradient(circle_at_35%_28%,rgba(255,255,255,0.34),rgba(180,142,255,0.2)_42%,rgba(58,32,96,0.75)_100%)] shadow-[inset_0_1px_10px_rgba(255,255,255,0.2),inset_0_-10px_20px_rgba(15,23,42,0.42),0_0_0_1px_rgba(255,255,255,0.2),0_0_34px_rgba(139,92,246,0.45)] transition-all duration-700"
         style={{
           transform: `translate(-50%, -50%) scale(${level >= 1 ? 1 : 0.75})`,
           opacity: level >= 1 ? 1 : 0,
         }}
       >
-        <div className="flex h-full items-center justify-center text-sm font-semibold tracking-[0.08em] text-white">
-          Innerbloom
+        <div className="flex h-full items-center justify-center">
+          <img
+            src="/IB-COLOR-LOGO.png"
+            alt="Innerbloom logo"
+            className="h-9 w-9 object-contain drop-shadow-[0_0_14px_rgba(196,181,253,0.45)]"
+          />
         </div>
       </div>
 
@@ -82,7 +115,7 @@ export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
         className="absolute left-1/2 top-1/2 h-52 w-52 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/15 transition-all duration-700"
         style={{
           background:
-            "conic-gradient(from -90deg, rgba(34,197,94,0.35) 0deg 120deg, rgba(59,130,246,0.35) 120deg 240deg, rgba(244,114,182,0.35) 240deg 360deg)",
+            "conic-gradient(from -90deg, rgba(125,152,255,0.5) 0deg 120deg, rgba(192,122,255,0.5) 120deg 240deg, rgba(88,182,192,0.48) 240deg 360deg)",
           mask: "radial-gradient(circle, transparent 33%, black 34%, black 74%, transparent 75%)",
           opacity: level >= 2 ? 1 : 0,
           transform: `translate(-50%, -50%) scale(${level >= 2 ? 1 : 0.82})`,
@@ -98,13 +131,18 @@ export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
         return (
           <div
             key={pillar}
-            className="pointer-events-none absolute left-1/2 top-1/2 text-xs font-semibold uppercase tracking-[0.22em] text-white/90 transition-all duration-700"
+            className="pointer-events-none absolute left-1/2 top-1/2 transition-all duration-700"
             style={{
               transform: `translate(calc(-50% + ${x}px), calc(-50% + ${y}px)) scale(${level >= 2 ? 1 : 0.75})`,
               opacity: level >= 2 ? 1 : 0,
             }}
           >
-            {pillar}
+            <div
+              className={`inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-gradient-to-r px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] shadow-[0_6px_18px_rgba(15,23,42,0.3)] ${PILLAR_ACCENTS[pillar].label} ${PILLAR_ACCENTS[pillar].chip}`}
+            >
+              <span className="text-[11px]">{PILLAR_ACCENTS[pillar].icon}</span>
+              {pillar}
+            </div>
           </div>
         );
       })}
@@ -113,7 +151,7 @@ export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
         className="absolute left-1/2 top-1/2 h-[18.2rem] w-[18.2rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/10 transition-all duration-700"
         style={{
           background:
-            "repeating-conic-gradient(from -90deg, rgba(255,255,255,0.24) 0deg 2deg, rgba(255,255,255,0.08) 2deg 12deg)",
+            "repeating-conic-gradient(from -90deg, rgba(248,250,252,0.3) 0deg 0.85deg, rgba(148,163,184,0.06) 0.85deg 12deg)",
           mask: "radial-gradient(circle, transparent 69%, black 70%, black 90%, transparent 91%)",
           opacity: level >= 3 ? 1 : 0,
           transform: `translate(-50%, -50%) scale(${level >= 3 ? 1 : 0.86})`,
@@ -122,27 +160,42 @@ export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
 
       {TRAIT_SEGMENTS.map(({ trait, index, pillar }) => {
         const angle = -90 + index * 12 + 6;
-        const radius = 162;
+        const radius = 156;
         const x = Math.cos((angle * Math.PI) / 180) * radius;
         const y = Math.sin((angle * Math.PI) / 180) * radius;
-        const color =
-          pillar === "Body"
-            ? "text-emerald-100/85"
-            : pillar === "Mind"
-              ? "text-sky-100/85"
-              : "text-pink-100/85";
+        const textAnchor = angle > 90 && angle < 270 ? "end" : "start";
+        const rotate = textAnchor === "end" ? angle + 180 : angle;
 
         return (
-          <div
+          <svg
             key={`${pillar}-${trait}`}
-            className={`pointer-events-none absolute left-1/2 top-1/2 text-[9px] font-medium leading-none transition-all duration-700 ${color}`}
+            className="pointer-events-none absolute left-1/2 top-1/2 overflow-visible transition-all duration-700"
             style={{
-              transform: `translate(calc(-50% + ${x}px), calc(-50% + ${y}px)) rotate(${angle + 90}deg)`,
+              transform: `translate(calc(-50% + ${x}px), calc(-50% + ${y}px))`,
               opacity: level >= 3 ? 1 : 0,
             }}
           >
-            {trait}
-          </div>
+            <line
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="8"
+              stroke={PILLAR_ACCENTS[pillar].soft}
+              strokeWidth="1.1"
+              transform={`rotate(${angle + 90})`}
+            />
+            <text
+              x="0"
+              y="-1"
+              fill={PILLAR_ACCENTS[pillar].soft}
+              fontSize="8.2"
+              letterSpacing="0.08em"
+              textAnchor={textAnchor}
+              transform={`rotate(${rotate}) translate(0, -8)`}
+            >
+              {trait}
+            </text>
+          </svg>
         );
       })}
     </div>

--- a/apps/web/src/pages/labs/editor-guide/guideConfig.ts
+++ b/apps/web/src/pages/labs/editor-guide/guideConfig.ts
@@ -2,8 +2,7 @@ export type EditorGuideStepId =
   | "wheel-core"
   | "wheel-pillars"
   | "wheel-traits"
-  | "search"
-  | "pillars"
+  | "filters"
   | "task-list"
   | "new-task"
   | "suggestions";
@@ -13,6 +12,7 @@ export interface EditorGuideStep {
   title: string;
   copy: string;
   targetSelector?: string;
+  panelPlacement?: "top" | "bottom" | "center";
 }
 
 export const EDITOR_GUIDE_STEPS: EditorGuideStep[] = [
@@ -32,34 +32,32 @@ export const EDITOR_GUIDE_STEPS: EditorGuideStep[] = [
     copy: "Cada pilar se divide en 10 rasgos para ubicar mejor tus tareas.",
   },
   {
-    id: "search",
-    title: "Buscador",
-    copy: "Acá podés buscar tus tareas.",
-    targetSelector: '[data-editor-guide-target="search"]',
-  },
-  {
-    id: "pillars",
-    title: "Filtros por pilar",
-    copy: "Acá podés filtrar por Body / Mind / Soul.",
-    targetSelector: '[data-editor-guide-target="pillars"]',
+    id: "filters",
+    title: "Buscador + filtros",
+    copy: "Desde acá encontrás tareas rápido y filtrás por pilar.",
+    targetSelector: '[data-editor-guide-target="search-pillar-zone"]',
+    panelPlacement: "bottom",
   },
   {
     id: "task-list",
     title: "Lista de tareas",
     copy: "Abajo ves y administrás tus tareas.",
     targetSelector: '[data-editor-guide-target="task-list"]',
+    panelPlacement: "top",
   },
   {
     id: "new-task",
     title: "Nueva tarea",
     copy: "Desde acá creás tareas nuevas.",
     targetSelector: '[data-editor-guide-target="new-task"]',
+    panelPlacement: "top",
   },
   {
     id: "suggestions",
     title: "Sugerencias",
-    copy: "Acá podés sumar tareas sugeridas a tu sistema.",
+    copy: "Excelente. Con este botón podés sumar ideas base y seguir iterando tu sistema.",
     targetSelector: '[data-editor-guide-target="suggestions"]',
+    panelPlacement: "center",
   },
 ];
 


### PR DESCRIPTION
### Motivation
- Mejorar de forma visual y UX la versión `labs/editor` sin tocar lógica productiva ni onboarding, elevando la estética a un producto premium 2026 manteniendo la colorimetría Innerbloom. 

### Description
- Reemplacé los botones textuales de la cabecera por pills icono (compass / sparkles) y los alineé a la derecha en desktop y mobile, con tratamiento glassy y focus refinado (`apps/web/src/pages/labs/EditorLabPage.tsx`).
- Unifiqué `Buscador + filtros por pilar` en un único bloque focalizable (`search-pillar-zone`) y actualicé la configuración de la guía para tener un único step `filters` en `guideConfig.ts` con `panelPlacement` por step (top/center/bottom) para layout mobile-first.
- Mejoré el overlay de foco en `EditorGuideOverlay.tsx` para aislar realmente la zona enfocada (oscurecer + blur + halo fino alrededor del target) y añadí lógica para anclar el panel explicativo según `panelPlacement`.
- Rediseñé la rueda en `EditorGuideWheel.tsx`: núcleo con el símbolo/flower de Innerbloom (imagen), material glass/resin, anillo de 3 pilares con cromas desaturadas alineadas a Innerbloom, y el anillo externo de 30 rasgos con render SVG radial y labels perpendiculares por sector.
- Rediseñé el modal de `Sugerencias` en `EditorLabPage.tsx` con header reforzado, botón `X` de cierre, cards agrupadas por pilar, selección integrada redonda (sin checkbox cuadrado) y footer CTA anclado/sticky.
- Añadí pequeños iconos SVG internos (guía / sugerencias / cerrar) y nombres de clases CSS nuevos para scope del lab; también añadí reglas de light-mode específicas en `apps/web/src/index.css` para evitar superficies lavadas.
- Archivos principales cambiados: `EditorLabPage.tsx`, `EditorGuideOverlay.tsx`, `EditorGuideWheel.tsx`, `guideConfig.ts`, `index.css`.

### Testing
- Ejecuté el chequeo TypeScript con `pnpm -C apps/web exec tsc --noEmit`, que mostró errores TypeScript preexistentes fuera del alcance de estos cambios y no introduje nuevos errores en los archivos modificados.  
- Verifiqué de forma enfocada con `pnpm -C apps/web exec tsc --noEmit --pretty false 2>&1 | rg "EditorLabPage|EditorGuide|index.css|guideConfig"` sin errores relevantes en los ficheros editados por este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e0dab1708332a89fcea06baacf46)