### PR TITLE
Add isolated labs hero with looping phone showcase experiment

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,7 @@ import LabsIndexPage from './pages/labs/LabsIndexPage';
 import LandingRhythmSectionMvpPage from './pages/labs/LandingRhythmSectionMvpPage';
 import EditorLabPage from './pages/labs/EditorLabPage';
 import PublicTasksDemoPage from './pages/labs/PublicTasksDemoPage';
+import HeroPhoneShowcaseLabPage from './pages/labs/HeroPhoneShowcaseLabPage';
 import { useGa4FunnelTracking } from './hooks/useGa4FunnelTracking';
 import { isNativeCapacitorPlatform } from './mobile/capacitor';
 import { writeMobileDebug } from './mobile/mobileDebug';
@@ -277,6 +278,7 @@ export default function App() {
         <Route path="/labs/demo-mode-select" element={<LabsDemoModeSelectPage legacyLabsPath />} />
         <Route path="/labs/logros" element={<LabsLogrosDemoPage />} />
         <Route path="/labs/tasks-demo" element={<PublicTasksDemoPage />} />
+        <Route path="/labs/hero-phone-showcase" element={<HeroPhoneShowcaseLabPage />} />
         <Route path="/demo/logros" element={<LabsLogrosDemoPage />} />
         <Route path="/demo/tasks" element={<PublicTasksDemoPage />} />
         <Route path="/labs/landing-rhythm-section" element={<LandingRhythmSectionMvpPage />} />

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -1,0 +1,329 @@
+.page {
+  min-height: 100vh;
+  padding: clamp(1.4rem, 2.8vw, 3rem);
+  color: #eef0ff;
+  background:
+    radial-gradient(circle at 85% 14%, rgba(122, 93, 255, 0.2), transparent 34%),
+    radial-gradient(circle at 20% 12%, rgba(78, 128, 255, 0.24), transparent 32%),
+    linear-gradient(180deg, #0b0b16 0%, #090911 100%);
+}
+
+.hero {
+  max-width: 1180px;
+  margin: 0 auto;
+  min-height: calc(100vh - 3rem);
+  display: grid;
+  gap: clamp(1.3rem, 3vw, 2.6rem);
+  grid-template-columns: minmax(0, 1fr) minmax(340px, 430px);
+  align-items: center;
+}
+
+.copyCol h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.7rem);
+  line-height: 1.04;
+  letter-spacing: -0.03em;
+}
+
+.copyCol h1 span {
+  color: #af9dff;
+}
+
+.copyCol > p {
+  margin: 0.95rem 0 0;
+  max-width: 55ch;
+  color: rgba(232, 233, 255, 0.82);
+  line-height: 1.6;
+}
+
+.kicker {
+  margin: 0 0 1rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(219, 210, 255, 0.65);
+}
+
+.ctaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin-top: 1.6rem;
+}
+
+.primaryCta,
+.secondaryCta {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 44px;
+  padding: 0.72rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.primaryCta {
+  background: linear-gradient(135deg, #8f78ff, #5c7fff);
+  color: #fbfbff;
+}
+
+.secondaryCta {
+  border: 1px solid rgba(198, 203, 255, 0.25);
+  color: rgba(239, 241, 255, 0.92);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.visualCol {
+  display: flex;
+  justify-content: center;
+}
+
+.phoneFrame {
+  width: min(100%, 365px);
+  aspect-ratio: 9 / 18.5;
+  border-radius: 38px;
+  background: linear-gradient(145deg, #202230, #060709);
+  padding: 10px;
+  box-shadow: 0 24px 64px rgba(9, 7, 26, 0.55), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.phoneNotch {
+  width: 36%;
+  height: 19px;
+  margin: 0 auto 8px;
+  background: #080910;
+  border-radius: 0 0 14px 14px;
+}
+
+.phoneScreen {
+  height: calc(100% - 27px);
+  border-radius: 30px;
+  overflow: hidden;
+  background: #0b1020;
+  border: 1px solid rgba(169, 173, 226, 0.23);
+}
+
+.phoneViewportTrack {
+  width: 300%;
+  height: 100%;
+  display: flex;
+  transition: transform 760ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.scenePanel {
+  width: 33.3334%;
+  height: 100%;
+  padding: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  background: linear-gradient(180deg, rgba(16, 18, 34, 0.96), rgba(10, 11, 22, 0.98));
+}
+
+.sceneHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.69rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(216, 219, 255, 0.76);
+}
+
+.badge {
+  padding: 0.16rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid rgba(173, 181, 247, 0.28);
+}
+
+.dashboardViewport {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  transition: transform 600ms ease;
+}
+
+.heroCard,
+.metricCard,
+.editorCard,
+.modalCard,
+.sealCard {
+  border-radius: 14px;
+  background: rgba(44, 50, 88, 0.35);
+  border: 1px solid rgba(167, 171, 233, 0.2);
+}
+
+.heroCard {
+  padding: 0.52rem;
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr);
+  align-items: center;
+  gap: 0.62rem;
+}
+
+.heroCard img {
+  width: 52px;
+  height: 52px;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.heroCard strong {
+  font-size: 0.78rem;
+}
+
+.heroCard p,
+.metricCard p,
+.editorCard p,
+.modalCard p {
+  margin: 0;
+  color: rgba(224, 226, 255, 0.75);
+  font-size: 0.67rem;
+}
+
+.metricCard {
+  padding: 0.62rem;
+}
+
+.metricCard strong,
+.editorCard strong {
+  display: block;
+  margin-top: 0.28rem;
+  font-size: 0.92rem;
+}
+
+.progressTrack,
+.aiProgressTrack {
+  margin-top: 0.55rem;
+  width: 100%;
+  height: 7px;
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progressTrack span,
+.aiProgressTrack span {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #75a0ff, #a48bff);
+  transition: width 500ms ease;
+}
+
+.miniBars {
+  display: flex;
+  gap: 0.3rem;
+  margin-top: 0.55rem;
+}
+
+.miniBars i {
+  width: 18%;
+  height: 7px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.13);
+}
+
+.activeBar {
+  background: linear-gradient(90deg, #7d8fff, #c08aff);
+}
+
+.sealGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+  margin-top: 0.15rem;
+}
+
+.sealCard {
+  padding: 0.7rem 0.55rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.42rem;
+  transform: translateY(0);
+}
+
+.sealCard span {
+  color: #b291ff;
+}
+
+.sealCard strong {
+  font-size: 0.72rem;
+  line-height: 1.2;
+}
+
+.sealCardActive {
+  animation: sealFloat 2.1s ease-in-out infinite;
+}
+
+.editorCard,
+.modalCard {
+  padding: 0.68rem;
+}
+
+.editorCard small,
+.modalCard small {
+  display: block;
+  margin-top: 0.36rem;
+  color: rgba(213, 217, 255, 0.65);
+  font-size: 0.66rem;
+}
+
+.modalCard {
+  opacity: 0;
+  transform: translateY(14px) scale(0.96);
+  transition: opacity 440ms ease, transform 440ms ease;
+}
+
+.modalCardVisible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.inputRow {
+  margin-top: 0.44rem;
+  border-radius: 10px;
+  border: 1px solid rgba(165, 170, 232, 0.2);
+  padding: 0.52rem;
+  font-size: 0.68rem;
+  color: rgba(231, 232, 255, 0.82);
+  background: rgba(10, 12, 22, 0.52);
+}
+
+@keyframes sealFloat {
+  0%,
+  100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+
+@media (max-width: 980px) {
+  .hero {
+    grid-template-columns: 1fr;
+    align-content: start;
+    min-height: unset;
+  }
+
+  .visualCol {
+    justify-content: flex-start;
+  }
+
+  .phoneFrame {
+    width: min(100%, 340px);
+  }
+}
+
+@media (max-width: 560px), (prefers-reduced-motion: reduce) {
+  .phoneViewportTrack,
+  .dashboardViewport,
+  .modalCard,
+  .progressTrack span,
+  .aiProgressTrack span {
+    transition-duration: 0ms;
+  }
+
+  .sealCardActive {
+    animation: none;
+  }
+}

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { useReducedMotion } from 'framer-motion';
+import styles from './HeroPhoneShowcaseLabPage.module.css';
+
+type SceneKey =
+  | 'dashboardIdle'
+  | 'dashboardScroll'
+  | 'toAchievements'
+  | 'achievementsIdle'
+  | 'toTaskEditor'
+  | 'taskModalOpen'
+  | 'taskAiCreate'
+  | 'backToDashboard';
+
+type SceneDefinition = {
+  key: SceneKey;
+  durationMs: number;
+};
+
+const SCENE_TIMELINE: SceneDefinition[] = [
+  { key: 'dashboardIdle', durationMs: 2500 },
+  { key: 'dashboardScroll', durationMs: 1700 },
+  { key: 'toAchievements', durationMs: 1400 },
+  { key: 'achievementsIdle', durationMs: 2200 },
+  { key: 'toTaskEditor', durationMs: 1400 },
+  { key: 'taskModalOpen', durationMs: 1400 },
+  { key: 'taskAiCreate', durationMs: 2200 },
+  { key: 'backToDashboard', durationMs: 1600 },
+];
+
+const LOOP_MS = SCENE_TIMELINE.reduce((total, scene) => total + scene.durationMs, 0);
+
+function useLoopTimeline() {
+  const prefersReducedMotion = useReducedMotion();
+  const [elapsedMs, setElapsedMs] = useState(0);
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setElapsedMs(0);
+      return;
+    }
+
+    let rafId = 0;
+    const start = performance.now();
+
+    const tick = (now: number) => {
+      setElapsedMs((now - start) % LOOP_MS);
+      rafId = window.requestAnimationFrame(tick);
+    };
+
+    rafId = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(rafId);
+  }, [prefersReducedMotion]);
+
+  if (prefersReducedMotion) {
+    return {
+      panelTranslatePercent: 0,
+      dashboardScrollOffset: 0,
+      sealsActive: false,
+      modalVisible: false,
+      aiProgress: 0,
+    };
+  }
+
+  let cursor = 0;
+  let current = SCENE_TIMELINE[0];
+  for (const scene of SCENE_TIMELINE) {
+    if (elapsedMs < cursor + scene.durationMs) {
+      current = scene;
+      break;
+    }
+    cursor += scene.durationMs;
+  }
+
+  const sceneProgress = Math.min(1, Math.max(0, (elapsedMs - cursor) / current.durationMs));
+
+  const panelTranslatePercent = (() => {
+    if (current.key === 'toAchievements') return -100 * sceneProgress;
+    if (current.key === 'achievementsIdle') return -100;
+    if (current.key === 'toTaskEditor') return -100 - 100 * sceneProgress;
+    if (current.key === 'taskModalOpen' || current.key === 'taskAiCreate') return -200;
+    if (current.key === 'backToDashboard') return -200 + 200 * sceneProgress;
+    return 0;
+  })();
+
+  const dashboardScrollOffset =
+    current.key === 'dashboardScroll'
+      ? -20 * sceneProgress
+      : current.key === 'toAchievements'
+        ? -20
+        : 0;
+
+  const modalVisible = current.key === 'taskModalOpen' || current.key === 'taskAiCreate';
+  const aiProgress = current.key === 'taskAiCreate' ? sceneProgress : current.key === 'backToDashboard' ? 1 : 0;
+
+  return {
+    panelTranslatePercent,
+    dashboardScrollOffset,
+    sealsActive: current.key === 'achievementsIdle',
+    modalVisible,
+    aiProgress,
+  };
+}
+
+function PhoneFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className={styles.phoneFrame}>
+      <div className={styles.phoneNotch} />
+      <div className={styles.phoneScreen}>{children}</div>
+    </div>
+  );
+}
+
+function DashboardScene({ scrollOffset }: { scrollOffset: number }) {
+  return (
+    <section className={styles.scenePanel}>
+      <div className={styles.sceneHeader}>
+        <span>Dashboard</span>
+        <span className={styles.badge}>Dark mode</span>
+      </div>
+      <div className={styles.dashboardViewport} style={{ transform: `translateY(${scrollOffset}px)` }}>
+        <article className={styles.heroCard}>
+          <img src="/Evolve-Mood.jpg" alt="Violet owl avatar" />
+          <div>
+            <strong>Violet Owl · Evolve</strong>
+            <p>GP 1,280 · Lvl 9 · 12-day streak</p>
+          </div>
+        </article>
+        <article className={styles.metricCard}>
+          <p>Daily Quest</p>
+          <strong>3/4 completed</strong>
+          <div className={styles.progressTrack}><span style={{ width: '75%' }} /></div>
+        </article>
+        <article className={styles.metricCard}>
+          <p>Energy Rhythm</p>
+          <strong>FLOW</strong>
+          <div className={styles.miniBars}>
+            <i /><i /><i /><i className={styles.activeBar} />
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}
+
+function AchievementsScene({ active }: { active: boolean }) {
+  return (
+    <section className={styles.scenePanel}>
+      <div className={styles.sceneHeader}><span>Achievements</span><span className={styles.badge}>Seals</span></div>
+      <div className={styles.sealGrid}>
+        {['7 Day Streak', 'Body Balance', 'Focus Master', 'Quest Combo'].map((seal, index) => (
+          <article
+            key={seal}
+            className={`${styles.sealCard} ${active ? styles.sealCardActive : ''}`}
+            style={{ animationDelay: `${index * 0.2}s` }}
+          >
+            <span>◉</span>
+            <strong>{seal}</strong>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function TaskEditorScene({ modalVisible, aiProgress }: { modalVisible: boolean; aiProgress: number }) {
+  return (
+    <section className={styles.scenePanel}>
+      <div className={styles.sceneHeader}><span>Task editor</span><span className={styles.badge}>AI assist</span></div>
+      <article className={styles.editorCard}>
+        <p>Mission draft</p>
+        <strong>Morning Focus Ritual</strong>
+        <small>Category: Mind · Frequency: Daily</small>
+      </article>
+      <article className={`${styles.modalCard} ${modalVisible ? styles.modalCardVisible : ''}`}>
+        <p>Create task with AI</p>
+        <div className={styles.inputRow}>“Build a 15-min focus reset after lunch”</div>
+        <div className={styles.aiProgressTrack}><span style={{ width: `${Math.max(8, aiProgress * 100)}%` }} /></div>
+        <small>{aiProgress >= 0.96 ? 'Task ready ✓' : 'Generating adaptive steps...'}</small>
+      </article>
+    </section>
+  );
+}
+
+function HeroPhoneShowcase() {
+  const timeline = useLoopTimeline();
+
+  return (
+    <PhoneFrame>
+      <div className={styles.phoneViewportTrack} style={{ transform: `translateX(${timeline.panelTranslatePercent}%)` }}>
+        <DashboardScene scrollOffset={timeline.dashboardScrollOffset} />
+        <AchievementsScene active={timeline.sealsActive} />
+        <TaskEditorScene modalVisible={timeline.modalVisible} aiProgress={timeline.aiProgress} />
+      </div>
+    </PhoneFrame>
+  );
+}
+
+export default function HeroPhoneShowcaseLabPage() {
+  return (
+    <main className={styles.page}>
+      <section className={styles.hero}>
+        <div className={styles.copyCol}>
+          <p className={styles.kicker}>Labs · Hero experiment</p>
+          <h1>
+            Tu progreso, <span>en tiempo real.</span>
+          </h1>
+          <p>
+            Variante experimental del primer fold: texto y CTAs originales + un showcase móvil de Innerbloom en loop
+            continuo para comunicar producto real desde el primer vistazo.
+          </p>
+          <div className={styles.ctaRow}>
+            <Link className={styles.primaryCta} to="/onboarding">Comenzar ahora</Link>
+            <a className={styles.secondaryCta} href="/landing-v2#highlights">Ver dashboard</a>
+          </div>
+        </div>
+
+        <div className={styles.visualCol}>
+          <HeroPhoneShowcase />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/pages/labs/LabsIndexPage.tsx
+++ b/apps/web/src/pages/labs/LabsIndexPage.tsx
@@ -18,6 +18,11 @@ const LAB_EXPERIMENTS = [
     description: 'Guided preview of the Achievements module for dashboard exploration.',
     href: '/labs/logros',
   },
+  {
+    title: 'Hero Phone Showcase',
+    description: 'Experimental hero fold replacing static AI art with a looping Innerbloom product phone showcase.',
+    href: '/labs/hero-phone-showcase',
+  },
 ];
 
 export default function LabsIndexPage() {


### PR DESCRIPTION
### Motivation
- Provide an isolated labs experiment that replaces the hero artwork with a realistic looping mobile phone showcase to evaluate UX without touching the main landing.
- Surface core product moments (dashboard → achievements → editor + AI task creation) in a compact, premium-feeling loop to improve first-impression clarity.
- Keep the experiment isolated under `/labs` so it can be iterated independently and follow Innerbloom visual language and reduced-motion preferences.

### Description
- Adds a new labs route at `/labs/hero-phone-showcase` and an entry in the labs index for discovery by adding `HeroPhoneShowcaseLabPage` and wiring it in `App.tsx` and `LabsIndexPage.tsx`.
- Implements a maintainable timeline-driven loop (`useLoopTimeline`) and scene pipeline (dashboard, achievements, task editor) with a horizontal viewport track inside a `PhoneFrame` shell.
- Creates modular subcomponents: `PhoneFrame`, `DashboardScene`, `AchievementsScene`, and `TaskEditorScene`, and styles in a dedicated CSS module that preserves dark mode and Innerbloom color accents.
- Respects `prefers-reduced-motion` by disabling the loop and micro-animations, and uses declarative RAF-based timing to keep the loop duration ~14.4s (inside the requested 12–18s range).

### Testing
- Ran production build with `npm -w @innerbloom/web run build`, which completed successfully (bundle produced). ✅
- Ran type-check with `npm -w @innerbloom/web run typecheck`, which failed due to pre-existing, unrelated TypeScript errors elsewhere in the repo (these are not introduced by this change). ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3ad9d4a88332a5fe20e6dde5ec35)