### PR TITLE
Eliminar contorno exterior del panel de guía en Labs Editor

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6470,7 +6470,6 @@
       rgba(255, 255, 255, 0.96),
       rgba(246, 242, 252, 0.94)
     );
-    border-color: color-mix(in srgb, var(--color-border-strong) 65%, white);
     color: var(--color-text);
     box-shadow: 0 22px 56px rgba(76, 29, 149, 0.18);
   }

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
@@ -259,7 +259,7 @@ export function EditorGuideOverlay({
       )}
 
       <section
-        className={`editor-guide-panel absolute left-1/2 flex w-[min(calc(100vw-1.5rem),42rem)] -translate-x-1/2 flex-col rounded-3xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-surface-elevated)] px-5 py-4 text-[color:var(--color-slate-100)] shadow-[0_20px_55px_rgba(15,23,42,0.6)] ${
+        className={`editor-guide-panel absolute left-1/2 flex w-[min(calc(100vw-1.5rem),42rem)] -translate-x-1/2 flex-col rounded-3xl bg-[color:var(--color-surface-elevated)] px-5 py-4 text-[color:var(--color-slate-100)] shadow-[0_20px_55px_rgba(15,23,42,0.6)] ${
           panelPlacement === "top"
             ? "top-3 md:top-6"
             : panelPlacement === "center"


### PR DESCRIPTION
### Motivation
- Quitar el contorno/borde fino que rodea el panel de la guía para que el componente se vea más premium, limpio y moderno sin alterar su jerarquía visual.
- Aplicar el cambio a todas las variantes del panel del `labs/editor` (top, center, bottom) manteniendo fondo, blur, radio y sombra.

### Description
- Eliminé las clases `border` y `border-[color:var(--color-border-soft)]` del contenedor `editor-guide-panel` en `apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx` para remover el borde exterior.
- Removí la regla `border-color` específica para `.editor-guide-panel` en el theme light en `apps/web/src/index.css` para evitar cualquier outline residual.
- No se modificó la lógica, el layout, el padding ni el contenido de la guía; se preservan sombras, radio de esquinas, fondo y comportamiento.

### Testing
- Ejecuté `pnpm -C apps/web exec eslint src/pages/labs/editor-guide/EditorGuideOverlay.tsx`, que falló por la configuración global de ESLint en este entorno (falta `eslint.config.*`).
- Ejecuté `pnpm -C apps/web exec tsc --noEmit`, que falló por errores de tipo preexistentes en otros módulos no relacionados con este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9eef6fa148332aa694c61ecb3d93b)