### PR TITLE
Fix New Task modal light-mode surface hierarchy

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5196,6 +5196,33 @@
   :root[data-theme="light"] [data-light-scope="editor"] {
     --color-slate-900-95: rgba(255, 255, 255, 0.97);
     --color-slate-950-80: rgba(241, 245, 255, 0.78);
+    --editor-modal-surface: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.99) 0%,
+      rgba(248, 244, 255, 0.98) 100%
+    );
+    --editor-modal-surface-muted: #f7f3ff;
+    --editor-modal-text: #1f2a44;
+    --editor-modal-text-muted: #556178;
+    --editor-modal-label-muted: #6c7a92;
+    --editor-modal-editable-label: #4f3e8a;
+    --editor-modal-secondary-border: #d7deec;
+    --editor-modal-secondary-hover-border: #bcc8dd;
+    --editor-modal-secondary-text: #44546c;
+    --editor-modal-secondary-hover-bg: #eef2fa;
+    --editor-modal-input-bg: #ffffff;
+    --editor-modal-input-border: #cfd8e6;
+    --editor-modal-input-placeholder: #8793a9;
+    --editor-modal-input-focus-border: #8d73eb;
+    --editor-modal-input-focus-ring: rgba(125, 94, 228, 0.22);
+    --editor-modal-shadow: 0 28px 72px rgba(37, 24, 79, 0.2);
+    --editor-modal-locked-bg: #f4f7fc;
+    --editor-modal-locked-border: #d8e0ed;
+    --editor-modal-locked-text: #5b6b82;
+    --editor-modal-status-checkbox-accent: #6f4ee0;
+    --editor-modal-primary-gradient: linear-gradient(90deg, #8c62ff 0%, #b679f4 50%, #f09fbc 100%);
+    --editor-modal-primary-text: #ffffff;
+    --editor-modal-primary-shadow: 0 12px 28px rgba(126, 89, 223, 0.34);
   }
 
   :root[data-theme="dark"]
@@ -5770,6 +5797,15 @@
     border-color: var(--editor-modal-secondary-border);
     color: var(--editor-modal-secondary-text);
     background: #ffffff;
+    box-shadow: 0 2px 8px rgba(30, 41, 59, 0.08);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__close:hover {
+    border-color: var(--editor-modal-secondary-hover-border);
+    background: var(--editor-modal-secondary-hover-bg);
+    color: var(--editor-modal-text);
   }
 
   :root[data-theme="light"]
@@ -5825,14 +5861,33 @@
     [data-light-scope="editor"]
     .create-task-ai-modal__manual-grid {
     border-color: var(--editor-modal-secondary-border);
-    background: color-mix(in srgb, var(--editor-modal-input-bg) 84%, #f8fafc);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--editor-modal-surface-muted) 78%, #ffffff) 0%,
+      color-mix(in srgb, var(--editor-modal-input-bg) 92%, #f8fafc) 100%
+    );
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
   }
 
   :root[data-theme="light"]
     [data-light-scope="editor"]
     .create-task-ai-modal__suggestion-strip {
-    border-top-color: color-mix(in srgb, var(--editor-modal-secondary-border) 68%, transparent);
-    border-bottom-color: color-mix(in srgb, var(--editor-modal-secondary-border) 58%, transparent);
+    border: 1px solid color-mix(in srgb, var(--editor-modal-secondary-border) 88%, #ffffff);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--editor-modal-surface-muted) 72%, #ffffff) 0%,
+      #ffffff 100%
+    );
+    border-radius: 0.9rem;
+    padding: 0.8rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.92);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .create-task-ai-modal__actions {
+    border-top: 1px solid color-mix(in srgb, var(--editor-modal-secondary-border) 70%, transparent);
+    padding-top: 0.9rem;
   }
 
   :root[data-theme="light"]

--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -2660,7 +2660,7 @@ function CreateTaskModal({
               />
             )}
 
-            <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
+            <div className="create-task-ai-modal__actions flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
               <button
                 type="button"
                 onClick={handleClose}


### PR DESCRIPTION
### Motivation
- The New Task (AI) modal in light mode appeared as a washed-out, outline-only overlay with poor surface hierarchy and weak input/card fills.  
- The goal is to restore a solid elevated card treatment in light mode while preserving dark-mode visuals and existing modal structure/logic.  
- Updates should preserve the Innerbloom visual language and only target light-mode tokens and scoped styles.

### Description
- Added a dedicated set of editor-scoped light-mode CSS tokens (surface, text, borders, inputs, focus rings, and shadows) under `:root[data-theme="light"] [data-light-scope="editor"]` to give modals real fills and consistent elevation (`apps/web/src/index.css`).  
- Updated the AI modal section styles to convert outline-only areas into filled panels by styling the analysis/manual cards and the suggestion strip with subtle gradients, borders, padding, and inset highlights (`apps/web/src/index.css`).  
- Improved affordances by adding a subtle drop shadow and a hover/fill state for the close button and a top divider/padding for the modal action row to separate action buttons from content (`apps/web/src/index.css`).  
- Wired a scoped class on the action-button row in the New Task modal markup (`create-task-ai-modal__actions`) so the new action-row rule can be applied without changing markup structure or behavior (`apps/web/src/pages/editor/index.tsx`).

### Testing
- Ran the repository typecheck using `npm --workspace apps/web run typecheck`, which failed due to pre-existing, unrelated TypeScript errors elsewhere in the codebase and not caused by this change set.  
- No automated visual tests were available in this environment to validate rendering; the edits are strictly scoped CSS/markup changes intended to affect only light-mode modal surfaces.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea206059888332a8e4cbc07d09a441)