### PR TITLE
Polish light-mode hierarchy in Editor suggestions panel

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6536,11 +6536,106 @@
   :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-modal {
     background: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.98),
-      rgba(244, 239, 251, 0.96)
+      rgba(255, 255, 255, 0.985),
+      rgba(244, 240, 252, 0.97)
     );
-    border-color: color-mix(in srgb, var(--color-border-strong) 68%, white);
-    box-shadow: 0 28px 74px rgba(91, 33, 182, 0.22);
+    border-color: color-mix(in srgb, var(--color-border-strong) 74%, white);
+    box-shadow:
+      0 34px 88px rgba(76, 29, 149, 0.2),
+      0 12px 32px rgba(15, 23, 42, 0.12);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-header {
+    color: var(--color-text);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-close {
+    border-color: color-mix(in srgb, var(--color-border-strong) 66%, white);
+    background: color-mix(in srgb, white 88%, #f5f3ff);
+    color: color-mix(in srgb, var(--color-text) 82%, #4338ca);
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-close:hover {
+    border-color: color-mix(in srgb, #6366f1 44%, var(--color-border-strong));
+    background: color-mix(in srgb, white 80%, #ede9fe);
+    color: color-mix(in srgb, var(--color-text) 70%, #4f46e5);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-summary {
+    border-color: color-mix(in srgb, var(--color-border-strong) 64%, white);
+    background: linear-gradient(180deg, rgba(251, 250, 255, 0.92), rgba(245, 241, 253, 0.96));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-summary-action {
+    border-color: color-mix(in srgb, var(--color-border-strong) 60%, white);
+    background: rgba(255, 255, 255, 0.86);
+    color: color-mix(in srgb, var(--color-text) 76%, #4f46e5);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-summary-action:hover {
+    border-color: color-mix(in srgb, #6366f1 42%, var(--color-border-strong));
+    background: color-mix(in srgb, white 78%, #eef2ff);
+    color: color-mix(in srgb, var(--color-text) 66%, #4338ca);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-card {
+    border-color: color-mix(in srgb, var(--color-border-strong) 54%, white);
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.98), rgba(250, 247, 255, 0.9));
+    box-shadow:
+      0 8px 22px rgba(15, 23, 42, 0.08),
+      0 2px 6px rgba(99, 102, 241, 0.08);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-card:hover {
+    border-color: color-mix(in srgb, #818cf8 38%, var(--color-border-strong));
+    box-shadow:
+      0 10px 24px rgba(30, 41, 59, 0.1),
+      0 4px 14px rgba(99, 102, 241, 0.14);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .editor-suggestions-card[aria-pressed="true"] {
+    border-color: color-mix(in srgb, #8b5cf6 56%, white);
+    background: linear-gradient(155deg, rgba(238, 230, 255, 0.96), rgba(224, 231, 255, 0.9));
+    box-shadow:
+      0 12px 30px rgba(99, 102, 241, 0.22),
+      0 2px 8px rgba(76, 29, 149, 0.14);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-card-selector {
+    border-color: color-mix(in srgb, var(--color-border-strong) 58%, white);
+    background: rgba(255, 255, 255, 0.88);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="editor"]
+    .editor-suggestions-card[aria-pressed="true"]
+    .editor-suggestions-card-selector {
+    border-color: rgba(129, 140, 248, 0.76);
+    background: rgba(199, 210, 254, 0.95);
+    color: rgba(67, 56, 202, 0.95);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-card-pill {
+    border-color: rgba(129, 140, 248, 0.32);
+    background: rgba(224, 231, 255, 0.7);
+    color: rgba(55, 48, 163, 0.88);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-suggestions-footer {
+    border-color: color-mix(in srgb, var(--color-border-strong) 66%, white);
+    background: linear-gradient(
+      180deg,
+      rgba(243, 238, 252, 0.24),
+      rgba(248, 246, 254, 0.97) 26%,
+      rgba(244, 240, 252, 0.995)
+    );
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.8),
+      0 -14px 28px rgba(76, 29, 149, 0.08);
   }
 
   :root[data-theme="light"]

--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -3331,7 +3331,7 @@ function SuggestionsLabModal({
         className="absolute inset-0 h-full w-full"
       />
       <section className="editor-suggestions-modal relative z-10 w-full max-w-3xl rounded-t-3xl border border-[color:var(--color-border-subtle)] bg-[linear-gradient(180deg,rgba(15,23,42,0.95),rgba(15,23,42,0.92))] p-4 shadow-[0_28px_80px_rgba(2,6,23,0.5)] md:rounded-3xl md:p-6">
-        <div className="flex items-start justify-between gap-4">
+        <div className="editor-suggestions-header flex items-start justify-between gap-4">
           <div>
             <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-violet-200/85">
               Sugerencias
@@ -3347,12 +3347,12 @@ function SuggestionsLabModal({
             type="button"
             onClick={onClose}
             aria-label="Cerrar sugerencias"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-white/5 text-[color:var(--color-slate-200)] transition hover:border-white/35 hover:text-white"
+            className="editor-suggestions-close inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-white/5 text-[color:var(--color-slate-200)] transition hover:border-white/35 hover:text-white"
           >
             <CloseTinyIcon className="h-4 w-4" />
           </button>
         </div>
-        <div className="mt-4 flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-white/[0.02] px-3 py-2">
+        <div className="editor-suggestions-summary mt-4 flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-white/[0.02] px-3 py-2">
           <p className="text-xs text-[color:var(--color-slate-300)]">
             {selectedCount} de {totalAvailableSuggestions} seleccionadas
           </p>
@@ -3366,7 +3366,7 @@ function SuggestionsLabModal({
                     : EDITOR_LAB_QUICK_START_SEED.map((task) => task.id),
                 )
               }
-              className="rounded-full border border-white/15 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--color-slate-200)] transition hover:border-white/30 hover:text-white"
+              className="editor-suggestions-summary-action rounded-full border border-white/15 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--color-slate-200)] transition hover:border-white/30 hover:text-white"
             >
               {isEverythingSelected ? "Limpiar" : "Seleccionar todo"}
             </button>
@@ -3405,10 +3405,10 @@ function SuggestionsLabModal({
                         )
                       }
                       aria-pressed={checked}
-                      className={`group flex items-start gap-3 rounded-2xl border px-3 py-3 text-left transition ${checked ? "border-violet-300/60 bg-[linear-gradient(155deg,rgba(167,139,250,0.25),rgba(129,140,248,0.12))] shadow-[0_10px_24px_rgba(139,92,246,0.24)]" : "border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:border-white/25"}`}
+                      className={`editor-suggestions-card group flex items-start gap-3 rounded-2xl border px-3 py-3 text-left transition ${checked ? "border-violet-300/60 bg-[linear-gradient(155deg,rgba(167,139,250,0.25),rgba(129,140,248,0.12))] shadow-[0_10px_24px_rgba(139,92,246,0.24)]" : "border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:border-white/25"}`}
                     >
                       <span
-                        className={`mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] transition ${checked ? "border-violet-100 bg-violet-200/90 text-violet-700" : "border-white/25 text-transparent group-hover:border-white/40"}`}
+                        className={`editor-suggestions-card-selector mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] transition ${checked ? "border-violet-100 bg-violet-200/90 text-violet-700" : "border-white/25 text-transparent group-hover:border-white/40"}`}
                       >
                         ✓
                       </span>
@@ -3416,7 +3416,7 @@ function SuggestionsLabModal({
                         <span className="block text-sm font-medium text-[color:var(--color-slate-100)]">
                           {task.title}
                         </span>
-                        <span className="mt-1 inline-flex rounded-full border border-violet-200/20 bg-violet-400/10 px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-violet-100/85">
+                        <span className="editor-suggestions-card-pill mt-1 inline-flex rounded-full border border-violet-200/20 bg-violet-400/10 px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-violet-100/85">
                           {task.trait}
                         </span>
                       </span>
@@ -3427,7 +3427,7 @@ function SuggestionsLabModal({
             </div>
           ))}
         </div>
-        <div className="absolute inset-x-0 bottom-0 flex items-center justify-between gap-3 border-t border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.05),rgba(15,23,42,0.96)_24%)] px-4 py-4 backdrop-blur-md md:px-6">
+        <div className="editor-suggestions-footer absolute inset-x-0 bottom-0 flex items-center justify-between gap-3 border-t border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.05),rgba(15,23,42,0.96)_24%)] px-4 py-4 backdrop-blur-md md:px-6">
           <p className="text-xs text-[color:var(--color-slate-400)]">
             {hasSelectedSuggestions
               ? `Listo para sumar ${selectedCount} tarea(s) a tu sistema.`


### PR DESCRIPTION
### Motivation
- The Suggestions modal on the production Editor (`/editor`) looked washed-out in light mode with weak contrast and muddy surface hierarchy, so the visual treatment needed tuning without changing layout, copy, or behavior. 
- The goal was to create a polished, premium light-mode appearance with clearer sheet elevation, card separation, coherent shadows, and an anchored footer, while preserving dark mode.

### Description
- Added scoped hook classnames in the suggestions modal markup to target light-mode visual tuning: `editor-suggestions-header`, `editor-suggestions-close`, `editor-suggestions-summary`, `editor-suggestions-summary-action`, `editor-suggestions-card`, `editor-suggestions-card-selector`, `editor-suggestions-card-pill`, and `editor-suggestions-footer` (file: `apps/web/src/pages/editor/index.tsx`).
- Implemented light-theme CSS rules to strengthen the modal sheet contrast and border hierarchy, introduce layered cool shadows, and refine gradients for the modal container (file: `apps/web/src/index.css`).
- Tuned header/close control, improved the summary/counter strip contrast and control feel, adjusted suggestion card base/hover/selected fills, borders and shadows, increased selector and trait-pill readability, and anchored the sticky footer with a distinct surface and subtle top shadow (file: `apps/web/src/index.css`).
- Changes are strictly presentation-only for light mode; layout, selection logic, copy, and dark mode remain unchanged.

### Testing
- `npm -C apps/web run lint -- --max-warnings=0` could not be executed because a `lint` script is not defined in the project (script missing). (failure)
- `npm -C apps/web run typecheck` was executed and failed due to pre-existing, unrelated TypeScript errors in other parts of the codebase, so no typecheck pass was produced by this PR. (failure)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea28a9c8508332974955523da6e0a3)