### PR TITLE
Polish public demos: compact close button, achievements wordmark, mobile spacing, editor intro delay

### DIFF
--- a/apps/web/src/components/demo/GuidedDemoOverlay.tsx
+++ b/apps/web/src/components/demo/GuidedDemoOverlay.tsx
@@ -25,7 +25,7 @@ const MOBILE_TOOLTIP_BOTTOM_GAP_LOWER = 2;
 const TOOLTIP_HEIGHT_DESKTOP = 252;
 const TOOLTIP_HEIGHT_MOBILE = 238;
 const TOOLTIP_HEIGHT_MOBILE_COMPACT = 210;
-const MOBILE_DASHBOARD_FOCUS_DEFAULT_OFFSET = 8;
+const MOBILE_DASHBOARD_FOCUS_DEFAULT_OFFSET = 2;
 const MOBILE_MODAL_FOCUS_DEFAULT_OFFSET = 6;
 const DAILY_QUEST_MODAL_EXTRA_HEADER_GAP = 8;
 const DAILY_QUEST_INTRO_STEP_ID = 'daily-quest-intro';
@@ -33,13 +33,21 @@ const DAILY_QUEST_FOOTER_STEP_ID = 'daily-quest-footer';
 const DAILY_QUEST_MODERATION_STEP_ID = 'daily-quest-moderation';
 
 const MOBILE_DASHBOARD_STEP_FOCUS_OFFSET: Record<string, number> = {
-  'overall-progress': 12,
-  'streaks-top': 4,
-  'streaks-bottom': 4,
-  balance: 6,
-  'emotion-chart': 6,
-  'daily-energy': 18,
-  'info-dot': 18,
+  'overall-progress': 6,
+  'streaks-top': 2,
+  'streaks-bottom': 2,
+  balance: 4,
+  'emotion-chart': 4,
+  'daily-energy': 12,
+  'info-dot': 12,
+  'logros-shelves': 0,
+  'logros-carousel-structure': 0,
+  'logros-pillar-selector': 0,
+  'logros-carousel-track': 0,
+  'logros-achieved-card': 0,
+  'logros-blocked-card': 0,
+  'logros-weekly': 0,
+  'logros-monthly': 0,
 };
 
 const MOBILE_DAILY_QUEST_STEP_FOCUS_OFFSET: Record<string, number> = {

--- a/apps/web/src/pages/DemoDashboard.tsx
+++ b/apps/web/src/pages/DemoDashboard.tsx
@@ -190,9 +190,10 @@ export default function DemoDashboardPage() {
                 event.preventDefault();
                 handleDemoExit();
               }}
-              className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-3 py-1.5 text-xs font-semibold text-[color:var(--color-text)]"
+              aria-label={language === 'es' ? 'Cerrar demo del Dashboard y volver al hub público' : 'Close Dashboard demo and return to the public hub'}
+              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] text-lg font-semibold leading-none text-[color:var(--color-text)] transition-colors hover:bg-[color:var(--color-overlay-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/45 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-bg)]"
             >
-              {language === 'es' ? 'Salir demo' : 'Exit demo'}
+              <span aria-hidden>×</span>
             </Link>
           </div>
         }

--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -242,10 +242,23 @@ export default function TaskEditorPage({ publicDemo = false }: TaskEditorPagePro
     if (!ENABLE_EDITOR_GUIDE_AUTO_OPEN) {
       return;
     }
-    if (shouldAutoOpenEditorGuide()) {
-      setShowGuideModal(true);
+    if (!shouldAutoOpenEditorGuide()) {
+      return;
     }
-  }, []);
+
+    if (!publicDemo) {
+      setShowGuideModal(true);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setShowGuideModal(true);
+    }, 650);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [publicDemo]);
 
   useEffect(() => {
     const missingTraitsByPillar = new Map<string, Set<string>>();

--- a/apps/web/src/pages/labs/LogrosDemoPage.tsx
+++ b/apps/web/src/pages/labs/LogrosDemoPage.tsx
@@ -99,7 +99,10 @@ export default function LabsLogrosDemoPage() {
       <header className="sticky top-0 z-40 border-b border-[color:var(--glass-border)] bg-[image:var(--glass-bg)] px-3 py-3 backdrop-blur-xl md:px-6">
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
-            <p className="text-[0.62rem] uppercase tracking-[0.22em] text-[color:var(--color-text-subtle)] md:text-xs">Innerbloom</p>
+            <p className="inline-flex items-center gap-1.5 text-[0.62rem] uppercase tracking-[0.22em] text-[color:var(--color-text-subtle)] md:text-xs">
+              <span>INNERBLOOM</span>
+              <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logomark" className="h-[0.95rem] w-auto shrink-0" />
+            </p>
             <h1 className="font-display text-[1.05rem] font-semibold text-[color:var(--color-text)] md:text-xl">{language === 'es' ? 'Logros' : 'Achievements'}</h1>
           </div>
           <Link


### PR DESCRIPTION
### Motivation
- Aplicar pequeños ajustes visuales y de comportamiento en las demos públicas para que la experiencia se sienta más pulida sin tocar la lógica productiva. 
- Reducir el peso visual del control de salida del Dashboard para que no compita con otros elementos. 
- Asegurar que la demo de Achievements muestre el wordmark completo (texto + flor/logomark) para consistencia visual. 
- Mejorar la separación visual en mobile entre el panel explicativo de la guía y el área destacada, y añadir una breve pausa antes de abrir la guía en la demo pública del Editor.

### Description
- Reemplacé el CTA textual de salida del Dashboard por un botón circular compacto con solo `×` y `aria-label` para accesibilidad en `apps/web/src/pages/DemoDashboard.tsx`. 
- Añadí la flor/logomark junto al wordmark `INNERBLOOM` en el header de la demo de Logros en `apps/web/src/pages/labs/LogrosDemoPage.tsx`. 
- Ajusté offsets móviles en el overlay guiado cambiando `MOBILE_DASHBOARD_FOCUS_DEFAULT_OFFSET` y varios valores en `MOBILE_DASHBOARD_STEP_FOCUS_OFFSET` para que los highlights queden ligeramente más arriba y ganen separación respecto al panel, en `apps/web/src/components/demo/GuidedDemoOverlay.tsx`. 
- Modifiqué la apertura automática de la guía en la demo pública del Editor para esperar ~650ms antes de abrir con `setTimeout`, mientras que el flujo autenticado/no-demo mantiene el comportamiento previo, en `apps/web/src/pages/editor/index.tsx`.

### Testing
- Ejecuté `pnpm -C apps/web exec eslint ...` sobre los archivos cambiados y la ejecución falló por ausencia de `eslint.config.*` en este entorno, por lo que no fue posible validar con ESLint aquí. 
- Ejecuté `pnpm -C apps/web run typecheck` y el chequeo TypeScript falló por errores TypeScript preexistentes en el repositorio que no están relacionados con estos cambios. 
- Realicé una revisión estática del diff y verifiqué las inserciones de `aria-label`, `×` y la inclusión del `img` logomark, así como la lógica de `setTimeout` y los offsets modificados, y no detecté cambios lógicos fuera del alcance pedido. 
- No se generaron pruebas E2E automáticas ni capturas visuales desde este entorno por limitaciones de ejecución de navegador.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea58003214833299671cd823599234)