### PR TITLE
Refina CTA y jerarquía visual en el modal Nueva tarea guiada

### DIFF
--- a/apps/web/src/i18n/post-login/editor.ts
+++ b/apps/web/src/i18n/post-login/editor.ts
@@ -103,8 +103,8 @@ export const editorTranslations = {
     en: 'E.g. Walk for 30 minutes',
   },
   'editor.modal.aiCreate.suggestButton': {
-    es: 'Sugerir categoría',
-    en: 'Suggest category',
+    es: 'Generar categoría',
+    en: 'Generate category',
   },
   'editor.modal.aiCreate.analyzing': {
     es: 'Analizando tarea…',
@@ -115,8 +115,8 @@ export const editorTranslations = {
     en: 'Reviewing intent, context, and habit pattern.',
   },
   'editor.modal.aiCreate.suggestedCategory': {
-    es: 'Categoría sugerida',
-    en: 'Suggested category',
+    es: 'Categoría generada',
+    en: 'Generated category',
   },
   'editor.modal.aiCreate.retrySuggestion': {
     es: 'Reintentar sugerencia',
@@ -131,8 +131,8 @@ export const editorTranslations = {
     en: 'Confirm task',
   },
   'editor.modal.aiCreate.confirmationRequired': {
-    es: 'Primero usa “Sugerir categoría”.',
-    en: 'Please use “Suggest category” first.',
+    es: 'Primero usa “Generar categoría”.',
+    en: 'Please use “Generate category” first.',
   },
   'editor.modal.aiCreate.catalogFallback': {
     es: 'No hay catálogo suficiente para sugerir una categoría por ahora.',

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5411,9 +5411,17 @@
 
   .create-task-ai-modal__suggest-button {
     color: #ffffff;
-    background: linear-gradient(128deg, #6f67ff 0%, #ad78ff 62%, #f197c4 100%);
-    box-shadow: 0 10px 24px rgba(153, 101, 233, 0.34);
+    border: 1px solid color-mix(in srgb, #b287ff 56%, rgba(255, 255, 255, 0.18));
+    background:
+      linear-gradient(140deg, rgba(22, 27, 52, 0.88) 0%, rgba(37, 31, 66, 0.86) 58%, rgba(49, 36, 74, 0.84) 100%),
+      color-mix(in srgb, var(--color-overlay-2) 88%, transparent);
+    box-shadow: 0 8px 20px rgba(128, 92, 211, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.08);
     letter-spacing: 0.01em;
+  }
+
+  .create-task-ai-modal__suggest-button:hover {
+    border-color: color-mix(in srgb, #c2a2ff 62%, rgba(255, 255, 255, 0.22));
+    box-shadow: 0 10px 24px rgba(132, 97, 213, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.1);
   }
 
   .create-task-ai-modal__analysis-card,
@@ -5425,6 +5433,13 @@
   .create-task-ai-modal__suggestion-strip {
     border-top: 1px solid color-mix(in srgb, var(--color-border-subtle) 62%, transparent);
     border-bottom: 1px solid color-mix(in srgb, var(--color-border-subtle) 50%, transparent);
+  }
+
+  .create-task-ai-modal__result-pill {
+    border-color: color-mix(in srgb, var(--color-border-soft) 78%, transparent);
+    background: color-mix(in srgb, var(--color-overlay-2) 72%, #0b1120);
+    color: #f8f9ff;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
   }
 
   .create-task-ai-modal__pulse {
@@ -5787,6 +5802,24 @@
 
   :root[data-theme="light"]
     [data-light-scope="editor"]
+    .create-task-ai-modal__suggest-button {
+    border-color: color-mix(in srgb, #8a5bff 44%, #ffffff);
+    background:
+      linear-gradient(145deg, #f7f6ff 0%, #f0ecff 55%, #ece7ff 100%),
+      color-mix(in srgb, var(--editor-modal-input-bg) 90%, #f8fafc);
+    color: #2f2362;
+    box-shadow: 0 8px 18px rgba(112, 84, 196, 0.18), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__suggest-button:hover {
+    border-color: color-mix(in srgb, #7d4dff 55%, #ffffff);
+    box-shadow: 0 10px 20px rgba(115, 89, 198, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.95);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
     .create-task-ai-modal__analysis-card,
   :root[data-theme="light"]
     [data-light-scope="editor"]
@@ -5800,6 +5833,15 @@
     .create-task-ai-modal__suggestion-strip {
     border-top-color: color-mix(in srgb, var(--editor-modal-secondary-border) 68%, transparent);
     border-bottom-color: color-mix(in srgb, var(--editor-modal-secondary-border) 58%, transparent);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__result-pill {
+    border-color: color-mix(in srgb, #8a5bff 32%, var(--editor-modal-secondary-border));
+    background: color-mix(in srgb, #ece6ff 62%, #ffffff);
+    color: #2a2158;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.86);
   }
 
   :root[data-theme="light"]

--- a/apps/web/src/pages/labs/EditorLabPage.tsx
+++ b/apps/web/src/pages/labs/EditorLabPage.tsx
@@ -2497,7 +2497,7 @@ function CreateTaskModal({
               <button
                 type="button"
                 data-editor-guide-target="new-task-modal-ai-action"
-                className="create-task-ai-modal__suggest-button inline-flex w-full items-center justify-center gap-2 rounded-xl px-3.5 py-2 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+                className="create-task-ai-modal__suggest-button inline-flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
                 onClick={() => void handleSuggestCategory()}
                 disabled={isSuggestDisabled}
               >
@@ -2539,25 +2539,25 @@ function CreateTaskModal({
 
             {suggestion && suggestionStatus === "ready" && (
               <section
-                className="create-task-ai-modal__suggestion-strip space-y-2.5 py-1"
+                className="create-task-ai-modal__suggestion-strip space-y-3.5 py-2"
                 data-editor-guide-target="new-task-modal-ai-result"
               >
-                <p className="create-task-ai-modal__field-label text-[11px] font-semibold uppercase tracking-[0.24em]">
+                <p className="create-task-ai-modal__field-label text-center text-[11px] font-semibold uppercase tracking-[0.24em]">
                   {t("editor.modal.aiCreate.suggestedCategory")}
                 </p>
-                <div className="flex items-center gap-2 text-sm">
-                  <span className="rounded-full border px-3 py-1 font-semibold">
+                <div className="flex items-center justify-center gap-2 text-base">
+                  <span className="create-task-ai-modal__result-pill rounded-full border px-4 py-1.5 font-semibold">
                     {suggestion.pillarLabel}
                   </span>
                   <span className="create-task-ai-modal__hint">/</span>
-                  <span className="rounded-full border px-3 py-1 font-semibold">
+                  <span className="create-task-ai-modal__result-pill rounded-full border px-4 py-1.5 font-semibold">
                     {suggestion.traitLabel}
                   </span>
                 </div>
-                <p className="create-task-ai-modal__hint text-sm">
+                <p className="create-task-ai-modal__hint text-center text-sm">
                   {suggestion.rationale}
                 </p>
-                <div className="flex flex-wrap items-center justify-end gap-3 pt-1">
+                <div className="flex flex-wrap items-center justify-center gap-4 pt-1">
                   <button
                     type="button"
                     className="create-task-ai-modal__retry text-xs font-semibold underline decoration-dotted underline-offset-4"


### PR DESCRIPTION
### Motivation
- Mejorar la comunicación del CTA de IA haciendo el verbo más decidido y product-native (de `Sugerir` a `Generar`).
- Reducir la competencia visual entre la acción intermedia de IA y el CTA final de confirmar para clarificar flujo: `Generar categoría` = acción intermedia; `Confirmar tarea` = acción final.
- Aumentar la jerarquía del resultado generado por la IA sin añadir contenedores pesados, usando alineación, spacing y contraste.

### Description
- Actualiza i18n para cambiar el copy del botón y etiquetas de resultado en español e inglés en `apps/web/src/i18n/post-login/editor.ts` (`Sugerir category` → `Generar categoría` / `Suggest` → `Generate`, y `Categoría sugerida` → `Categoría generada`).
- Ajustes JSX en `apps/web/src/pages/labs/EditorLabPage.tsx` para mejorar la presentación: mayor padding del botón de IA, centrado del label y del bloque de resultado, pills más grandes para pilar/rasgo, mayor spacing y reubicación de las acciones secundarias para que respiren debajo del resultado.
- Añade y refina estilos en `apps/web/src/index.css` para bajar jerarquía visual del botón `Generar categoría` (tratamiento premium oscuro/glass con borde violeta y glow controlado) y para definir apariencia de los `result-pill` en temas claro/oscuro; incluye hover states más contenidos.
- Cambios limitados al alcance pedido (solo archivos dentro de `apps/web` y la modal de labs/editor) y respetan la regla de no tocar lógica de backend/IA ni producción.

### Testing
- Ejecuté `pnpm -C apps/web typecheck`, que falló por errores de TypeScript preexistentes en el repo no relacionados con estos cambios (errores en `runtimeAuth.tsx`, `PreviewAchievementCard` y algunos tests de tipos); el cambio de copy/estilos no introdujo errores de TS adicionales en las partes editadas. (typecheck: failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91b4e80508332a619bdfabecac3e1)