### PR TITLE
Auto-open editor guide for public demo after 1.5s (start on wheel-core)

### DIFF
--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -243,27 +243,27 @@ export default function TaskEditorPage({ publicDemo = false }: TaskEditorPagePro
     if (!ENABLE_EDITOR_GUIDE_AUTO_OPEN) {
       return;
     }
+
+    if (publicDemo) {
+      setShowGuideModal(false);
+      setActiveGuideStepId("wheel-core");
+      const timeoutId = window.setTimeout(() => {
+        setActiveGuideStepId("wheel-core");
+        setShowGuideModal(true);
+      }, PUBLIC_DEMO_EDITOR_GUIDE_AUTO_OPEN_DELAY_MS);
+
+      return () => {
+        window.clearTimeout(timeoutId);
+      };
+    }
+
     if (!shouldAutoOpenEditorGuide()) {
       return;
     }
 
-    if (!publicDemo) {
-      setActiveGuideStepId("wheel-core");
-      setShowGuideModal(true);
-      return;
-    }
-
-    setShowGuideModal(false);
     setActiveGuideStepId("wheel-core");
-    const timeoutId = window.setTimeout(() => {
-      setActiveGuideStepId("wheel-core");
-      setShowGuideModal(true);
-    }, PUBLIC_DEMO_EDITOR_GUIDE_AUTO_OPEN_DELAY_MS);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [publicDemo]);
+    setShowGuideModal(true);
+  }, [location.key, publicDemo]);
 
   useEffect(() => {
     const missingTraitsByPillar = new Map<string, Set<string>>();


### PR DESCRIPTION
### Motivation
- Asegurar que al entrar a la demo pública del Editor se muestre primero la pantalla base durante `1500ms` y luego se abra automáticamente la guía empezando siempre en el paso introductorio `wheel-core`.
- Aplicar este comportamiento solo para `publicDemo` y evitar que la guía aparezca en un paso anterior o provoque flicker/doble apertura.
- Forzar el paso `wheel-core` antes de programar el timeout y justo antes de abrir el modal para evitar reaparición en un paso distinto.
- Limpiar correctamente cualquier timeout para evitar timers colgantes y condiciones de carrera con la navegación.

### Description
- Actualicé el efecto de auto-apertura en `apps/web/src/pages/editor/index.tsx` para separar explícitamente el flujo `publicDemo` del flujo normal; el flujo demo ahora ejecuta `setShowGuideModal(false)` y `setActiveGuideStepId("wheel-core")` antes de crear un `setTimeout` de `PUBLIC_DEMO_EDITOR_GUIDE_AUTO_OPEN_DELAY_MS` y vuelve a forzar `setActiveGuideStepId("wheel-core")` justo antes de abrir el modal.
- Añadí cleanup del timeout con `window.clearTimeout(timeoutId)` en el `return` del efecto para prevenir doble apertura y flicker.
- Mantuve el flujo del editor normal (no `publicDemo`) gobernado por `shouldAutoOpenEditorGuide()` y sin cambios en el botón manual “Ver guía” (sigue llamando `setShowGuideModal(true)`).
- Cambié las dependencias del efecto a `[location.key, publicDemo]` para que la inicialización se reinicie correctamente en cambios de navegación relevantes.

### Testing
- Ejecuté intentos de lint focalizado (`pnpm`/`eslint`) contra `apps/web/src/pages/editor/index.tsx`, que no pudieron completarse por la configuración del workspace o falta de `eslint.config.*` en la ruta, por lo que no se obtuvo un resultado de lint válido.
- Ejecuté `npm --workspace apps/web run typecheck`, que falló por errores de TypeScript preexistentes en múltiples archivos no relacionados con este cambio, por lo que no fue posible validar el cambio mediante `tsc` en este entorno.
- No se detectaron errores introducidos por esta modificación durante las comprobaciones realizadas y no se tocaron los handlers manuales de la guía; no se ejecutaron tests automatizados end-to-end del comportamiento visual en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6e2db8348332b603ffab15809ed1)