### PR TITLE
feat(api): add AI task classification endpoint for editor

### DIFF
--- a/apps/api/prompts/task-classify.json
+++ b/apps/api/prompts/task-classify.json
@@ -1,0 +1,30 @@
+{
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "TaskClassification",
+      "schema": {
+        "type": "object",
+        "required": ["pillar_code", "trait_code"],
+        "properties": {
+          "pillar_code": { "type": "string", "minLength": 1 },
+          "trait_code": { "type": "string", "minLength": 1 },
+          "rationale": { "type": "string" },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "additionalProperties": false
+      },
+      "strict": true
+    }
+  },
+  "messages": [
+    {
+      "role": "system",
+      "content": "You classify one task into exactly one valid pillar and one valid trait from the provided catalogs. Use only provided codes. The trait must belong to the selected pillar. Return JSON only."
+    },
+    {
+      "role": "user",
+      "content": "Task title: {{TASK_TITLE}}\n\nValid pillars from DB:\n{{CATALOG_PILLARS}}\n\nValid traits from DB:\n{{CATALOG_TRAITS}}\n\nReturn JSON with:\n- pillar_code\n- trait_code\n- rationale (optional, concise)\n- confidence (optional, number between 0 and 1)"
+    }
+  ]
+}

--- a/apps/api/src/controllers/tasks/classify-user-task.test.ts
+++ b/apps/api/src/controllers/tasks/classify-user-task.test.ts
@@ -1,0 +1,111 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockEnsureUserExists, mockVerifyToken, mockClassifyTaskForUser } = vi.hoisted(() => ({
+  mockEnsureUserExists: vi.fn(),
+  mockVerifyToken: vi.fn(),
+  mockClassifyTaskForUser: vi.fn(),
+}));
+
+vi.mock('../../db.js', () => ({
+  pool: {
+    query: vi.fn(),
+  },
+  dbReady: Promise.resolve(),
+  runWithDbContext: (_context: string, callback: () => unknown) => callback(),
+}));
+
+vi.mock('../users/shared.js', () => ({
+  ensureUserExists: mockEnsureUserExists,
+}));
+
+vi.mock('../../services/task-classification.service.js', () => ({
+  classifyTaskForUser: mockClassifyTaskForUser,
+}));
+
+vi.mock('../../services/auth-service.js', () => ({
+  getAuthService: () => ({
+    verifyToken: mockVerifyToken,
+  }),
+  createAuthRepository: vi.fn(),
+  createAuthService: vi.fn(),
+  resetAuthServiceCache: vi.fn(),
+}));
+
+vi.mock('../../middlewares/require-active-subscription.js', () => ({
+  requireActiveSubscription: (_req: unknown, _res: unknown, next: (error?: unknown) => void) => next(),
+}));
+
+import app from '../../app.js';
+
+const userId = '11111111-2222-3333-4444-555555555555';
+
+describe('POST /api/users/:id/tasks/classify', () => {
+  beforeEach(() => {
+    mockEnsureUserExists.mockReset();
+    mockVerifyToken.mockReset();
+    mockClassifyTaskForUser.mockReset();
+  });
+
+  it('classifies task and returns pillar/trait metadata', async () => {
+    mockVerifyToken.mockResolvedValueOnce({
+      id: userId,
+      clerkId: 'user_123',
+      email: 'test@example.com',
+      isNew: false,
+    });
+    mockEnsureUserExists.mockResolvedValueOnce(undefined);
+    mockClassifyTaskForUser.mockResolvedValueOnce({
+      pillar_id: 1,
+      trait_id: 4,
+      pillar_code: 'BODY',
+      pillar_name: 'Body',
+      trait_code: 'HEALTH',
+      trait_name: 'Health',
+      rationale: 'Walking after dinner supports physical wellbeing.',
+      confidence: 0.91,
+    });
+
+    const response = await request(app)
+      .post(`/api/users/${userId}/tasks/classify`)
+      .set('Authorization', 'Bearer token')
+      .send({ title: 'Caminar 20 minutos después de cenar' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      classification: {
+        pillar_id: 1,
+        trait_id: 4,
+        pillar_code: 'BODY',
+        pillar_name: 'Body',
+        trait_code: 'HEALTH',
+        trait_name: 'Health',
+        rationale: 'Walking after dinner supports physical wellbeing.',
+        confidence: 0.91,
+      },
+    });
+    expect(mockEnsureUserExists).toHaveBeenCalledWith(userId);
+    expect(mockClassifyTaskForUser).toHaveBeenCalledWith({
+      userId,
+      title: 'Caminar 20 minutos después de cenar',
+    });
+  });
+
+  it('returns 400 when title is missing', async () => {
+    mockVerifyToken.mockResolvedValueOnce({
+      id: userId,
+      clerkId: 'user_123',
+      email: 'test@example.com',
+      isNew: false,
+    });
+
+    const response = await request(app)
+      .post(`/api/users/${userId}/tasks/classify`)
+      .set('Authorization', 'Bearer token')
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('invalid_request');
+    expect(mockClassifyTaskForUser).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/controllers/tasks/classify-user-task.ts
+++ b/apps/api/src/controllers/tasks/classify-user-task.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { AsyncHandler } from '../../lib/async-handler.js';
+import { uuidSchema } from '../../lib/validation.js';
+import { ensureUserExists } from '../users/shared.js';
+import { classifyTaskForUser } from '../../services/task-classification.service.js';
+
+const paramsSchema = z.object({
+  id: uuidSchema,
+});
+
+const bodySchema = z.object({
+  title: z
+    .string({
+      required_error: 'title is required',
+      invalid_type_error: 'title must be a string',
+    })
+    .trim()
+    .min(1, 'title is required'),
+});
+
+export const classifyUserTask: AsyncHandler = async (req, res) => {
+  const { id } = paramsSchema.parse(req.params);
+  const { title } = bodySchema.parse(req.body);
+
+  await ensureUserExists(id);
+
+  const classification = await classifyTaskForUser({
+    userId: id,
+    title,
+  });
+
+  res.status(200).json({ classification });
+};

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -3,6 +3,7 @@ import { getUserEmotions } from '../controllers/emotions/get-user-emotions.js';
 import { getUserDailyXp } from '../controllers/logs/get-user-daily-xp.js';
 import { getUserJourney } from '../controllers/logs/get-user-journey.js';
 import { createUserTask } from '../controllers/tasks/create-user-task.js';
+import { classifyUserTask } from '../controllers/tasks/classify-user-task.js';
 import { getUserTasks } from '../controllers/tasks/get-user-tasks.js';
 import { getCurrentUser } from '../controllers/users/get-user-me.js';
 import { getUserSubscription } from '../controllers/users/get-user-subscription.js';
@@ -40,6 +41,7 @@ const userScopedRoutes = Router({ mergeParams: true });
 
 userScopedRoutes.get('/tasks', asyncHandler(getUserTasks));
 userScopedRoutes.post('/tasks', asyncHandler(createUserTask));
+userScopedRoutes.post('/tasks/classify', asyncHandler(classifyUserTask));
 userScopedRoutes.patch('/tasks/:taskId', asyncHandler(updateUserTask));
 userScopedRoutes.delete('/tasks/:taskId', asyncHandler(deleteUserTask));
 userScopedRoutes.get('/xp/daily', asyncHandler(getUserDailyXp));

--- a/apps/api/src/services/task-classification.service.ts
+++ b/apps/api/src/services/task-classification.service.ts
@@ -1,0 +1,356 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { Ajv, type AnySchema, type ErrorObject } from 'ajv';
+import type {
+  Response as OpenAIResponse,
+  ResponseCreateParamsNonStreaming,
+  ResponseFormatTextConfig,
+} from 'openai/resources/responses/responses';
+import { pool } from '../db.js';
+import { HttpError } from '../lib/http-error.js';
+import { isReasoningModel, sanitizeReasoningParameters } from '../lib/taskgen/openaiPayload.js';
+import { callOpenAiWithRetry, resolveOpenAiRequestConfigFromEnv } from '../lib/taskgen/openaiClient.js';
+
+type PromptMessage = {
+  role: 'system' | 'user';
+  content: string;
+};
+
+type PromptJsonSchemaConfig = {
+  name?: string;
+  schema?: AnySchema;
+  description?: string;
+  strict?: boolean | null;
+  [key: string]: unknown;
+};
+
+type PromptResponseFormat =
+  | ({ type: 'json_schema'; json_schema?: PromptJsonSchemaConfig } & Record<string, unknown>)
+  | ({ type: 'text' } & Record<string, unknown>)
+  | ({ type: 'json_object' } & Record<string, unknown>);
+
+type PromptFile = {
+  response_format?: PromptResponseFormat;
+  messages: PromptMessage[];
+};
+
+type PillarRow = {
+  pillar_id: number;
+  code: string;
+  name: string | null;
+};
+
+type TraitRow = {
+  trait_id: number;
+  pillar_id: number;
+  code: string;
+  name: string | null;
+};
+
+type ClassificationModelOutput = {
+  pillar_code: string;
+  trait_code: string;
+  rationale?: string;
+  confidence?: number;
+};
+
+export type TaskClassificationResult = {
+  pillar_id: number;
+  trait_id: number;
+  pillar_code: string;
+  pillar_name: string | null;
+  trait_code: string;
+  trait_name: string | null;
+  rationale: string | null;
+  confidence: number | null;
+};
+
+const LOG_PREFIX = '[task-classification]';
+const DEFAULT_MODEL = process.env.OPENAI_MODEL ?? 'gpt-4.1-mini';
+
+const runtimeDir = path.dirname(fileURLToPath(import.meta.url));
+const appRootCandidates = [
+  process.cwd(),
+  path.resolve(process.cwd(), 'apps/api'),
+  path.resolve(runtimeDir, '../../..'),
+  path.resolve(runtimeDir, '../../../..'),
+];
+
+const PROMPTS_DIR_CANDIDATES = [
+  process.env.TASKGEN_PROMPTS_PATH,
+  ...appRootCandidates.map((base) => path.resolve(base, 'prompts')),
+  ...appRootCandidates.map((base) => path.resolve(base, 'dist/taskgen/prompts')),
+].filter((value): value is string => Boolean(value));
+
+function logInfo(message: string, metadata?: Record<string, unknown>) {
+  if (metadata) {
+    console.info(LOG_PREFIX, message, metadata);
+    return;
+  }
+  console.info(LOG_PREFIX, message);
+}
+
+function logWarn(message: string, metadata?: Record<string, unknown>) {
+  if (metadata) {
+    console.warn(LOG_PREFIX, message, metadata);
+    return;
+  }
+  console.warn(LOG_PREFIX, message);
+}
+
+function logError(message: string, metadata?: Record<string, unknown>) {
+  if (metadata) {
+    console.error(LOG_PREFIX, message, metadata);
+    return;
+  }
+  console.error(LOG_PREFIX, message);
+}
+
+function normalizePrompt(raw: string): PromptFile {
+  const parsed = JSON.parse(raw) as { messages?: PromptMessage[]; response_format?: PromptResponseFormat };
+
+  if (!Array.isArray(parsed.messages) || parsed.messages.length === 0) {
+    throw new Error('Invalid task classification prompt: missing messages');
+  }
+
+  return {
+    response_format: parsed.response_format,
+    messages: parsed.messages,
+  };
+}
+
+async function loadPrompt(): Promise<PromptFile> {
+  const candidates = PROMPTS_DIR_CANDIDATES.map((dir) => path.resolve(dir, 'task-classify.json'));
+  for (const candidate of candidates) {
+    try {
+      const raw = await fs.readFile(candidate, 'utf8');
+      return normalizePrompt(raw);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error(`Task classification prompt not found. Checked: ${candidates.join(', ')}`);
+}
+
+function applyPlaceholders(template: string, placeholders: Record<string, string>): string {
+  return template.replace(/\{\{\s*([A-Z0-9_]+)\s*\}\}/g, (fullMatch, key: string) => {
+    return placeholders[key] ?? fullMatch;
+  });
+}
+
+function buildResponseFormatConfig(format: PromptResponseFormat | undefined): ResponseFormatTextConfig | undefined {
+  if (!format) {
+    return undefined;
+  }
+
+  if (format.type === 'json_schema') {
+    const jsonSchema = format.json_schema;
+    if (!jsonSchema?.schema) {
+      return undefined;
+    }
+
+    return {
+      type: 'json_schema',
+      name: typeof jsonSchema.name === 'string' ? jsonSchema.name : 'TaskClassification',
+      schema: jsonSchema.schema as Record<string, unknown>,
+      strict: typeof jsonSchema.strict === 'boolean' ? jsonSchema.strict : undefined,
+      description: typeof jsonSchema.description === 'string' ? jsonSchema.description : undefined,
+    };
+  }
+
+  if (format.type === 'text') {
+    return { type: 'text' };
+  }
+
+  if (format.type === 'json_object') {
+    return { type: 'json_object' };
+  }
+
+  return undefined;
+}
+
+function extractJsonSchema(format: PromptResponseFormat | undefined): AnySchema | undefined {
+  if (format?.type !== 'json_schema') {
+    return undefined;
+  }
+  return format.json_schema?.schema;
+}
+
+function modelSupportsTemperature(model: string): boolean {
+  return !isReasoningModel(model);
+}
+
+function validateOutputSchema(
+  output: ClassificationModelOutput,
+  schema: AnySchema | undefined,
+): { valid: boolean; errors: string[] } {
+  if (!schema) {
+    return { valid: true, errors: [] };
+  }
+
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  const validate = ajv.compile(schema);
+  const valid = validate(output);
+
+  if (valid) {
+    return { valid: true, errors: [] };
+  }
+
+  return {
+    valid: false,
+    errors: (validate.errors ?? []).map((err: ErrorObject) => `${err.instancePath} ${err.message ?? ''}`.trim()),
+  };
+}
+
+function buildCatalogStrings(pillars: PillarRow[], traits: TraitRow[]): { pillars: string; traits: string } {
+  const pillarsText = pillars
+    .map((pillar) => `${pillar.code}: ${pillar.name ?? pillar.code}`)
+    .join('\n');
+
+  const pillarById = new Map(pillars.map((pillar) => [pillar.pillar_id, pillar] as const));
+  const traitsText = traits
+    .map((trait) => {
+      const pillar = pillarById.get(trait.pillar_id);
+      const pillarCode = pillar?.code ?? `pillar_${trait.pillar_id}`;
+      return `${trait.code} (pillar=${pillarCode}): ${trait.name ?? trait.code}`;
+    })
+    .join('\n');
+
+  return {
+    pillars: pillarsText,
+    traits: traitsText,
+  };
+}
+
+export async function classifyTaskForUser(input: { userId: string; title: string }): Promise<TaskClassificationResult> {
+  const [pillarsResult, traitsResult, prompt] = await Promise.all([
+    pool.query<PillarRow>('SELECT pillar_id, code, name FROM cat_pillar ORDER BY pillar_id ASC'),
+    pool.query<TraitRow>('SELECT trait_id, pillar_id, code, name FROM cat_trait ORDER BY trait_id ASC'),
+    loadPrompt(),
+  ]);
+
+  const pillars = pillarsResult.rows;
+  const traits = traitsResult.rows;
+
+  if (pillars.length === 0 || traits.length === 0) {
+    throw new HttpError(500, 'internal_error', 'Task classification catalogs are unavailable');
+  }
+
+  const catalogStrings = buildCatalogStrings(pillars, traits);
+  const placeholders = {
+    TASK_TITLE: input.title,
+    CATALOG_PILLARS: catalogStrings.pillars,
+    CATALOG_TRAITS: catalogStrings.traits,
+  };
+
+  const messages = prompt.messages.map((msg) => ({
+    role: msg.role,
+    content: applyPlaceholders(msg.content, placeholders),
+  }));
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new HttpError(500, 'internal_error', 'OPENAI_API_KEY is not configured');
+  }
+
+  const requestBody: ResponseCreateParamsNonStreaming = {
+    model: DEFAULT_MODEL,
+    input: messages,
+  };
+
+  if (modelSupportsTemperature(DEFAULT_MODEL)) {
+    requestBody.temperature = 0.2;
+  }
+
+  const responseFormat = buildResponseFormatConfig(prompt.response_format);
+  if (responseFormat) {
+    requestBody.text = { format: responseFormat };
+  }
+
+  const { body: sanitizedRequestBody, removedKeys } = sanitizeReasoningParameters(requestBody, requestBody.model);
+  const { timeoutMs, maxAttempts, baseDelayMs, jitterMs } = resolveOpenAiRequestConfigFromEnv();
+
+  logInfo('OPENAI_REQUEST', {
+    model: requestBody.model,
+    messageCount: messages.length,
+    response_format: responseFormat?.type ?? null,
+    filteredParams: removedKeys,
+  });
+
+  const openAiOutcome = await callOpenAiWithRetry({
+    apiKey,
+    requestBody: sanitizedRequestBody,
+    timeoutMs,
+    maxAttempts,
+    baseDelayMs,
+    jitterMs,
+    logger: { info: logInfo, warn: logWarn, error: logError },
+    logContext: {
+      user_id: input.userId,
+      feature: 'task_classification',
+    },
+  });
+
+  if (!openAiOutcome.ok) {
+    throw new HttpError(
+      502,
+      'upstream_error',
+      `OpenAI task classification failed after ${openAiOutcome.attempts} attempts: ${openAiOutcome.reason}`,
+    );
+  }
+
+  const raw = (openAiOutcome.response as OpenAIResponse).output_text ?? '';
+
+  let parsed: ClassificationModelOutput;
+  try {
+    parsed = JSON.parse(raw) as ClassificationModelOutput;
+  } catch {
+    throw new HttpError(502, 'upstream_error', 'OpenAI returned invalid JSON for task classification');
+  }
+
+  const schemaValidation = validateOutputSchema(parsed, extractJsonSchema(prompt.response_format));
+  if (!schemaValidation.valid) {
+    throw new HttpError(502, 'upstream_error', 'OpenAI task classification failed schema validation', {
+      errors: schemaValidation.errors,
+    });
+  }
+
+  const pillarByCode = new Map(pillars.map((pillar) => [pillar.code, pillar] as const));
+  const traitByCode = new Map(traits.map((trait) => [trait.code, trait] as const));
+
+  const pillar = pillarByCode.get(parsed.pillar_code);
+  const trait = traitByCode.get(parsed.trait_code);
+
+  if (!pillar) {
+    throw new HttpError(502, 'upstream_error', `OpenAI returned unknown pillar_code: ${parsed.pillar_code}`);
+  }
+
+  if (!trait) {
+    throw new HttpError(502, 'upstream_error', `OpenAI returned unknown trait_code: ${parsed.trait_code}`);
+  }
+
+  if (trait.pillar_id !== pillar.pillar_id) {
+    throw new HttpError(
+      502,
+      'upstream_error',
+      `OpenAI returned trait_code ${parsed.trait_code} that does not belong to pillar_code ${parsed.pillar_code}`,
+    );
+  }
+
+  return {
+    pillar_id: pillar.pillar_id,
+    trait_id: trait.trait_id,
+    pillar_code: pillar.code,
+    pillar_name: pillar.name,
+    trait_code: trait.code,
+    trait_name: trait.name,
+    rationale: typeof parsed.rationale === 'string' ? parsed.rationale : null,
+    confidence: typeof parsed.confidence === 'number' ? parsed.confidence : null,
+  };
+}


### PR DESCRIPTION
### Motivation

- Provide an AI-backed classification endpoint for the editor that assigns only `pillar_id` and `trait_id` (plus optional UI metadata) without changing the existing task creation/persistence flow. 
- Reuse the repository's existing OpenAI patterns (client, retry, response_format/schema validation) and real DB catalogs so the model cannot invent pillars/traits. 

### Description

- Added a strict prompt `apps/api/prompts/task-classify.json` that requests `pillar_code`/`trait_code` (and optional `rationale`/`confidence`) in `json_schema` format. 
- Implemented `apps/api/src/services/task-classification.service.ts` which loads the prompt, reads `cat_pillar` and `cat_trait` from the DB, builds placeholdered messages, calls OpenAI using `callOpenAiWithRetry` + `resolveOpenAiRequestConfigFromEnv` + `sanitizeReasoningParameters`, validates the model output against the prompt schema and catalog coherence, and resolves DB ids and names. 
- Implemented controller `apps/api/src/controllers/tasks/classify-user-task.ts` and added the route `POST /users/:id/tasks/classify` inside the existing user-scoped routes so auth/own-user/subscription behavior is preserved. 
- Added tests `apps/api/src/controllers/tasks/classify-user-task.test.ts` covering a successful classification response and a 400 validation case. 
- No changes to `POST /users/:id/tasks` or its persistence; AI only recommends pillar/trait and returns metadata for the UI. 

### Testing

- Ran the new controller tests with `npm --workspace apps/api run test -- classify-user-task.test.ts` and they passed. 
- Ran type checking with `npm --workspace apps/api run typecheck` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f31de4a48332a5784d0f6eb89df5)