### PR TITLE
fix(web): alinear labels de "Tres pilares" al centro de sus sectores

### DIFF
--- a/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
@@ -4,6 +4,11 @@ type Locale = "es" | "en";
 type PillarKey = "Body" | "Mind" | "Soul";
 
 const PILLARS: PillarKey[] = ["Soul", "Mind", "Body"];
+const PILLAR_LABEL_ANGLES: Record<PillarKey, number> = {
+  Soul: 225,
+  Mind: 345,
+  Body: 105,
+};
 
 const TRAITS_BY_PILLAR: Record<Locale, Record<PillarKey, string[]>> = {
   es: {
@@ -192,8 +197,8 @@ export function EditorGuideWheel({
         }}
       />
 
-      {PILLARS.map((pillar, index) => {
-        const angle = -90 + index * 120 + 60;
+      {PILLARS.map((pillar) => {
+        const angle = PILLAR_LABEL_ANGLES[pillar];
         const position = polarToCartesian(angle, pillarLabelRadius);
 
         return (
@@ -207,7 +212,10 @@ export function EditorGuideWheel({
           >
             <span
               className="block text-[10px] font-semibold uppercase tracking-[0.06em]"
-              style={{ color: PILLAR_META[pillar].text, textShadow: `0 0 12px ${PILLAR_META[pillar].glow}` }}
+              style={{
+                color: PILLAR_META[pillar].text,
+                textShadow: `0 0 12px ${PILLAR_META[pillar].glow}`,
+              }}
             >
               {PILLAR_META[pillar].label[locale]}
             </span>


### PR DESCRIPTION
### Motivation
- Los labels de los pilares estaban desalineados porque el ángulo se calculaba a partir del índice del array en lugar de usar la posición real del sector renderizado. 

### Description
- Añadí un mapa explícito `PILLAR_LABEL_ANGLES` con los ángulos solicitados: `Soul: 225`, `Mind: 345`, `Body: 105`.
- Dejé de derivar el ángulo por índice y ahora se usa `const angle = PILLAR_LABEL_ANGLES[pillar]` junto con `polarToCartesian(angle, pillarLabelRadius)` para posicionar los labels.
- Mantengo `pillarLabelRadius` en `52`, el render es texto-only y no se tocaron el anillo interior ni la estructura general del gráfico.

### Testing
- Ejecuté `pnpm exec prettier --write apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx` y la formateación se aplicó correctamente.
- Verifiqué con `pnpm exec prettier --check apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx` y pasó la comprobación.
- Intenté `pnpm eslint` y `pnpm tsc --noEmit` en el workspace, pero ambas fallaron por configuraciones/errores globales del repositorio no relacionados con este cambio (eslint: configuración ausente; tsc: errores preexistentes en otros archivos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e947a66d588332b88bbbd35ba0c265)