### PR TITLE
Fix AI New Task modal localization labels in Editor

### DIFF
--- a/apps/web/src/i18n/post-login/editor.ts
+++ b/apps/web/src/i18n/post-login/editor.ts
@@ -88,7 +88,7 @@ export const editorTranslations = {
     es: 'Selecciona una dificultad…',
     en: 'Select a difficulty…',
   },
-  'editor.modal.aiCreate.badge': { es: 'Asistente IA', en: 'AI Assistant' },
+  'editor.modal.aiCreate.badge': { es: 'Nueva tarea', en: 'New Task' },
   'editor.modal.aiCreate.title': { es: 'Nueva tarea guiada', en: 'Guided new task' },
   'editor.modal.aiCreate.description': {
     es: 'Escribe tu intención y deja que la IA sugiera la mejor categoría.',

--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -2127,23 +2127,22 @@ function CreateTaskModal({
       return {
         pillarId: resolvedPillarId,
         traitId: resolvedTraitId,
-        pillarLabel:
-          classification.pillarName
-          ?? (pillarFromCatalog
-            ? localizePillarLabel(pillarFromCatalog.name, language)
-            : normalizeCode(classification.pillarCode) ?? resolvedPillarId),
-        traitLabel:
-          classification.traitName
-          ?? (traitFromManualList
-            ? localizeTraitLabel(
-              {
-                name: traitFromManualList.name,
-                code: traitFromManualList.code,
-                fallback: traitFromManualList.id,
-              },
-              language,
-            )
-            : normalizeCode(classification.traitCode) ?? resolvedTraitId),
+        pillarLabel: localizePillarLabel(
+          pillarFromCatalog?.name
+            ?? classification.pillarName
+            ?? normalizeCode(classification.pillarCode)
+            ?? resolvedPillarId,
+          language,
+        ),
+        traitLabel: localizeTraitLabel(
+          {
+            name: traitFromManualList?.name ?? classification.traitName,
+            code: traitFromManualList?.code ?? classification.traitCode,
+            fallback:
+              normalizeCode(classification.traitCode) ?? resolvedTraitId,
+          },
+          language,
+        ),
         rationale:
           classification.rationale
           ?? t("editor.modal.aiCreate.suggestedCategory"),


### PR DESCRIPTION
### Motivation
- The AI-assisted New Task modal was rendering backend pillar/trait names directly which caused English UI to show Spanish labels (e.g. “Cuerpo / Energía”) and the AI badge read “AI Assistant” instead of the product-approved badge.
- The goal was to fix only the display layer so UI labels are localized while leaving classification payloads and IDs untouched.

### Description
- Updated the AI suggestion mapping in `CreateTaskModal` to always pass candidate names/codes through `localizePillarLabel` and `localizeTraitLabel` so displayed chips use the editor-localized labels (file: `apps/web/src/pages/editor/index.tsx`).
- Ensured the trait localization uses the existing `{ name, code, fallback }` shape so manual-catalog names and classification fallback codes are handled consistently (file: `apps/web/src/pages/editor/index.tsx`).
- Replaced the `editor.modal.aiCreate.badge` translation value to the product copy (`ES: "Nueva tarea"`, `EN: "New Task"`) in `apps/web/src/i18n/post-login/editor.ts` so the modal pre-title/badge reflects requested wording.
- Did not change any backend classification logic, IDs, or payload semantics; all changes are presentation-only.

### Testing
- Ran ESLint invocation `pnpm -C apps/web exec eslint src/pages/editor/index.tsx src/i18n/post-login/editor.ts` which failed due to workspace ESLint configuration not being discoverable by direct ESLint v9 invocation, not due to the edits.
- Ran `npm run typecheck:web` which reported many pre-existing TypeScript errors across the workspace unrelated to the changed files, so no typecheck regression was introduced by these edits.
- Manual verification notes: English UI should now show localized labels like `Body / Energy` and Spanish UI should continue to show `Cuerpo / Energía`, and the modal badge shows `New Task` (EN) / `Nueva tarea` (ES).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1dad820c8332b953978f1446bd77)