### PR TITLE
Refine Editor Lab guide flow, modal targets and wheel visuals

### DIFF
--- a/apps/web/src/pages/labs/EditorLabPage.tsx
+++ b/apps/web/src/pages/labs/EditorLabPage.tsx
@@ -397,15 +397,26 @@ export default function EditorLabPage() {
 
   const handleGuideStepChange = useCallback((stepId: EditorGuideStepId) => {
     setActiveGuideStepId(stepId);
+    setTaskToEdit(null);
+    setShowSuggestionsModal(false);
 
-    const modalSteps = new Set<EditorGuideStepId>([
-      "modal-entry",
-      "modal-input",
-      "modal-difficulty",
-      "modal-ai-thinking",
-    ]);
-
-    setShowCreateModal(modalSteps.has(stepId));
+    switch (stepId) {
+      case "modal-entry":
+      case "modal-input":
+      case "modal-difficulty":
+      case "modal-ai-thinking":
+        setShowCreateModal(true);
+        break;
+      case "filters":
+      case "task-list":
+      case "suggestions":
+      case "wheel-core":
+      case "wheel-pillars":
+      case "wheel-traits":
+      default:
+        setShowCreateModal(false);
+        break;
+    }
   }, []);
 
   const handleDeleteModalClose = useCallback(() => {
@@ -2566,15 +2577,15 @@ function CreateTaskModal({
                 </p>
                 <div className="flex items-center justify-center gap-2 text-base">
                   <span className="create-task-ai-modal__result-pill rounded-full border px-4 py-1.5 font-semibold">
-                    {suggestion.pillarLabel}
+                    {visibleSuggestion.pillarLabel}
                   </span>
                   <span className="create-task-ai-modal__hint">/</span>
                   <span className="create-task-ai-modal__result-pill rounded-full border px-4 py-1.5 font-semibold">
-                    {suggestion.traitLabel}
+                    {visibleSuggestion.traitLabel}
                   </span>
                 </div>
                 <p className="create-task-ai-modal__hint text-center text-sm">
-                  {suggestion.rationale}
+                  {visibleSuggestion.rationale}
                 </p>
                 <div className="flex flex-wrap items-center justify-center gap-4 pt-1">
                   <button

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
@@ -85,10 +85,17 @@ export function EditorGuideOverlay({
     update();
     window.addEventListener("resize", update);
     window.addEventListener("scroll", update, true);
+    const observer = new MutationObserver(update);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+    });
 
     return () => {
       window.removeEventListener("resize", update);
       window.removeEventListener("scroll", update, true);
+      observer.disconnect();
     };
   }, [isOpen, step]);
 

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
@@ -159,10 +159,10 @@ export function EditorGuideWheel({
   const size = 332;
   const center = size / 2;
   const ringSize = 206;
-  const traitRingSize = 244;
+  const traitRingSize = 228;
   const pillarLabelRadius = 68;
-  const traitTickRadius = 110;
-  const traitLabelRadius = 126;
+  const traitTickRadius = 96;
+  const traitLabelRadius = 108;
 
   return (
     <div className="relative mx-auto h-[21.5rem] w-full max-w-[22.5rem] overflow-visible">
@@ -210,7 +210,7 @@ export function EditorGuideWheel({
             }}
           >
             <div
-              className="inline-flex min-w-[70px] max-w-[76px] items-center justify-center gap-1 rounded-full bg-black/20 px-2 py-1 text-[8px] font-semibold uppercase tracking-[0.1em] backdrop-blur-[1px]"
+              className="inline-flex min-w-[58px] max-w-[64px] items-center justify-center gap-1 rounded-full border border-white/10 bg-black/[0.12] px-1.5 py-0.5 text-[7px] font-medium uppercase tracking-[0.06em] backdrop-blur-[1px]"
               style={{ color: PILLAR_META[pillar].text, textShadow: `0 0 14px ${PILLAR_META[pillar].glow}` }}
             >
               <span className="text-[13px] leading-none">{PILLAR_META[pillar].icon}</span>

--- a/apps/web/src/pages/labs/editor-guide/guideConfig.ts
+++ b/apps/web/src/pages/labs/editor-guide/guideConfig.ts
@@ -45,8 +45,8 @@ const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
     {
       id: "modal-input",
       title: "Descripción / input",
-      copy: "Acá definís el contexto de la tarea. Luego elegís dificultad para calibrar el esfuerzo.",
-      targetSelector: '[data-editor-guide-target="new-task-modal-difficulty"]',
+      copy: "Acá escribís la tarea y el contexto para que la clasificación tenga sentido.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-input"]',
       panelPlacement: "top",
     },
     {
@@ -59,7 +59,7 @@ const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
     {
       id: "modal-ai-thinking",
       title: "Sugerencia IA",
-      copy: "Con un click, la IA analiza la tarea y sugiere automáticamente pilar + rasgo.",
+      copy: "Tocás la acción de IA, la guía muestra el análisis y ves la sugerencia automática de pilar + rasgo en este mismo paso.",
       targetSelector: '[data-editor-guide-target="new-task-modal-dialog"]',
       panelPlacement: "top",
     },
@@ -111,8 +111,8 @@ const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
     {
       id: "modal-input",
       title: "Description / input",
-      copy: "Set the task context first, then define difficulty to size the effort.",
-      targetSelector: '[data-editor-guide-target="new-task-modal-difficulty"]',
+      copy: "Write the task context here so the classification has clear intent.",
+      targetSelector: '[data-editor-guide-target="new-task-modal-input"]',
       panelPlacement: "top",
     },
     {
@@ -125,7 +125,7 @@ const EDITOR_GUIDE_STEPS_BY_LOCALE: Record<"es" | "en", EditorGuideStep[]> = {
     {
       id: "modal-ai-thinking",
       title: "AI suggestion",
-      copy: "With one action, AI analyzes the task and suggests pillar + trait automatically.",
+      copy: "Tap the AI action, see the analysis state, and review the automatic pillar + trait suggestion in this same step.",
       targetSelector: '[data-editor-guide-target="new-task-modal-dialog"]',
       panelPlacement: "top",
     },


### PR DESCRIPTION
### Motivation
- Clarificar el storytelling y que los focos del guide coincidan con lo que el copy explica para que la guía muestre elementos visibles y comprensibles.
- Alinear la orquestación del modal de nueva tarea con los `step` reales definidos en el guide (abrirlo solo durante el flujo modal y cerrarlo antes de los pasos de lista/filtros/sugerencias).
- Mejorar la legibilidad y densidad visual del círculo de pilares/rasgos sin sacrificar el tamaño del ícono.

### Description
- Alineé la lógica de orquestación en `handleGuideStepChange` para abrir `CreateTaskModal` solo en `modal-entry`, `modal-input`, `modal-difficulty` y `modal-ai-thinking`, y forzar su cierre en `filters`, `task-list`, `suggestions` y los pasos del wheel; además cierro edición y overlay de sugerencias para evitar focos contaminados (file: `EditorLabPage.tsx`).
- Corregí el target del paso `modal-input` para apuntar al input real `data-editor-guide-target="new-task-modal-input"` y actualicé el copy ES/EN para `modal-input` y `modal-ai-thinking` para unificar el storytelling de la acción IA en un único paso (file: `guideConfig.ts`).
- Unifiqué la presentación de la sugerencia IA dentro del mismo step usando `visibleSuggestion` para renderizar resultado mock/análisis/sugerencia en un solo bloque (file: `EditorLabPage.tsx`).
- Hice el tracking del foco más robusto en `EditorGuideOverlay` añadiendo un `MutationObserver` además de `resize`/`scroll`, para recalcular el frame cuando cambian el DOM o aparecen elementos tras transición de pasos (file: `EditorGuideOverlay.tsx`).
- Ajusté la composición del wheel en `EditorGuideWheel`: reduje el radio del anillo de rasgos y tick/label radii, disminuí tamaño y peso visual de los chips/labels (manteniendo el tamaño de los íconos) y mantuve la asignación de colores `Soul` (amarillo/dorado), `Mind` (violeta), `Body` (celeste) consistente en los metadatos (file: `EditorGuideWheel.tsx`).

### Testing
- Ejecuté `npm run typecheck:web` para el workspace web y la verificación general de TypeScript falló por errores preexistentes en otras partes del repo no relacionadas con estos cambios, por lo que el paso global reporta fallo.
- Ejecuté un chequeo focalizado (`npm --workspace apps/web run typecheck ... | rg "EditorLabPage|EditorGuide"`) y no se reportaron errores de tipo en los archivos modificados, confirmando que los cambios en `EditorLabPage`, `EditorGuideOverlay`, `guideConfig` y `EditorGuideWheel` no introdujeron errores TS en esas rutas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92a0dfc9c8332a071e96475a2ad92)