### PR TITLE
labs: rebuild hero phone showcase using real Innerbloom views

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -108,7 +108,7 @@
   height: calc(100% - 27px);
   border-radius: 30px;
   overflow: hidden;
-  background: radial-gradient(circle at 76% 18%, rgba(247, 193, 151, 0.07), transparent 30%), #101322;
+  background: #050816;
   border: 1px solid rgba(216, 194, 246, 0.24);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.12),
@@ -125,183 +125,29 @@
 .scenePanel {
   width: 33.3334%;
   height: 100%;
-  padding: 0.9rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-  background: linear-gradient(180deg, rgba(16, 18, 34, 0.96), rgba(10, 11, 22, 0.98));
-}
-
-.sceneHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.69rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: rgba(216, 219, 255, 0.76);
-}
-
-.badge {
-  padding: 0.16rem 0.45rem;
-  border-radius: 999px;
-  border: 1px solid rgba(173, 181, 247, 0.28);
-}
-
-.dashboardViewport {
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-  will-change: transform;
-}
-
-.heroCard,
-.metricCard,
-.editorCard,
-.modalCard,
-.sealCard {
-  border-radius: 14px;
-  background: rgba(44, 49, 82, 0.4);
-  border: 1px solid rgba(205, 190, 235, 0.2);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
-}
-
-.heroCard {
-  padding: 0.52rem;
-  display: grid;
-  grid-template-columns: 52px minmax(0, 1fr);
-  align-items: center;
-  gap: 0.62rem;
-}
-
-.heroCard img {
-  width: 52px;
-  height: 52px;
-  object-fit: cover;
-  border-radius: 12px;
-}
-
-.heroCard strong {
-  font-size: 0.78rem;
-}
-
-.heroCard p,
-.metricCard p,
-.editorCard p,
-.modalCard p {
-  margin: 0;
-  color: rgba(224, 226, 255, 0.75);
-  font-size: 0.67rem;
-}
-
-.metricCard {
-  padding: 0.62rem;
-}
-
-.metricCard strong,
-.editorCard strong {
-  display: block;
-  margin-top: 0.28rem;
-  font-size: 0.92rem;
-}
-
-.progressTrack,
-.aiProgressTrack {
-  margin-top: 0.55rem;
-  width: 100%;
-  height: 7px;
-  background: rgba(255, 255, 255, 0.07);
-  border-radius: 999px;
+  position: relative;
   overflow: hidden;
+  background: #050816;
 }
 
-.progressTrack span,
-.aiProgressTrack span {
-  display: block;
-  height: 100%;
-  border-radius: 999px;
-  background: linear-gradient(90deg, #7a9bf3, #b58ff1);
-  transition: width 580ms cubic-bezier(0.2, 0.65, 0.2, 1);
+.realViewport {
+  position: absolute;
+  inset: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
 }
 
-.miniBars {
-  display: flex;
-  gap: 0.3rem;
-  margin-top: 0.55rem;
+.realViewport::-webkit-scrollbar {
+  display: none;
 }
 
-.miniBars i {
-  width: 18%;
-  height: 7px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.13);
-}
-
-.activeBar {
-  background: linear-gradient(90deg, #8898f0, #c89af1);
-}
-
-.sealGrid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.7rem;
-  margin-top: 0.15rem;
-}
-
-.sealCard {
-  padding: 0.7rem 0.55rem;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.42rem;
-  transform: translateY(0);
-  will-change: transform;
-}
-
-.sealCard span {
-  color: #b291ff;
-}
-
-.sealCard strong {
-  font-size: 0.72rem;
-  line-height: 1.2;
-}
-
-.sealCardActive {
-  animation: sealFloat var(--seal-duration, 3.8s) cubic-bezier(0.42, 0, 0.22, 1) infinite;
-}
-
-.editorCard,
-.modalCard {
-  padding: 0.68rem;
-}
-
-.editorCard small,
-.modalCard small {
-  display: block;
-  margin-top: 0.36rem;
-  color: rgba(213, 217, 255, 0.65);
-  font-size: 0.66rem;
-}
-
-.modalCard {
-  will-change: transform, opacity;
-}
-
-.inputRow {
-  margin-top: 0.44rem;
-  border-radius: 10px;
-  border: 1px solid rgba(165, 170, 232, 0.2);
-  padding: 0.52rem;
-  font-size: 0.68rem;
-  color: rgba(231, 232, 255, 0.82);
-  background: rgba(10, 12, 22, 0.52);
-}
-
-@keyframes sealFloat {
-  0%,
-  100% { transform: translateY(0); }
-  50% { transform: translateY(calc(var(--seal-motion, 2px) * -1)); }
+.realSceneScale {
+  width: 436px;
+  min-height: 100%;
+  transform: scale(0.72);
+  transform-origin: top left;
+  padding: 14px 10px 120px;
 }
 
 @media (max-width: 980px) {
@@ -318,23 +164,5 @@
   .phoneFrame {
     width: min(100%, 340px);
     transform: none;
-  }
-}
-
-@media (max-width: 560px), (prefers-reduced-motion: reduce) {
-  .phoneFrame {
-    transform: none;
-  }
-
-  .phoneViewportTrack,
-  .dashboardViewport,
-  .modalCard,
-  .progressTrack span,
-  .aiProgressTrack span {
-    transition-duration: 0ms;
-  }
-
-  .sealCardActive {
-    animation: none;
   }
 }

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -1,6 +1,19 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type ReactNode,
+} from 'react';
 import { Link } from 'react-router-dom';
 import { useReducedMotion } from 'framer-motion';
+import { DashboardOverview } from '../DashboardV3';
+import { getDashboardSectionConfig } from '../dashboardSections';
+import TaskEditorPage from '../editor';
+import { RewardsSection, type RewardsSectionDemoControls } from '../../components/dashboard-v3/RewardsSection';
+import { getDemoLogrosData, getDemoLogrosPreviewByTaskId } from '../../data/demoLogrosData';
+import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
 import styles from './HeroPhoneShowcaseLabPage.module.css';
 
 type SceneKey =
@@ -18,14 +31,36 @@ type SceneDefinition = {
   durationMs: number;
 };
 
+const DEMO_DAILY_QUEST_READINESS = {
+  hasTasks: true,
+  firstTasksConfirmed: true,
+  completedFirstDailyQuest: true,
+  canOpenDailyQuest: true,
+  canShowDailyQuestPopup: true,
+  canAutoOpenDailyQuestPopup: false,
+  showOnboardingGuidance: false,
+  showJourneyPreparing: false,
+  tasksStatus: 'success' as const,
+  journeyStatus: 'success' as const,
+  journey: {
+    first_date_log: null,
+    days_of_journey: 0,
+    quantity_daily_logs: 0,
+    first_programmed: true,
+    first_tasks_confirmed: true,
+    completed_first_daily_quest: true,
+  },
+  reload: () => undefined,
+};
+
 const SCENE_TIMELINE: SceneDefinition[] = [
-  { key: 'dashboardIdle', durationMs: 2300 },
-  { key: 'dashboardScroll', durationMs: 1900 },
-  { key: 'toAchievements', durationMs: 1250 },
-  { key: 'achievementsIdle', durationMs: 2000 },
-  { key: 'toTaskEditor', durationMs: 1250 },
-  { key: 'taskModalOpen', durationMs: 1300 },
-  { key: 'taskAiCreate', durationMs: 2300 },
+  { key: 'dashboardIdle', durationMs: 1700 },
+  { key: 'dashboardScroll', durationMs: 2400 },
+  { key: 'toAchievements', durationMs: 1300 },
+  { key: 'achievementsIdle', durationMs: 2400 },
+  { key: 'toTaskEditor', durationMs: 1300 },
+  { key: 'taskModalOpen', durationMs: 1400 },
+  { key: 'taskAiCreate', durationMs: 2600 },
   { key: 'backToDashboard', durationMs: 1700 },
 ];
 
@@ -55,11 +90,9 @@ function useLoopTimeline() {
 
   if (prefersReducedMotion) {
     return {
+      scene: 'dashboardIdle' as SceneKey,
+      sceneProgress: 0,
       panelTranslatePercent: 0,
-      dashboardScrollOffset: 0,
-      sealsProgress: 0,
-      modalProgress: 0,
-      aiProgress: 0,
     };
   }
 
@@ -75,7 +108,6 @@ function useLoopTimeline() {
 
   const sceneProgress = Math.min(1, Math.max(0, (elapsedMs - cursor) / current.durationMs));
   const easeInOut = sceneProgress * sceneProgress * (3 - 2 * sceneProgress);
-  const easeOut = 1 - Math.pow(1 - sceneProgress, 3);
 
   const panelTranslatePercent = (() => {
     if (current.key === 'toAchievements') return -100 * easeInOut;
@@ -86,42 +118,10 @@ function useLoopTimeline() {
     return 0;
   })();
 
-  const dashboardScrollOffset =
-    current.key === 'dashboardScroll'
-      ? -16 * easeInOut
-      : current.key === 'toAchievements'
-        ? -16
-        : 0;
-
-  const modalProgress =
-    current.key === 'taskModalOpen'
-      ? easeOut
-      : current.key === 'taskAiCreate'
-        ? 1
-        : current.key === 'backToDashboard'
-          ? 1 - easeOut
-          : 0;
-
-  const aiProgress =
-    current.key === 'taskAiCreate'
-      ? 0.18 + easeInOut * 0.82
-      : current.key === 'backToDashboard'
-        ? 1 - easeInOut
-        : 0;
-
-  const sealsProgress =
-    current.key === 'achievementsIdle'
-      ? 1
-      : current.key === 'toTaskEditor'
-        ? 1 - easeInOut
-        : 0;
-
   return {
+    scene: current.key,
+    sceneProgress,
     panelTranslatePercent,
-    dashboardScrollOffset,
-    sealsProgress,
-    modalProgress,
-    aiProgress,
   };
 }
 
@@ -134,96 +134,176 @@ function PhoneFrame({ children }: { children: ReactNode }) {
   );
 }
 
-function DashboardScene({ scrollOffset }: { scrollOffset: number }) {
+function RealDashboardScene({
+  scene,
+  sceneProgress,
+}: {
+  scene: SceneKey;
+  sceneProgress: number;
+}) {
+  const { language } = usePostLoginLanguage();
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const section = useMemo(
+    () => getDashboardSectionConfig('dashboard', '/dashboard', language),
+    [language],
+  );
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+    const progressByScene =
+      scene === 'dashboardScroll'
+        ? sceneProgress
+        : scene === 'toAchievements' || scene === 'achievementsIdle' || scene === 'toTaskEditor'
+          ? 1
+          : scene === 'backToDashboard'
+            ? 1 - sceneProgress
+            : 0;
+
+    viewport.scrollTop = maxScroll * progressByScene;
+  }, [scene, sceneProgress]);
+
   return (
-    <section className={styles.scenePanel}>
-      <div className={styles.sceneHeader}>
-        <span>Dashboard</span>
-        <span className={styles.badge}>Dark mode</span>
-      </div>
-      <div className={styles.dashboardViewport} style={{ transform: `translateY(${scrollOffset}px)` }}>
-        <article className={styles.heroCard}>
-          <img src="/Evolve-Mood.jpg" alt="Violet owl avatar" />
-          <div>
-            <strong>Violet Owl · Evolve</strong>
-            <p>GP 1,280 · Lvl 9 · 12-day streak</p>
-          </div>
-        </article>
-        <article className={styles.metricCard}>
-          <p>Daily Quest</p>
-          <strong>3/4 completed</strong>
-          <div className={styles.progressTrack}><span style={{ width: '75%' }} /></div>
-        </article>
-        <article className={styles.metricCard}>
-          <p>Energy Rhythm</p>
-          <strong>FLOW</strong>
-          <div className={styles.miniBars}>
-            <i /><i /><i /><i className={styles.activeBar} />
-          </div>
-        </article>
+    <section className={styles.scenePanel} data-light-scope="dashboard-v3">
+      <div ref={viewportRef} className={styles.realViewport}>
+        <div className={styles.realSceneScale}>
+          <DashboardOverview
+            userId="demo-public-user"
+            gameMode="flow"
+            avatarProfile={null}
+            weeklyTarget={3}
+            isJourneyGenerating={false}
+            dailyQuestReadiness={DEMO_DAILY_QUEST_READINESS}
+            showOnboardingGuidance={false}
+            section={section}
+            onOpenReminderScheduler={() => undefined}
+            onOpenModerationEdit={() => undefined}
+            shouldShowFirstDailyQuestCta={false}
+            onOpenDailyQuest={() => undefined}
+            showOnboardingCompletionBanner={false}
+            onUpgradeAccepted={() => undefined}
+          />
+        </div>
       </div>
     </section>
   );
 }
 
-function AchievementsScene({ motionIntensity }: { motionIntensity: number }) {
+function RealAchievementsScene({
+  scene,
+  sceneProgress,
+  controlsRef,
+}: {
+  scene: SceneKey;
+  sceneProgress: number;
+  controlsRef: MutableRefObject<RewardsSectionDemoControls | null>;
+}) {
+  const { language } = usePostLoginLanguage();
+
+  useEffect(() => {
+    const controls = controlsRef.current;
+    if (!controls) return;
+
+    if (scene === 'achievementsIdle') {
+      if (sceneProgress < 0.45) {
+        controls.closeAllOverlays();
+        controls.focusCarouselCard('task-dinner-before-22');
+      } else {
+        controls.openAchievedCard();
+      }
+    }
+
+    if (scene === 'toTaskEditor') {
+      controls.closeAllOverlays();
+    }
+  }, [controlsRef, scene, sceneProgress]);
+
+  const demoConfig = useMemo(
+    () => ({
+      disableRemote: true,
+      forceAchievementsViewMode: 'carousel' as const,
+      mockPreviewAchievementByTaskId: getDemoLogrosPreviewByTaskId(language),
+      controls: {
+        onReady: (controls: RewardsSectionDemoControls) => {
+          controlsRef.current = controls;
+        },
+      },
+    }),
+    [controlsRef, language],
+  );
+
   return (
-    <section className={styles.scenePanel}>
-      <div className={styles.sceneHeader}><span>Achievements</span><span className={styles.badge}>Seals</span></div>
-      <div className={styles.sealGrid}>
-        {['7 Day Streak', 'Body Balance', 'Focus Master', 'Quest Combo'].map((seal, index) => (
-          <article
-            key={seal}
-            className={`${styles.sealCard} ${motionIntensity > 0.04 ? styles.sealCardActive : ''}`}
-            style={{
-              animationDelay: `${index * 0.24}s`,
-              animationDuration: `${3.6 + index * 0.12}s`,
-              ['--seal-motion' as string]: `${(1.8 + index * 0.2) * motionIntensity}px`,
-            }}
-          >
-            <span>◉</span>
-            <strong>{seal}</strong>
-          </article>
-        ))}
+    <section className={styles.scenePanel} data-light-scope="dashboard-v3">
+      <div className={styles.realViewport}>
+        <div className={styles.realSceneScale}>
+          <RewardsSection
+            userId=""
+            initialData={getDemoLogrosData(language)}
+            demoConfig={demoConfig}
+          />
+        </div>
       </div>
     </section>
   );
 }
 
-function TaskEditorScene({ modalProgress, aiProgress }: { modalProgress: number; aiProgress: number }) {
+function RealEditorScene({ scene }: { scene: SceneKey }) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const aiRequestedRef = useRef(false);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    if (scene === 'taskModalOpen' || scene === 'taskAiCreate') {
+      const createTrigger = root.querySelector<HTMLButtonElement>('[data-editor-guide-target="new-task-trigger"]');
+      if (createTrigger) {
+        createTrigger.click();
+      }
+    }
+
+    if (scene === 'taskAiCreate' && !aiRequestedRef.current) {
+      const aiButton = root.querySelector<HTMLButtonElement>('[data-editor-guide-target="new-task-modal-ai-action"]');
+      if (aiButton) {
+        aiButton.click();
+        aiRequestedRef.current = true;
+      }
+    }
+
+    if (scene === 'backToDashboard') {
+      const closeButton = root.querySelector<HTMLButtonElement>('.create-task-ai-modal__close');
+      closeButton?.click();
+      aiRequestedRef.current = false;
+    }
+  }, [scene]);
+
   return (
-    <section className={styles.scenePanel}>
-      <div className={styles.sceneHeader}><span>Task editor</span><span className={styles.badge}>AI assist</span></div>
-      <article className={styles.editorCard}>
-        <p>Mission draft</p>
-        <strong>Morning Focus Ritual</strong>
-        <small>Category: Mind · Frequency: Daily</small>
-      </article>
-      <article
-        className={styles.modalCard}
-        style={{
-          opacity: modalProgress,
-          transform: `translateY(${10 - modalProgress * 10}px) scale(${0.985 + modalProgress * 0.015})`,
-        }}
-      >
-        <p>Create task with AI</p>
-        <div className={styles.inputRow}>“Build a 15-min focus reset after lunch”</div>
-        <div className={styles.aiProgressTrack}><span style={{ width: `${Math.max(8, aiProgress * 100)}%` }} /></div>
-        <small>{aiProgress >= 0.96 ? 'Task ready ✓' : 'Drafting 3 concrete steps...'}</small>
-      </article>
+    <section className={styles.scenePanel} data-light-scope="dashboard-v3">
+      <div className={styles.realViewport}>
+        <div ref={rootRef} className={styles.realSceneScale}>
+          <TaskEditorPage publicDemo />
+        </div>
+      </div>
     </section>
   );
 }
 
 function HeroPhoneShowcase() {
   const timeline = useLoopTimeline();
+  const achievementsControlsRef = useRef<RewardsSectionDemoControls | null>(null);
 
   return (
     <PhoneFrame>
       <div className={styles.phoneViewportTrack} style={{ transform: `translateX(${timeline.panelTranslatePercent}%)` }}>
-        <DashboardScene scrollOffset={timeline.dashboardScrollOffset} />
-        <AchievementsScene motionIntensity={timeline.sealsProgress} />
-        <TaskEditorScene modalProgress={timeline.modalProgress} aiProgress={timeline.aiProgress} />
+        <RealDashboardScene scene={timeline.scene} sceneProgress={timeline.sceneProgress} />
+        <RealAchievementsScene
+          scene={timeline.scene}
+          sceneProgress={timeline.sceneProgress}
+          controlsRef={achievementsControlsRef}
+        />
+        <RealEditorScene scene={timeline.scene} />
       </div>
     </PhoneFrame>
   );
@@ -239,8 +319,8 @@ export default function HeroPhoneShowcaseLabPage() {
             Tu progreso, <span>en tiempo real.</span>
           </h1>
           <p>
-            Variante experimental del primer fold: texto y CTAs originales + un showcase móvil de Innerbloom en loop
-            continuo para comunicar producto real desde el primer vistazo.
+            Showcase dentro de móvil usando vistas reales de Innerbloom: dashboard real, logros reales y editor real
+            con flujo de creación asistida.
           </p>
           <div className={styles.ctaRow}>
             <Link className={styles.primaryCta} to="/onboarding">Comenzar ahora</Link>


### PR DESCRIPTION
### Motivation
- The previous hero used invented miniature UI (fake cards, seals and a simulated modal) instead of product surfaces, which breaks the source-of-truth principle and feels like marketing mockups.
- The goal is to show real Innerbloom product screens (dashboard, achievements, editor) inside a phone frame so the showcase feels credible and reuses existing demos/components.

### Description
- Replaced the synthetic scenes with real product views in `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`, mounting `DashboardOverview`, `RewardsSection` (with demo data) and `TaskEditorPage publicDemo` as the three panels.
- Added scene orchestration that animates a horizontal track (`translateX`) and drives real interactions: vertical `scrollTop` inside the dashboard viewport, `RewardsSection` demo controls to focus/open achievement cards, and triggering the editor create-modal + AI action via existing `data-editor-guide-target` selectors.
- Reworked styles in `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css` to provide a phone bezel, clipped viewport, scene scaling and scrolling behavior instead of the old fake card styles.
- Removed all fake UI elements (invented cards/seals/modal progress) and kept only thin wrappers/layouts that mount the real components; no product UI was reimplemented or duplicated.

### Testing
- Ran `pnpm --filter web exec eslint src/pages/labs/HeroPhoneShowcaseLabPage.tsx`; this check failed due to repository ESLint configuration (ESLint v9 flat-config migration not present), not due to the new code style itself.
- Ran TypeScript checks with `pnpm --filter web exec tsc -p tsconfig.json --noEmit`; this failed because of pre-existing repository-wide TypeScript errors unrelated to the changed lab files.
- No unit or e2e tests were modified or executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4217261c833292a8640335d98849)