### PR TITLE
Fix Achievements demo logo placement and Editor demo guide timing

### DIFF
--- a/apps/web/src/components/demo/GuidedDemoOverlay.tsx
+++ b/apps/web/src/components/demo/GuidedDemoOverlay.tsx
@@ -627,6 +627,9 @@ export function GuidedDemoOverlay({
           <div className="mb-5 space-y-4">
             <div className="flex items-center justify-center text-[11px] font-semibold uppercase tracking-[0.34em] text-white/70 sm:text-xs">
               <span>Innerbloom</span>
+              {step.id === 'logros-intro' ? (
+                <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logomark" className="h-[0.95rem] w-auto shrink-0" />
+              ) : null}
             </div>
           </div>
         ) : null}

--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -61,6 +61,7 @@ import {
 
 export const FEATURE_TASK_EDITOR_MOBILE_LIST_V1 = true;
 const ENABLE_EDITOR_GUIDE_AUTO_OPEN = true;
+const PUBLIC_DEMO_EDITOR_GUIDE_AUTO_OPEN_DELAY_MS = 700;
 
 type TaskEditorPageProps = {
   publicDemo?: boolean;
@@ -251,9 +252,10 @@ export default function TaskEditorPage({ publicDemo = false }: TaskEditorPagePro
       return;
     }
 
+    setShowGuideModal(false);
     const timeoutId = window.setTimeout(() => {
       setShowGuideModal(true);
-    }, 650);
+    }, PUBLIC_DEMO_EDITOR_GUIDE_AUTO_OPEN_DELAY_MS);
 
     return () => {
       window.clearTimeout(timeoutId);

--- a/apps/web/src/pages/labs/LogrosDemoPage.tsx
+++ b/apps/web/src/pages/labs/LogrosDemoPage.tsx
@@ -99,10 +99,7 @@ export default function LabsLogrosDemoPage() {
       <header className="sticky top-0 z-40 border-b border-[color:var(--glass-border)] bg-[image:var(--glass-bg)] px-3 py-3 backdrop-blur-xl md:px-6">
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
-            <p className="inline-flex items-center gap-1.5 text-[0.62rem] uppercase tracking-[0.22em] text-[color:var(--color-text-subtle)] md:text-xs">
-              <span>INNERBLOOM</span>
-              <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logomark" className="h-[0.95rem] w-auto shrink-0" />
-            </p>
+            <p className="inline-flex items-center gap-1.5 text-[0.62rem] uppercase tracking-[0.22em] text-[color:var(--color-text-subtle)] md:text-xs">INNERBLOOM</p>
             <h1 className="font-display text-[1.05rem] font-semibold text-[color:var(--color-text)] md:text-xl">{language === 'es' ? 'Logros' : 'Achievements'}</h1>
           </div>
           <Link


### PR DESCRIPTION
### Motivation
- Corregir la posición de la flor/logomark en la demo pública de Achievements para que no aparezca en el header sticky y sí en el primer panel de la guía. 
- Mejorar la secuencia inicial de la demo pública del Editor para que el editor sea visible brevemente antes de que se abra automáticamente la guía, con un delay perceptible (0.5–0.8s). 
- Mantener cambios puntuales sin refactors ni modificaciones adicionales a la lógica del botón “View guide”.

### Description
- Eliminé la imagen `IB-COLOR-LOGO.png` del header sticky de la página de Logros en `apps/web/src/pages/labs/LogrosDemoPage.tsx` dejando solo el wordmark `INNERBLOOM` en esa barra. 
- Rendericé condicionalmente la flor dentro del primer popup intro del overlay guiado añadiendo el `img` únicamente cuando `step.id === 'logros-intro'` en `apps/web/src/components/demo/GuidedDemoOverlay.tsx`. 
- Añadí una constante `PUBLIC_DEMO_EDITOR_GUIDE_AUTO_OPEN_DELAY_MS = 700` y en `apps/web/src/pages/editor/index.tsx` forcé `setShowGuideModal(false)` antes de abrir la guía con `setTimeout(..., PUBLIC_DEMO_EDITOR_GUIDE_AUTO_OPEN_DELAY_MS)` para garantizar que el editor se muestre primero y la guía se abra automáticamente después del delay. 
- Los cambios son acotados y no modifican el comportamiento del botón manual “View guide” ni reestructuran componentes existentes.

### Testing
- Ejecuté la verificación de tipos con `npm run typecheck:web` y el comando falló por errores TypeScript preexistentes en partes no modificadas del repo, por lo que el fallo no está relacionado con los cambios introducidos en este PR. 
- No se ejecutaron otros tests automatizados adicionales; los cambios afectan únicamente renderizado/UX del overlay y el timeout de auto-apertura.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5d8b86ac83328d0f93865842a379)