### PR TITLE
Transición interna overview→detalle en step “Descripción + dificultad” del Editor Guide

### DIFF
--- a/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
@@ -8,6 +8,10 @@ import {
 } from "./guideConfig";
 
 type Rect = { top: number; left: number; width: number; height: number };
+type ModalCoreFocusPhase = "overview" | "detail";
+
+const MODAL_CORE_OVERVIEW_SELECTOR =
+  '[data-editor-guide-target="new-task-modal-dialog"]';
 const INTERACTIVE_ELEMENT_SELECTOR = [
   "button",
   "a",
@@ -52,6 +56,8 @@ export function EditorGuideOverlay({
 }) {
   const [stepIndex, setStepIndex] = useState(0);
   const [targetRect, setTargetRect] = useState<Rect | null>(null);
+  const [modalCoreFocusPhase, setModalCoreFocusPhase] =
+    useState<ModalCoreFocusPhase>("detail");
 
   const guideSteps = getEditorGuideSteps(locale);
   const step = guideSteps[stepIndex];
@@ -81,16 +87,44 @@ export function EditorGuideOverlay({
     if (!isOpen) {
       setStepIndex(0);
       setTargetRect(null);
+      setModalCoreFocusPhase("detail");
       return;
     }
 
-    if (!step.targetSelector) {
+    if (step.id !== "modal-core") {
+      setModalCoreFocusPhase("detail");
+      return;
+    }
+
+    setModalCoreFocusPhase("overview");
+    const timeoutId = window.setTimeout(() => {
+      setModalCoreFocusPhase("detail");
+    }, 320);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [isOpen, step.id]);
+
+  const activeTargetSelector = useMemo(() => {
+    if (step.id === "modal-core" && modalCoreFocusPhase === "overview") {
+      return MODAL_CORE_OVERVIEW_SELECTOR;
+    }
+    return step.targetSelector;
+  }, [modalCoreFocusPhase, step.id, step.targetSelector]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (!activeTargetSelector) {
       setTargetRect(null);
       return;
     }
 
     const update = () => {
-      const nextRect = findVisibleTarget(step.targetSelector!);
+      const nextRect = findVisibleTarget(activeTargetSelector);
       setTargetRect(nextRect);
     };
 
@@ -109,7 +143,7 @@ export function EditorGuideOverlay({
       window.removeEventListener("scroll", update, true);
       observer.disconnect();
     };
-  }, [isOpen, step]);
+  }, [activeTargetSelector, isOpen]);
 
   useEffect(() => {
     if (!isOpen) {


### PR DESCRIPTION
### Motivation
- Mejorar la percepción del paso `Descripción + dificultad` mostrando primero el modal completo como preview y luego contrayendo el foco al bloque de `descripción + dificultad` para dar contexto antes del detalle.
- Mantener el flujo dentro del mismo step sin añadir pasos nuevos ni cambiar copy o la lógica de navegación de la guía.
- Conseguir una sensación premium y rápida (overview breve y contracción suave) aprovechando la infraestructura de overlay y animaciones ya existentes.

### Description
- Se actualizó `apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx` para introducir una fase de foco interna con el estado `modalCoreFocusPhase` que puede ser `overview` o `detail`.
- Se añadió `MODAL_CORE_OVERVIEW_SELECTOR` apuntando a `data-editor-guide-target="new-task-modal-dialog"` y se usa un `activeTargetSelector` (via `useMemo`) para alternar entre el overview y el target final del step `modal-core`.
- Al entrar al step `modal-core` se dispara primero la fase `overview` y tras un timeout corto de `320ms` se pasa a la fase `detail`, lo que provoca que el cálculo de `targetRect` apunte primero al modal completo y luego al bloque `new-task-modal-core`.
- La implementación reutiliza el cálculo existente de `targetRect`/`frame` y las clases de transición del overlay, por lo que no se altera el blur/focus ni el panel de copy existente.

### Testing
- Ejecuté el chequeo de TypeScript con `pnpm -C apps/web exec tsc --noEmit`, el cual falló por errores de tipado preexistentes en otras áreas del proyecto y no relacionados con este cambio.
- Intenté validar con ESLint (`pnpm -C apps/web exec eslint src/pages/labs/editor-guide/EditorGuideOverlay.tsx`), pero la invocación falló en este entorno porque no se encuentra un `eslint.config.*` aplicable; por tanto no se pudo completar la verificación estática de lint en este paso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9490bfb3c8332bb5913f5994f95c6)