### PR TITLE
feat(web): prototype AI-native New Task modal in labs editor

### DIFF
--- a/apps/web/src/i18n/post-login/editor.ts
+++ b/apps/web/src/i18n/post-login/editor.ts
@@ -88,6 +88,60 @@ export const editorTranslations = {
     es: 'Selecciona una dificultad…',
     en: 'Select a difficulty…',
   },
+  'editor.modal.aiCreate.badge': { es: 'Asistente IA', en: 'AI Assistant' },
+  'editor.modal.aiCreate.title': { es: 'Nueva tarea guiada', en: 'Guided new task' },
+  'editor.modal.aiCreate.description': {
+    es: 'Escribe tu intención y deja que la IA sugiera la mejor categoría.',
+    en: 'Write your intent and let AI suggest the best category.',
+  },
+  'editor.modal.aiCreate.taskTitleLabel': {
+    es: '¿Qué tarea querés sumar?',
+    en: 'What task do you want to add?',
+  },
+  'editor.modal.aiCreate.taskTitlePlaceholder': {
+    es: 'Ej. Caminar 30 minutos',
+    en: 'E.g. Walk for 30 minutes',
+  },
+  'editor.modal.aiCreate.suggestButton': {
+    es: 'Sugerir categoría',
+    en: 'Suggest category',
+  },
+  'editor.modal.aiCreate.analyzing': {
+    es: 'Analizando tarea…',
+    en: 'Analyzing task…',
+  },
+  'editor.modal.aiCreate.analyzingHint': {
+    es: 'Revisando intención, contexto y patrón de hábito.',
+    en: 'Reviewing intent, context, and habit pattern.',
+  },
+  'editor.modal.aiCreate.suggestedCategory': {
+    es: 'Categoría sugerida',
+    en: 'Suggested category',
+  },
+  'editor.modal.aiCreate.retrySuggestion': {
+    es: 'Reintentar sugerencia',
+    en: 'Retry suggestion',
+  },
+  'editor.modal.aiCreate.confirmButton': {
+    es: 'Confirmar tarea',
+    en: 'Confirm task',
+  },
+  'editor.modal.aiCreate.confirmationRequired': {
+    es: 'Primero usa “Sugerir categoría”.',
+    en: 'Please use “Suggest category” first.',
+  },
+  'editor.modal.aiCreate.catalogFallback': {
+    es: 'No hay catálogo suficiente para sugerir una categoría por ahora.',
+    en: 'Catalog data is not enough to suggest a category right now.',
+  },
+  'editor.modal.aiCreate.noTraits': {
+    es: 'No encontramos rasgos para el pilar sugerido.',
+    en: 'No traits were found for the suggested pillar.',
+  },
+  'editor.modal.aiCreate.suggestionError': {
+    es: 'No pudimos sugerir categoría. Intenta nuevamente.',
+    en: 'Could not suggest a category. Please try again.',
+  },
   'editor.modal.edit.badge': { es: 'Editar tarea', en: 'Edit task' },
   'editor.modal.edit.panelTitle': { es: 'Editar tarea', en: 'Edit task' },
   'editor.modal.edit.title': { es: 'Actualiza los detalles de tu tarea', en: 'Update your task details' },

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5364,6 +5364,84 @@
     color: #ffffff;
   }
 
+  .create-task-ai-modal__badge,
+  .create-task-ai-modal__field-label,
+  .create-task-ai-modal__hint {
+    color: var(--color-slate-400);
+  }
+
+  .create-task-ai-modal__title {
+    color: #ffffff;
+  }
+
+  .create-task-ai-modal__description {
+    color: var(--color-slate-300);
+  }
+
+  .create-task-ai-modal__close {
+    border-color: var(--color-border-subtle);
+    color: var(--color-slate-200);
+    background: var(--color-overlay-1);
+  }
+
+  .create-task-ai-modal__close:hover {
+    border-color: var(--color-border-soft);
+    color: #ffffff;
+  }
+
+  .create-task-ai-modal__control {
+    border-color: var(--color-border-subtle);
+    background: color-mix(in srgb, var(--color-overlay-2) 78%, transparent);
+    color: var(--color-slate-100);
+  }
+
+  .create-task-ai-modal__control::placeholder {
+    color: var(--color-slate-400);
+  }
+
+  .create-task-ai-modal__control:focus {
+    border-color: var(--color-border-soft);
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.2);
+  }
+
+  .create-task-ai-modal__option {
+    background: #0f172a;
+    color: var(--color-slate-100);
+  }
+
+  .create-task-ai-modal__suggest-button {
+    color: #ffffff;
+    background: linear-gradient(125deg, #7066ff 0%, #b577ff 52%, #ff98ad 100%);
+    box-shadow: 0 16px 36px rgba(167, 112, 239, 0.35);
+  }
+
+  .create-task-ai-modal__analysis-card,
+  .create-task-ai-modal__suggestion-card {
+    border-color: var(--color-border-subtle);
+    background: color-mix(in srgb, var(--color-overlay-2) 80%, transparent);
+  }
+
+  .create-task-ai-modal__pulse {
+    background: linear-gradient(90deg, #a770ef 0%, #cf8bf3 50%, #fdb99b 100%);
+    animation: create-task-ai-pulse 1.3s ease-in-out infinite;
+  }
+
+  @keyframes create-task-ai-pulse {
+    0%,
+    100% {
+      opacity: 0.35;
+      transform: scaleX(0.94);
+    }
+    50% {
+      opacity: 1;
+      transform: scaleX(1);
+    }
+  }
+
+  .create-task-ai-modal__retry {
+    color: var(--color-slate-300);
+  }
+
   .edit-task-modal__title {
     color: var(--color-text);
   }
@@ -5636,6 +5714,85 @@
     border-color: var(--editor-modal-secondary-hover-border);
     background: var(--editor-modal-secondary-hover-bg);
     color: var(--editor-modal-text);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__badge,
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__field-label {
+    color: var(--editor-modal-editable-label);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__hint {
+    color: var(--editor-modal-label-muted);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__title {
+    color: var(--editor-modal-text);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__description {
+    color: var(--editor-modal-text-muted);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__close {
+    border-color: var(--editor-modal-secondary-border);
+    color: var(--editor-modal-secondary-text);
+    background: #ffffff;
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__control {
+    background-color: var(--editor-modal-input-bg);
+    border-color: var(--editor-modal-input-border);
+    color: var(--editor-modal-text);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__control::placeholder {
+    color: var(--editor-modal-input-placeholder);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__control:focus {
+    border-color: var(--editor-modal-input-focus-border);
+    box-shadow: 0 0 0 3px var(--editor-modal-input-focus-ring);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__option {
+    background: #ffffff;
+    color: var(--editor-modal-text);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__analysis-card,
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__suggestion-card {
+    border-color: var(--editor-modal-secondary-border);
+    background: color-mix(in srgb, var(--editor-modal-input-bg) 84%, #f8fafc);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__retry {
+    color: var(--editor-modal-secondary-text);
   }
 
   :root[data-theme="dark"]

--- a/apps/web/src/pages/labs/EditorLabPage.tsx
+++ b/apps/web/src/pages/labs/EditorLabPage.tsx
@@ -31,6 +31,7 @@ import {
   fetchCatalogStats,
   fetchCatalogTraits,
   type Pillar,
+  type Trait,
 } from "../../lib/api/catalogs";
 import { useAppMode } from "../../hooks/useAppMode";
 import { useDailyQuestReadiness } from "../../hooks/useDailyQuestReadiness";
@@ -1909,6 +1910,160 @@ interface CreateTaskModalProps {
   onRetryPillars: () => void;
 }
 
+type SuggestedPillarGroup = "body" | "mind" | "soul";
+
+type TaskCategorySuggestion = {
+  pillarId: string;
+  pillarLabel: string;
+  traitId: string;
+  traitLabel: string;
+  rationale: string;
+};
+
+const CATEGORY_KEYWORDS: Record<SuggestedPillarGroup, string[]> = {
+  body: [
+    "caminar",
+    "walk",
+    "run",
+    "correr",
+    "train",
+    "entren",
+    "gym",
+    "agua",
+    "water",
+    "hidr",
+    "sleep",
+    "dorm",
+    "stretch",
+    "mov",
+    "exercise",
+    "comer",
+    "eat",
+  ],
+  mind: [
+    "leer",
+    "read",
+    "study",
+    "estudi",
+    "focus",
+    "foco",
+    "trabajo",
+    "work",
+    "plan",
+    "organ",
+    "deep work",
+    "learn",
+    "aprender",
+  ],
+  soul: [
+    "hablar",
+    "talk",
+    "call",
+    "llamar",
+    "agradec",
+    "gratitude",
+    "medit",
+    "rez",
+    "pray",
+    "connect",
+    "conectar",
+    "friend",
+    "famil",
+    "journal",
+    "respirar",
+    "breathe",
+  ],
+};
+
+function normalizeForMatching(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
+function detectSuggestedPillarGroup(taskTitle: string): SuggestedPillarGroup {
+  const normalizedTitle = normalizeForMatching(taskTitle);
+  const scores = (Object.keys(CATEGORY_KEYWORDS) as SuggestedPillarGroup[]).map(
+    (group) => ({
+      group,
+      score: CATEGORY_KEYWORDS[group].reduce(
+        (total, keyword) =>
+          normalizedTitle.includes(normalizeForMatching(keyword))
+            ? total + 1
+            : total,
+        0,
+      ),
+    }),
+  );
+
+  const topScore = scores.reduce(
+    (best, current) => (current.score > best.score ? current : best),
+    { group: "mind" as SuggestedPillarGroup, score: 0 },
+  );
+
+  if (topScore.score === 0) {
+    return "mind";
+  }
+
+  return topScore.group;
+}
+
+function resolvePillarFromCatalog(
+  pillars: Pillar[],
+  group: SuggestedPillarGroup,
+): Pillar | null {
+  const byCode = pillars.find((pillar) =>
+    normalizeForMatching(pillar.code).includes(group),
+  );
+  if (byCode) {
+    return byCode;
+  }
+
+  const labelHints: Record<SuggestedPillarGroup, string[]> = {
+    body: ["body", "cuerpo", "salud", "fisico", "physical"],
+    mind: ["mind", "mente", "focus", "foco", "mental"],
+    soul: ["soul", "alma", "conexion", "connection", "spirit"],
+  };
+
+  const byName = pillars.find((pillar) =>
+    labelHints[group].some((hint) =>
+      normalizeForMatching(pillar.name).includes(hint),
+    ),
+  );
+
+  return byName ?? pillars[0] ?? null;
+}
+
+function resolveSuggestedTrait(traits: Trait[], group: SuggestedPillarGroup): Trait | null {
+  const traitHints: Record<SuggestedPillarGroup, string[]> = {
+    body: ["hydr", "sleep", "movement", "fitness", "energia", "energy", "health"],
+    mind: ["focus", "clarity", "learn", "discipline", "product", "study"],
+    soul: ["connection", "gratitude", "mindful", "calm", "compassion", "bond"],
+  };
+
+  const hinted = traits.find((trait) => {
+    const searchable = `${trait.name} ${trait.code}`;
+    return traitHints[group].some((hint) =>
+      normalizeForMatching(searchable).includes(hint),
+    );
+  });
+
+  return hinted ?? traits[0] ?? null;
+}
+
+function buildSuggestionRationale(
+  language: "es" | "en",
+  taskTitle: string,
+  pillarLabel: string,
+  traitLabel: string,
+): string {
+  if (language === "es") {
+    return `“${taskTitle}” se alinea con ${pillarLabel} > ${traitLabel}.`;
+  }
+  return `“${taskTitle}” aligns with ${pillarLabel} > ${traitLabel}.`;
+}
+
 function CreateTaskModal({
   open,
   onClose,
@@ -1920,10 +2075,14 @@ function CreateTaskModal({
 }: CreateTaskModalProps) {
   const { language, t } = usePostLoginLanguage();
   const activeLocale = language === "es" ? "es" : "en";
-  const [selectedPillarId, setSelectedPillarId] = useState("");
-  const [selectedTraitId, setSelectedTraitId] = useState("");
   const [title, setTitle] = useState("");
   const [difficultyId, setDifficultyId] = useState("");
+  const [suggestionStatus, setSuggestionStatus] = useState<
+    "idle" | "analyzing" | "ready"
+  >("idle");
+  const [suggestion, setSuggestion] = useState<TaskCategorySuggestion | null>(
+    null,
+  );
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [toast, setToast] = useState<ToastMessage | null>(null);
 
@@ -1940,12 +2099,6 @@ function CreateTaskModal({
 
   const { createTask, status: createStatus } = useCreateTask();
   const {
-    data: traits,
-    isLoading: isLoadingTraits,
-    error: traitsError,
-    reload: reloadTraits,
-  } = useTraits(open ? selectedPillarId : null);
-  const {
     data: difficulties,
     isLoading: isLoadingDifficulties,
     error: difficultiesError,
@@ -1958,10 +2111,10 @@ function CreateTaskModal({
 
   useEffect(() => {
     if (!open) {
-      setSelectedPillarId("");
-      setSelectedTraitId("");
       setTitle("");
       setDifficultyId("");
+      setSuggestionStatus("idle");
+      setSuggestion(null);
       setErrors({});
       setToast(null);
     }
@@ -1993,20 +2146,11 @@ function CreateTaskModal({
     return undefined;
   }, [toast]);
 
-  useEffect(() => {
-    setSelectedTraitId("");
-    clearError("trait");
-  }, [selectedPillarId, clearError]);
-
   const sortedPillars = useMemo(() => {
     return [...pillars].sort((a, b) =>
       a.name.localeCompare(b.name, activeLocale, { sensitivity: "base" }),
     );
   }, [activeLocale, pillars]);
-
-  const filteredTraits = useMemo(() => {
-    return traits.filter((trait) => trait.pillarId === selectedPillarId);
-  }, [traits, selectedPillarId]);
 
   const sortedDifficulties = useMemo(() => {
     return [...difficulties].sort((a, b) =>
@@ -2015,25 +2159,109 @@ function CreateTaskModal({
   }, [activeLocale, difficulties]);
 
   const isSubmitting = createStatus === "loading";
+  const isAnalyzing = suggestionStatus === "analyzing";
   const isSubmitDisabled =
     isSubmitting ||
-    !selectedPillarId ||
-    !selectedTraitId ||
+    !suggestion ||
     title.trim().length === 0 ||
     !userId;
+  const isSuggestDisabled =
+    isAnalyzing ||
+    title.trim().length === 0 ||
+    isLoadingPillars ||
+    Boolean(pillarsError);
+
+  const handleSuggestCategory = useCallback(async () => {
+    const validationErrors: Record<string, string> = {};
+    if (title.trim().length === 0) {
+      validationErrors.title = t("editor.validation.titleRequired");
+    }
+    if (sortedPillars.length === 0) {
+      validationErrors.suggestion = t("editor.modal.aiCreate.catalogFallback");
+    }
+    setErrors(validationErrors);
+    if (Object.keys(validationErrors).length > 0) {
+      return;
+    }
+
+    const pillarGroup = detectSuggestedPillarGroup(title);
+    const selectedPillar = resolvePillarFromCatalog(sortedPillars, pillarGroup);
+    if (!selectedPillar) {
+      setErrors((previous) => ({
+        ...previous,
+        suggestion: t("editor.modal.aiCreate.catalogFallback"),
+      }));
+      return;
+    }
+
+    setSuggestionStatus("analyzing");
+    setSuggestion(null);
+    clearError("suggestion");
+    await new Promise((resolve) => window.setTimeout(resolve, 1200));
+
+    try {
+      const pillarTraits = await fetchCatalogTraits(selectedPillar.id);
+      const selectedTrait = resolveSuggestedTrait(pillarTraits, pillarGroup);
+      if (!selectedTrait) {
+        setSuggestionStatus("idle");
+        setErrors((previous) => ({
+          ...previous,
+          suggestion: t("editor.modal.aiCreate.noTraits"),
+        }));
+        return;
+      }
+
+      const localizedPillar = localizePillarLabel(selectedPillar.name, language);
+      const localizedTrait = localizeTraitLabel(
+        {
+          name: selectedTrait.name,
+          code: selectedTrait.code,
+          fallback: selectedTrait.id,
+        },
+        language,
+      );
+
+      setSuggestion({
+        pillarId: selectedPillar.id,
+        pillarLabel: localizedPillar,
+        traitId: selectedTrait.id,
+        traitLabel: localizedTrait,
+        rationale: buildSuggestionRationale(
+          activeLocale,
+          title.trim(),
+          localizedPillar,
+          localizedTrait,
+        ),
+      });
+      setSuggestionStatus("ready");
+    } catch (error) {
+      console.error("Failed to resolve AI suggestion for lab editor", error);
+      setSuggestionStatus("idle");
+      setErrors((previous) => ({
+        ...previous,
+        suggestion: t("editor.modal.aiCreate.suggestionError"),
+      }));
+    }
+  }, [
+    activeLocale,
+    clearError,
+    language,
+    sortedPillars,
+    t,
+    title,
+  ]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const validationErrors: Record<string, string> = {};
-    if (!selectedPillarId) {
-      validationErrors.pillar = t("editor.validation.selectPillar");
-    }
-    if (!selectedTraitId) {
-      validationErrors.trait = t("editor.validation.selectTrait");
-    }
     if (title.trim().length === 0) {
       validationErrors.title = t("editor.validation.titleRequired");
+    }
+    if (!suggestion) {
+      validationErrors.suggestion = t(
+        "editor.modal.aiCreate.confirmationRequired",
+      );
     }
     if (!userId) {
       validationErrors.user = t("editor.validation.userNotFound");
@@ -2048,14 +2276,16 @@ function CreateTaskModal({
     try {
       await createTask(userId!, {
         title: title.trim(),
-        pillarId: selectedPillarId,
-        traitId: selectedTraitId,
+        pillarId: suggestion!.pillarId,
+        traitId: suggestion!.traitId,
         statId: null,
         difficultyId: difficultyId || null,
       });
       setToast({ type: "success", text: t("editor.toast.create.success") });
       setTitle("");
       setDifficultyId("");
+      setSuggestionStatus("idle");
+      setSuggestion(null);
       setErrors({});
     } catch (error) {
       const message =
@@ -2087,158 +2317,47 @@ function CreateTaskModal({
         >
           <div className="create-task-modal space-y-6">
             <header className="space-y-1">
-              <p className="create-task-modal__badge text-[11px] font-semibold uppercase tracking-[0.24em]">
-                {t("editor.modal.create.badge")}
-              </p>
-              <h2 className="create-task-modal__title text-xl font-semibold">
-                {t("editor.modal.create.title")}
-              </h2>
-              <p className="create-task-modal__description text-sm">
-                {t("editor.modal.create.description")}
-              </p>
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <p className="create-task-ai-modal__badge text-[11px] font-semibold uppercase tracking-[0.24em]">
+                    {t("editor.modal.aiCreate.badge")}
+                  </p>
+                  <h2 className="create-task-ai-modal__title text-xl font-semibold">
+                    {t("editor.modal.aiCreate.title")}
+                  </h2>
+                  <p className="create-task-ai-modal__description text-sm">
+                    {t("editor.modal.aiCreate.description")}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  aria-label={t("editor.button.close")}
+                  className="create-task-ai-modal__close inline-flex h-9 w-9 items-center justify-center rounded-full border text-lg transition"
+                  onClick={handleClose}
+                >
+                  ×
+                </button>
+              </div>
             </header>
-
-            <section className="space-y-4">
-              <div className="space-y-1.5">
-                <p className="create-task-modal__section-label text-[11px] font-semibold uppercase tracking-[0.24em]">
-                  {t("editor.modal.create.step1")}
-                </p>
-                <div className="flex flex-col gap-2">
-                  <select
-                    value={selectedPillarId}
-                    onChange={(event) => {
-                      setSelectedPillarId(event.target.value);
-                      clearError("pillar");
-                    }}
-                    className="create-task-modal__control create-task-modal__control--pill w-full appearance-none rounded-full border px-4 py-2.5 text-sm ios-touch-input focus:outline-none disabled:cursor-not-allowed"
-                    disabled={isLoadingPillars || pillarsError != null}
-                  >
-                    <option value="" className="create-task-modal__option">
-                      {t("editor.modal.create.selectPillarPlaceholder")}
-                    </option>
-                    {sortedPillars.map((pillar) => (
-                      <option
-                        key={pillar.id}
-                        value={pillar.id}
-                        className="create-task-modal__option"
-                      >
-                        {localizePillarLabel(pillar.name, language)}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                {isLoadingPillars && (
-                  <p className="create-task-modal__hint text-[11px] uppercase tracking-[0.2em]">
-                    {t("editor.loading.pillars")}
-                  </p>
-                )}
-                {pillarsError && (
-                  <div className="space-y-1 rounded-xl border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100">
-                    <p>{t("editor.error.pillars.load")}</p>
-                    <button
-                      type="button"
-                      onClick={onRetryPillars}
-                      className="font-semibold text-rose-200 underline decoration-dotted"
-                    >
-                      {t("editor.button.retry")}
-                    </button>
-                  </div>
-                )}
-                {errors.pillar && (
-                  <p className="text-xs text-rose-300">{errors.pillar}</p>
-                )}
-                {!isLoadingPillars &&
-                  !pillarsError &&
-                  sortedPillars.length === 0 && (
-                    <p className="create-task-modal__hint text-xs">
-                      No encontramos pilares disponibles por ahora.
-                    </p>
-                  )}
-              </div>
-
-              <div className="space-y-1.5">
-                <p className="create-task-modal__section-label text-[11px] font-semibold uppercase tracking-[0.24em]">
-                  {t("editor.modal.create.step2")}
-                </p>
-                <div className="flex flex-col gap-2">
-                  <select
-                    value={selectedTraitId}
-                    onChange={(event) => {
-                      setSelectedTraitId(event.target.value);
-                      clearError("trait");
-                    }}
-                    className="create-task-modal__control create-task-modal__control--pill w-full appearance-none rounded-full border px-4 py-2.5 text-sm ios-touch-input focus:outline-none disabled:cursor-not-allowed"
-                    disabled={!selectedPillarId || isLoadingTraits}
-                  >
-                    <option value="" className="create-task-modal__option">
-                      {selectedPillarId
-                        ? t("editor.modal.create.selectTraitPlaceholder")
-                        : t("editor.modal.create.selectPillarFirst")}
-                    </option>
-                    {filteredTraits.map((trait) => (
-                      <option
-                        key={trait.id}
-                        value={trait.id}
-                        className="create-task-modal__option"
-                      >
-                        {localizeTraitLabel(
-                          {
-                            name: trait.name,
-                            code: trait.code,
-                            fallback: trait.id,
-                          },
-                          language,
-                        )}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                {isLoadingTraits && (
-                  <p className="create-task-modal__hint text-[11px] uppercase tracking-[0.2em]">
-                    {t("editor.loading.traits")}
-                  </p>
-                )}
-                {traitsError && (
-                  <div className="space-y-1 rounded-xl border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100">
-                    <p>{t("editor.error.traits.load")}</p>
-                    <button
-                      type="button"
-                      onClick={reloadTraits}
-                      className="font-semibold text-rose-200 underline decoration-dotted"
-                    >
-                      {t("editor.button.retry")}
-                    </button>
-                  </div>
-                )}
-                {errors.trait && (
-                  <p className="text-xs text-rose-300">{errors.trait}</p>
-                )}
-                {selectedPillarId &&
-                  !isLoadingTraits &&
-                  filteredTraits.length === 0 &&
-                  !traitsError && (
-                    <p className="create-task-modal__hint text-xs">
-                      {t("editor.empty.noTraits")}
-                    </p>
-                  )}
-              </div>
-            </section>
 
             <section className="space-y-4">
               <div className="space-y-2">
                 <label className="flex flex-col gap-2">
-                  <span className="create-task-modal__field-label text-xs font-semibold uppercase tracking-[0.18em]">
-                    {t("editor.modal.create.taskTitleLabel")}
+                  <span className="create-task-ai-modal__field-label text-xs font-semibold uppercase tracking-[0.18em]">
+                    {t("editor.modal.aiCreate.taskTitleLabel")}
                   </span>
-                  <input
-                    type="text"
+                  <textarea
                     value={title}
                     onChange={(event) => {
                       setTitle(event.target.value);
                       clearError("title");
+                      clearError("suggestion");
+                      setSuggestionStatus("idle");
+                      setSuggestion(null);
                     }}
-                    placeholder={t("editor.modal.taskTitle.placeholder")}
-                    className="create-task-modal__control w-full rounded-2xl border px-4 py-3 text-sm ios-touch-input focus:outline-none"
+                    placeholder={t("editor.modal.aiCreate.taskTitlePlaceholder")}
+                    className="create-task-ai-modal__control w-full rounded-2xl border px-4 py-3 text-sm ios-touch-input focus:outline-none"
+                    rows={3}
                   />
                 </label>
                 {errors.title && (
@@ -2248,23 +2367,23 @@ function CreateTaskModal({
 
               <div className="space-y-2">
                 <label className="flex flex-col gap-2">
-                  <span className="create-task-modal__field-label text-xs font-semibold uppercase tracking-[0.18em]">
+                  <span className="create-task-ai-modal__field-label text-xs font-semibold uppercase tracking-[0.18em]">
                     {t("editor.field.difficulty")}
                   </span>
                   <select
                     value={difficultyId}
                     onChange={(event) => setDifficultyId(event.target.value)}
-                    className="create-task-modal__control w-full appearance-none rounded-2xl border px-4 py-3 text-sm ios-touch-input focus:outline-none disabled:cursor-not-allowed"
+                    className="create-task-ai-modal__control w-full appearance-none rounded-2xl border px-4 py-3 text-sm ios-touch-input focus:outline-none disabled:cursor-not-allowed"
                     disabled={isLoadingDifficulties}
                   >
-                    <option value="" className="create-task-modal__option">
+                    <option value="" className="create-task-ai-modal__option">
                       {t("editor.modal.create.selectDifficultyPlaceholder")}
                     </option>
                     {sortedDifficulties.map((difficulty) => (
                       <option
                         key={difficulty.id}
                         value={difficulty.id}
-                        className="create-task-modal__option"
+                        className="create-task-ai-modal__option"
                       >
                         {localizeDifficultyLabel(difficulty.name, language)}
                       </option>
@@ -2291,6 +2410,80 @@ function CreateTaskModal({
               </div>
             </section>
 
+            <section className="space-y-3">
+              <button
+                type="button"
+                className="create-task-ai-modal__suggest-button inline-flex w-full items-center justify-center rounded-2xl px-5 py-3 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={() => void handleSuggestCategory()}
+                disabled={isSuggestDisabled}
+              >
+                {isAnalyzing
+                  ? t("editor.modal.aiCreate.analyzing")
+                  : t("editor.modal.aiCreate.suggestButton")}
+              </button>
+              {isLoadingPillars && (
+                <p className="create-task-ai-modal__hint text-[11px] uppercase tracking-[0.2em]">
+                  {t("editor.loading.pillars")}
+                </p>
+              )}
+              {pillarsError && (
+                <div className="space-y-1 rounded-xl border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-100">
+                  <p>{t("editor.error.pillars.load")}</p>
+                  <button
+                    type="button"
+                    onClick={onRetryPillars}
+                    className="font-semibold text-rose-200 underline decoration-dotted"
+                  >
+                    {t("editor.button.retry")}
+                  </button>
+                </div>
+              )}
+            </section>
+
+            {isAnalyzing && (
+              <section className="create-task-ai-modal__analysis-card space-y-2 rounded-2xl border p-4">
+                <div className="create-task-ai-modal__pulse h-2 w-24 rounded-full" />
+                <p className="text-sm font-semibold">
+                  {t("editor.modal.aiCreate.analyzing")}
+                </p>
+                <p className="create-task-ai-modal__hint text-xs">
+                  {t("editor.modal.aiCreate.analyzingHint")}
+                </p>
+              </section>
+            )}
+
+            {suggestion && suggestionStatus === "ready" && (
+              <section className="create-task-ai-modal__suggestion-card space-y-3 rounded-2xl border p-4">
+                <p className="create-task-ai-modal__field-label text-[11px] font-semibold uppercase tracking-[0.24em]">
+                  {t("editor.modal.aiCreate.suggestedCategory")}
+                </p>
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="rounded-full border px-3 py-1 font-semibold">
+                    {suggestion.pillarLabel}
+                  </span>
+                  <span className="create-task-ai-modal__hint">/</span>
+                  <span className="rounded-full border px-3 py-1 font-semibold">
+                    {suggestion.traitLabel}
+                  </span>
+                </div>
+                <p className="create-task-ai-modal__hint text-sm">
+                  {suggestion.rationale}
+                </p>
+                <div className="flex justify-end">
+                  <button
+                    type="button"
+                    className="create-task-ai-modal__retry text-xs font-semibold underline decoration-dotted underline-offset-4"
+                    onClick={() => void handleSuggestCategory()}
+                  >
+                    {t("editor.modal.aiCreate.retrySuggestion")}
+                  </button>
+                </div>
+              </section>
+            )}
+
+            {errors.suggestion && (
+              <p className="text-xs text-rose-300">{errors.suggestion}</p>
+            )}
             {errors.user && (
               <p className="text-xs text-rose-300">{errors.user}</p>
             )}
@@ -2322,7 +2515,7 @@ function CreateTaskModal({
               >
                 {isSubmitting
                   ? t("editor.button.creating")
-                  : t("editor.button.createTask")}
+                  : t("editor.modal.aiCreate.confirmButton")}
               </button>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Probar una experiencia "AI-native" en el `labs/editor` para que el usuario escriba la intención y la IA (mock) sugiera pilar+rasgo, sin tocar lógica de producción ni backend real.

### Description
- Reemplaza el modal de creación de tarea en `apps/web/src/pages/labs/EditorLabPage.tsx` por un flujo guiado (campo de intención, selector de dificultad, botón `Sugerir categoría`, estado de análisis, card de sugerencia y confirmación).
- Añade una clasificación mock/local implementada con heurística de keywords ES/EN y utilidades (`detectSuggestedPillarGroup`, `resolvePillarFromCatalog`, `resolveSuggestedTrait`, `buildSuggestionRationale`) que resuelven IDs contra los catálogos existentes via `fetchCatalogTraits`.
- Introduce estados de sugerencia (`idle`, `analyzing`, `ready`), invalidación automática de la sugerencia al editar el texto, y reutiliza `createTask` para crear la tarea con los IDs sugeridos (todo encapsulado en el lab, sin llamadas externas ni tokens).
- Agrega estilos específicos para el modal AI en `apps/web/src/index.css` (tratamiento premium, dark/light) y copias i18n completas EN/ES en `apps/web/src/i18n/post-login/editor.ts`.

### Testing
- Ejecuté `pnpm -C apps/web test src/pages/editor/__tests__/labelLocalization.test.ts` y los tests pasaron (1 archivo, 3 tests) ✅.
- Ejecuté `pnpm -C apps/web typecheck` y el typecheck falló por errores TypeScript preexistentes en el repositorio ajenos a este cambio; no se detectaron errores nuevos específicos de `EditorLabPage` durante la verificación local ⚠️.
- Cambios limitados al lab (no se modificó el modal de producción ni se integró IA/backend real) y el flujo prototipo está operativo en esa rama para evaluación visual/manual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8eb2da34c8332a3da149ac2697146)