### PR TITLE
Sincronizar guía del Editor con el modal real y unificar overlay de demos (táctil + visual)

### DIFF
--- a/apps/web/src/components/demo/GuidedDemoOverlay.tsx
+++ b/apps/web/src/components/demo/GuidedDemoOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type PointerEvent as ReactPointerEvent } from 'react';
 import { DEMO_GUIDED_STEPS, type DemoLanguage, type GuidedStep } from '../../config/demoGuidedTour';
 
 type Props = {
@@ -81,6 +81,18 @@ const LABS_LOGROS_MOBILE_TOP_RATIO_BY_STEP: Record<string, number> = {
   'logros-seal-months': 0.04,
   'logros-monthly': 0.06,
 };
+const INTERACTIVE_ELEMENT_SELECTOR = [
+  "button",
+  "a",
+  "input",
+  "select",
+  "textarea",
+  "label",
+  "[role='button']",
+  "[role='link']",
+  "[contenteditable='true']",
+  ".guided-demo-panel",
+].join(',');
 
 type Placement = 'top' | 'right' | 'bottom' | 'left';
 type WalkthroughMode = 'dashboard' | 'daily-quest-modal';
@@ -505,6 +517,7 @@ export function GuidedDemoOverlay({
   }, [isCompactMobile, isIntroModalStep, isLogrosModalStep, step.id, step.tooltipPlacement, targetRect, viewport.height, viewport.width]);
 
   const isLast = stepIndex === steps.length - 1;
+  const canGoBack = stepIndex > 0;
   const finalPrimaryLabel = finalPrimaryActionLabel?.[language]
     ?? (step.id === 'tour-end'
       ? (language === 'es' ? 'Comenzar mi Journey' : 'Start my Journey')
@@ -520,11 +533,42 @@ export function GuidedDemoOverlay({
   const primaryButtonClass = `ib-primary-button !min-h-0 !px-4 !py-2 !font-semibold !text-xs !uppercase !tracking-[0.16em] focus-visible:ring-offset-[color:var(--color-surface-elevated)] ${walkthroughButtonSizeClass}`;
   const tertiaryButtonClass = `ml-auto inline-flex items-center justify-center rounded-full border border-[color:var(--color-border-subtle)]/70 font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-muted)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/35 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-surface-elevated)] ${walkthroughButtonSizeClass}`;
   const overlayZClass = isDailyQuestStep ? 'z-[10020]' : 'z-[520]';
-  const overlayMaskClass = 'bg-slate-950/80 backdrop-blur-[7px]';
+  const overlayMaskClass = 'bg-slate-950/88 backdrop-blur-[6px] backdrop-saturate-[0.82]';
+
+  const goToPreviousStep = () => {
+    if (canGoBack && !isTransitioningStep) {
+      goToStep(stepIndex - 1);
+    }
+  };
+
+  const goToNextStep = () => {
+    if (!isTransitioningStep) {
+      goToStep(stepIndex + 1);
+    }
+  };
+
+  const handleBackgroundTouchNavigation = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.pointerType !== 'touch' && event.pointerType !== 'pen') {
+      return;
+    }
+
+    if ((event.target as Element).closest(INTERACTIVE_ELEMENT_SELECTOR)) {
+      return;
+    }
+
+    const tappedLeftSide = event.clientX < window.innerWidth / 2;
+    if (tappedLeftSide) {
+      goToPreviousStep();
+      return;
+    }
+
+    goToNextStep();
+  };
 
   return (
     <div
       className={`pointer-events-auto fixed inset-0 ${overlayZClass}`}
+      onPointerUp={handleBackgroundTouchNavigation}
       onWheel={(event) => {
         if (isInteractionLocked) {
           event.preventDefault();
@@ -562,13 +606,13 @@ export function GuidedDemoOverlay({
 
       {targetRect ? (
         <div
-          className="absolute rounded-2xl border border-[color:var(--color-accent-primary)]/90 bg-white/[0.025] shadow-[0_0_0_2px_rgba(56,189,248,0.58),0_0_34px_rgba(56,189,248,0.28),0_20px_45px_rgba(0,0,0,0.45)] transition-all"
+          className="pointer-events-none absolute rounded-2xl border border-violet-200/70 shadow-[0_0_0_1px_rgba(255,255,255,0.3),0_0_0_9999px_rgba(2,6,23,0.28),0_0_52px_rgba(139,92,246,0.42)] transition-all"
           style={{ top: targetRect.top, left: targetRect.left, width: targetRect.width, height: targetRect.height }}
         />
       ) : null}
 
       <aside
-        className={`pointer-events-auto absolute rounded-2xl border border-[color:var(--color-border-strong)] bg-[color:var(--color-surface-elevated)] text-[color:var(--color-text)] shadow-2xl ${isCompactMobile ? 'p-3' : 'p-4'} ${isIntroModalStep ? 'max-w-lg overflow-hidden border-white/20 bg-[#0a133d]/92 text-center text-white shadow-[0_0_45px_rgba(79,70,229,0.22)] backdrop-blur-xl' : ''}`}
+        className={`guided-demo-panel pointer-events-auto absolute rounded-2xl border border-violet-200/60 bg-slate-950/92 text-[color:var(--color-text)] shadow-[0_24px_60px_rgba(2,6,23,0.55)] backdrop-blur-xl ${isCompactMobile ? 'p-3' : 'p-4'} ${isIntroModalStep ? 'max-w-lg overflow-hidden border-white/20 bg-[#0a133d]/92 text-center text-white shadow-[0_0_45px_rgba(79,70,229,0.22)]' : ''}`}
         style={tooltipStyle}
       >
         {isIntroModalStep ? (
@@ -621,7 +665,7 @@ export function GuidedDemoOverlay({
           {!isLast ? (
             <button
               type="button"
-              onClick={() => goToStep(stepIndex - 1)}
+              onClick={goToPreviousStep}
               disabled={stepIndex === 0 || isTransitioningStep}
               className={secondaryButtonClass}
             >
@@ -631,7 +675,7 @@ export function GuidedDemoOverlay({
           {!isLast ? (
             <button
               type="button"
-              onClick={() => goToStep(stepIndex + 1)}
+              onClick={goToNextStep}
               disabled={isTransitioningStep}
               className={primaryButtonClass}
             >

--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -459,10 +459,6 @@ export default function TaskEditorPage({ publicDemo = false }: TaskEditorPagePro
   };
 
   const handleCreateClick = () => {
-    if (publicDemo) {
-      setShowGuideModal(true);
-      return;
-    }
     setShowCreateModal(true);
   };
 
@@ -968,7 +964,7 @@ export default function TaskEditorPage({ publicDemo = false }: TaskEditorPagePro
             {t("editor.button.newTask")}
           </button>
         )}
-        {!publicDemo && <CreateTaskModal
+        <CreateTaskModal
           open={showCreateModal}
           onClose={() => setShowCreateModal(false)}
           userId={effectiveBackendUserId ?? null}
@@ -977,7 +973,7 @@ export default function TaskEditorPage({ publicDemo = false }: TaskEditorPagePro
           pillarsError={pillarsError}
           onRetryPillars={reloadPillars}
           guideStepId={showGuideModal ? activeGuideStepId : null}
-        />}
+        />
         {!publicDemo && <EditTaskModal
           open={taskToEdit != null}
           onClose={handleCloseEdit}


### PR DESCRIPTION
### Motivation
- Corregir el bug de la demo pública del Editor donde los pasos de la guía que describen el modal de "Nueva tarea" no abrían el modal real, dejando la guía desincronizada con la UI visible. 
- Hacer que el botón "New task / Nueva tarea" funcione en la demo pública tras cerrar/terminar la guía (no debe relanzar la guía). 
- Unificar la interacción táctil (tap mitad izquierda/derecha) y el lenguaje visual de la "ventana de atención" entre Editor, Dashboard y Logros para que las 3 demos se sientan coherentes.

### Description
- Hice que la demo pública del Editor monte y reutilice el `CreateTaskModal` real quitando la rama que evitaba renderizarlo en `publicDemo`, dejando `guideStepId` conectado para mantener la guía sincronizada con el contenido del modal (`apps/web/src/pages/editor/index.tsx`).
- Cambié `handleCreateClick` para que el FAB de "New task / Nueva tarea" siempre abra el modal real (antes en demo público relanzaba la guía), solucionando el botón "roto" tras la guía (`apps/web/src/pages/editor/index.tsx`).
- En `GuidedDemoOverlay` añadí navegación táctil por media pantalla (tap izquierda = anterior, tap derecha = siguiente) usando `onPointerUp` y replicando el patrón ya existente en `EditorGuideOverlay`, y prevengo la navegación si el tap ocurre sobre elementos interactivos reales o sobre el panel de guía mediante `INTERACTIVE_ELEMENT_SELECTOR` (`apps/web/src/components/demo/GuidedDemoOverlay.tsx`).
- Alineé el look & feel del overlay con la demo del Editor: ajusté la máscara (`backdrop-blur`/saturación), la clase del frame destacado (tono violeta / sombra similar) y el estilo del panel de guía para reproducir la misma sensación visual entre demos (`apps/web/src/components/demo/GuidedDemoOverlay.tsx`).
- Archivos modificados: `apps/web/src/pages/editor/index.tsx` y `apps/web/src/components/demo/GuidedDemoOverlay.tsx`.
- Técnica de orquestación de modal: mantuve centralizada la lógica que abre/cierra el modal desde `handleGuideStepChange`, que abre el modal para los pasos `modal-core` y `modal-ai-thinking` y lo cierra para los pasos no-modales (por ejemplo `modal-entry`, `filters`, `task-list`, `suggestions`, `wheel-*`).

### Testing
- Ejecuté el chequeo de tipos con `npm run typecheck:web` y la comprobación falló; el fallo proviene de errores de tipado preexistentes en `apps/web` que no están relacionados con estos cambios (Clerk typings y tipos de preview achievements), por lo que no es causado por esta PR. 
- No se ejecutaron tests unitarios o E2E adicionales como parte automática en este entorno; las validaciones táctiles y visuales restantes deben verificarse en runtime del navegador contra los casos manuales listados en la descripción del cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea27d757c883329c517ce95e0bd199)