### PR TITLE
feat(web): use Achievements 'Ver guía' chip in Editor controls

### DIFF
--- a/apps/web/src/pages/labs/EditorLabPage.tsx
+++ b/apps/web/src/pages/labs/EditorLabPage.tsx
@@ -987,9 +987,11 @@ function TaskFilters({
           type="button"
           onClick={onOpenGuide}
           aria-label={language === "es" ? "Abrir guía" : "Open guide"}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[linear-gradient(170deg,rgba(255,255,255,0.12),rgba(148,163,184,0.02))] text-[color:var(--color-slate-100)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_8px_18px_rgba(15,23,42,0.24)] transition hover:border-violet-200/40 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-200/60"
+          title={language === "es" ? "Ver guía" : "View guide"}
+          className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/55 bg-violet-100/95 px-2.5 py-1 text-xs font-semibold text-violet-700 shadow-[0_4px_12px_rgba(124,58,237,0.16)] transition hover:border-violet-500/60 hover:bg-violet-200/90 hover:text-violet-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-400 disabled:cursor-not-allowed disabled:opacity-45 dark:border-violet-300/55 dark:bg-violet-500/35 dark:text-violet-50 dark:shadow-[0_6px_18px_rgba(124,58,237,0.35)] dark:hover:border-violet-200/80 dark:hover:bg-violet-500/45 dark:hover:text-white dark:focus-visible:outline-violet-200"
         >
-          <GuideCompassIcon className="h-[18px] w-[18px]" />
+          <GuideCompassIcon className="h-3.5 w-3.5" />
+          <span>{language === "es" ? "Ver guía" : "View guide"}</span>
         </button>
         <button
           type="button"
@@ -1008,9 +1010,11 @@ function TaskFilters({
               type="button"
               onClick={onOpenGuide}
               aria-label={language === "es" ? "Abrir guía" : "Open guide"}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[linear-gradient(170deg,rgba(255,255,255,0.12),rgba(148,163,184,0.02))] text-[color:var(--color-slate-100)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_8px_18px_rgba(15,23,42,0.24)] transition hover:border-violet-200/40 hover:text-white"
+              title={language === "es" ? "Ver guía" : "View guide"}
+              className="inline-flex items-center gap-1.5 rounded-full border border-violet-400/55 bg-violet-100/95 px-2.5 py-1 text-xs font-semibold text-violet-700 shadow-[0_4px_12px_rgba(124,58,237,0.16)] transition hover:border-violet-500/60 hover:bg-violet-200/90 hover:text-violet-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-400 disabled:cursor-not-allowed disabled:opacity-45 dark:border-violet-300/55 dark:bg-violet-500/35 dark:text-violet-50 dark:shadow-[0_6px_18px_rgba(124,58,237,0.35)] dark:hover:border-violet-200/80 dark:hover:bg-violet-500/45 dark:hover:text-white dark:focus-visible:outline-violet-200"
             >
-              <GuideCompassIcon className="h-[18px] w-[18px]" />
+              <GuideCompassIcon className="h-3.5 w-3.5" />
+              <span>{language === "es" ? "Ver guía" : "View guide"}</span>
             </button>
             <button
               type="button"


### PR DESCRIPTION
### Motivation
- Make the Editor's guide entry point visually identical to the existing Achievements "Ver guía" chip so the UI is consistent and uses the same premium pill/chip pattern.

### Description
- Replaced the icon-only guide buttons (desktop + mobile) in `apps/web/src/pages/labs/EditorLabPage.tsx` with the same chip/pill markup and Tailwind classes used in the Achievements section, including icon + visible text. 
- Added localized visible copy inside the chip using the existing `language` flag: Spanish `Ver guía` and English `View guide`.
- Kept the existing click behavior (`onOpenGuide`) and guide-related attributes (e.g., `data-editor-guide-target` on other controls) unchanged.
- Minimal change scope: only presentation for the Editor guide entry point was modified (`EditorLabPage.tsx`).

### Testing
- Ran ESLint check for the edited file, which failed because the repo environment lacks a compatible ESLint config for ESLint v9 (error from ESLint about missing `eslint.config.*`).
- Ran TypeScript typecheck (`pnpm -C apps/web run typecheck`), which failed due to unrelated pre-existing TypeScript errors in other files; the failures are not caused by this small presentation change.
- The change was compiled and committed locally; runtime/manual verification in a browser is recommended in CI or locally due to the monorepo typecheck issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e944cba7a483328b71a4584901b73b)