### PR TITLE
Reuse DemoDashboard composition in hero phone showcase lab

### DIFF
--- a/apps/web/src/components/demo/DemoDashboardOverviewScene.tsx
+++ b/apps/web/src/components/demo/DemoDashboardOverviewScene.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+import { DashboardOverview } from '../../pages/DashboardV3';
+import { getDashboardSectionConfig } from '../../pages/dashboardSections';
+import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
+import type { DailyQuestReadiness } from '../../hooks/useDailyQuestReadiness';
+import type { GameMode } from '../../lib/gameMode';
+
+export const DEMO_USER_ID = 'demo-public-user';
+
+export const DEMO_DAILY_QUEST_READINESS: DailyQuestReadiness = {
+  hasTasks: true,
+  firstTasksConfirmed: true,
+  completedFirstDailyQuest: true,
+  canOpenDailyQuest: true,
+  canShowDailyQuestPopup: true,
+  canAutoOpenDailyQuestPopup: false,
+  showOnboardingGuidance: false,
+  showJourneyPreparing: false,
+  tasksStatus: 'success',
+  journeyStatus: 'success',
+  journey: {
+    first_date_log: null,
+    days_of_journey: 0,
+    quantity_daily_logs: 0,
+    first_programmed: true,
+    first_tasks_confirmed: true,
+    completed_first_daily_quest: true,
+  },
+  reload: () => undefined,
+};
+
+interface DemoDashboardOverviewSceneProps {
+  gameMode?: GameMode | string | null;
+  onOpenDailyQuest?: () => void;
+}
+
+export function DemoDashboardOverviewScene({
+  gameMode = 'flow',
+  onOpenDailyQuest,
+}: DemoDashboardOverviewSceneProps) {
+  const { language } = usePostLoginLanguage();
+  const overviewSection = useMemo(
+    () => getDashboardSectionConfig('dashboard', '/dashboard', language),
+    [language],
+  );
+
+  return (
+    <DashboardOverview
+      userId={DEMO_USER_ID}
+      gameMode={gameMode}
+      avatarProfile={null}
+      weeklyTarget={3}
+      isJourneyGenerating={false}
+      dailyQuestReadiness={DEMO_DAILY_QUEST_READINESS}
+      showOnboardingGuidance={false}
+      section={overviewSection}
+      onOpenReminderScheduler={() => undefined}
+      onOpenModerationEdit={() => undefined}
+      shouldShowFirstDailyQuestCta={false}
+      onOpenDailyQuest={onOpenDailyQuest ?? (() => undefined)}
+      showOnboardingCompletionBanner={false}
+      onUpgradeAccepted={() => undefined}
+    />
+  );
+}

--- a/apps/web/src/pages/DemoDashboard.tsx
+++ b/apps/web/src/pages/DemoDashboard.tsx
@@ -2,9 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties }
 import { useAuth } from '@clerk/clerk-react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Navbar } from '../components/layout/Navbar';
-import { DashboardOverview } from './DashboardV3';
-import type { DailyQuestReadiness } from '../hooks/useDailyQuestReadiness';
-import { getDashboardSectionConfig } from './dashboardSections';
 import { usePostLoginLanguage } from '../i18n/postLoginLanguage';
 import { useThemePreference } from '../theme/ThemePreferenceProvider';
 import { emitDemoEvent } from '../lib/telemetry';
@@ -16,32 +13,9 @@ import { getPublicDemoHubPath, resolveDemoEntryContext } from '../lib/demoEntry'
 import { getLabsGameModeConfig } from '../config/labsGameModes';
 import { DASHBOARD_PATH } from '../config/auth';
 import { usePageMeta } from '../lib/seo';
-
-const DEMO_USER_ID = 'demo-public-user';
+import { DemoDashboardOverviewScene } from '../components/demo/DemoDashboardOverviewScene';
 
 const DEMO_SHARE_IMAGE = 'https://innerbloomjourney.org/og/neneOGP.png';
-
-const DEMO_DAILY_QUEST_READINESS: DailyQuestReadiness = {
-  hasTasks: true,
-  firstTasksConfirmed: true,
-  completedFirstDailyQuest: true,
-  canOpenDailyQuest: true,
-  canShowDailyQuestPopup: true,
-  canAutoOpenDailyQuestPopup: false,
-  showOnboardingGuidance: false,
-  showJourneyPreparing: false,
-  tasksStatus: 'success',
-  journeyStatus: 'success',
-  journey: {
-    first_date_log: null,
-    days_of_journey: 0,
-    quantity_daily_logs: 0,
-    first_programmed: true,
-    first_tasks_confirmed: true,
-    completed_first_daily_quest: true,
-  },
-  reload: () => undefined,
-};
 
 const DAILY_QUEST_STEP_IDS = new Set([
   'daily-quest-intro',
@@ -139,8 +113,6 @@ export default function DemoDashboardPage() {
 
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [dashboardPath, demoContext.fromOnboarding, demoContext.mode, demoContext.source, guidedSteps.length, navigate, userId]);
-
-  const overviewSection = getDashboardSectionConfig('dashboard', '/dashboard', language);
 
   return (
     <div className="min-h-screen bg-transparent" data-light-scope="dashboard-v3">
@@ -242,21 +214,9 @@ export default function DemoDashboardPage() {
         data-demo-mode={demoContext.mode}
         style={{ '--demo-mode-accent': selectedModeConfig.accentColor } as CSSProperties}
       >
-        <DashboardOverview
-          userId={DEMO_USER_ID}
+        <DemoDashboardOverviewScene
           gameMode={demoContext.gameMode}
-          avatarProfile={null}
-          weeklyTarget={3}
-          isJourneyGenerating={false}
-          dailyQuestReadiness={DEMO_DAILY_QUEST_READINESS}
-          showOnboardingGuidance={false}
-          section={overviewSection}
-          onOpenReminderScheduler={() => undefined}
-          onOpenModerationEdit={() => undefined}
-          shouldShowFirstDailyQuestCta={false}
           onOpenDailyQuest={() => dailyQuestModalRef.current?.open()}
-          showOnboardingCompletionBanner={false}
-          onUpgradeAccepted={() => undefined}
         />
       </main>
     </div>

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -1,33 +1,9 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { useReducedMotion } from 'framer-motion';
-import { DashboardOverview } from '../DashboardV3';
-import { getDashboardSectionConfig } from '../dashboardSections';
-import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
 import { setDashboardDemoModeEnabled } from '../../lib/demoMode';
+import { DemoDashboardOverviewScene } from '../../components/demo/DemoDashboardOverviewScene';
 import styles from './HeroPhoneShowcaseLabPage.module.css';
-
-const DEMO_DAILY_QUEST_READINESS = {
-  hasTasks: true,
-  firstTasksConfirmed: true,
-  completedFirstDailyQuest: true,
-  canOpenDailyQuest: true,
-  canShowDailyQuestPopup: true,
-  canAutoOpenDailyQuestPopup: false,
-  showOnboardingGuidance: false,
-  showJourneyPreparing: false,
-  tasksStatus: 'success' as const,
-  journeyStatus: 'success' as const,
-  journey: {
-    first_date_log: null,
-    days_of_journey: 0,
-    quantity_daily_logs: 0,
-    first_programmed: true,
-    first_tasks_confirmed: true,
-    completed_first_daily_quest: true,
-  },
-  reload: () => undefined,
-};
 
 const INITIAL_PAUSE_MS = 400;
 const SCROLL_DURATION_MS = 3000;
@@ -85,15 +61,9 @@ function RealDashboardScene({
   scrollProgress: number;
   onReady: () => void;
 }) {
-  const { language } = usePostLoginLanguage();
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const readyReportedRef = useRef(false);
   const scrollRangeRef = useRef({ start: 0, end: 0 });
-
-  const section = useMemo(
-    () => getDashboardSectionConfig('dashboard', '/dashboard', language),
-    [language],
-  );
 
   useEffect(() => {
     const viewport = viewportRef.current;
@@ -158,22 +128,7 @@ function RealDashboardScene({
     >
       <div ref={viewportRef} className={styles.realViewport}>
         <div className={`${styles.realSceneScale} ${styles.dashboardSceneScale}`}>
-          <DashboardOverview
-            userId="demo-public-user"
-            gameMode="flow"
-            avatarProfile={null}
-            weeklyTarget={3}
-            isJourneyGenerating={false}
-            dailyQuestReadiness={DEMO_DAILY_QUEST_READINESS}
-            showOnboardingGuidance={false}
-            section={section}
-            onOpenReminderScheduler={() => undefined}
-            onOpenModerationEdit={() => undefined}
-            shouldShowFirstDailyQuestCta={false}
-            onOpenDailyQuest={() => undefined}
-            showOnboardingCompletionBanner={false}
-            onUpgradeAccepted={() => undefined}
-          />
+          <DemoDashboardOverviewScene gameMode="flow" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Provide a clean phone-hero variant of the real demo dashboard without inventing fake UI by reusing the composition already used by the demo page. 
- Keep the hero showcase visually faithful to the real `DashboardOverview` (avatar + progress, emotion chart, streaks) while isolating it inside a phone frame. 
- Ensure the hero uses demo/mock data (no real backend, no auth, no guided demo or full-page chrome). 

### Description
- Extracted a reusable scene component `DemoDashboardOverviewScene` that mounts the real `DashboardOverview` with demo mock inputs and section config from `getDashboardSectionConfig` (`apps/web/src/components/demo/DemoDashboardOverviewScene.tsx`).
- Updated `DemoDashboard` to render `DemoDashboardOverviewScene` inside its `<main>` so the demo page remains the source-of-truth composition (`apps/web/src/pages/DemoDashboard.tsx`).
- Replaced the isolated `DashboardOverview` usage in the labs hero with `DemoDashboardOverviewScene` and kept the phone frame + smooth vertical auto-scroll (~3000ms easing) that targets real anchors (`overall-progress`, `emotion-chart`, `streaks`) (`apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`).
- Preserved demo-mode behavior via `setDashboardDemoModeEnabled(true)` so the dashboard reads demo/mock responses from the existing `api` demo branches and the change does not introduce new backend/auth dependencies.

### Testing
- Ran ESLint on the changed files with `pnpm -C apps/web exec eslint ...` which failed due to a missing ESLint flat config in this environment (repository-wide configuration issue), not introduced by this change. 
- Ran TypeScript check with `pnpm -C apps/web exec tsc --noEmit` which failed due to pre-existing project-wide TypeScript errors in unrelated files, so no type errors attributable to these edits were introduced.
- Confirmed by code inspection that the hero mounts the real overview composition and that demo-mode flag is toggled where the phone scene is mounted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea942473d0833298c6e780d072cafb)