### PR TITLE
Demo Hub público: reemplazar selector por secciones (Dashboard, Logros, Tareas)

### DIFF
--- a/apps/web/demo-mode-select/index.html
+++ b/apps/web/demo-mode-select/index.html
@@ -12,15 +12,15 @@
     <link rel="apple-touch-icon" href="/IB-COLOR-LOGO.png" />
     <meta
       name="description"
-      content="Explora la demo oficial de Innerbloom y elige LOW, CHILL, FLOW o EVOLVE para entrar a la experiencia guiada."
+      content="Explora la demo pública de Innerbloom por secciones del producto: Dashboard, Logros y Tareas."
     />
     <link rel="canonical" href="https://innerbloomjourney.org/demo-mode-select" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Innerbloom" />
-    <meta property="og:title" content="Innerbloom Demo · Elige tu Game Mode" />
+    <meta property="og:title" content="Innerbloom Demo Hub · Explora el producto" />
     <meta
       property="og:description"
-      content="Explora la demo oficial de Innerbloom y elige LOW, CHILL, FLOW o EVOLVE para entrar a la experiencia guiada."
+      content="Explora la demo pública de Innerbloom por secciones del producto: Dashboard, Logros y Tareas."
     />
     <meta property="og:url" content="https://innerbloomjourney.org/demo-mode-select" />
     <meta property="og:image" content="https://innerbloomjourney.org/og/IBOG1.jpg" />
@@ -30,14 +30,14 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Preview oficial de la demo de Innerbloom" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Innerbloom Demo · Elige tu Game Mode" />
+    <meta name="twitter:title" content="Innerbloom Demo Hub · Explora el producto" />
     <meta
       name="twitter:description"
-      content="Explora la demo oficial de Innerbloom y elige LOW, CHILL, FLOW o EVOLVE para entrar a la experiencia guiada."
+      content="Explora la demo pública de Innerbloom por secciones del producto: Dashboard, Logros y Tareas."
     />
     <meta name="twitter:image" content="https://innerbloomjourney.org/og/IBOG1.jpg" />
     <meta name="twitter:image:alt" content="Preview oficial de la demo de Innerbloom" />
-    <title>Innerbloom Demo · Elige tu Game Mode</title>
+    <title>Innerbloom Demo Hub · Explora el producto</title>
     <script>
       (function () {
         var key = 'ib:gradient';

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,6 +28,7 @@ import LabsLogrosDemoPage from './pages/labs/LogrosDemoPage';
 import LabsIndexPage from './pages/labs/LabsIndexPage';
 import LandingRhythmSectionMvpPage from './pages/labs/LandingRhythmSectionMvpPage';
 import EditorLabPage from './pages/labs/EditorLabPage';
+import PublicTasksDemoPage from './pages/labs/PublicTasksDemoPage';
 import { useGa4FunnelTracking } from './hooks/useGa4FunnelTracking';
 import { isNativeCapacitorPlatform } from './mobile/capacitor';
 import { writeMobileDebug } from './mobile/mobileDebug';
@@ -275,6 +276,7 @@ export default function App() {
         <Route path="/labs" element={<LabsIndexPage />} />
         <Route path="/labs/demo-mode-select" element={<LabsDemoModeSelectPage legacyLabsPath />} />
         <Route path="/labs/logros" element={<LabsLogrosDemoPage />} />
+        <Route path="/labs/tasks-demo" element={<PublicTasksDemoPage />} />
         <Route path="/labs/landing-rhythm-section" element={<LandingRhythmSectionMvpPage />} />
         <Route
           path="/labs/editor"

--- a/apps/web/src/pages/LabsDemoModeSelect.tsx
+++ b/apps/web/src/pages/LabsDemoModeSelect.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Sparkles, Target, WandSparkles } from 'lucide-react';
 import { OFFICIAL_DESIGN_TOKENS } from '../content/officialDesignTokens';
 import { usePostLoginLanguage } from '../i18n/postLoginLanguage';
 import { buildDemoUrl, getDemoModeSelectPath, type DemoEntrySource } from '../lib/demoEntry';
@@ -12,12 +13,6 @@ import {
 } from '../lib/demoModeSelectSeo';
 import { BrandWordmark } from '../components/layout/BrandWordmark';
 import { usePageMeta } from '../lib/seo';
-import {
-  getLabsGameModeLabel,
-  LABS_DEMO_MODE_SELECT_COPY,
-  LABS_GAME_MODE_ORDER,
-  LABS_GAME_MODES,
-} from '../config/labsGameModes';
 
 type DemoModeSelectPageProps = {
   legacyLabsPath?: boolean;
@@ -29,7 +24,6 @@ export default function LabsDemoModeSelectPage({ legacyLabsPath = false }: DemoM
   const navigate = useNavigate();
   const sourceParam = new URLSearchParams(location.search).get('source');
   const source: DemoEntrySource = sourceParam === 'selector' || sourceParam === 'labs' ? sourceParam : 'landing';
-  const copy = LABS_DEMO_MODE_SELECT_COPY[language];
   const purpleAfternoon = OFFICIAL_DESIGN_TOKENS.gradients.find((gradient) => gradient.name === 'purple_afternoon');
   const landingBackground = purpleAfternoon
     ? {
@@ -42,93 +36,92 @@ export default function LabsDemoModeSelectPage({ legacyLabsPath = false }: DemoM
   }, [location.search, syncLocaleLanguage]);
 
   usePageMeta({
-    title: language === 'es' ? 'Innerbloom Demo · Elige tu ritmo' : 'Innerbloom Demo · Choose your rhythm',
+    title: language === 'es' ? 'Innerbloom Demo Hub · Explora el producto' : 'Innerbloom Demo Hub · Explore the product',
     description:
       language === 'es'
-        ? 'Explora la demo oficial de Innerbloom. Elige LOW, CHILL, FLOW o EVOLVE y entra a la experiencia guiada en tu idioma.'
-        : 'Explore the official Innerbloom demo. Choose LOW, CHILL, FLOW, or EVOLVE and enter the guided experience in your language.',
+        ? 'Explora la demo pública de Innerbloom por secciones del producto: Dashboard, Logros y Tareas.'
+        : 'Explore the public Innerbloom demo by product section: Dashboard, Achievements, and Tasks.',
     image: DEMO_MODE_SELECT_OG_IMAGE_PATH,
-    imageAlt: language === 'es' ? 'Preview oficial de la demo de Innerbloom' : 'Official Innerbloom demo preview',
+    imageAlt: language === 'es' ? 'Hub público de demos de Innerbloom' : 'Innerbloom public demo hub',
     ogImageSecureUrl: DEMO_MODE_SELECT_OG_IMAGE_PATH,
     ogImageType: DEMO_MODE_SELECT_OG_IMAGE_TYPE,
     ogImageWidth: DEMO_MODE_SELECT_OG_IMAGE_WIDTH,
     ogImageHeight: DEMO_MODE_SELECT_OG_IMAGE_HEIGHT,
     twitterImage: DEMO_MODE_SELECT_OG_IMAGE_PATH,
-    twitterImageAlt: language === 'es' ? 'Preview oficial de la demo de Innerbloom' : 'Official Innerbloom demo preview',
+    twitterImageAlt: language === 'es' ? 'Hub público de demos de Innerbloom' : 'Innerbloom public demo hub',
     url: getDemoModeSelectPath(legacyLabsPath),
   });
 
-  const cards = useMemo(
-    () => LABS_GAME_MODE_ORDER.map((modeId) => ({
-      ...LABS_GAME_MODES[modeId],
-      label: getLabsGameModeLabel(modeId, language),
-      href: buildDemoUrl({ language, source: legacyLabsPath ? 'labs' : 'selector', mode: modeId }),
-    })),
-    [language, legacyLabsPath],
-  );
-
-  const handleClose = () => {
-    navigate(buildLocalizedAuthPath('/', language));
-  };
+  const cards = [
+    {
+      id: 'dashboard',
+      title: language === 'es' ? 'Dashboard' : 'Dashboard',
+      description: language === 'es' ? 'Vista general de progreso, foco y energía diaria.' : 'A guided overview of progress, focus, and daily energy.',
+      href: buildDemoUrl({ language, source: legacyLabsPath ? 'labs' : source }),
+      Icon: Target,
+    },
+    {
+      id: 'logros',
+      title: language === 'es' ? 'Logros' : 'Achievements',
+      description: language === 'es' ? 'Explora badges, sellos y recompensas desbloqueables.' : 'Explore badges, seals, and unlockable reward cards.',
+      href: `/labs/logros?lang=${language}&source=${legacyLabsPath ? 'labs' : source}`,
+      Icon: Sparkles,
+    },
+    {
+      id: 'tareas',
+      title: language === 'es' ? 'Tareas' : 'Tasks',
+      description: language === 'es' ? 'Editor público con datos mock y guía de uso incluida.' : 'Public editor preview with mock data and built-in guidance.',
+      href: `/labs/tasks-demo?lang=${language}&source=${legacyLabsPath ? 'labs' : source}`,
+      Icon: WandSparkles,
+    },
+  ];
 
   return (
-    <main
-      className="min-h-screen text-[color:var(--color-text)] md:h-svh md:min-h-svh"
-      style={landingBackground}
-    >
+    <main className="min-h-screen text-[color:var(--color-text)] md:h-svh md:min-h-svh" style={landingBackground}>
       <div className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-4 py-4 sm:px-6 sm:py-5 md:h-svh md:min-h-svh md:max-w-5xl md:px-8 md:py-6 lg:max-w-6xl lg:px-10 lg:py-7 xl:max-w-[84rem] xl:px-12">
         <section className="relative isolate flex flex-1 flex-col overflow-hidden rounded-[2rem] border border-white/12 bg-[linear-gradient(140deg,rgba(255,255,255,0.085),rgba(167,123,245,0.075)_48%,rgba(72,43,126,0.05))] px-5 py-4 shadow-[0_22px_56px_rgba(26,12,52,0.22),inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-[20px] sm:px-6 sm:py-5 md:rounded-[2.35rem] md:px-7 md:py-5 md:shadow-[0_28px_80px_rgba(26,12,52,0.28),inset_0_1px_0_rgba(255,255,255,0.2)] lg:px-8 lg:py-6 xl:px-10 xl:py-6">
           <div className="pointer-events-none absolute inset-x-2 -top-3 h-24 rounded-full bg-[radial-gradient(circle_at_50%_52%,rgba(176,122,255,0.3),rgba(176,122,255,0.08)_54%,transparent_74%)] blur-[18px] md:h-28 md:blur-[22px]" />
-          <div className="pointer-events-none absolute inset-y-8 left-1/2 w-[90%] -translate-x-1/2 rounded-full bg-[radial-gradient(ellipse_at_center,rgba(168,115,255,0.2),rgba(168,115,255,0.06)_44%,transparent_72%)] blur-3xl md:inset-y-10 md:w-[96%] lg:w-[92%]" />
-          <div className="pointer-events-none absolute -bottom-10 right-0 h-40 w-[56%] rounded-full bg-[radial-gradient(circle_at_center,rgba(126,95,255,0.16),transparent_64%)] blur-3xl md:h-52 md:w-[46%]" />
-          <div className="pointer-events-none absolute inset-0 rounded-[2rem] bg-[radial-gradient(circle_at_14%_20%,rgba(255,255,255,0.12),transparent_58%),radial-gradient(circle_at_84%_80%,rgba(186,161,255,0.08),transparent_56%),linear-gradient(140deg,rgba(167,123,245,0.08),rgba(72,43,126,0.05))]" />
-
           <button
             type="button"
-            onClick={handleClose}
-            aria-label={language === 'es' ? 'Cerrar selector y volver al inicio' : 'Close selector and return home'}
-            className="absolute right-4 top-4 z-10 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/12 bg-white/[0.06] text-xl leading-none text-white/82 shadow-[0_12px_28px_rgba(26,12,52,0.2),inset_0_1px_0_rgba(255,255,255,0.12)] backdrop-blur-md transition duration-200 ease-out hover:border-white/18 hover:bg-white/[0.1] hover:text-white active:scale-[0.97] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70 md:right-5 md:top-5"
+            onClick={() => navigate(buildLocalizedAuthPath('/', language))}
+            aria-label={language === 'es' ? 'Cerrar demo hub y volver al inicio' : 'Close demo hub and return home'}
+            className="absolute right-4 top-4 z-10 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/12 bg-white/[0.06] text-xl leading-none text-white/82 shadow-[0_12px_28px_rgba(26,12,52,0.2),inset_0_1px_0_rgba(255,255,255,0.12)] backdrop-blur-md transition duration-200 ease-out hover:border-white/18 hover:bg-white/[0.1] hover:text-white active:scale-[0.97] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
           >
             <span aria-hidden="true">×</span>
           </button>
 
           <div className="relative flex flex-col gap-4 text-center sm:gap-[1.125rem] md:gap-5">
-            <BrandWordmark
-              className="text-white/84"
-              textClassName="text-[0.72rem] font-semibold tracking-[0.34em] text-white/72 sm:text-xs md:text-[0.8rem] lg:text-[0.84rem]"
-              iconClassName="h-[1.65em] sm:h-[1.75em]"
-            />
-            <div className="mx-auto flex w-full max-w-[22rem] flex-col gap-2 sm:max-w-[28rem] md:max-w-[42rem] md:gap-2.5 lg:max-w-[58rem]">
-              <h1 className="mx-auto max-w-[14ch] text-balance text-[1.8rem] font-semibold leading-[0.98] tracking-[-0.03em] text-white sm:max-w-[15ch] sm:text-[2rem] md:max-w-[20ch] md:text-[2.35rem] lg:max-w-[24ch] lg:text-[2.7rem] xl:max-w-[26ch] xl:text-[2.85rem]">
-                {copy.title}
+            <BrandWordmark className="text-white/84" textClassName="text-[0.72rem] font-semibold tracking-[0.34em] text-white/72 sm:text-xs" iconClassName="h-[1.65em] sm:h-[1.75em]" />
+            <div className="mx-auto flex w-full max-w-[56rem] flex-col gap-2 md:gap-2.5">
+              <h1 className="mx-auto max-w-[24ch] text-balance text-[1.8rem] font-semibold leading-[0.98] tracking-[-0.03em] text-white sm:text-[2rem] md:text-[2.4rem] lg:text-[2.75rem]">
+                {language === 'es' ? 'Explora Innerbloom por sección de producto' : 'Explore Innerbloom by product section'}
               </h1>
-              <p className="mx-auto max-w-[34ch] text-sm leading-[1.45] text-white/78 sm:max-w-[36ch] sm:text-[0.94rem] md:max-w-[46ch] md:text-[0.98rem] md:leading-[1.55] lg:max-w-[56ch]">
-                {copy.subtitle}
+              <p className="mx-auto max-w-[58ch] text-sm leading-[1.5] text-white/78 sm:text-[0.96rem] md:text-[1.02rem]">
+                {language === 'es'
+                  ? 'Elige una demo pública para recorrer Dashboard, Logros o Tareas con una experiencia guiada y visual consistente.'
+                  : 'Choose a public demo to explore Dashboard, Achievements, or Tasks with a guided and consistent product experience.'}
               </p>
             </div>
           </div>
 
-          <div className="relative mt-4 grid grid-cols-2 items-start gap-2.5 self-center sm:mt-5 sm:gap-3 md:mt-5 md:gap-3.5 lg:mt-6 lg:grid-cols-4 lg:gap-3.5 xl:gap-4">
-            {cards.map((card) => (
+          <div className="relative mt-6 grid grid-cols-1 gap-3 md:mt-8 md:grid-cols-3 md:gap-4">
+            {cards.map(({ id, title, description, href, Icon }) => (
               <Link
-                key={card.id}
-                to={card.href}
-                className="group relative flex min-w-0 flex-col overflow-hidden rounded-[1.35rem] border border-white/10 bg-white/[0.04] shadow-[0_14px_30px_rgba(26,12,52,0.14),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-sm transition duration-200 ease-out hover:-translate-y-0.5 hover:border-white/16 hover:bg-white/[0.055] hover:shadow-[0_18px_36px_rgba(26,12,52,0.18),inset_0_1px_0_rgba(255,255,255,0.12)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70 md:rounded-[1.55rem] md:shadow-[0_20px_42px_rgba(26,12,52,0.18),inset_0_1px_0_rgba(255,255,255,0.1)]"
+                key={id}
+                to={href}
+                className="group relative flex min-h-[15rem] flex-col justify-between rounded-[1.5rem] border border-white/12 bg-white/[0.045] p-5 shadow-[0_14px_30px_rgba(26,12,52,0.14),inset_0_1px_0_rgba(255,255,255,0.08)] transition duration-200 ease-out hover:-translate-y-0.5 hover:border-white/20 hover:bg-white/[0.07] hover:shadow-[0_18px_36px_rgba(26,12,52,0.2),inset_0_1px_0_rgba(255,255,255,0.14)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
               >
-                <div className="absolute inset-x-4 top-0 h-9 rounded-b-[1.2rem] bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.14),transparent_72%)] opacity-75 transition duration-200 group-hover:opacity-95" />
-                <div className="aspect-[0.94/1] overflow-hidden bg-[linear-gradient(180deg,rgba(255,255,255,0.045),rgba(255,255,255,0.02))] md:aspect-[1.02/1] lg:aspect-[0.78/1] xl:aspect-[0.8/1]">
-                  <img
-                    src={card.image}
-                    alt=""
-                    className="h-full w-full object-cover object-top transition duration-300 ease-out group-hover:scale-[1.025]"
-                    loading="lazy"
-                  />
+                <div className="inline-flex h-14 w-14 items-center justify-center rounded-2xl border border-white/15 bg-white/[0.08] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] transition group-hover:scale-[1.03]">
+                  <Icon className="h-7 w-7" strokeWidth={2.1} />
                 </div>
-                <div className="relative border-t border-white/8 bg-[linear-gradient(180deg,rgba(19,14,43,0.08),rgba(19,14,43,0.18))] px-2.5 py-2 text-center md:px-3 md:py-2.5 lg:px-2.5 lg:py-3">
-                  <span className="line-clamp-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/92 sm:text-[11px] md:text-[0.76rem] md:tracking-[0.22em]">
-                    {card.label}
-                  </span>
+                <div className="space-y-2">
+                  <h2 className="text-xl font-semibold tracking-[-0.02em] text-white">{title}</h2>
+                  <p className="text-sm leading-relaxed text-white/78">{description}</p>
                 </div>
+                <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/82 transition group-hover:text-white">
+                  {language === 'es' ? 'Abrir demo' : 'Open demo'}
+                  <span aria-hidden>→</span>
+                </span>
               </Link>
             ))}
           </div>

--- a/apps/web/src/pages/labs/PublicTasksDemoPage.tsx
+++ b/apps/web/src/pages/labs/PublicTasksDemoPage.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { Target, Sparkles, WandSparkles } from 'lucide-react';
+import { Card } from '../../components/common/Card';
+import { MobileBottomNav } from '../../components/layout/MobileBottomNav';
+import { Navbar } from '../../components/layout/Navbar';
+import { ToastBanner } from '../../components/common/ToastBanner';
+import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
+import { resolveAuthLanguage } from '../../lib/authLanguage';
+import { type UserTask } from '../../lib/api';
+import { TaskList } from '../editor';
+
+const MOCK_TASKS: UserTask[] = [
+  {
+    id: 'demo-task-focus',
+    title: 'Bloque de foco de 25 minutos sin interrupciones',
+    pillarId: 'mind',
+    traitId: 'focus',
+    statId: 'consistency',
+    difficultyId: 'easy',
+    isActive: true,
+    xp: 20,
+    createdAt: '2026-01-03T09:00:00Z',
+    updatedAt: '2026-01-07T10:00:00Z',
+    completedAt: null,
+    archivedAt: null,
+  },
+  {
+    id: 'demo-task-walk',
+    title: 'Caminar 20 minutos después del almuerzo',
+    pillarId: 'body',
+    traitId: 'movement',
+    statId: 'energy',
+    difficultyId: 'medium',
+    isActive: true,
+    xp: 25,
+    createdAt: '2026-01-04T12:00:00Z',
+    updatedAt: '2026-01-08T08:00:00Z',
+    completedAt: null,
+    archivedAt: null,
+  },
+  {
+    id: 'demo-task-journal',
+    title: 'Escribir 3 líneas de cierre del día',
+    pillarId: 'soul',
+    traitId: 'presence',
+    statId: 'clarity',
+    difficultyId: 'easy',
+    isActive: true,
+    xp: 15,
+    createdAt: '2026-01-02T21:00:00Z',
+    updatedAt: '2026-01-08T21:30:00Z',
+    completedAt: null,
+    archivedAt: null,
+  },
+];
+
+export default function PublicTasksDemoPage() {
+  const location = useLocation();
+  const { language, syncLocaleLanguage } = usePostLoginLanguage();
+  const [showToast, setShowToast] = useState(false);
+
+  useEffect(() => {
+    syncLocaleLanguage(resolveAuthLanguage(location.search));
+  }, [location.search, syncLocaleLanguage]);
+
+  const sections = useMemo(
+    () => [
+      { key: 'dashboard', label: language === 'es' ? 'Dashboard' : 'Dashboard', to: '/demo', icon: <Target /> },
+      { key: 'rewards', label: language === 'es' ? 'Logros' : 'Achievements', to: '/labs/logros', icon: <Sparkles /> },
+      { key: 'editor', label: language === 'es' ? 'Tareas' : 'Tasks', to: '/labs/tasks-demo', icon: <WandSparkles />, end: true },
+    ],
+    [language],
+  );
+
+  const pillarNames = new Map([
+    ['mind', 'Mind'],
+    ['body', 'Body'],
+    ['soul', 'Soul'],
+  ]);
+  const traitNames = new Map([
+    ['focus', language === 'es' ? 'Enfoque' : 'Focus'],
+    ['movement', language === 'es' ? 'Movimiento' : 'Movement'],
+    ['presence', language === 'es' ? 'Presencia' : 'Presence'],
+  ]);
+  const statNames = new Map([
+    ['consistency', language === 'es' ? 'Consistencia' : 'Consistency'],
+    ['energy', language === 'es' ? 'Energía' : 'Energy'],
+    ['clarity', language === 'es' ? 'Claridad' : 'Clarity'],
+  ]);
+  const difficultyNames = new Map([
+    ['easy', language === 'es' ? 'Baja' : 'Low'],
+    ['medium', language === 'es' ? 'Media' : 'Medium'],
+  ]);
+
+  return (
+    <div className="min-h-screen bg-transparent" data-light-scope="dashboard-v3">
+      <Navbar title={language === 'es' ? 'Demo de Tareas' : 'Tasks Demo'} sections={sections} />
+      <main className="mx-auto w-full max-w-5xl px-3 py-4 md:px-5 md:py-6">
+        <Card className="border border-[color:var(--glass-border)] bg-[image:var(--glass-bg)] p-4 md:p-6">
+          <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-[0.2em] text-[color:var(--color-text-subtle)]">Innerbloom Labs</p>
+              <h1 className="font-display text-2xl font-semibold text-[color:var(--color-text)]">
+                {language === 'es' ? 'Editor de tareas (demo pública)' : 'Task editor (public demo)'}
+              </h1>
+              <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">
+                {language === 'es'
+                  ? 'Esta versión funciona sin login, usa datos mock y mantiene la estructura visual del editor.'
+                  : 'This version runs without login, uses mock data, and preserves the editor visual structure.'}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShowToast(true)}
+                className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--color-text)] hover:border-[color:var(--color-border-strong)]"
+              >
+                {language === 'es' ? 'Ver guía' : 'Open guide'}
+              </button>
+              <Link
+                to="/demo-mode-select"
+                className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--color-text)] hover:border-[color:var(--color-border-strong)]"
+              >
+                {language === 'es' ? 'Volver al hub' : 'Back to hub'}
+              </Link>
+            </div>
+          </div>
+
+          <TaskList
+            tasks={MOCK_TASKS}
+            pillarNamesById={pillarNames}
+            traitNamesById={traitNames}
+            statNamesById={statNames}
+            difficultyNamesById={difficultyNames}
+            onEditTask={() => setShowToast(true)}
+            onDeleteTask={() => setShowToast(true)}
+            onDuplicateTask={() => setShowToast(true)}
+            onImproveTask={() => setShowToast(true)}
+            duplicatingTaskId={null}
+          />
+        </Card>
+      </main>
+      <MobileBottomNav items={sections} />
+      {showToast ? (
+        <div className="fixed bottom-20 right-4 z-50 max-w-sm">
+          <ToastBanner
+            tone="info"
+            message={language === 'es' ? 'Guía demo: explora la lista, abre acciones y prueba la navegación pública.' : 'Demo guide: explore the task list, open actions, and test public navigation.'}
+          />
+          <button
+            type="button"
+            onClick={() => setShowToast(false)}
+            className="mt-2 text-xs text-[color:var(--color-text-subtle)] underline"
+          >
+            {language === 'es' ? 'Cerrar' : 'Close'}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Reemplazar el antiguo selector público orientado a avatares/ritmos por un hub de demos organizado por secciones reales del producto (Dashboard, Logros, Tareas).  
- Asegurar que todas las demos sean accesibles públicamente sin requerir autenticación real, creando variantes mock cuando hace falta.  
- Mantener la estética y componentes premium de Innerbloom y reutilizar la mayor cantidad de UI/overlays/mocks existentes para evitar duplicación arquitectónica.  

### Description
- Sustituí la lógica de selector basada en `LABS_GAME_MODES` por un Hub de demos en `apps/web/src/pages/LabsDemoModeSelect.tsx` que muestra 3 cards (`Dashboard`, `Logros`, `Tareas`) con iconos de navbar, copy actualizado y estilos glass/premium.  
- Añadí una nueva página pública `apps/web/src/pages/labs/PublicTasksDemoPage.tsx` expuesta en la ruta `'/labs/tasks-demo'` que reutiliza `TaskList`, `Navbar`, `MobileBottomNav`, `Card` y presenta datos `MOCK_TASKS` sin depender de `RequireUser` ni de backend real; las acciones muestran una guía/toast en lugar de persistir.  
- Registré la ruta pública en el enrutador (`apps/web/src/App.tsx`) y actualicé el HTML/SEO prerendered en `apps/web/demo-mode-select/index.html` para reflejar el nuevo concepto del hub (títulos, descripción OG/Twitter, `<title>`).  
- Cambios clave por archivo: `LabsDemoModeSelect.tsx` (nuevo copy/estructura de cards), `PublicTasksDemoPage.tsx` (nuevo demo mock de tareas), `App.tsx` (ruta añadida), `demo-mode-select/index.html` (metadatos actualizados).  

### Testing
- Ejecuté el test prerender HTML con `pnpm -C apps/web vitest run src/demoModeSelectHtml.test.ts` y pasó correctamente (1 test pasado).  
- Ejecuté `pnpm -C apps/web tsc --noEmit` y falló debido a errores TypeScript preexistentes en el repositorio que no fueron introducidos por este cambio (se listan como advertencia en el rollout).  
- Intenté correr `eslint` sobre los archivos modificados pero la configuración de ESLint en el entorno actual no estaba presente y la comprobación no se pudo completar (error de configuración global no relacionado con los cambios).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea099c37a8833297490fddfdf3ea3a)