### PR TITLE
Refina guía del Editor Lab y ajusta composición del wheel (pilares/rasgos)

### DIFF
--- a/apps/web/src/pages/labs/EditorLabPage.tsx
+++ b/apps/web/src/pages/labs/EditorLabPage.tsx
@@ -113,6 +113,8 @@ export default function EditorLabPage() {
     null,
   );
   const [showGuideModal, setShowGuideModal] = useState(false);
+  const [activeGuideStepId, setActiveGuideStepId] =
+    useState<EditorGuideStepId>("wheel-core");
   const [showSuggestionsModal, setShowSuggestionsModal] = useState(false);
   const [isApplyingSuggestions, setIsApplyingSuggestions] = useState(false);
 
@@ -394,20 +396,16 @@ export default function EditorLabPage() {
   };
 
   const handleGuideStepChange = useCallback((stepId: EditorGuideStepId) => {
+    setActiveGuideStepId(stepId);
+
     const modalSteps = new Set<EditorGuideStepId>([
+      "modal-entry",
       "modal-input",
-      "modal-ai-action",
-      "modal-ai-result",
+      "modal-difficulty",
+      "modal-ai-thinking",
     ]);
 
-    if (modalSteps.has(stepId)) {
-      setShowCreateModal(true);
-      return;
-    }
-
-    if (stepId === "modal-entry") {
-      setShowCreateModal(false);
-    }
+    setShowCreateModal(modalSteps.has(stepId));
   }, []);
 
   const handleDeleteModalClose = useCallback(() => {
@@ -820,6 +818,7 @@ export default function EditorLabPage() {
           isLoadingPillars={isLoadingPillars}
           pillarsError={pillarsError}
           onRetryPillars={reloadPillars}
+          guideStepId={showGuideModal ? activeGuideStepId : null}
         />
         <EditTaskModal
           open={taskToEdit != null}
@@ -1928,6 +1927,7 @@ interface CreateTaskModalProps {
   isLoadingPillars: boolean;
   pillarsError: Error | null;
   onRetryPillars: () => void;
+  guideStepId: EditorGuideStepId | null;
 }
 
 type SuggestedPillarGroup = "body" | "mind" | "soul";
@@ -2092,6 +2092,7 @@ function CreateTaskModal({
   isLoadingPillars,
   pillarsError,
   onRetryPillars,
+  guideStepId,
 }: CreateTaskModalProps) {
   const { language, t } = usePostLoginLanguage();
   const activeLocale = language === "es" ? "es" : "en";
@@ -2234,13 +2235,29 @@ function CreateTaskModal({
 
   const isSubmitting = createStatus === "loading";
   const isAnalyzing = suggestionStatus === "analyzing";
+  const isGuideAIThinkingStep = guideStepId === "modal-ai-thinking";
+  const guideSuggestion =
+    isGuideAIThinkingStep && sortedPillars.length > 0
+      ? {
+          pillarId: sortedPillars[0].id,
+          pillarLabel: localizePillarLabel(sortedPillars[0].name, language),
+          traitId: "guide-trait",
+          traitLabel: language === "es" ? "Enfoque" : "Focus",
+          rationale:
+            language === "es"
+              ? "La guía simula cómo la IA propone automáticamente pilar + rasgo."
+              : "The guide simulates how AI automatically proposes pillar + trait.",
+        }
+      : null;
+  const visibleSuggestion = suggestion ?? guideSuggestion;
+  const showAnalyzingCard = isAnalyzing || isGuideAIThinkingStep;
   const isSubmitDisabled =
     isSubmitting ||
     (!suggestion && !(manualCategoryEnabled && manualPillarId && manualTraitId)) ||
     title.trim().length === 0 ||
     !userId;
   const isSuggestDisabled =
-    isAnalyzing ||
+    (isAnalyzing && !isGuideAIThinkingStep) ||
     title.trim().length === 0 ||
     isLoadingPillars ||
     Boolean(pillarsError);
@@ -2454,6 +2471,7 @@ function CreateTaskModal({
                     {t("editor.field.difficulty")}
                   </span>
                   <select
+                    data-editor-guide-target="new-task-modal-difficulty"
                     value={difficultyId}
                     onChange={(event) => setDifficultyId(event.target.value)}
                     className="create-task-ai-modal__control w-full appearance-none rounded-2xl border px-4 py-3 text-sm ios-touch-input focus:outline-none disabled:cursor-not-allowed"
@@ -2525,7 +2543,7 @@ function CreateTaskModal({
               )}
             </section>
 
-            {isAnalyzing && (
+            {showAnalyzingCard && (
               <section className="create-task-ai-modal__analysis-card space-y-2 rounded-xl border p-3">
                 <div className="create-task-ai-modal__pulse h-2 w-24 rounded-full" />
                 <p className="text-sm font-semibold">
@@ -2537,7 +2555,8 @@ function CreateTaskModal({
               </section>
             )}
 
-            {suggestion && suggestionStatus === "ready" && (
+            {visibleSuggestion &&
+              (suggestionStatus === "ready" || isGuideAIThinkingStep) && (
               <section
                 className="create-task-ai-modal__suggestion-strip space-y-2.5 py-1"
                 data-editor-guide-target="new-task-modal-ai-result"
@@ -2547,15 +2566,15 @@ function CreateTaskModal({
                 </p>
                 <div className="flex items-center gap-2 text-sm">
                   <span className="rounded-full border px-3 py-1 font-semibold">
-                    {suggestion.pillarLabel}
+                    {visibleSuggestion.pillarLabel}
                   </span>
                   <span className="create-task-ai-modal__hint">/</span>
                   <span className="rounded-full border px-3 py-1 font-semibold">
-                    {suggestion.traitLabel}
+                    {visibleSuggestion.traitLabel}
                   </span>
                 </div>
                 <p className="create-task-ai-modal__hint text-sm">
-                  {suggestion.rationale}
+                  {visibleSuggestion.rationale}
                 </p>
                 <div className="flex flex-wrap items-center justify-end gap-3 pt-1">
                   <button

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
@@ -3,7 +3,7 @@ import type { EditorGuideStepId } from "./guideConfig";
 type Locale = "es" | "en";
 type PillarKey = "Body" | "Mind" | "Soul";
 
-const PILLARS: PillarKey[] = ["Body", "Mind", "Soul"];
+const PILLARS: PillarKey[] = ["Soul", "Mind", "Body"];
 
 const TRAITS_BY_PILLAR: Record<Locale, Record<PillarKey, string[]>> = {
   es: {
@@ -98,18 +98,18 @@ const PILLAR_META: Record<
   Soul: {
     icon: "🏵️",
     label: { es: "Alma", en: "Soul" },
-    glow: "rgba(250, 205, 95, 0.45)",
-    segment: "rgba(250, 205, 95, 0.55)",
-    text: "rgba(255, 242, 204, 0.96)",
-    line: "rgba(250, 205, 95, 0.74)",
+    glow: "rgba(245, 192, 72, 0.52)",
+    segment: "rgba(245, 192, 72, 0.56)",
+    text: "rgba(255, 236, 170, 0.98)",
+    line: "rgba(245, 192, 72, 0.78)",
   },
   Body: {
     icon: "🫀",
     label: { es: "Cuerpo", en: "Body" },
-    glow: "rgba(98, 225, 232, 0.43)",
-    segment: "rgba(98, 225, 232, 0.52)",
+    glow: "rgba(89, 224, 236, 0.45)",
+    segment: "rgba(89, 224, 236, 0.55)",
     text: "rgba(224, 252, 255, 0.95)",
-    line: "rgba(98, 225, 232, 0.7)",
+    line: "rgba(89, 224, 236, 0.74)",
   },
   Mind: {
     icon: "🧠",
@@ -128,7 +128,7 @@ function levelFromStep(stepId: EditorGuideStepId): 1 | 2 | 3 {
 }
 
 function compactTraitLabel(label: string): string {
-  return label.length > 11 ? `${label.slice(0, 10)}…` : label;
+  return label.length > 13 ? `${label.slice(0, 12)}…` : label;
 }
 
 function polarToCartesian(angleDeg: number, radius: number) {
@@ -156,16 +156,16 @@ export function EditorGuideWheel({
     })),
   );
 
-  const size = 320;
+  const size = 332;
   const center = size / 2;
-  const ringSize = 196;
-  const traitRingSize = 272;
-  const pillarLabelRadius = 72;
-  const traitTickRadius = 129;
-  const traitLabelRadius = 147;
+  const ringSize = 206;
+  const traitRingSize = 244;
+  const pillarLabelRadius = 68;
+  const traitTickRadius = 110;
+  const traitLabelRadius = 126;
 
   return (
-    <div className="relative mx-auto h-[20.5rem] w-full max-w-[21.75rem] overflow-visible">
+    <div className="relative mx-auto h-[21.5rem] w-full max-w-[22.5rem] overflow-visible">
       <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle,rgba(139,92,246,0.19),transparent_72%)]" />
 
       <div
@@ -189,7 +189,7 @@ export function EditorGuideWheel({
         style={{
           width: `${ringSize}px`,
           height: `${ringSize}px`,
-          background: `conic-gradient(from -90deg, ${PILLAR_META.Body.segment} 0deg 120deg, ${PILLAR_META.Mind.segment} 120deg 240deg, ${PILLAR_META.Soul.segment} 240deg 360deg)`,
+          background: `conic-gradient(from -90deg, ${PILLAR_META.Soul.segment} 0deg 120deg, ${PILLAR_META.Mind.segment} 120deg 240deg, ${PILLAR_META.Body.segment} 240deg 360deg)`,
           mask: "radial-gradient(circle, transparent 33%, black 34%, black 74%, transparent 75%)",
           opacity: level >= 2 ? 1 : 0,
           transform: `translate(-50%, -50%) scale(${level >= 2 ? 1 : 0.82})`,
@@ -210,7 +210,7 @@ export function EditorGuideWheel({
             }}
           >
             <div
-              className="inline-flex min-w-[84px] items-center justify-center gap-1.5 rounded-full bg-black/15 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.13em] backdrop-blur-[1px]"
+              className="inline-flex min-w-[70px] max-w-[76px] items-center justify-center gap-1 rounded-full bg-black/20 px-2 py-1 text-[8px] font-semibold uppercase tracking-[0.1em] backdrop-blur-[1px]"
               style={{ color: PILLAR_META[pillar].text, textShadow: `0 0 14px ${PILLAR_META[pillar].glow}` }}
             >
               <span className="text-[13px] leading-none">{PILLAR_META[pillar].icon}</span>
@@ -259,7 +259,7 @@ export function EditorGuideWheel({
                 x={center + labelPoint.x}
                 y={center + labelPoint.y}
                 fill={PILLAR_META[pillar].text}
-                fontSize="9"
+                fontSize="8"
                 fontWeight="500"
                 letterSpacing="0.01em"
                 textAnchor={textAnchor}

--- a/apps/web/src/pages/labs/editor-guide/guideConfig.ts
+++ b/apps/web/src/pages/labs/editor-guide/guideConfig.ts
@@ -4,8 +4,8 @@ export type EditorGuideStepId =
   | "wheel-traits"
   | "modal-entry"
   | "modal-input"
-  | "modal-ai-action"
-  | "modal-ai-result"
+  | "modal-difficulty"
+  | "modal-ai-thinking"
   | "filters"
   | "task-list"
   | "suggestions";
@@ -38,28 +38,28 @@ const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
     {
       id: "modal-entry",
       title: "Nueva tarea",
-      copy: "Desde acá creás tareas nuevas.",
-      targetSelector: '[data-editor-guide-target="new-task"]',
+      copy: "Este modal concentra todo el flujo para crear una nueva tarea.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-dialog"]',
       panelPlacement: "top",
     },
     {
       id: "modal-input",
-      title: "Descripción",
-      copy: "Escribís la tarea que querés sumar.",
-      targetSelector: '[data-editor-guide-target="new-task-modal-dialog"]',
+      title: "Descripción / input",
+      copy: "Acá definís el contexto de la tarea. Luego elegís dificultad para calibrar el esfuerzo.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-difficulty"]',
       panelPlacement: "top",
     },
     {
-      id: "modal-ai-action",
+      id: "modal-difficulty",
+      title: "Dificultad",
+      copy: "Seleccionás la dificultad esperada antes de pedir la sugerencia.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-difficulty"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "modal-ai-thinking",
       title: "Sugerencia IA",
-      copy: "Innerbloom puede sugerirte automáticamente pilar y rasgo.",
-      targetSelector: '[data-editor-guide-target="new-task-modal-dialog"]',
-      panelPlacement: "top",
-    },
-    {
-      id: "modal-ai-result",
-      title: "Resultado sugerido",
-      copy: "Si te sirve, confirmás; si no, reintentás o elegís manualmente.",
+      copy: "Con un click, la IA analiza la tarea y sugiere automáticamente pilar + rasgo.",
       targetSelector: '[data-editor-guide-target="new-task-modal-dialog"]',
       panelPlacement: "top",
     },
@@ -104,28 +104,28 @@ const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
     {
       id: "modal-entry",
       title: "New task",
-      copy: "Create new tasks from this button.",
-      targetSelector: '[data-editor-guide-target="new-task"]',
+      copy: "This modal contains the full flow to create a new task.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-dialog"]',
       panelPlacement: "top",
     },
     {
       id: "modal-input",
-      title: "Task input",
-      copy: "Write the task you want to add.",
-      targetSelector: '[data-editor-guide-target="new-task-modal-dialog"]',
+      title: "Description / input",
+      copy: "Set the task context first, then define difficulty to size the effort.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-difficulty"]',
       panelPlacement: "top",
     },
     {
-      id: "modal-ai-action",
+      id: "modal-difficulty",
+      title: "Difficulty",
+      copy: "Choose the expected challenge before requesting the suggestion.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-difficulty"]',
+      panelPlacement: "top",
+    },
+    {
+      id: "modal-ai-thinking",
       title: "AI suggestion",
-      copy: "Innerbloom can suggest a pillar and trait automatically.",
-      targetSelector: '[data-editor-guide-target="new-task-modal-dialog"]',
-      panelPlacement: "top",
-    },
-    {
-      id: "modal-ai-result",
-      title: "Suggested result",
-      copy: "If it fits, confirm it; if not, retry or set it manually.",
+      copy: "With one action, AI analyzes the task and suggests pillar + trait automatically.",
       targetSelector: '[data-editor-guide-target="new-task-modal-dialog"]',
       panelPlacement: "top",
     },


### PR DESCRIPTION
### Motivation
- La guía del `labs/editor` necesitaba reordenarse para un storytelling coherente (Innerbloom → pilares → rasgos → nueva tarea → input → dificultad → IA pensando+sugiriendo → buscar+filtros → lista → sugerencias). 
- El modal de nueva tarea debía abrirse solo en los pasos del flujo modal y cerrarse en los pasos del editor base para evitar contaminación visual y blur incorrecto. 
- La representación visual del wheel requería que los labels de pilares quedaran dentro del círculo, reducción del tamaño del texto (manteniendo iconos) y corrección exacta de colores y orden de sectores. 

### Description
- Reorganicé los pasos de la guía en `apps/web/src/pages/labs/editor-guide/guideConfig.ts`, agregando `modal-difficulty` y unificando la UX de IA en un solo paso `modal-ai-thinking`, y retargeteando el foco del step de descripción hacia el selector de dificultad (`new-task-modal-difficulty`). 
- Hice determinística la apertura/cierre del modal en `apps/web/src/pages/labs/EditorLabPage.tsx` mediante `handleGuideStepChange`, pasé el `activeGuideStepId` al `CreateTaskModal` y añadí lógica de simulación de estado “IA pensando” para la guía sin tocar IA real. 
- Ajusté `CreateTaskModal` para exponer el target `data-editor-guide-target="new-task-modal-difficulty"`, simular una sugerencia visible durante el paso de guía y mostrar la tarjeta de análisis/sugerencia dentro del mismo step (eliminando el paso independiente de resultado). 
- Retocqué la composición del wheel en `apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx`: cambié el orden visual `Soul → Mind → Body`, actualicé colores (Soul = dorado, Mind = violeta, Body = turquesa), reduje el tamaño tipográfico de labels, ajusté radios/tamaños (`size`, `ringSize`, `traitRingSize`, `pillarLabelRadius`, `traitTickRadius`, `traitLabelRadius`) y compacté `compactTraitLabel` para mejorar el ajuste de nombres dentro del anillo. 
- Archivos modificados: `guideConfig.ts`, `EditorLabPage.tsx`, `EditorGuideWheel.tsx`.

### Testing
- Se ejecutó la comprobación de tipos con `pnpm -C apps/web exec tsc --noEmit`, la cual falló por errores de tipado preexistentes en módulos no relacionados a estos cambios, por lo que no se consideran regresiones introducidas por esta PR. 
- No se ejecutaron tests unitarios adicionales automatizados en este rollout; los cambios están enfocados en UI/guía y debería validarse visualmente en staging antes de pasar a producción.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91a49b5248332871f00950d398faf)