### PR TITLE
Replace hero phone lab with fully local mock dashboard scene

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -1,36 +1,39 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { useReducedMotion } from 'framer-motion';
-import { DashboardOverview } from '../DashboardV3';
-import { getDashboardSectionConfig } from '../dashboardSections';
-import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
-import { setDashboardDemoModeEnabled } from '../../lib/demoMode';
 import styles from './HeroPhoneShowcaseLabPage.module.css';
-
-const DEMO_DAILY_QUEST_READINESS = {
-  hasTasks: true,
-  firstTasksConfirmed: true,
-  completedFirstDailyQuest: true,
-  canOpenDailyQuest: true,
-  canShowDailyQuestPopup: true,
-  canAutoOpenDailyQuestPopup: false,
-  showOnboardingGuidance: false,
-  showJourneyPreparing: false,
-  tasksStatus: 'success' as const,
-  journeyStatus: 'success' as const,
-  journey: {
-    first_date_log: null,
-    days_of_journey: 0,
-    quantity_daily_logs: 0,
-    first_programmed: true,
-    first_tasks_confirmed: true,
-    completed_first_daily_quest: true,
-  },
-  reload: () => undefined,
-};
 
 const INITIAL_PAUSE_MS = 400;
 const SCROLL_DURATION_MS = 3000;
+
+const MOCK_PROFILE = {
+  name: 'Sofía M.',
+  gpTotal: 1280,
+  level: 9,
+  progress: 72,
+};
+
+const MOCK_ENERGY = [
+  { label: 'Body', value: 78, color: '#8fe6d5' },
+  { label: 'Mind', value: 64, color: '#9a97ff' },
+  { label: 'Soul', value: 81, color: '#f7bc8a' },
+] as const;
+
+const MOCK_BALANCE = [
+  { label: 'Body', value: 35, color: '#8fe6d5' },
+  { label: 'Mind', value: 30, color: '#9a97ff' },
+  { label: 'Soul', value: 35, color: '#f7bc8a' },
+] as const;
+
+const MOCK_EMOTION_POINTS = [58, 62, 57, 70, 66, 74, 69, 78] as const;
+
+const MOCK_STREAKS = {
+  cadence: 'FLOW · 3x / WEEK',
+  streak: '12-day streak',
+  week: 'week 3/3',
+  month: 'month 11/12',
+  quarter: '3m 29/36',
+};
 
 function easeInOut(progress: number) {
   return progress < 0.5
@@ -78,22 +81,185 @@ function PhoneFrame({ children }: { children: ReactNode }) {
   );
 }
 
-function RealDashboardScene({
-  scrollProgress,
-  onReady,
-}: {
-  scrollProgress: number;
-  onReady: () => void;
-}) {
-  const { language } = usePostLoginLanguage();
+function MockOverallProgressCard() {
+  return (
+    <article style={cardStyle}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <div
+          aria-hidden
+          style={{
+            width: 46,
+            height: 46,
+            borderRadius: '50%',
+            background: 'linear-gradient(145deg, #b991ff, #6f83ff)',
+            boxShadow: '0 0 0 2px rgba(255,255,255,0.16)',
+          }}
+        />
+        <div>
+          <p style={eyebrowStyle}>Overall Progress</p>
+          <p style={headlineStyle}>{MOCK_PROFILE.name}</p>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginTop: 14 }}>
+        <div style={metricBoxStyle}>
+          <p style={metricLabelStyle}>GP total</p>
+          <p style={metricValueStyle}>{MOCK_PROFILE.gpTotal}</p>
+        </div>
+        <div style={metricBoxStyle}>
+          <p style={metricLabelStyle}>Level</p>
+          <p style={metricValueStyle}>{MOCK_PROFILE.level}</p>
+        </div>
+      </div>
+
+      <div style={{ marginTop: 14 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+          <p style={metricLabelStyle}>Progress</p>
+          <p style={metricLabelStyle}>{MOCK_PROFILE.progress}%</p>
+        </div>
+        <div style={progressTrackStyle}>
+          <div style={{ ...progressFillStyle, width: `${MOCK_PROFILE.progress}%` }} />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function MockEnergyCard() {
+  return (
+    <article style={cardStyle}>
+      <p style={eyebrowStyle}>Daily Energy</p>
+      <div style={{ marginTop: 10, display: 'grid', gap: 10 }}>
+        {MOCK_ENERGY.map((item) => (
+          <div key={item.label}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5 }}>
+              <p style={metricLabelStyle}>{item.label}</p>
+              <p style={metricValueSmallStyle}>{item.value}</p>
+            </div>
+            <div style={progressTrackStyle}>
+              <div style={{ ...progressFillStyle, width: `${item.value}%`, background: item.color }} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+function MockBalanceCard() {
+  return (
+    <article style={cardStyle}>
+      <p style={eyebrowStyle}>Balance</p>
+      <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
+        {MOCK_BALANCE.map((item) => (
+          <div key={item.label} style={{ flex: 1 }}>
+            <p style={{ ...metricLabelStyle, marginBottom: 6 }}>{item.label}</p>
+            <div style={{ ...progressTrackStyle, height: 52, position: 'relative' }}>
+              <div
+                style={{
+                  position: 'absolute',
+                  insetInline: 0,
+                  bottom: 0,
+                  height: `${item.value}%`,
+                  borderRadius: 12,
+                  background: `linear-gradient(180deg, ${item.color}, rgba(255,255,255,0.08))`,
+                }}
+              />
+            </div>
+            <p style={{ ...metricValueSmallStyle, marginTop: 6 }}>{item.value}%</p>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+function MockEmotionChartCard({ anchorRef }: { anchorRef: React.RefObject<HTMLElement | null> }) {
+  const points = useMemo(
+    () =>
+      MOCK_EMOTION_POINTS
+        .map((value, index) => {
+          const x = 18 + index * 34;
+          const y = 96 - value;
+          return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
+        })
+        .join(' '),
+    [],
+  );
+
+  return (
+    <article ref={anchorRef} style={cardStyle}>
+      <p style={eyebrowStyle}>Emotion Chart</p>
+      <div style={{ marginTop: 12, background: 'rgba(8, 10, 24, 0.88)', borderRadius: 14, padding: 10 }}>
+        <svg viewBox="0 0 280 110" width="100%" height="110" role="img" aria-label="Mock emotion chart">
+          <defs>
+            <linearGradient id="emotionStroke" x1="0%" x2="100%" y1="0%" y2="0%">
+              <stop offset="0%" stopColor="#8fe6d5" />
+              <stop offset="100%" stopColor="#b292ff" />
+            </linearGradient>
+          </defs>
+          <path d="M 18 96 L 256 96" stroke="rgba(255,255,255,0.14)" strokeWidth="1" />
+          <path d={points} fill="none" stroke="url(#emotionStroke)" strokeWidth="3" strokeLinecap="round" />
+          {MOCK_EMOTION_POINTS.map((value, index) => {
+            const x = 18 + index * 34;
+            const y = 96 - value;
+            return <circle key={`${x}-${y}`} cx={x} cy={y} r="3.2" fill="#f4f0ff" />;
+          })}
+        </svg>
+      </div>
+    </article>
+  );
+}
+
+function MockStreaksCard({ anchorRef }: { anchorRef: React.RefObject<HTMLElement | null> }) {
+  return (
+    <article ref={anchorRef} style={{ ...cardStyle, marginBottom: 28 }}>
+      <p style={eyebrowStyle}>Streaks</p>
+      <p style={{ ...headlineStyle, marginTop: 8 }}>{MOCK_STREAKS.cadence}</p>
+      <p style={{ ...metricValueStyle, marginTop: 6 }}>{MOCK_STREAKS.streak}</p>
+      <div style={{ marginTop: 12, display: 'grid', gap: 8 }}>
+        {[MOCK_STREAKS.week, MOCK_STREAKS.month, MOCK_STREAKS.quarter].map((item) => (
+          <div key={item} style={metricBoxStyle}>
+            <p style={{ ...metricValueSmallStyle, fontWeight: 600 }}>{item}</p>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+function MockDashboardScene({ scrollProgress, onReady }: { scrollProgress: number; onReady: () => void }) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
-  const readyReportedRef = useRef(false);
+  const emotionRef = useRef<HTMLElement | null>(null);
+  const streaksRef = useRef<HTMLElement | null>(null);
+  const readyRef = useRef(false);
   const scrollRangeRef = useRef({ start: 0, end: 0 });
 
-  const section = useMemo(
-    () => getDashboardSectionConfig('dashboard', '/dashboard', language),
-    [language],
-  );
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    const emotion = emotionRef.current;
+    const streaks = streaksRef.current;
+    if (!viewport || !emotion || !streaks || readyRef.current) return;
+
+    const timer = window.setTimeout(() => {
+      const viewportRect = viewport.getBoundingClientRect();
+      const resolveTop = (element: HTMLElement) =>
+        element.getBoundingClientRect().top - viewportRect.top + viewport.scrollTop;
+      const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+      const emotionTop = resolveTop(emotion);
+      const streakTop = resolveTop(streaks);
+      const start = 0;
+      const endTarget = Math.max(emotionTop - viewport.clientHeight * 0.2, streakTop - viewport.clientHeight * 0.55);
+      const end = Math.max(start, Math.min(maxScroll, endTarget));
+
+      scrollRangeRef.current = { start, end };
+      viewport.scrollTop = start;
+      readyRef.current = true;
+      onReady();
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, [onReady]);
 
   useEffect(() => {
     const viewport = viewportRef.current;
@@ -103,77 +269,15 @@ function RealDashboardScene({
     viewport.scrollTop = start + (end - start) * scrollProgress;
   }, [scrollProgress]);
 
-  useEffect(() => {
-    const viewport = viewportRef.current;
-    if (!viewport || readyReportedRef.current) return;
-
-    let intervalId = 0;
-
-    const resolveIfReady = () => {
-      const overallProgress = viewport.querySelector<HTMLElement>('[data-demo-anchor="overall-progress"]');
-      const emotionChart = viewport.querySelector<HTMLElement>('[data-demo-anchor="emotion-chart"]');
-      const streaks = viewport.querySelector<HTMLElement>('[data-demo-anchor="streaks"]');
-      if (!overallProgress || !emotionChart || !streaks) return false;
-
-      const viewportRect = viewport.getBoundingClientRect();
-      const resolveTop = (element: HTMLElement) =>
-        element.getBoundingClientRect().top - viewportRect.top + viewport.scrollTop;
-
-      const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
-      const overallTop = resolveTop(overallProgress);
-      const emotionTop = resolveTop(emotionChart);
-      const streakTop = resolveTop(streaks);
-      const start = Math.max(0, Math.min(maxScroll, overallTop - 18));
-      const endTarget = Math.max(
-        emotionTop - viewport.clientHeight * 0.42,
-        streakTop - viewport.clientHeight * 0.28,
-      );
-      const end = Math.max(start, Math.min(maxScroll, endTarget));
-
-      scrollRangeRef.current = { start, end };
-      viewport.scrollTop = start;
-
-      readyReportedRef.current = true;
-      onReady();
-      return true;
-    };
-
-    if (!resolveIfReady()) {
-      intervalId = window.setInterval(() => {
-        if (resolveIfReady()) {
-          window.clearInterval(intervalId);
-        }
-      }, 80);
-    }
-
-    return () => {
-      if (intervalId) window.clearInterval(intervalId);
-    };
-  }, [onReady]);
-
   return (
-    <section
-      className={`${styles.scenePanel} ${styles.scenePanelSingle} ${styles.sceneDashboard}`}
-      data-light-scope="dashboard-v3"
-    >
+    <section className={`${styles.scenePanel} ${styles.scenePanelSingle}`}>
       <div ref={viewportRef} className={styles.realViewport}>
-        <div className={`${styles.realSceneScale} ${styles.dashboardSceneScale}`}>
-          <DashboardOverview
-            userId="demo-public-user"
-            gameMode="flow"
-            avatarProfile={null}
-            weeklyTarget={3}
-            isJourneyGenerating={false}
-            dailyQuestReadiness={DEMO_DAILY_QUEST_READINESS}
-            showOnboardingGuidance={false}
-            section={section}
-            onOpenReminderScheduler={() => undefined}
-            onOpenModerationEdit={() => undefined}
-            shouldShowFirstDailyQuestCta={false}
-            onOpenDailyQuest={() => undefined}
-            showOnboardingCompletionBanner={false}
-            onUpgradeAccepted={() => undefined}
-          />
+        <div style={sceneInnerStyle}>
+          <MockOverallProgressCard />
+          <MockEnergyCard />
+          <MockBalanceCard />
+          <MockEmotionChartCard anchorRef={emotionRef} />
+          <MockStreaksCard anchorRef={streaksRef} />
         </div>
       </div>
     </section>
@@ -184,16 +288,9 @@ function HeroPhoneShowcase() {
   const [dashboardReady, setDashboardReady] = useState(false);
   const scrollProgress = useDashboardScrollProgress(dashboardReady);
 
-  useEffect(() => {
-    setDashboardDemoModeEnabled(true);
-    return () => {
-      setDashboardDemoModeEnabled(false);
-    };
-  }, []);
-
   return (
     <PhoneFrame>
-      <RealDashboardScene scrollProgress={scrollProgress} onReady={() => setDashboardReady(true)} />
+      <MockDashboardScene scrollProgress={scrollProgress} onReady={() => setDashboardReady(true)} />
     </PhoneFrame>
   );
 }
@@ -224,3 +321,79 @@ export default function HeroPhoneShowcaseLabPage() {
     </main>
   );
 }
+
+const sceneInnerStyle: CSSProperties = {
+  padding: '14px 14px 0',
+  minHeight: '100%',
+  display: 'grid',
+  gap: 10,
+  background: 'linear-gradient(180deg, #070a19 0%, #050816 60%, #060712 100%)',
+};
+
+const cardStyle: CSSProperties = {
+  background: 'linear-gradient(180deg, rgba(20,24,44,0.9), rgba(9,12,27,0.92))',
+  border: '1px solid rgba(186, 174, 235, 0.26)',
+  borderRadius: 16,
+  padding: 14,
+  boxShadow: '0 10px 24px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255,255,255,0.08)',
+};
+
+const eyebrowStyle: CSSProperties = {
+  margin: 0,
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.12em',
+  color: 'rgba(224, 220, 250, 0.78)',
+};
+
+const headlineStyle: CSSProperties = {
+  margin: 0,
+  marginTop: 2,
+  fontSize: 16,
+  lineHeight: 1.15,
+  fontWeight: 700,
+  color: '#f4f0ff',
+};
+
+const metricBoxStyle: CSSProperties = {
+  borderRadius: 12,
+  border: '1px solid rgba(171, 163, 218, 0.26)',
+  background: 'rgba(10, 13, 32, 0.75)',
+  padding: '8px 10px',
+};
+
+const metricLabelStyle: CSSProperties = {
+  margin: 0,
+  fontSize: 11,
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+  color: 'rgba(219, 214, 244, 0.75)',
+};
+
+const metricValueStyle: CSSProperties = {
+  margin: 0,
+  marginTop: 4,
+  fontSize: 22,
+  fontWeight: 700,
+  color: '#fbf8ff',
+};
+
+const metricValueSmallStyle: CSSProperties = {
+  margin: 0,
+  fontSize: 14,
+  fontWeight: 700,
+  color: '#f5f1ff',
+};
+
+const progressTrackStyle: CSSProperties = {
+  height: 8,
+  borderRadius: 999,
+  background: 'rgba(234, 229, 255, 0.12)',
+  overflow: 'hidden',
+};
+
+const progressFillStyle: CSSProperties = {
+  height: '100%',
+  borderRadius: 999,
+  background: 'linear-gradient(90deg, #8fe6d5, #9a97ff)',
+};


### PR DESCRIPTION
### Motivation
- Replace the current mobile demo scene which depended on DashboardOverview and demo/auth hooks with a fully local, visual-only mock so the lab is stable and has no remote dependencies.
- Provide a single, attractive dashboard scene inside the existing phone frame that shows clear hardcoded data and a smooth vertical presentation for product/design review.
- Ensure the lab contains no API/auth/backend/provider hooks, no loading or error states, and no use of `DashboardOverview`, `DemoDashboardPage`, or other components that pull remote data.

### Description
- Removed the `DashboardOverview` usage and related demo/auth imports (`getDashboardSectionConfig`, `usePostLoginLanguage`, `setDashboardDemoModeEnabled`) and replaced the phone scene with a local `MockDashboardScene` inside `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`.
- Implemented local mock components in the same file: `MockOverallProgressCard`, `MockEnergyCard`, `MockBalanceCard`, `MockEmotionChartCard`, and `MockStreaksCard`, all driven by hardcoded constants (`MOCK_PROFILE`, `MOCK_ENERGY`, `MOCK_BALANCE`, `MOCK_EMOTION_POINTS`, `MOCK_STREAKS`).
- Kept the existing `PhoneFrame`, respected reduced-motion via `useReducedMotion`, and implemented the requested scroll choreography with an initial pause of `0.4s` and a ~`3s` smooth scroll using `requestAnimationFrame` and an `easeInOut` easing function.
- Ensured the scene is visual-only, dark/premium styled, contains the required visible values (`GP total: 1280`, `Level: 9`, `Progress: 72%`, `Daily Energy` values, `Balance` percentages, emotion chart points, and streaks text), and does not reference any API/auth/backend hooks or remote providers.

### Testing
- Ran TypeScript compile for the web app with `pnpm -C apps/web exec tsc --noEmit`, which failed due to unrelated, pre-existing type errors elsewhere in the repository (the failure is not caused by the changes in this file).
- Attempted ESLint for the file with `pnpm -C apps/web exec eslint src/pages/labs/HeroPhoneShowcaseLabPage.tsx`, which could not run in this environment because the workspace lacks an ESLint v9 flat `eslint.config.js` (not a failure introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6e142c5c8332b4995ba82d06d50b)