### PR TITLE
Fix TaskClassification JSON schema required/nullable fields

### DIFF
--- a/apps/api/prompts/task-classify.json
+++ b/apps/api/prompts/task-classify.json
@@ -5,12 +5,35 @@
       "name": "TaskClassification",
       "schema": {
         "type": "object",
-        "required": ["pillar_code", "trait_code"],
+        "required": [
+          "pillar_code",
+          "trait_code",
+          "rationale",
+          "confidence"
+        ],
         "properties": {
-          "pillar_code": { "type": "string", "minLength": 1 },
-          "trait_code": { "type": "string", "minLength": 1 },
-          "rationale": { "type": "string" },
-          "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+          "pillar_code": {
+            "type": "string",
+            "minLength": 1
+          },
+          "trait_code": {
+            "type": "string",
+            "minLength": 1
+          },
+          "rationale": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "confidence": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 1
+          }
         },
         "additionalProperties": false
       },


### PR DESCRIPTION
### Motivation
- The response schema for `TaskClassification` declared properties that were not all present in `required`, which caused strict schema validation failures from the structured output system.
- Those validation failures surfaced as backend errors and bubbled up to the frontend; the schema must require all properties while allowing some fields to be null when appropriate.

### Description
- Edited `apps/api/prompts/task-classify.json` to set `required` to `["pillar_code","trait_code","rationale","confidence"]` so every property in `properties` is listed under `required`.
- Made `rationale` nullable with `"type": ["string","null"]` to express it is optional-in-practice while satisfying `strict: true` validation.
- Made `confidence` nullable with `"type": ["number","null"]` and preserved `"minimum": 0` and `"maximum": 1` for numeric values.
- Kept `additionalProperties: false` and `strict: true` intact to retain strict output constraints.

### Testing
- Ran `jq empty apps/api/prompts/task-classify.json` to verify the JSON parses successfully, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fe5b270483328110b2097c111c63)