### PR TITLE
Refine labs hero phone showcase to run on stable demo-driven timeline

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -14,6 +14,7 @@ import TaskEditorPage from '../editor';
 import { RewardsSection, type RewardsSectionDemoControls } from '../../components/dashboard-v3/RewardsSection';
 import { getDemoLogrosData, getDemoLogrosPreviewByTaskId } from '../../data/demoLogrosData';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
+import { setDashboardDemoModeEnabled } from '../../lib/demoMode';
 import styles from './HeroPhoneShowcaseLabPage.module.css';
 
 type SceneKey =
@@ -53,13 +54,13 @@ const DEMO_DAILY_QUEST_READINESS = {
 };
 
 const SCENE_TIMELINE: SceneDefinition[] = [
-  { key: 'dashboardStill', durationMs: 650 },
+  { key: 'dashboardStill', durationMs: 600 },
   { key: 'dashboardDrift', durationMs: 1800 },
   { key: 'toAchievements', durationMs: 550 },
-  { key: 'achievementsShowcase', durationMs: 1750 },
+  { key: 'achievementsShowcase', durationMs: 1800 },
   { key: 'toTaskEditor', durationMs: 550 },
   { key: 'taskEditorStory', durationMs: 2200 },
-  { key: 'backToDashboard', durationMs: 650 },
+  { key: 'backToDashboard', durationMs: 500 },
 ];
 
 const LOOP_MS = SCENE_TIMELINE.reduce((total, scene) => total + scene.durationMs, 0);
@@ -154,30 +155,52 @@ function RealDashboardScene({
     if (!viewport) return;
 
     const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
-    const dashboardScrollCap = 0.24;
-    const progressByScene =
+    const dashboardScrollCap = 0.08;
+    const driftProgress =
       scene === 'dashboardDrift'
-        ? sceneProgress
+        ? Math.max(0, Math.min(1, (sceneProgress - 0.2) / 0.8))
         : scene === 'toAchievements' || scene === 'achievementsShowcase' || scene === 'toTaskEditor'
           ? 1
           : scene === 'backToDashboard'
             ? 1 - sceneProgress
             : 0;
 
-    viewport.scrollTop = maxScroll * dashboardScrollCap * progressByScene;
+    viewport.scrollTop = maxScroll * dashboardScrollCap * driftProgress;
   }, [scene, sceneProgress]);
 
   useEffect(() => {
     const viewport = viewportRef.current;
     if (!viewport || readyReportedRef.current) return;
 
-    let rafId = window.requestAnimationFrame(() => {
-      if (readyReportedRef.current) return;
-      readyReportedRef.current = true;
-      onReady();
-    });
+    const hasCriticalBlocks = () => {
+      const hasAvatar = viewport.querySelector('[data-demo-anchor="overall-progress"]');
+      const hasEmotionChart = viewport.querySelector('[data-demo-anchor="emotion-chart"]');
+      const hasStreaks = viewport.querySelector('[data-demo-anchor="streaks"]');
+      return Boolean(hasAvatar && hasEmotionChart && hasStreaks);
+    };
 
-    return () => window.cancelAnimationFrame(rafId);
+    const markReadyIfStable = () => {
+      if (!hasCriticalBlocks() || readyReportedRef.current) {
+        return false;
+      }
+
+      window.setTimeout(() => {
+        if (readyReportedRef.current || !hasCriticalBlocks()) return;
+        readyReportedRef.current = true;
+        onReady();
+      }, 120);
+      return true;
+    };
+
+    if (markReadyIfStable()) return;
+
+    const intervalId = window.setInterval(() => {
+      if (markReadyIfStable()) {
+        window.clearInterval(intervalId);
+      }
+    }, 80);
+
+    return () => window.clearInterval(intervalId);
   }, [onReady]);
 
   return (
@@ -225,7 +248,7 @@ function RealAchievementsScene({
 
     if (scene === 'achievementsShowcase') {
       controls.closeAllOverlays();
-      if (sceneProgress < 0.58) {
+      if (sceneProgress < 0.68) {
         controls.focusCarouselCard('task-dinner-before-22');
       } else {
         controls.focusCarouselCard('task-gym');
@@ -245,7 +268,9 @@ function RealAchievementsScene({
       controls: {
         onReady: (controls: RewardsSectionDemoControls) => {
           controlsRef.current = controls;
-          onReady();
+          window.setTimeout(() => {
+            onReady();
+          }, 140);
         },
       },
     }),
@@ -322,7 +347,7 @@ function RealEditorScene({
       return;
     }
 
-    if (sceneProgress >= 0.2 && !storyStepsRef.current.triggerPressed) {
+    if (sceneProgress >= 0.32 && !storyStepsRef.current.triggerPressed) {
       const createTrigger = root.querySelector<HTMLButtonElement>('[data-editor-guide-target="new-task-trigger"]');
       if (createTrigger) {
         createTrigger.click();
@@ -330,7 +355,7 @@ function RealEditorScene({
       }
     }
 
-    if (sceneProgress >= 0.52 && !storyStepsRef.current.aiRequested) {
+    if (sceneProgress >= 0.64 && !storyStepsRef.current.aiRequested) {
       const aiButton = root.querySelector<HTMLButtonElement>('[data-editor-guide-target="new-task-modal-ai-action"]');
       if (aiButton) {
         aiButton.click();
@@ -356,8 +381,31 @@ function HeroPhoneShowcase() {
     achievements: false,
     editor: false,
   });
-  const timeline = useLoopTimeline(sceneReadyMap.dashboard && sceneReadyMap.achievements && sceneReadyMap.editor);
+  const [loopCanStart, setLoopCanStart] = useState(false);
+  const timeline = useLoopTimeline(loopCanStart);
   const achievementsControlsRef = useRef<RewardsSectionDemoControls | null>(null);
+  const allScenesReady = sceneReadyMap.dashboard && sceneReadyMap.achievements && sceneReadyMap.editor;
+
+  useEffect(() => {
+    setDashboardDemoModeEnabled(true);
+    return () => {
+      setDashboardDemoModeEnabled(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!allScenesReady) {
+      setLoopCanStart(false);
+      return;
+    }
+
+    const settleId = window.setTimeout(() => {
+      setLoopCanStart(true);
+    }, 320);
+
+    return () => window.clearTimeout(settleId);
+  }, [allScenesReady]);
+
   const markReady = (scene: 'dashboard' | 'achievements' | 'editor') => {
     setSceneReadyMap((prev) => (prev[scene] ? prev : { ...prev, [scene]: true }));
   };


### PR DESCRIPTION
### Motivation
- Keep the existing /labs/hero-phone-showcase experiment but make the three scenes read like a premium, demo-driven showcase rather than live/partial data.
- Remove long scrolling and early/erratic interactions that make the sequence look manual and noisy.
- Ensure the loop only starts when scenes are visually stable and that all data shown is demo/mock-driven.

### Description
- Updated the scene timeline to a clear 8.0s loop and tuned per-scene durations to improve pacing: `dashboardStill` 600ms, `dashboardDrift` 1800ms, `toAchievements` 550ms, `achievementsShowcase` 1800ms, `toTaskEditor` 550ms, `taskEditorStory` 2200ms, `backToDashboard` 500ms. 
- Dashboard micro-drift: reduced scroll cap to a small micro-drift (`dashboardScrollCap = 0.08`) and computed a `driftProgress` so the view stays quiet initially then performs a controlled, short drift instead of a long scroll. 
- Dashboard readiness gating: wait for critical anchors (`overall-progress`, `emotion-chart`, `streaks`) and a short stabilization delay before marking dashboard ready; this prevents the loop from starting while content is still painting. 
- Achievements and Editor sequences: delayed achievements carousel focus to show unlocked first (`sceneProgress < 0.68`) then blocked, added a small `onReady` delay for controls (140ms), and delayed editor actions for narrative clarity (`trigger` at 0.32, `AI` at 0.64). 
- Loop start gating and demo-mode: introduced `loopCanStart` so the timeline only runs after all scenes report ready and a 320ms settle timeout, and enable demo mode during the showcase lifecycle via `setDashboardDemoModeEnabled(true)` to guarantee demo-driven behavior. 
- Kept all changes inside `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`, reused existing demo helpers (`getDemoLogrosData`, `getDemoLogrosPreviewByTaskId`, `DEMO_DAILY_QUEST_READINESS`) and preserved `publicDemo` / `disableRemote` and hardcoded demo user usage to avoid any API/database calls.

### Testing
- Ran type checking with `npm --workspace apps/web run typecheck`, which failed due to pre-existing type errors elsewhere in the repo not introduced by this change. 
- No other automated tests were modified or run as part of this PR; the change is limited to the single labs file and compiles functionally in the demo runtime where demo hooks are already exercised by the app.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5db473508332aec5659993862370)