### PR TITLE
Refine labs/editor guide composition, flow order, and AI modal UX

### DIFF
--- a/apps/web/src/i18n/post-login/editor.ts
+++ b/apps/web/src/i18n/post-login/editor.ts
@@ -122,6 +122,10 @@ export const editorTranslations = {
     es: 'Reintentar sugerencia',
     en: 'Retry suggestion',
   },
+  'editor.modal.aiCreate.manualCategory': {
+    es: 'Elegir manualmente',
+    en: 'Set manually',
+  },
   'editor.modal.aiCreate.confirmButton': {
     es: 'Confirmar tarea',
     en: 'Confirm task',

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5411,14 +5411,20 @@
 
   .create-task-ai-modal__suggest-button {
     color: #ffffff;
-    background: linear-gradient(125deg, #7066ff 0%, #b577ff 52%, #ff98ad 100%);
-    box-shadow: 0 16px 36px rgba(167, 112, 239, 0.35);
+    background: linear-gradient(128deg, #6f67ff 0%, #ad78ff 62%, #f197c4 100%);
+    box-shadow: 0 10px 24px rgba(153, 101, 233, 0.34);
+    letter-spacing: 0.01em;
   }
 
   .create-task-ai-modal__analysis-card,
-  .create-task-ai-modal__suggestion-card {
+  .create-task-ai-modal__manual-grid {
     border-color: var(--color-border-subtle);
     background: color-mix(in srgb, var(--color-overlay-2) 80%, transparent);
+  }
+
+  .create-task-ai-modal__suggestion-strip {
+    border-top: 1px solid color-mix(in srgb, var(--color-border-subtle) 62%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--color-border-subtle) 50%, transparent);
   }
 
   .create-task-ai-modal__pulse {
@@ -5784,9 +5790,16 @@
     .create-task-ai-modal__analysis-card,
   :root[data-theme="light"]
     [data-light-scope="editor"]
-    .create-task-ai-modal__suggestion-card {
+    .create-task-ai-modal__manual-grid {
     border-color: var(--editor-modal-secondary-border);
     background: color-mix(in srgb, var(--editor-modal-input-bg) 84%, #f8fafc);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__suggestion-strip {
+    border-top-color: color-mix(in srgb, var(--editor-modal-secondary-border) 68%, transparent);
+    border-bottom-color: color-mix(in srgb, var(--editor-modal-secondary-border) 58%, transparent);
   }
 
   :root[data-theme="light"]

--- a/apps/web/src/pages/labs/EditorLabPage.tsx
+++ b/apps/web/src/pages/labs/EditorLabPage.tsx
@@ -48,6 +48,7 @@ import {
   markEditorGuideAsSeen,
   shouldAutoOpenEditorGuide,
 } from "./editor-guide/EditorGuideOverlay";
+import type { EditorGuideStepId } from "./editor-guide/guideConfig";
 import {
   getActiveSection,
   getDashboardSectionConfig,
@@ -391,6 +392,23 @@ export default function EditorLabPage() {
   const handleCreateClick = () => {
     setShowCreateModal(true);
   };
+
+  const handleGuideStepChange = useCallback((stepId: EditorGuideStepId) => {
+    const modalSteps = new Set<EditorGuideStepId>([
+      "modal-input",
+      "modal-ai-action",
+      "modal-ai-result",
+    ]);
+
+    if (modalSteps.has(stepId)) {
+      setShowCreateModal(true);
+      return;
+    }
+
+    if (stepId === "modal-entry") {
+      setShowCreateModal(false);
+    }
+  }, []);
 
   const handleDeleteModalClose = useCallback(() => {
     if (isDeletingTask) {
@@ -825,9 +843,11 @@ export default function EditorLabPage() {
         <EditorGuideOverlay
           isOpen={showGuideModal}
           locale={language === "es" ? "es" : "en"}
+          onStepChange={handleGuideStepChange}
           onClose={() => {
             markEditorGuideAsSeen();
             setShowGuideModal(false);
+            setShowCreateModal(false);
           }}
         />
         <SuggestionsLabModal
@@ -2083,6 +2103,9 @@ function CreateTaskModal({
   const [suggestion, setSuggestion] = useState<TaskCategorySuggestion | null>(
     null,
   );
+  const [manualCategoryEnabled, setManualCategoryEnabled] = useState(false);
+  const [manualPillarId, setManualPillarId] = useState("");
+  const [manualTraitId, setManualTraitId] = useState("");
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [toast, setToast] = useState<ToastMessage | null>(null);
 
@@ -2115,6 +2138,9 @@ function CreateTaskModal({
       setDifficultyId("");
       setSuggestionStatus("idle");
       setSuggestion(null);
+      setManualCategoryEnabled(false);
+      setManualPillarId("");
+      setManualTraitId("");
       setErrors({});
       setToast(null);
     }
@@ -2158,11 +2184,59 @@ function CreateTaskModal({
     );
   }, [activeLocale, difficulties]);
 
+  const selectedManualPillar = useMemo(
+    () => sortedPillars.find((pillar) => pillar.id === manualPillarId) ?? null,
+    [manualPillarId, sortedPillars],
+  );
+
+  const [manualTraits, setManualTraits] = useState<Trait[]>([]);
+  const [isLoadingManualTraits, setIsLoadingManualTraits] = useState(false);
+  const [manualTraitsError, setManualTraitsError] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!manualCategoryEnabled || !manualPillarId) {
+      setManualTraits([]);
+      setManualTraitsError(null);
+      setManualTraitId("");
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingManualTraits(true);
+    setManualTraitsError(null);
+    void fetchCatalogTraits(manualPillarId)
+      .then((traits) => {
+        if (cancelled) {
+          return;
+        }
+        setManualTraits(traits);
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+        console.error("Failed to load traits for manual selection", error);
+        setManualTraitsError(t("editor.error.traits.load"));
+        setManualTraits([]);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoadingManualTraits(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [manualCategoryEnabled, manualPillarId, t]);
+
   const isSubmitting = createStatus === "loading";
   const isAnalyzing = suggestionStatus === "analyzing";
   const isSubmitDisabled =
     isSubmitting ||
-    !suggestion ||
+    (!suggestion && !(manualCategoryEnabled && manualPillarId && manualTraitId)) ||
     title.trim().length === 0 ||
     !userId;
   const isSuggestDisabled =
@@ -2259,9 +2333,11 @@ function CreateTaskModal({
       validationErrors.title = t("editor.validation.titleRequired");
     }
     if (!suggestion) {
-      validationErrors.suggestion = t(
-        "editor.modal.aiCreate.confirmationRequired",
-      );
+      if (!(manualCategoryEnabled && manualPillarId && manualTraitId)) {
+        validationErrors.suggestion = t(
+          "editor.modal.aiCreate.confirmationRequired",
+        );
+      }
     }
     if (!userId) {
       validationErrors.user = t("editor.validation.userNotFound");
@@ -2274,10 +2350,12 @@ function CreateTaskModal({
     }
 
     try {
+      const resolvedPillarId = suggestion?.pillarId ?? manualPillarId;
+      const resolvedTraitId = suggestion?.traitId ?? manualTraitId;
       await createTask(userId!, {
         title: title.trim(),
-        pillarId: suggestion!.pillarId,
-        traitId: suggestion!.traitId,
+        pillarId: resolvedPillarId,
+        traitId: resolvedTraitId,
         statId: null,
         difficultyId: difficultyId || null,
       });
@@ -2286,6 +2364,9 @@ function CreateTaskModal({
       setDifficultyId("");
       setSuggestionStatus("idle");
       setSuggestion(null);
+      setManualCategoryEnabled(false);
+      setManualPillarId("");
+      setManualTraitId("");
       setErrors({});
     } catch (error) {
       const message =
@@ -2347,6 +2428,7 @@ function CreateTaskModal({
                     {t("editor.modal.aiCreate.taskTitleLabel")}
                   </span>
                   <textarea
+                    data-editor-guide-target="new-task-modal-input"
                     value={title}
                     onChange={(event) => {
                       setTitle(event.target.value);
@@ -2413,10 +2495,12 @@ function CreateTaskModal({
             <section className="space-y-3">
               <button
                 type="button"
-                className="create-task-ai-modal__suggest-button inline-flex w-full items-center justify-center rounded-2xl px-5 py-3 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60"
+                data-editor-guide-target="new-task-modal-ai-action"
+                className="create-task-ai-modal__suggest-button inline-flex w-full items-center justify-center gap-2 rounded-xl px-3.5 py-2 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
                 onClick={() => void handleSuggestCategory()}
                 disabled={isSuggestDisabled}
               >
+                <span aria-hidden>✨</span>
                 {isAnalyzing
                   ? t("editor.modal.aiCreate.analyzing")
                   : t("editor.modal.aiCreate.suggestButton")}
@@ -2441,7 +2525,7 @@ function CreateTaskModal({
             </section>
 
             {isAnalyzing && (
-              <section className="create-task-ai-modal__analysis-card space-y-2 rounded-2xl border p-4">
+              <section className="create-task-ai-modal__analysis-card space-y-2 rounded-xl border p-3">
                 <div className="create-task-ai-modal__pulse h-2 w-24 rounded-full" />
                 <p className="text-sm font-semibold">
                   {t("editor.modal.aiCreate.analyzing")}
@@ -2453,7 +2537,10 @@ function CreateTaskModal({
             )}
 
             {suggestion && suggestionStatus === "ready" && (
-              <section className="create-task-ai-modal__suggestion-card space-y-3 rounded-2xl border p-4">
+              <section
+                className="create-task-ai-modal__suggestion-strip space-y-2.5 py-1"
+                data-editor-guide-target="new-task-modal-ai-result"
+              >
                 <p className="create-task-ai-modal__field-label text-[11px] font-semibold uppercase tracking-[0.24em]">
                   {t("editor.modal.aiCreate.suggestedCategory")}
                 </p>
@@ -2469,7 +2556,7 @@ function CreateTaskModal({
                 <p className="create-task-ai-modal__hint text-sm">
                   {suggestion.rationale}
                 </p>
-                <div className="flex justify-end">
+                <div className="flex flex-wrap items-center justify-end gap-3 pt-1">
                   <button
                     type="button"
                     className="create-task-ai-modal__retry text-xs font-semibold underline decoration-dotted underline-offset-4"
@@ -2477,7 +2564,77 @@ function CreateTaskModal({
                   >
                     {t("editor.modal.aiCreate.retrySuggestion")}
                   </button>
+                  <button
+                    type="button"
+                    className="create-task-ai-modal__retry text-xs font-semibold underline decoration-dotted underline-offset-4"
+                    onClick={() => {
+                      setManualCategoryEnabled(true);
+                      clearError("suggestion");
+                    }}
+                  >
+                    {t("editor.modal.aiCreate.manualCategory")}
+                  </button>
                 </div>
+              </section>
+            )}
+
+            {manualCategoryEnabled && (
+              <section
+                className="create-task-ai-modal__manual-grid grid gap-3 rounded-xl border p-3"
+                data-editor-guide-target="new-task-modal-ai-result"
+              >
+                <label className="flex flex-col gap-2">
+                  <span className="create-task-ai-modal__field-label text-[11px] font-semibold uppercase tracking-[0.2em]">
+                    {t("editor.field.pillar")}
+                  </span>
+                  <select
+                    value={manualPillarId}
+                    onChange={(event) => {
+                      setManualPillarId(event.target.value);
+                      setManualTraitId("");
+                      clearError("suggestion");
+                    }}
+                    className="create-task-ai-modal__control w-full appearance-none rounded-xl border px-3 py-2 text-sm ios-touch-input focus:outline-none"
+                  >
+                    <option value="">{t("editor.modal.create.selectPillarPlaceholder")}</option>
+                    {sortedPillars.map((pillar) => (
+                      <option key={pillar.id} value={pillar.id}>
+                        {localizePillarLabel(pillar.name, language)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex flex-col gap-2">
+                  <span className="create-task-ai-modal__field-label text-[11px] font-semibold uppercase tracking-[0.2em]">
+                    {t("editor.field.trait")}
+                  </span>
+                  <select
+                    value={manualTraitId}
+                    onChange={(event) => {
+                      setManualTraitId(event.target.value);
+                      clearError("suggestion");
+                    }}
+                    className="create-task-ai-modal__control w-full appearance-none rounded-xl border px-3 py-2 text-sm ios-touch-input focus:outline-none"
+                    disabled={!selectedManualPillar || isLoadingManualTraits}
+                  >
+                    <option value="">
+                      {selectedManualPillar
+                        ? t("editor.modal.create.selectTraitPlaceholder")
+                        : t("editor.modal.create.selectPillarFirst")}
+                    </option>
+                    {manualTraits.map((trait) => (
+                      <option key={trait.id} value={trait.id}>
+                        {localizeTraitLabel(
+                          { name: trait.name, code: trait.code, fallback: trait.id },
+                          language,
+                        )}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                {manualTraitsError && (
+                  <p className="text-xs text-rose-300">{manualTraitsError}</p>
+                )}
               </section>
             )}
 

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
@@ -3,6 +3,7 @@ import { EditorGuideWheel } from "./EditorGuideWheel";
 import { EditorGuideStep } from "./EditorGuideStep";
 import {
   EDITOR_GUIDE_FIRST_TIME_STORAGE_KEY,
+  type EditorGuideStepId,
   getEditorGuideSteps,
 } from "./guideConfig";
 
@@ -30,10 +31,12 @@ export function EditorGuideOverlay({
   isOpen,
   onClose,
   locale,
+  onStepChange,
 }: {
   isOpen: boolean;
   onClose: () => void;
   locale: "es" | "en";
+  onStepChange?: (stepId: EditorGuideStepId) => void;
 }) {
   const [stepIndex, setStepIndex] = useState(0);
   const [targetRect, setTargetRect] = useState<Rect | null>(null);
@@ -88,6 +91,13 @@ export function EditorGuideOverlay({
       window.removeEventListener("scroll", update, true);
     };
   }, [isOpen, step]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    onStepChange?.(step.id);
+  }, [isOpen, onStepChange, step.id]);
 
   const canGoBack = stepIndex > 0;
   const isLast = stepIndex === guideSteps.length - 1;

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
@@ -131,6 +131,14 @@ function compactTraitLabel(label: string): string {
   return label.length > 11 ? `${label.slice(0, 10)}…` : label;
 }
 
+function polarToCartesian(angleDeg: number, radius: number) {
+  const radians = (angleDeg * Math.PI) / 180;
+  return {
+    x: Math.cos(radians) * radius,
+    y: Math.sin(radians) * radius,
+  };
+}
+
 export function EditorGuideWheel({
   stepId,
   locale,
@@ -148,8 +156,16 @@ export function EditorGuideWheel({
     })),
   );
 
+  const size = 320;
+  const center = size / 2;
+  const ringSize = 196;
+  const traitRingSize = 252;
+  const pillarLabelRadius = 72;
+  const traitTickRadius = 126;
+  const traitLabelRadius = 142;
+
   return (
-    <div className="relative mx-auto h-[21.5rem] w-[21.5rem] max-w-full">
+    <div className="relative mx-auto h-[20.5rem] w-full max-w-[20.5rem] overflow-hidden">
       <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle,rgba(139,92,246,0.19),transparent_72%)]" />
 
       <div
@@ -169,8 +185,10 @@ export function EditorGuideWheel({
       </div>
 
       <div
-        className="absolute left-1/2 top-1/2 h-52 w-52 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/15 transition-all duration-700"
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/15 transition-all duration-700"
         style={{
+          width: `${ringSize}px`,
+          height: `${ringSize}px`,
           background: `conic-gradient(from -90deg, ${PILLAR_META.Body.segment} 0deg 120deg, ${PILLAR_META.Mind.segment} 120deg 240deg, ${PILLAR_META.Soul.segment} 240deg 360deg)`,
           mask: "radial-gradient(circle, transparent 33%, black 34%, black 74%, transparent 75%)",
           opacity: level >= 2 ? 1 : 0,
@@ -180,21 +198,19 @@ export function EditorGuideWheel({
 
       {PILLARS.map((pillar, index) => {
         const angle = -90 + index * 120 + 60;
-        const radius = 76;
-        const x = Math.cos((angle * Math.PI) / 180) * radius;
-        const y = Math.sin((angle * Math.PI) / 180) * radius;
+        const position = polarToCartesian(angle, pillarLabelRadius);
 
         return (
           <div
             key={pillar}
             className="pointer-events-none absolute left-1/2 top-1/2 transition-all duration-700"
             style={{
-              transform: `translate(calc(-50% + ${x}px), calc(-50% + ${y}px)) scale(${level >= 2 ? 1 : 0.75})`,
+              transform: `translate(calc(-50% + ${position.x}px), calc(-50% + ${position.y}px)) scale(${level >= 2 ? 1 : 0.75})`,
               opacity: level >= 2 ? 1 : 0,
             }}
           >
             <div
-              className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-[0.14em]"
+              className="inline-flex min-w-[84px] items-center justify-center gap-1.5 rounded-full bg-black/15 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.13em] backdrop-blur-[1px]"
               style={{ color: PILLAR_META[pillar].text, textShadow: `0 0 14px ${PILLAR_META[pillar].glow}` }}
             >
               <span className="text-[13px] leading-none">{PILLAR_META[pillar].icon}</span>
@@ -205,8 +221,10 @@ export function EditorGuideWheel({
       })}
 
       <div
-        className="absolute left-1/2 top-1/2 h-[17rem] w-[17rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/10 transition-all duration-700"
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/10 transition-all duration-700"
         style={{
+          width: `${traitRingSize}px`,
+          height: `${traitRingSize}px`,
           background:
             "repeating-conic-gradient(from -90deg, rgba(248,250,252,0.36) 0deg 0.9deg, rgba(148,163,184,0.06) 0.9deg 12deg)",
           mask: "radial-gradient(circle, transparent 65%, black 66%, black 89%, transparent 90%)",
@@ -215,47 +233,46 @@ export function EditorGuideWheel({
         }}
       />
 
-      {traitSegments.map(({ trait, index, pillar }) => {
-        const angle = -90 + index * 12 + 6;
-        const radius = 131;
-        const x = Math.cos((angle * Math.PI) / 180) * radius;
-        const y = Math.sin((angle * Math.PI) / 180) * radius;
-        const textAnchor = angle > 90 && angle < 270 ? "end" : "start";
-        const rotate = textAnchor === "end" ? angle + 180 : angle;
+      <svg
+        viewBox={`0 0 ${size} ${size}`}
+        className="pointer-events-none absolute inset-0 h-full w-full overflow-hidden transition-all duration-700"
+        style={{ opacity: level >= 3 ? 1 : 0 }}
+      >
+        {traitSegments.map(({ trait, index, pillar }) => {
+          const angle = -90 + index * 12 + 6;
+          const tickStart = polarToCartesian(angle, traitTickRadius);
+          const tickEnd = polarToCartesian(angle, traitTickRadius + 8);
+          const labelPoint = polarToCartesian(angle, traitLabelRadius);
+          const textAnchor = angle > 90 && angle < 270 ? "end" : "start";
+          const rotate = textAnchor === "end" ? angle + 180 : angle;
 
-        return (
-          <svg
-            key={`${pillar}-${trait}`}
-            className="pointer-events-none absolute left-1/2 top-1/2 overflow-visible transition-all duration-700"
-            style={{
-              transform: `translate(calc(-50% + ${x}px), calc(-50% + ${y}px))`,
-              opacity: level >= 3 ? 1 : 0,
-            }}
-          >
-            <line
-              x1="0"
-              y1="0"
-              x2="0"
-              y2="7"
-              stroke={PILLAR_META[pillar].line}
-              strokeWidth="1"
-              transform={`rotate(${angle + 90})`}
-            />
-            <text
-              x="0"
-              y="-1"
-              fill={PILLAR_META[pillar].text}
-              fontSize="9.4"
-              fontWeight="500"
-              letterSpacing="0.02em"
-              textAnchor={textAnchor}
-              transform={`rotate(${rotate}) translate(0, -7)`}
-            >
-              {trait}
-            </text>
-          </svg>
-        );
-      })}
+          return (
+            <g key={`${pillar}-${trait}`}>
+              <line
+                x1={center + tickStart.x}
+                y1={center + tickStart.y}
+                x2={center + tickEnd.x}
+                y2={center + tickEnd.y}
+                stroke={PILLAR_META[pillar].line}
+                strokeWidth="1"
+              />
+              <text
+                x={center + labelPoint.x}
+                y={center + labelPoint.y}
+                fill={PILLAR_META[pillar].text}
+                fontSize="9"
+                fontWeight="500"
+                letterSpacing="0.01em"
+                textAnchor={textAnchor}
+                dominantBaseline="central"
+                transform={`rotate(${rotate} ${center + labelPoint.x} ${center + labelPoint.y})`}
+              >
+                {trait}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
     </div>
   );
 }

--- a/apps/web/src/pages/labs/editor-guide/guideConfig.ts
+++ b/apps/web/src/pages/labs/editor-guide/guideConfig.ts
@@ -2,9 +2,12 @@ export type EditorGuideStepId =
   | "wheel-core"
   | "wheel-pillars"
   | "wheel-traits"
+  | "modal-entry"
+  | "modal-input"
+  | "modal-ai-action"
+  | "modal-ai-result"
   | "filters"
   | "task-list"
-  | "new-task"
   | "suggestions";
 
 export interface EditorGuideStep {
@@ -33,6 +36,34 @@ const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
       copy: "Cada pilar se divide en 10 rasgos para ubicar mejor tus tareas.",
     },
     {
+      id: "modal-entry",
+      title: "Nueva tarea",
+      copy: "Desde acá creás tareas nuevas.",
+      targetSelector: '[data-editor-guide-target="new-task"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "modal-input",
+      title: "Descripción",
+      copy: "Escribís la tarea que querés sumar.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-input"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "modal-ai-action",
+      title: "Sugerencia IA",
+      copy: "Innerbloom puede sugerirte automáticamente pilar y rasgo.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-ai-action"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "modal-ai-result",
+      title: "Resultado sugerido",
+      copy: "Si te sirve, confirmás; si no, reintentás o elegís manualmente.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-ai-result"]',
+      panelPlacement: "top",
+    },
+    {
       id: "filters",
       title: "Buscador + filtros",
       copy: "Desde acá encontrás tareas rápido y filtrás por pilar.",
@@ -44,13 +75,6 @@ const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
       title: "Lista de tareas",
       copy: "Abajo ves y administrás tus tareas.",
       targetSelector: '[data-editor-guide-target="task-list"]',
-      panelPlacement: "top",
-    },
-    {
-      id: "new-task",
-      title: "Nueva tarea",
-      copy: "Desde acá creás tareas nuevas.",
-      targetSelector: '[data-editor-guide-target="new-task"]',
       panelPlacement: "top",
     },
     {
@@ -78,6 +102,34 @@ const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
       copy: "Each pillar is divided into 10 traits so you can place tasks with precision.",
     },
     {
+      id: "modal-entry",
+      title: "New task",
+      copy: "Create new tasks from this button.",
+      targetSelector: '[data-editor-guide-target="new-task"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "modal-input",
+      title: "Task input",
+      copy: "Write the task you want to add.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-input"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "modal-ai-action",
+      title: "AI suggestion",
+      copy: "Innerbloom can suggest a pillar and trait automatically.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-ai-action"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "modal-ai-result",
+      title: "Suggested result",
+      copy: "If it fits, confirm it; if not, retry or set it manually.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-ai-result"]',
+      panelPlacement: "top",
+    },
+    {
       id: "filters",
       title: "Search + filters",
       copy: "Use this area to find tasks fast and filter by pillar.",
@@ -89,13 +141,6 @@ const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
       title: "Task list",
       copy: "This is where you review and manage your tasks.",
       targetSelector: '[data-editor-guide-target="task-list"]',
-      panelPlacement: "top",
-    },
-    {
-      id: "new-task",
-      title: "New task",
-      copy: "Create new tasks from this button.",
-      targetSelector: '[data-editor-guide-target="new-task"]',
       panelPlacement: "top",
     },
     {


### PR DESCRIPTION
### Motivation
- Mejorar la composición visual del `labs/editor` (rueda + anillo de rasgos) para que los iconos/labels estén centrados y no desborden el canvas. 
- Ajustar la UX visual del modal de `Nueva tarea` para una sugerencia IA menos invasiva y una alternativa manual más clara. 
- Reordenar el storytelling de la guía para seguir una narrativa lógica: sistema → creación de tarea → navegación/gestión. 

### Description
- Reordené y extendí los pasos de la guía en `apps/web/src/pages/labs/editor-guide/guideConfig.ts` añadiendo sub-steps del modal (`modal-entry`, `modal-input`, `modal-ai-action`, `modal-ai-result`) y colocando los pasos en el nuevo orden narrativo en ES/EN. 
- Añadí un callback `onStepChange` a `EditorGuideOverlay` y lo consumo desde `EditorLabPage` para abrir automáticamente el modal cuando la guía entra en los pasos del modal. 
- Reimplementé la rueda/guía en `EditorGuideWheel.tsx` usando cálculo polar y un `SVG` centrado para el anillo de 30 rasgos y posicionamiento de los chips de pilar, corrigiendo centrado, distribución y overflow. 
- Refiné el modal `CreateTaskModal` en `EditorLabPage.tsx`: botón de sugerencia IA más compacto con icono, presentación de la sugerencia sin la card pesada (strip más ligera), acción secundaria `Elegir manualmente / Set manually` y flujo manual local para elegir `pilar + rasgo`, más traducción añadida y ajustes CSS en `index.css`. 

### Testing
- Ejecuté el typecheck con `pnpm --filter @innerbloom/web typecheck`, el proceso falló por errores TypeScript preexistentes a nivel repo que no están relacionados con los cambios puntuales en `labs/editor`. 
- No se ejecutaron tests e2e/unit adicionales en esta PR; los cambios están limitados a `apps/web/src/pages/labs` y estilos asociados para facilitar revisión visual en entorno local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e905939ac48332ac543c4989ac8259)