### PR TITLE
Fix success toast placement on Editor page

### DIFF
--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -686,17 +686,23 @@ export default function TaskEditorPage() {
           <div ref={editorTopRef} className="scroll-mt-24" />
           <div className="mx-auto w-full max-w-7xl px-2 py-4 md:px-5 md:py-6 lg:px-6 lg:py-8">
             <SectionHeader section={taskEditorSection} showLabBadge={location.pathname.startsWith("/labs/")} />
+            <div
+              className={`overflow-hidden transition-[max-height,margin,opacity] duration-200 ${
+                pageToast
+                  ? "mb-3 max-h-28 opacity-100 md:mb-4"
+                  : "max-h-0 opacity-0"
+              }`}
+            >
+              {pageToast && (
+                <ToastBanner
+                  tone={pageToast.type}
+                  message={pageToast.text}
+                  className="border-emerald-300/70 bg-emerald-500 text-white shadow-[0_14px_36px_rgba(16,185,129,0.45)]"
+                />
+              )}
+            </div>
             <Card className="px-4 py-5 md:p-6">
               <div className="flex flex-col gap-5">
-                {pageToast && (
-                  <div className="fixed inset-x-3 top-[calc(env(safe-area-inset-top,0px)+4.5rem)] z-[70] md:inset-x-auto md:right-8 md:top-24 md:w-[24rem]">
-                    <ToastBanner
-                      tone={pageToast.type}
-                      message={pageToast.text}
-                      className="border-emerald-300/70 bg-emerald-500 text-white shadow-[0_14px_36px_rgba(16,185,129,0.45)]"
-                    />
-                  </div>
-                )}
                 {shouldShowInlineNotice && (
                   <div className="ib-onboarding-alert ib-onboarding-alert--progress mb-2 rounded-2xl px-3 py-2.5 md:mb-3 md:px-4">
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION
### Motivation
- The success toast was rendered as a fixed overlay and overlapped the top of the editor content, making it feel visually detached from the page layout.
- The intent is to show the same success message but have it appear in normal flow so it pushes the editor content down while visible.
- Maintain the existing message content, tone and timeout logic while making the visual behavior consistent with other top banners/notices.

### Description
- Moved the `pageToast` render out of the fixed overlay and into the normal page flow directly beneath the `SectionHeader` in `apps/web/src/pages/editor/index.tsx`.
- Removed the previous fixed-position wrapper and render of `ToastBanner` inside the card, keeping the `ToastBanner` props (`pageToast.type` / `pageToast.text`) unchanged.
- Added an overflow-hidden transition wrapper using `max-height`, `margin`, and `opacity` to smoothly expand/collapse the banner so it naturally pushes the editor card down while visible.
- Preserved mobile-first behavior and existing visual styling of the `ToastBanner` so the banner remains visually consistent with other top notices.

### Testing
- Ran `pnpm -C apps/web exec tsc --noEmit` which failed due to unrelated, pre-existing TypeScript errors elsewhere in the repo (not caused by this change).
- Ran ESLint against the file (via `pnpm -C apps/web exec eslint src/pages/editor/index.tsx`) which could not run under the current environment because ESLint v9 expects an `eslint.config.*` and the repo uses a legacy config format, so lint could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1da3e3888332a67c6737c006e076)