### PR TITLE
Remove duplicate 'Logros' heading in RewardsSection and tighten spacing

### DIFF
--- a/apps/web/src/components/dashboard-v3/RewardsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/RewardsSection.tsx
@@ -1043,12 +1043,7 @@ function AchievedShelf({
   };
 
   return (
-    <div className="space-y-4" data-demo-anchor={demoAnchors?.shelves}>
-      <div>
-        <h2 className="text-lg font-semibold text-[color:var(--color-text-strong)]">
-          {language === 'es' ? 'Logros' : 'Achievements'}
-        </h2>
-      </div>
+    <div className="space-y-3" data-demo-anchor={demoAnchors?.shelves}>
       {!isCarouselView && isShelfFocusStep ? (
         <div
           data-demo-anchor="logros-shelves-pillars"


### PR DESCRIPTION
### Motivation
- Evitar la repetición del título “Logros” dentro del bloque de estantes para recuperar espacio vertical y subir visualmente el contenido.

### Description
- Eliminé el encabezado interno `<h2>` y cambié la clase del contenedor de `space-y-4` a `space-y-3` en `apps/web/src/components/dashboard-v3/RewardsSection.tsx`, manteniendo el botón `Ver guía` en su posición.

### Testing
- Ejecuté `npm --workspace apps/web run typecheck` y falló debido a errores de TypeScript preexistentes que no están relacionados con este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fb6dacac8332ac0e93b0e4c61a86)