### PR TITLE
Adjust editor guide wheel label spacing and trait label visibility

### DIFF
--- a/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
@@ -143,10 +143,6 @@ function levelFromStep(stepId: EditorGuideStepId): 1 | 2 | 3 {
   return 3;
 }
 
-function compactTraitLabel(label: string): string {
-  return label.length > 13 ? `${label.slice(0, 12)}…` : label;
-}
-
 function polarToCartesian(angleDeg: number, radius: number) {
   const radians = (angleDeg * Math.PI) / 180;
   return {
@@ -171,21 +167,21 @@ export function EditorGuideWheel({
 
     return traits.map((trait, index) => ({
       pillar,
-      trait: compactTraitLabel(trait),
+      trait,
       angle: startAngle + traitSlotAngle * (index + 0.5),
     }));
   });
 
-  const size = 332;
+  const size = 356;
   const center = size / 2;
-  const ringSize = 190;
-  const traitRingSize = 256;
-  const pillarLabelRadius = 52;
-  const traitTickRadius = 116;
-  const traitLabelRadius = 129;
+  const ringSize = 204;
+  const traitRingSize = 276;
+  const pillarLabelRadius = 66;
+  const traitTickRadius = 126;
+  const traitLabelRadius = 141;
 
   return (
-    <div className="relative mx-auto h-[21.5rem] w-full max-w-[22.5rem] overflow-visible">
+    <div className="relative mx-auto h-[23rem] w-full max-w-[24.5rem] overflow-visible">
       <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle,rgba(139,92,246,0.19),transparent_72%)]" />
 
       <div
@@ -257,7 +253,7 @@ export function EditorGuideWheel({
 
       <svg
         viewBox={`0 0 ${size} ${size}`}
-        className="pointer-events-none absolute inset-0 h-full w-full overflow-hidden transition-all duration-700"
+        className="pointer-events-none absolute inset-0 h-full w-full overflow-visible transition-all duration-700"
         style={{ opacity: level >= 3 ? 1 : 0 }}
       >
         {traitSegments.map(({ trait, angle, pillar }) => {


### PR DESCRIPTION
### Motivation
- Fix visual issues in the Labs Editor guide wheel so pillar labels sit farther into their colored wedges and trait labels are no longer clipped or artificially truncated while preserving pillar/trait mapping and sector geometry.

### Description
- Increased pillar label radius from `52` to `66` so ALMA / CUERPO / MENTE sit farther outward while keeping the same wedge-centered angles.
- Enlarged the wheel footprint and related radii to give labels more horizontal room by changing `size: 332 → 356`, `ringSize: 190 → 204`, `traitRingSize: 256 → 276`, `traitTickRadius: 116 → 126`, and `traitLabelRadius: 129 → 141`, and expanded wrapper sizing from `h-[21.5rem] max-w-[22.5rem]` to `h-[23rem] max-w-[24.5rem]` so the circle can breathe inside the guide card.
- Switched the trait SVG container from `overflow-hidden` to `overflow-visible` to avoid left/right clipping of long labels.
- Removed `compactTraitLabel()` usage and render full trait strings so names like `Autocontrol`, `Resiliencia`, `Espiritualidad`, and `Moderación` are shown when space allows.
- Kept pillar membership, trait ordering, sector geometry, colors, styles, locale support, and level-based reveal behavior unchanged.

### Testing
- Attempted `pnpm -C apps/web exec eslint src/pages/labs/editor-guide/EditorGuideWheel.tsx`, but ESLint invocation failed due to the workspace using a different ESLint config format (no discoverable `eslint.config.*`) and did not validate this file here.
- Ran `npm run typecheck:web` which fails due to pre-existing TypeScript errors in other parts of the workspace; no new type errors were isolated that indicate this component change introduced regressions in typechecking.
- No component-specific automated visual tests were available in this environment; visual verification should be performed in a browser/preview to confirm the pillar label placement and that long trait labels are no longer clipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e0b0bf148332845f3c6e91f9c619)