### PR TITLE
Adjust pillar label spacing in EditorGuideWheel

### DIFF
--- a/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx
@@ -176,7 +176,7 @@ export function EditorGuideWheel({
   const center = size / 2;
   const ringSize = 204;
   const traitRingSize = 276;
-  const pillarLabelRadius = 66;
+  const pillarLabelRadius = 70;
   const traitTickRadius = 126;
   const traitLabelRadius = 141;
 


### PR DESCRIPTION
### Motivation
- Fix a small visual issue where the pillar labels (ALMA, CUERPO, MENTE) appear slightly too close to the inner center circle so they sit more naturally inside their colored wedges.

### Description
- Increased `const pillarLabelRadius` from `66` to `70` in `apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx`, keeping the same centering logic, angular positions, and all other styling and geometry unchanged.

### Testing
- Verified the change by inspecting the diff with `git diff -- apps/web/src/pages/labs/editor-guide/EditorGuideWheel.tsx` and viewing the file with `nl`/`sed`, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ea8aba28833297fb5acdc7bde633)