### PR TITLE
Mejora visual de la guía del labs/editor: centrado, rueda radial y i18n

### DIFF
--- a/apps/web/src/pages/labs/EditorLabPage.tsx
+++ b/apps/web/src/pages/labs/EditorLabPage.tsx
@@ -823,6 +823,7 @@ export default function EditorLabPage() {
         />
         <EditorGuideOverlay
           isOpen={showGuideModal}
+          locale={language === "es" ? "es" : "en"}
           onClose={() => {
             markEditorGuideAsSeen();
             setShowGuideModal(false);
@@ -893,7 +894,7 @@ function TaskFilters({
   onOpenGuide,
   onOpenSuggestions,
 }: TaskFiltersProps) {
-  const { t } = usePostLoginLanguage();
+  const { t, language } = usePostLoginLanguage();
   if (!FEATURE_TASK_EDITOR_MOBILE_LIST_V1) {
     return (
       <div className="flex flex-col gap-3 md:flex-row md:items-end">
@@ -955,19 +956,19 @@ function TaskFilters({
         <button
           type="button"
           onClick={onOpenGuide}
-          aria-label="Abrir guía"
-          className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[linear-gradient(170deg,rgba(255,255,255,0.12),rgba(148,163,184,0.02))] text-[color:var(--color-slate-100)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_8px_18px_rgba(15,23,42,0.24)] transition hover:border-violet-200/40 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-200/60"
+          aria-label={language === "es" ? "Abrir guía" : "Open guide"}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[linear-gradient(170deg,rgba(255,255,255,0.12),rgba(148,163,184,0.02))] text-[color:var(--color-slate-100)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_8px_18px_rgba(15,23,42,0.24)] transition hover:border-violet-200/40 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-200/60"
         >
-          <GuideCompassIcon className="h-3.5 w-3.5" />
+          <GuideCompassIcon className="h-4 w-4" />
         </button>
         <button
           type="button"
           onClick={onOpenSuggestions}
-          aria-label="Abrir sugerencias"
+          aria-label={language === "es" ? "Abrir sugerencias" : "Open suggestions"}
           data-editor-guide-target="suggestions"
-          className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-violet-300/40 bg-[linear-gradient(170deg,rgba(167,139,250,0.26),rgba(129,140,248,0.08))] text-violet-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.2),0_10px_18px_rgba(76,29,149,0.3)] transition hover:border-violet-200/70 hover:bg-violet-500/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-200/65"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-violet-300/40 bg-[linear-gradient(170deg,rgba(167,139,250,0.26),rgba(129,140,248,0.08))] text-violet-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.2),0_10px_18px_rgba(76,29,149,0.3)] transition hover:border-violet-200/70 hover:bg-violet-500/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-200/65"
         >
-          <SuggestionsMagicIcon className="h-3.5 w-3.5" />
+          <SuggestionsMagicIcon className="h-4 w-4" />
         </button>
       </div>
       <div className="md:hidden">
@@ -976,19 +977,19 @@ function TaskFilters({
             <button
               type="button"
               onClick={onOpenGuide}
-              aria-label="Abrir guía"
-              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[linear-gradient(170deg,rgba(255,255,255,0.12),rgba(148,163,184,0.02))] text-[color:var(--color-slate-100)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_8px_18px_rgba(15,23,42,0.24)] transition hover:border-violet-200/40 hover:text-white"
+              aria-label={language === "es" ? "Abrir guía" : "Open guide"}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[linear-gradient(170deg,rgba(255,255,255,0.12),rgba(148,163,184,0.02))] text-[color:var(--color-slate-100)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_8px_18px_rgba(15,23,42,0.24)] transition hover:border-violet-200/40 hover:text-white"
             >
-              <GuideCompassIcon className="h-3.5 w-3.5" />
+              <GuideCompassIcon className="h-4 w-4" />
             </button>
             <button
               type="button"
               onClick={onOpenSuggestions}
-              aria-label="Abrir sugerencias"
+              aria-label={language === "es" ? "Abrir sugerencias" : "Open suggestions"}
               data-editor-guide-target="suggestions"
-              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-violet-300/40 bg-[linear-gradient(170deg,rgba(167,139,250,0.26),rgba(129,140,248,0.08))] text-violet-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.2),0_10px_18px_rgba(76,29,149,0.3)] transition hover:border-violet-200/70 hover:bg-violet-500/20"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-violet-300/40 bg-[linear-gradient(170deg,rgba(167,139,250,0.26),rgba(129,140,248,0.08))] text-violet-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.2),0_10px_18px_rgba(76,29,149,0.3)] transition hover:border-violet-200/70 hover:bg-violet-500/20"
             >
-              <SuggestionsMagicIcon className="h-3.5 w-3.5" />
+              <SuggestionsMagicIcon className="h-4 w-4" />
             </button>
           </div>
           <div

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
@@ -3,7 +3,7 @@ import { EditorGuideWheel } from "./EditorGuideWheel";
 import { EditorGuideStep } from "./EditorGuideStep";
 import {
   EDITOR_GUIDE_FIRST_TIME_STORAGE_KEY,
-  EDITOR_GUIDE_STEPS,
+  getEditorGuideSteps,
 } from "./guideConfig";
 
 type Rect = { top: number; left: number; width: number; height: number };
@@ -29,14 +29,17 @@ function findVisibleTarget(selector: string): Rect | null {
 export function EditorGuideOverlay({
   isOpen,
   onClose,
+  locale,
 }: {
   isOpen: boolean;
   onClose: () => void;
+  locale: "es" | "en";
 }) {
   const [stepIndex, setStepIndex] = useState(0);
   const [targetRect, setTargetRect] = useState<Rect | null>(null);
 
-  const step = EDITOR_GUIDE_STEPS[stepIndex];
+  const guideSteps = getEditorGuideSteps(locale);
+  const step = guideSteps[stepIndex];
   const isWheelStep = step.id.startsWith("wheel");
   const panelPlacement = step.panelPlacement ?? (isWheelStep ? "center" : "bottom");
 
@@ -87,9 +90,13 @@ export function EditorGuideOverlay({
   }, [isOpen, step]);
 
   const canGoBack = stepIndex > 0;
-  const isLast = stepIndex === EDITOR_GUIDE_STEPS.length - 1;
+  const isLast = stepIndex === guideSteps.length - 1;
 
-  const nextLabel = isLast ? "Finalizar" : "Siguiente";
+  const copy = locale === "es"
+    ? { aria: "Guía", back: "Anterior", skip: "Saltar", finish: "Finalizar", next: "Siguiente", label: "Guía" }
+    : { aria: "Guide", back: "Previous", skip: "Skip", finish: "Finish", next: "Next", label: "Guide" };
+
+  const nextLabel = isLast ? copy.finish : copy.next;
 
   const frame = useMemo(() => {
     if (!targetRect) {
@@ -113,7 +120,7 @@ export function EditorGuideOverlay({
       className="editor-guide-overlay fixed inset-0 z-[90]"
       role="dialog"
       aria-modal="true"
-      aria-label="Guía del editor"
+      aria-label={copy.aria}
     >
       {frame && !isWheelStep ? (
         <>
@@ -152,7 +159,7 @@ export function EditorGuideOverlay({
       )}
 
       <section
-        className={`editor-guide-panel absolute inset-x-3 mx-auto flex w-full max-w-xl flex-col rounded-3xl border border-white/15 bg-[color:var(--color-slate-900-95)] px-5 py-4 text-white shadow-[0_20px_55px_rgba(15,23,42,0.6)] md:inset-x-0 ${
+        className={`editor-guide-panel absolute left-1/2 flex w-[min(calc(100vw-1.5rem),42rem)] -translate-x-1/2 flex-col rounded-3xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-surface-elevated)] px-5 py-4 text-[color:var(--color-slate-100)] shadow-[0_20px_55px_rgba(15,23,42,0.6)] ${
           panelPlacement === "top"
             ? "top-3 md:top-6"
             : panelPlacement === "center"
@@ -162,10 +169,10 @@ export function EditorGuideOverlay({
       >
         {isWheelStep && (
           <div className="mb-3 rounded-2xl border border-white/10 bg-white/[0.02] px-2 py-3">
-            <EditorGuideWheel stepId={step.id} />
+            <EditorGuideWheel stepId={step.id} locale={locale} />
           </div>
         )}
-        <EditorGuideStep step={step} />
+        <EditorGuideStep step={step} label={copy.label} />
 
         <div className="mt-4 flex items-center gap-2">
           {canGoBack && (
@@ -176,7 +183,7 @@ export function EditorGuideOverlay({
               }
               className="inline-flex rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--color-slate-100)]"
             >
-              Anterior
+              {copy.back}
             </button>
           )}
           <button
@@ -184,7 +191,7 @@ export function EditorGuideOverlay({
             onClick={onClose}
             className="inline-flex rounded-full border border-white/15 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--color-slate-300)]"
           >
-            Saltar
+            {copy.skip}
           </button>
           <button
             type="button"
@@ -194,7 +201,7 @@ export function EditorGuideOverlay({
                 return;
               }
               setStepIndex((current) =>
-                Math.min(EDITOR_GUIDE_STEPS.length - 1, current + 1),
+                Math.min(guideSteps.length - 1, current + 1),
               );
             }}
             className="ml-auto inline-flex rounded-full bg-violet-500 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-white"

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideStep.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideStep.tsx
@@ -1,15 +1,21 @@
 import type { EditorGuideStep as EditorGuideStepConfig } from "./guideConfig";
 
-export function EditorGuideStep({ step }: { step: EditorGuideStepConfig }) {
+export function EditorGuideStep({
+  step,
+  label,
+}: {
+  step: EditorGuideStepConfig;
+  label: string;
+}) {
   return (
     <>
       <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-violet-200/90">
-        Guía del editor
+        {label}
       </p>
-      <h3 className="mt-1 text-base font-semibold md:text-lg">{step.title}</h3>
-      <p className="mt-1 text-sm text-[color:var(--color-slate-300)]">
-        {step.copy}
-      </p>
+      <h3 className="mt-1 text-base font-semibold text-[color:var(--color-slate-100)] md:text-lg">
+        {step.title}
+      </h3>
+      <p className="mt-1 text-sm text-[color:var(--color-slate-300)]">{step.copy}</p>
     </>
   );
 }

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
@@ -1,99 +1,156 @@
 import type { EditorGuideStepId } from "./guideConfig";
 
-const PILLARS = ["Body", "Mind", "Soul"] as const;
+type Locale = "es" | "en";
+type PillarKey = "Body" | "Mind" | "Soul";
 
-const TRAITS_BY_PILLAR = {
-  Body: [
-    "Energía",
-    "Nutrición",
-    "Sueño",
-    "Recuperación",
-    "Hidratación",
-    "Higiene",
-    "Vitalidad",
-    "Postura",
-    "Movilidad",
-    "Moderación",
-  ],
-  Mind: [
-    "Enfoque",
-    "Aprendizaje",
-    "Creatividad",
-    "Gestión",
-    "Autocontrol",
-    "Resiliencia",
-    "Orden",
-    "Proyección",
-    "Finanzas",
-    "Agilidad",
-  ],
-  Soul: [
-    "Conexión",
-    "Espiritualidad",
-    "Propósito",
-    "Valores",
-    "Altruismo",
-    "Insight",
-    "Gratitud",
-    "Naturaleza",
-    "Gozo",
-    "Autoestima",
-  ],
-} as const;
+const PILLARS: PillarKey[] = ["Body", "Mind", "Soul"];
 
-const TRAIT_SEGMENTS = PILLARS.flatMap((pillar) =>
-  TRAITS_BY_PILLAR[pillar].map((trait, index) => ({
-    pillar,
-    trait,
-    index: PILLARS.indexOf(pillar) * 10 + index,
-  })),
-);
+const TRAITS_BY_PILLAR: Record<Locale, Record<PillarKey, string[]>> = {
+  es: {
+    Body: [
+      "Energía",
+      "Nutrición",
+      "Sueño",
+      "Recuperación",
+      "Hidratación",
+      "Higiene",
+      "Vitalidad",
+      "Postura",
+      "Movilidad",
+      "Moderación",
+    ],
+    Mind: [
+      "Enfoque",
+      "Aprendizaje",
+      "Creatividad",
+      "Gestión",
+      "Autocontrol",
+      "Resiliencia",
+      "Orden",
+      "Proyección",
+      "Finanzas",
+      "Agilidad",
+    ],
+    Soul: [
+      "Conexión",
+      "Espiritualidad",
+      "Propósito",
+      "Valores",
+      "Altruismo",
+      "Insight",
+      "Gratitud",
+      "Naturaleza",
+      "Gozo",
+      "Autoestima",
+    ],
+  },
+  en: {
+    Body: [
+      "Energy",
+      "Nutrition",
+      "Sleep",
+      "Recovery",
+      "Hydration",
+      "Hygiene",
+      "Vitality",
+      "Posture",
+      "Mobility",
+      "Moderation",
+    ],
+    Mind: [
+      "Focus",
+      "Learning",
+      "Creativity",
+      "Management",
+      "Self-control",
+      "Resilience",
+      "Order",
+      "Vision",
+      "Finances",
+      "Agility",
+    ],
+    Soul: [
+      "Connection",
+      "Spirituality",
+      "Purpose",
+      "Values",
+      "Altruism",
+      "Insight",
+      "Gratitude",
+      "Nature",
+      "Joy",
+      "Self-esteem",
+    ],
+  },
+};
 
-const PILLAR_ACCENTS: Record<
-  (typeof PILLARS)[number],
+const PILLAR_META: Record<
+  PillarKey,
   {
-    soft: string;
-    label: string;
-    chip: string;
     icon: string;
+    label: Record<Locale, string>;
+    glow: string;
+    segment: string;
+    text: string;
+    line: string;
   }
 > = {
+  Soul: {
+    icon: "🏵️",
+    label: { es: "Alma", en: "Soul" },
+    glow: "rgba(250, 205, 95, 0.45)",
+    segment: "rgba(250, 205, 95, 0.55)",
+    text: "rgba(255, 242, 204, 0.96)",
+    line: "rgba(250, 205, 95, 0.74)",
+  },
   Body: {
-    soft: "rgba(126,145,255,0.44)",
-    label: "text-[color:var(--color-slate-100)]",
-    chip: "from-[#8FA2FF]/35 to-[#7DD6F3]/35",
-    icon: "✦",
+    icon: "🫀",
+    label: { es: "Cuerpo", en: "Body" },
+    glow: "rgba(98, 225, 232, 0.43)",
+    segment: "rgba(98, 225, 232, 0.52)",
+    text: "rgba(224, 252, 255, 0.95)",
+    line: "rgba(98, 225, 232, 0.7)",
   },
   Mind: {
-    soft: "rgba(180,116,255,0.43)",
-    label: "text-[color:var(--color-slate-100)]",
-    chip: "from-[#D580FF]/35 to-[#A58CFF]/35",
-    icon: "◈",
-  },
-  Soul: {
-    soft: "rgba(74,160,185,0.44)",
-    label: "text-[color:var(--color-slate-100)]",
-    chip: "from-[#63B9C4]/35 to-[#6C80CC]/35",
-    icon: "✧",
+    icon: "🧠",
+    label: { es: "Mente", en: "Mind" },
+    glow: "rgba(184, 141, 255, 0.45)",
+    segment: "rgba(184, 141, 255, 0.54)",
+    text: "rgba(240, 231, 255, 0.96)",
+    line: "rgba(184, 141, 255, 0.76)",
   },
 };
 
 function levelFromStep(stepId: EditorGuideStepId): 1 | 2 | 3 {
-  if (stepId === "wheel-core") {
-    return 1;
-  }
-  if (stepId === "wheel-pillars") {
-    return 2;
-  }
+  if (stepId === "wheel-core") return 1;
+  if (stepId === "wheel-pillars") return 2;
   return 3;
 }
 
-export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
+function compactTraitLabel(label: string): string {
+  return label.length > 11 ? `${label.slice(0, 10)}…` : label;
+}
+
+export function EditorGuideWheel({
+  stepId,
+  locale,
+}: {
+  stepId: EditorGuideStepId;
+  locale: Locale;
+}) {
   const level = levelFromStep(stepId);
+
+  const traitSegments = PILLARS.flatMap((pillar) =>
+    TRAITS_BY_PILLAR[locale][pillar].map((trait, index) => ({
+      pillar,
+      trait: compactTraitLabel(trait),
+      index: PILLARS.indexOf(pillar) * 10 + index,
+    })),
+  );
 
   return (
     <div className="relative mx-auto h-[21.5rem] w-[21.5rem] max-w-full">
-      <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle,_rgba(139,92,246,0.2),_transparent_70%)]" />
+      <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle,rgba(139,92,246,0.19),transparent_72%)]" />
 
       <div
         className="absolute left-1/2 top-1/2 h-24 w-24 -translate-x-1/2 -translate-y-1/2 rounded-full border border-violet-100/35 bg-[radial-gradient(circle_at_35%_28%,rgba(255,255,255,0.34),rgba(180,142,255,0.2)_42%,rgba(58,32,96,0.75)_100%)] shadow-[inset_0_1px_10px_rgba(255,255,255,0.2),inset_0_-10px_20px_rgba(15,23,42,0.42),0_0_0_1px_rgba(255,255,255,0.2),0_0_34px_rgba(139,92,246,0.45)] transition-all duration-700"
@@ -106,7 +163,7 @@ export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
           <img
             src="/IB-COLOR-LOGO.png"
             alt="Innerbloom logo"
-            className="h-9 w-9 object-contain drop-shadow-[0_0_14px_rgba(196,181,253,0.45)]"
+            className="h-12 w-12 object-contain drop-shadow-[0_0_18px_rgba(196,181,253,0.5)]"
           />
         </div>
       </div>
@@ -114,8 +171,7 @@ export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
       <div
         className="absolute left-1/2 top-1/2 h-52 w-52 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/15 transition-all duration-700"
         style={{
-          background:
-            "conic-gradient(from -90deg, rgba(125,152,255,0.5) 0deg 120deg, rgba(192,122,255,0.5) 120deg 240deg, rgba(88,182,192,0.48) 240deg 360deg)",
+          background: `conic-gradient(from -90deg, ${PILLAR_META.Body.segment} 0deg 120deg, ${PILLAR_META.Mind.segment} 120deg 240deg, ${PILLAR_META.Soul.segment} 240deg 360deg)`,
           mask: "radial-gradient(circle, transparent 33%, black 34%, black 74%, transparent 75%)",
           opacity: level >= 2 ? 1 : 0,
           transform: `translate(-50%, -50%) scale(${level >= 2 ? 1 : 0.82})`,
@@ -124,7 +180,7 @@ export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
 
       {PILLARS.map((pillar, index) => {
         const angle = -90 + index * 120 + 60;
-        const radius = 90;
+        const radius = 76;
         const x = Math.cos((angle * Math.PI) / 180) * radius;
         const y = Math.sin((angle * Math.PI) / 180) * radius;
 
@@ -138,29 +194,30 @@ export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
             }}
           >
             <div
-              className={`inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-gradient-to-r px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] shadow-[0_6px_18px_rgba(15,23,42,0.3)] ${PILLAR_ACCENTS[pillar].label} ${PILLAR_ACCENTS[pillar].chip}`}
+              className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-[0.14em]"
+              style={{ color: PILLAR_META[pillar].text, textShadow: `0 0 14px ${PILLAR_META[pillar].glow}` }}
             >
-              <span className="text-[11px]">{PILLAR_ACCENTS[pillar].icon}</span>
-              {pillar}
+              <span className="text-[13px] leading-none">{PILLAR_META[pillar].icon}</span>
+              <span>{PILLAR_META[pillar].label[locale]}</span>
             </div>
           </div>
         );
       })}
 
       <div
-        className="absolute left-1/2 top-1/2 h-[18.2rem] w-[18.2rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/10 transition-all duration-700"
+        className="absolute left-1/2 top-1/2 h-[17rem] w-[17rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/10 transition-all duration-700"
         style={{
           background:
-            "repeating-conic-gradient(from -90deg, rgba(248,250,252,0.3) 0deg 0.85deg, rgba(148,163,184,0.06) 0.85deg 12deg)",
-          mask: "radial-gradient(circle, transparent 69%, black 70%, black 90%, transparent 91%)",
+            "repeating-conic-gradient(from -90deg, rgba(248,250,252,0.36) 0deg 0.9deg, rgba(148,163,184,0.06) 0.9deg 12deg)",
+          mask: "radial-gradient(circle, transparent 65%, black 66%, black 89%, transparent 90%)",
           opacity: level >= 3 ? 1 : 0,
           transform: `translate(-50%, -50%) scale(${level >= 3 ? 1 : 0.86})`,
         }}
       />
 
-      {TRAIT_SEGMENTS.map(({ trait, index, pillar }) => {
+      {traitSegments.map(({ trait, index, pillar }) => {
         const angle = -90 + index * 12 + 6;
-        const radius = 156;
+        const radius = 131;
         const x = Math.cos((angle * Math.PI) / 180) * radius;
         const y = Math.sin((angle * Math.PI) / 180) * radius;
         const textAnchor = angle > 90 && angle < 270 ? "end" : "start";
@@ -179,19 +236,20 @@ export function EditorGuideWheel({ stepId }: { stepId: EditorGuideStepId }) {
               x1="0"
               y1="0"
               x2="0"
-              y2="8"
-              stroke={PILLAR_ACCENTS[pillar].soft}
-              strokeWidth="1.1"
+              y2="7"
+              stroke={PILLAR_META[pillar].line}
+              strokeWidth="1"
               transform={`rotate(${angle + 90})`}
             />
             <text
               x="0"
               y="-1"
-              fill={PILLAR_ACCENTS[pillar].soft}
-              fontSize="8.2"
-              letterSpacing="0.08em"
+              fill={PILLAR_META[pillar].text}
+              fontSize="9.4"
+              fontWeight="500"
+              letterSpacing="0.02em"
               textAnchor={textAnchor}
-              transform={`rotate(${rotate}) translate(0, -8)`}
+              transform={`rotate(${rotate}) translate(0, -7)`}
             >
               {trait}
             </text>

--- a/apps/web/src/pages/labs/editor-guide/guideConfig.ts
+++ b/apps/web/src/pages/labs/editor-guide/guideConfig.ts
@@ -15,51 +15,102 @@ export interface EditorGuideStep {
   panelPlacement?: "top" | "bottom" | "center";
 }
 
-export const EDITOR_GUIDE_STEPS: EditorGuideStep[] = [
-  {
-    id: "wheel-core",
-    title: "Innerbloom",
-    copy: "Innerbloom busca crecimiento en todas las direcciones.",
-  },
-  {
-    id: "wheel-pillars",
-    title: "Tres pilares",
-    copy: "Innerbloom organiza tu crecimiento en tres pilares.",
-  },
-  {
-    id: "wheel-traits",
-    title: "30 rasgos",
-    copy: "Cada pilar se divide en 10 rasgos para ubicar mejor tus tareas.",
-  },
-  {
-    id: "filters",
-    title: "Buscador + filtros",
-    copy: "Desde acá encontrás tareas rápido y filtrás por pilar.",
-    targetSelector: '[data-editor-guide-target="search-pillar-zone"]',
-    panelPlacement: "bottom",
-  },
-  {
-    id: "task-list",
-    title: "Lista de tareas",
-    copy: "Abajo ves y administrás tus tareas.",
-    targetSelector: '[data-editor-guide-target="task-list"]',
-    panelPlacement: "top",
-  },
-  {
-    id: "new-task",
-    title: "Nueva tarea",
-    copy: "Desde acá creás tareas nuevas.",
-    targetSelector: '[data-editor-guide-target="new-task"]',
-    panelPlacement: "top",
-  },
-  {
-    id: "suggestions",
-    title: "Sugerencias",
-    copy: "Excelente. Con este botón podés sumar ideas base y seguir iterando tu sistema.",
-    targetSelector: '[data-editor-guide-target="suggestions"]',
-    panelPlacement: "center",
-  },
-];
+const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
+  es: [
+    {
+      id: "wheel-core",
+      title: "Innerbloom",
+      copy: "Innerbloom busca crecimiento en todas las direcciones.",
+    },
+    {
+      id: "wheel-pillars",
+      title: "Tres pilares",
+      copy: "Innerbloom organiza tu crecimiento en tres pilares.",
+    },
+    {
+      id: "wheel-traits",
+      title: "30 rasgos",
+      copy: "Cada pilar se divide en 10 rasgos para ubicar mejor tus tareas.",
+    },
+    {
+      id: "filters",
+      title: "Buscador + filtros",
+      copy: "Desde acá encontrás tareas rápido y filtrás por pilar.",
+      targetSelector: '[data-editor-guide-target="search-pillar-zone"]',
+      panelPlacement: "bottom",
+    },
+    {
+      id: "task-list",
+      title: "Lista de tareas",
+      copy: "Abajo ves y administrás tus tareas.",
+      targetSelector: '[data-editor-guide-target="task-list"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "new-task",
+      title: "Nueva tarea",
+      copy: "Desde acá creás tareas nuevas.",
+      targetSelector: '[data-editor-guide-target="new-task"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "suggestions",
+      title: "Sugerencias",
+      copy: "Excelente. Con este botón podés sumar ideas base y seguir iterando tu sistema.",
+      targetSelector: '[data-editor-guide-target="suggestions"]',
+      panelPlacement: "center",
+    },
+  ],
+  en: [
+    {
+      id: "wheel-core",
+      title: "Innerbloom",
+      copy: "Innerbloom supports growth in every direction.",
+    },
+    {
+      id: "wheel-pillars",
+      title: "Three pillars",
+      copy: "Innerbloom structures your growth across three pillars.",
+    },
+    {
+      id: "wheel-traits",
+      title: "30 traits",
+      copy: "Each pillar is divided into 10 traits so you can place tasks with precision.",
+    },
+    {
+      id: "filters",
+      title: "Search + filters",
+      copy: "Use this area to find tasks fast and filter by pillar.",
+      targetSelector: '[data-editor-guide-target="search-pillar-zone"]',
+      panelPlacement: "bottom",
+    },
+    {
+      id: "task-list",
+      title: "Task list",
+      copy: "This is where you review and manage your tasks.",
+      targetSelector: '[data-editor-guide-target="task-list"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "new-task",
+      title: "New task",
+      copy: "Create new tasks from this button.",
+      targetSelector: '[data-editor-guide-target="new-task"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "suggestions",
+      title: "Suggestions",
+      copy: "Great. Use this button to add starter ideas and keep refining your system.",
+      targetSelector: '[data-editor-guide-target="suggestions"]',
+      panelPlacement: "center",
+    },
+  ],
+};
+
+export function getEditorGuideSteps(locale: "es" | "en"): EditorGuideStep[] {
+  return EDITOR_GUIDE_STEPS_BY_LOCALE[locale];
+}
 
 export const EDITOR_GUIDE_FIRST_TIME_STORAGE_KEY =
   "innerbloom.editor-lab-guide.seen";


### PR DESCRIPTION
### Motivation
- Corregir problemas de resolución, alineación y mezcla de idiomas en la guía visual del `labs/editor` preservando el aspecto premium y sin tocar flujos ni lógica existentes. 
- Mejorar legibilidad y presencia de los elementos clave (glyphs superiores, núcleo central, etiquetas de pilares y rasgos) para que encajen dentro del área útil del modal. 

### Description
- Localización: centralicé los pasos de la guía en `getEditorGuideSteps` y añadí soporte `es`/`en` para títulos, copys y textos de controles, evitando mezcla de idiomas (archivo `editor-guide/guideConfig.ts`).
- Overlay y layout: `EditorGuideOverlay` ahora recibe `locale`, usa las steps por idioma, y el panel de guía se posiciona centrado y con ancho responsivo para evitar desplazamientos laterales (archivo `EditorGuideOverlay.tsx`).
- Cabecera y copy: cambié el rótulo superior a `Guía`/`Guide` y lo inyecto desde el overlay para todos los steps (archivo `EditorGuideStep.tsx`).
- Controles superiores: aumenté la presencia del glyph en los botones icon-only (guía + sugerencias) sin inflar excesivamente el chip y añadí `aria-label` dependientes de `language` (cambios en `EditorLabPage.tsx`).
- Rueda radial: rehice el `EditorGuideWheel` para aumentar el logo/flor central, integrar los labels de los pilares dentro de su sector con emojis oficiales (`🏵️`, `🫀`, `🧠`) y paleta alineada (Soul dorado, Body cian, Mind lila), además de reajustar el radio y el tipografiado de los 30 rasgos para mejor ajuste y contraste (archivo `EditorGuideWheel.tsx`).

### Testing
- Ejecuté tests focalizados con `pnpm -C apps/web exec vitest run src/pages/labs/editor-guide --passWithNoTests` y la tarea terminó correctamente (no hay tests en esa carpeta). 
- Ejecuté comprobación de tipos con `pnpm -C apps/web exec tsc --noEmit` y detecté fallos TypeScript preexistentes en otras partes del repo que no fueron introducidos por estos cambios. 
- Intenté lintar los archivos objetivo con `pnpm -C apps/web exec eslint ...` pero el runner del entorno no encontró la configuración de ESLint v9 (issue de entorno, no de los cambios aplicados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e614817483329a7bc571eb4a305a)