### PR TITLE
Connect labs/editor AI classification to backend classify endpoint

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1756,8 +1756,8 @@ export type ClassifyUserTaskInput = {
 };
 
 export type UserTaskClassification = {
-  pillarId: string | null;
-  traitId: string | null;
+  pillarId: number | null;
+  traitId: number | null;
   pillarCode: string | null;
   pillarName: string | null;
   traitCode: string | null;
@@ -1871,8 +1871,10 @@ export async function createUserTask(userId: string, payload: CreateUserTaskInpu
 }
 
 function normalizeUserTaskClassification(source: unknown): UserTaskClassification {
-  const record = isRecord(source) ? source : {};
-  const confidenceRaw = record.confidence;
+  const envelope = isRecord(source) ? source : {};
+  const record = isRecord(envelope.classification) ? envelope.classification : envelope;
+  const meta = isRecord(envelope.meta) ? envelope.meta : {};
+  const confidenceRaw = record.confidence ?? meta.confidence;
   const confidence =
     typeof confidenceRaw === 'number'
       ? confidenceRaw
@@ -1880,9 +1882,9 @@ function normalizeUserTaskClassification(source: unknown): UserTaskClassificatio
         ? Number.parseFloat(confidenceRaw)
         : null;
 
-  const pillarId = pickString(record.pillar_id);
-  const traitId = pickString(record.trait_id);
-  const requiresManualSelectionRaw = record.requires_manual_selection;
+  const pillarId = pickNumber(record.pillar_id);
+  const traitId = pickNumber(record.trait_id);
+  const requiresManualSelectionRaw = record.requires_manual_selection ?? envelope.requires_manual_selection;
   const requiresManualSelection =
     typeof requiresManualSelectionRaw === 'boolean'
       ? requiresManualSelectionRaw
@@ -1895,7 +1897,7 @@ function normalizeUserTaskClassification(source: unknown): UserTaskClassificatio
     pillarName: pickString(record.pillar_name),
     traitCode: pickString(record.trait_code),
     traitName: pickString(record.trait_name),
-    rationale: pickString(record.rationale),
+    rationale: pickString(record.rationale ?? meta.rationale),
     confidence: Number.isFinite(confidence) ? confidence : null,
     requiresManualSelection,
   };

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1751,6 +1751,22 @@ export type CreateUserTaskInput = {
   isActive?: boolean;
 };
 
+export type ClassifyUserTaskInput = {
+  title: string;
+};
+
+export type UserTaskClassification = {
+  pillarId: string | null;
+  traitId: string | null;
+  pillarCode: string | null;
+  pillarName: string | null;
+  traitCode: string | null;
+  traitName: string | null;
+  rationale: string | null;
+  confidence: number | null;
+  requiresManualSelection: boolean;
+};
+
 export type UpdateUserTaskInput = {
   title?: string;
   pillarId?: string | null;
@@ -1852,6 +1868,67 @@ export async function createUserTask(userId: string, payload: CreateUserTaskInpu
   }
 
   return normalized;
+}
+
+function normalizeUserTaskClassification(source: unknown): UserTaskClassification {
+  const record = isRecord(source) ? source : {};
+  const confidenceRaw = record.confidence;
+  const confidence =
+    typeof confidenceRaw === 'number'
+      ? confidenceRaw
+      : typeof confidenceRaw === 'string'
+        ? Number.parseFloat(confidenceRaw)
+        : null;
+
+  const pillarId = pickString(record.pillar_id);
+  const traitId = pickString(record.trait_id);
+  const requiresManualSelectionRaw = record.requires_manual_selection;
+  const requiresManualSelection =
+    typeof requiresManualSelectionRaw === 'boolean'
+      ? requiresManualSelectionRaw
+      : !pillarId || !traitId;
+
+  return {
+    pillarId,
+    traitId,
+    pillarCode: pickString(record.pillar_code),
+    pillarName: pickString(record.pillar_name),
+    traitCode: pickString(record.trait_code),
+    traitName: pickString(record.trait_name),
+    rationale: pickString(record.rationale),
+    confidence: Number.isFinite(confidence) ? confidence : null,
+    requiresManualSelection,
+  };
+}
+
+export async function classifyUserTask(
+  userId: string,
+  payload: ClassifyUserTaskInput,
+): Promise<UserTaskClassification> {
+  const title = pickString(payload.title);
+  if (!title) {
+    throw new Error('Task title is required.');
+  }
+
+  const path = `/users/${encodeURIComponent(userId)}/tasks/classify`;
+  const url = buildApiUrl(path);
+  const response = await apiAuthorizedFetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ title }),
+  });
+
+  const body = await response.json().catch(() => null);
+  logShape('user-task-classify', body);
+
+  if (!response.ok) {
+    throw new ApiError(response.status, body, url);
+  }
+
+  return normalizeUserTaskClassification(body);
 }
 
 export async function updateUserTask(

--- a/apps/web/src/pages/labs/EditorLabPage.tsx
+++ b/apps/web/src/pages/labs/EditorLabPage.tsx
@@ -2130,22 +2130,24 @@ function CreateTaskModal({
       if (!classification.pillarId || !classification.traitId) {
         return null;
       }
+      const resolvedPillarId = String(classification.pillarId);
+      const resolvedTraitId = String(classification.traitId);
 
       const pillarFromCatalog = sortedPillars.find(
-        (pillar) => pillar.id === classification.pillarId,
+        (pillar) => pillar.id === resolvedPillarId,
       );
       const traitFromManualList = manualTraits.find(
-        (trait) => trait.id === classification.traitId,
+        (trait) => trait.id === resolvedTraitId,
       );
 
       return {
-        pillarId: classification.pillarId,
-        traitId: classification.traitId,
+        pillarId: resolvedPillarId,
+        traitId: resolvedTraitId,
         pillarLabel:
           classification.pillarName
           ?? (pillarFromCatalog
             ? localizePillarLabel(pillarFromCatalog.name, language)
-            : classification.pillarCode ?? classification.pillarId),
+            : classification.pillarCode ?? resolvedPillarId),
         traitLabel:
           classification.traitName
           ?? (traitFromManualList
@@ -2157,7 +2159,7 @@ function CreateTaskModal({
               },
               language,
             )
-            : classification.traitCode ?? classification.traitId),
+            : classification.traitCode ?? resolvedTraitId),
         rationale:
           classification.rationale
           ?? t("editor.modal.aiCreate.suggestedCategory"),

--- a/apps/web/src/pages/labs/EditorLabPage.tsx
+++ b/apps/web/src/pages/labs/EditorLabPage.tsx
@@ -26,7 +26,7 @@ import {
   useStats,
   useTraits,
 } from "../../hooks/useCatalogs";
-import { type UserTask } from "../../lib/api";
+import { classifyUserTask, type UserTask, type UserTaskClassification } from "../../lib/api";
 import {
   fetchCatalogStats,
   fetchCatalogTraits,
@@ -1944,159 +1944,14 @@ interface CreateTaskModalProps {
   guideStepId: EditorGuideStepId | null;
 }
 
-type SuggestedPillarGroup = "body" | "mind" | "soul";
-
 type TaskCategorySuggestion = {
   pillarId: string;
   pillarLabel: string;
   traitId: string;
   traitLabel: string;
   rationale: string;
+  confidence: number | null;
 };
-
-const CATEGORY_KEYWORDS: Record<SuggestedPillarGroup, string[]> = {
-  body: [
-    "caminar",
-    "walk",
-    "run",
-    "correr",
-    "train",
-    "entren",
-    "gym",
-    "agua",
-    "water",
-    "hidr",
-    "sleep",
-    "dorm",
-    "stretch",
-    "mov",
-    "exercise",
-    "comer",
-    "eat",
-  ],
-  mind: [
-    "leer",
-    "read",
-    "study",
-    "estudi",
-    "focus",
-    "foco",
-    "trabajo",
-    "work",
-    "plan",
-    "organ",
-    "deep work",
-    "learn",
-    "aprender",
-  ],
-  soul: [
-    "hablar",
-    "talk",
-    "call",
-    "llamar",
-    "agradec",
-    "gratitude",
-    "medit",
-    "rez",
-    "pray",
-    "connect",
-    "conectar",
-    "friend",
-    "famil",
-    "journal",
-    "respirar",
-    "breathe",
-  ],
-};
-
-function normalizeForMatching(value: string): string {
-  return value
-    .normalize("NFD")
-    .replace(/\p{Diacritic}/gu, "")
-    .toLowerCase();
-}
-
-function detectSuggestedPillarGroup(taskTitle: string): SuggestedPillarGroup {
-  const normalizedTitle = normalizeForMatching(taskTitle);
-  const scores = (Object.keys(CATEGORY_KEYWORDS) as SuggestedPillarGroup[]).map(
-    (group) => ({
-      group,
-      score: CATEGORY_KEYWORDS[group].reduce(
-        (total, keyword) =>
-          normalizedTitle.includes(normalizeForMatching(keyword))
-            ? total + 1
-            : total,
-        0,
-      ),
-    }),
-  );
-
-  const topScore = scores.reduce(
-    (best, current) => (current.score > best.score ? current : best),
-    { group: "mind" as SuggestedPillarGroup, score: 0 },
-  );
-
-  if (topScore.score === 0) {
-    return "mind";
-  }
-
-  return topScore.group;
-}
-
-function resolvePillarFromCatalog(
-  pillars: Pillar[],
-  group: SuggestedPillarGroup,
-): Pillar | null {
-  const byCode = pillars.find((pillar) =>
-    normalizeForMatching(pillar.code).includes(group),
-  );
-  if (byCode) {
-    return byCode;
-  }
-
-  const labelHints: Record<SuggestedPillarGroup, string[]> = {
-    body: ["body", "cuerpo", "salud", "fisico", "physical"],
-    mind: ["mind", "mente", "focus", "foco", "mental"],
-    soul: ["soul", "alma", "conexion", "connection", "spirit"],
-  };
-
-  const byName = pillars.find((pillar) =>
-    labelHints[group].some((hint) =>
-      normalizeForMatching(pillar.name).includes(hint),
-    ),
-  );
-
-  return byName ?? pillars[0] ?? null;
-}
-
-function resolveSuggestedTrait(traits: Trait[], group: SuggestedPillarGroup): Trait | null {
-  const traitHints: Record<SuggestedPillarGroup, string[]> = {
-    body: ["hydr", "sleep", "movement", "fitness", "energia", "energy", "health"],
-    mind: ["focus", "clarity", "learn", "discipline", "product", "study"],
-    soul: ["connection", "gratitude", "mindful", "calm", "compassion", "bond"],
-  };
-
-  const hinted = traits.find((trait) => {
-    const searchable = `${trait.name} ${trait.code}`;
-    return traitHints[group].some((hint) =>
-      normalizeForMatching(searchable).includes(hint),
-    );
-  });
-
-  return hinted ?? traits[0] ?? null;
-}
-
-function buildSuggestionRationale(
-  language: "es" | "en",
-  taskTitle: string,
-  pillarLabel: string,
-  traitLabel: string,
-): string {
-  if (language === "es") {
-    return `“${taskTitle}” se alinea con ${pillarLabel} > ${traitLabel}.`;
-  }
-  return `“${taskTitle}” aligns with ${pillarLabel} > ${traitLabel}.`;
-}
 
 function CreateTaskModal({
   open,
@@ -2114,6 +1969,15 @@ function CreateTaskModal({
   const [difficultyId, setDifficultyId] = useState("");
   const [suggestionStatus, setSuggestionStatus] = useState<
     "idle" | "analyzing" | "ready"
+  >("idle");
+  const [flowState, setFlowState] = useState<
+    | "idle"
+    | "analyzing"
+    | "suggestion-ready"
+    | "manual-category-open"
+    | "confirming"
+    | "created"
+    | "error"
   >("idle");
   const [suggestion, setSuggestion] = useState<TaskCategorySuggestion | null>(
     null,
@@ -2152,6 +2016,7 @@ function CreateTaskModal({
       setTitle("");
       setDifficultyId("");
       setSuggestionStatus("idle");
+      setFlowState("idle");
       setSuggestion(null);
       setManualCategoryEnabled(false);
       setManualPillarId("");
@@ -2255,6 +2120,54 @@ function CreateTaskModal({
   >("idle");
 
   useEffect(() => {
+    if (isSubmitting) {
+      setFlowState("confirming");
+    }
+  }, [isSubmitting]);
+
+  const mapClassificationToSuggestion = useCallback(
+    (classification: UserTaskClassification): TaskCategorySuggestion | null => {
+      if (!classification.pillarId || !classification.traitId) {
+        return null;
+      }
+
+      const pillarFromCatalog = sortedPillars.find(
+        (pillar) => pillar.id === classification.pillarId,
+      );
+      const traitFromManualList = manualTraits.find(
+        (trait) => trait.id === classification.traitId,
+      );
+
+      return {
+        pillarId: classification.pillarId,
+        traitId: classification.traitId,
+        pillarLabel:
+          classification.pillarName
+          ?? (pillarFromCatalog
+            ? localizePillarLabel(pillarFromCatalog.name, language)
+            : classification.pillarCode ?? classification.pillarId),
+        traitLabel:
+          classification.traitName
+          ?? (traitFromManualList
+            ? localizeTraitLabel(
+              {
+                name: traitFromManualList.name,
+                code: traitFromManualList.code,
+                fallback: traitFromManualList.id,
+              },
+              language,
+            )
+            : classification.traitCode ?? classification.traitId),
+        rationale:
+          classification.rationale
+          ?? t("editor.modal.aiCreate.suggestedCategory"),
+        confidence: classification.confidence,
+      };
+    },
+    [language, manualTraits, sortedPillars, t],
+  );
+
+  useEffect(() => {
     if (!isGuideAIThinkingStep) {
       setGuideSimulationPhase("idle");
       return;
@@ -2286,6 +2199,7 @@ function CreateTaskModal({
           language === "es"
             ? "La simulación muestra una clasificación coherente: Alma + Gratitud."
             : "The simulation shows a coherent classification: Soul + Gratitude.",
+        confidence: null,
       }
     : null;
   const visibleSuggestion = suggestion ?? guideSuggestion;
@@ -2294,6 +2208,7 @@ function CreateTaskModal({
   const shouldShowGuideTrait =
     isGuideAIThinkingStep && guideSimulationPhase === "trait";
   const showAnalyzingCard = isAnalyzing || isGuideAIThinkingStep;
+  const isManualCategoryOpen = flowState === "manual-category-open";
   const hasManualCategorySelection = Boolean(manualPillarId && manualTraitId);
   const shouldUseManualCategory =
     manualCategoryEnabled && hasManualCategorySelection;
@@ -2305,87 +2220,66 @@ function CreateTaskModal({
   const isSuggestDisabled =
     (isAnalyzing && !isGuideAIThinkingStep) ||
     title.trim().length === 0 ||
-    isLoadingPillars ||
-    Boolean(pillarsError);
+    !userId;
 
   const handleSuggestCategory = useCallback(async () => {
     const validationErrors: Record<string, string> = {};
     if (title.trim().length === 0) {
       validationErrors.title = t("editor.validation.titleRequired");
     }
-    if (sortedPillars.length === 0) {
-      validationErrors.suggestion = t("editor.modal.aiCreate.catalogFallback");
+    if (!userId) {
+      validationErrors.user = t("editor.validation.userNotFound");
     }
     setErrors(validationErrors);
     if (Object.keys(validationErrors).length > 0) {
       return;
     }
 
-    const pillarGroup = detectSuggestedPillarGroup(title);
-    const selectedPillar = resolvePillarFromCatalog(sortedPillars, pillarGroup);
-    if (!selectedPillar) {
-      setErrors((previous) => ({
-        ...previous,
-        suggestion: t("editor.modal.aiCreate.catalogFallback"),
-      }));
-      return;
-    }
-
     setSuggestionStatus("analyzing");
+    setFlowState("analyzing");
     setSuggestion(null);
     clearError("suggestion");
-    await new Promise((resolve) => window.setTimeout(resolve, 1200));
 
     try {
-      const pillarTraits = await fetchCatalogTraits(selectedPillar.id);
-      const selectedTrait = resolveSuggestedTrait(pillarTraits, pillarGroup);
-      if (!selectedTrait) {
+      const classification = await classifyUserTask(userId!, {
+        title: title.trim(),
+      });
+
+      const resolvedSuggestion = mapClassificationToSuggestion(classification);
+      if (!resolvedSuggestion || classification.requiresManualSelection) {
         setSuggestionStatus("idle");
+        setFlowState("manual-category-open");
+        setManualCategoryEnabled(true);
         setErrors((previous) => ({
           ...previous,
-          suggestion: t("editor.modal.aiCreate.noTraits"),
+          suggestion: t("editor.modal.aiCreate.catalogFallback"),
         }));
         return;
       }
 
-      const localizedPillar = localizePillarLabel(selectedPillar.name, language);
-      const localizedTrait = localizeTraitLabel(
-        {
-          name: selectedTrait.name,
-          code: selectedTrait.code,
-          fallback: selectedTrait.id,
-        },
-        language,
-      );
-
-      setSuggestion({
-        pillarId: selectedPillar.id,
-        pillarLabel: localizedPillar,
-        traitId: selectedTrait.id,
-        traitLabel: localizedTrait,
-        rationale: buildSuggestionRationale(
-          activeLocale,
-          title.trim(),
-          localizedPillar,
-          localizedTrait,
-        ),
-      });
+      setSuggestion(resolvedSuggestion);
       setSuggestionStatus("ready");
+      setFlowState("suggestion-ready");
+      if (manualCategoryEnabled) {
+        setManualCategoryEnabled(false);
+      }
     } catch (error) {
       console.error("Failed to resolve AI suggestion for lab editor", error);
       setSuggestionStatus("idle");
+      setFlowState("error");
+      setManualCategoryEnabled(true);
       setErrors((previous) => ({
         ...previous,
         suggestion: t("editor.modal.aiCreate.suggestionError"),
       }));
     }
   }, [
-    activeLocale,
     clearError,
-    language,
-    sortedPillars,
+    manualCategoryEnabled,
+    mapClassificationToSuggestion,
     t,
     title,
+    userId,
   ]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -2427,6 +2321,7 @@ function CreateTaskModal({
         difficultyId: difficultyId || null,
       });
       setToast({ type: "success", text: t("editor.toast.create.success") });
+      setFlowState("created");
       setTitle("");
       setDifficultyId("");
       setSuggestionStatus("idle");
@@ -2438,6 +2333,7 @@ function CreateTaskModal({
     } catch (error) {
       const message =
         error instanceof Error ? error.message : t("editor.toast.create.error");
+      setFlowState("error");
       setToast({ type: "error", text: message });
     }
   };
@@ -2506,6 +2402,7 @@ function CreateTaskModal({
                       clearError("title");
                       clearError("suggestion");
                       setSuggestionStatus("idle");
+                      setFlowState("idle");
                       setSuggestion(null);
                     }}
                     placeholder={t("editor.modal.aiCreate.taskTitlePlaceholder")}
@@ -2662,6 +2559,9 @@ function CreateTaskModal({
                             if (previous) {
                               setManualPillarId("");
                               setManualTraitId("");
+                              setFlowState("suggestion-ready");
+                            } else {
+                              setFlowState("manual-category-open");
                             }
                             return !previous;
                           });
@@ -2676,7 +2576,7 @@ function CreateTaskModal({
                   </section>
                 )}
 
-              {manualCategoryEnabled && (
+              {(manualCategoryEnabled || isManualCategoryOpen) && (
                 <section
                   className="create-task-ai-modal__manual-grid grid gap-3 rounded-xl border p-3"
                   data-editor-guide-target="new-task-modal-ai-result"
@@ -2689,6 +2589,7 @@ function CreateTaskModal({
                         setManualCategoryEnabled(false);
                         setManualPillarId("");
                         setManualTraitId("");
+                        setFlowState("suggestion-ready");
                         clearError("suggestion");
                       }}
                     >


### PR DESCRIPTION
### Motivation
- Reemplazar la clasificación mock/local del modal `labs/editor` por la clasificación real provista por el backend (`POST /users/:id/tasks/classify`) manteniendo el flujo de creación existente.
- Exponer un cliente frontend tipado para el endpoint de clasificación que respete la autenticación y normalice la respuesta para la UI.

### Description
- Añadí `classifyUserTask(userId, { title })` en `apps/web/src/lib/api.ts` con tipos `ClassifyUserTaskInput` y `UserTaskClassification` y lógica de normalización de respuesta (IDs, codes/names, `rationale`, `confidence`, `requiresManualSelection`).
- Reemplacé la heurística/mock de keywords en `apps/web/src/pages/labs/EditorLabPage.tsx` por una llamada a `classifyUserTask` al tocar `Generar categoría`, incluyendo `mapClassificationToSuggestion` para adaptar la respuesta al shape que usa la UI.
- Mantengo intacto el flujo de creación real: `createTask` sigue usándose para confirmar y persistir la tarea, enviando `pillarId`/`traitId` (sugeridos por AI o sobrescritos manualmente), `difficultyId` y `title`.
- Conservé y explicité los estados UX del modal (`idle`, `analyzing`, `suggestion-ready`, `manual-category-open`, `confirming`, `created`, `error`) y la convivencia entre sugerencia AI y selección manual, habilitando fallback manual si la clasificación falla o devuelve datos incompletos.

### Testing
- Ejecuté el typecheck del paquete web con `pnpm -C apps/web typecheck`, que falló por errores de TypeScript preexistentes en otras partes del repo no relacionados con estos cambios (por ejemplo `runtimeAuth.tsx` y tipos/test de `dashboard-v3`).
- También ejecuté `tsc --noEmit` contra los archivos modificados; ambos checks reportaron errores a nivel de proyecto que son previos al cambio y no bloquean la integración funcional del flujo de `classifyUserTask` en el modal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f8397e048332b9da8223ff46fa79)