### PR TITLE
Improve light-mode readability in production Editor guide card

### DIFF
--- a/apps/web/src/pages/labs/editor-guide/EditorGuideStep.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideStep.tsx
@@ -9,13 +9,15 @@ export function EditorGuideStep({
 }) {
   return (
     <>
-      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-violet-200/90">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:color-mix(in_srgb,var(--color-accent-primary)_52%,var(--color-text)_48%)] dark:text-violet-200/90">
         {label}
       </p>
-      <h3 className="mt-1 text-base font-semibold text-[color:var(--color-slate-100)] md:text-lg">
+      <h3 className="mt-1 text-base font-semibold text-[color:var(--color-text)] dark:text-[color:var(--color-slate-100)] md:text-lg">
         {step.title}
       </h3>
-      <p className="mt-1 text-sm text-[color:var(--color-slate-300)]">{step.copy}</p>
+      <p className="mt-1 text-sm text-[color:var(--color-text-muted)] dark:text-[color:var(--color-slate-300)]">
+        {step.copy}
+      </p>
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- The guide card’s pre-title and some supporting copy were too faint in light mode because they relied on dark-mode-oriented violet tokens, so the pre-title needed to stay soft but be clearly readable while preserving the existing dark-mode look.

### Description
- Updated `apps/web/src/pages/labs/editor-guide/EditorGuideStep.tsx` to apply theme-aware colors: the pre-title now uses a `color-mix` of `--color-accent-primary` and `--color-text` in light mode while keeping `text-violet-200/90` in dark mode, the main title uses `--color-text` in light mode and the previous slate token in dark, and the body copy uses `--color-text-muted` in light mode and the previous slate token in dark; no layout, spacing, or navigation changes were made.

### Testing
- Attempted `pnpm -C apps/web exec eslint src/pages/labs/editor-guide/EditorGuideStep.tsx` which could not run due to the repository ESLint v9 flat-config expectation, and ran `pnpm -C apps/web exec tsc --noEmit` which surfaced pre-existing unrelated TypeScript errors, so automated checks in this environment did not report issues specific to the edited file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea1db5ead4833293b0c2dc90b25ef9)