### PR TITLE
Gate hero lab dashboard render until demo mode enabled to ensure demo/mock data

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -137,18 +137,29 @@ function RealDashboardScene({
 
 function HeroPhoneShowcase() {
   const [dashboardReady, setDashboardReady] = useState(false);
+  const [demoDataReady, setDemoDataReady] = useState(false);
   const scrollProgress = useDashboardScrollProgress(dashboardReady);
 
   useEffect(() => {
     setDashboardDemoModeEnabled(true);
+    setDemoDataReady(true);
     return () => {
+      setDemoDataReady(false);
       setDashboardDemoModeEnabled(false);
     };
   }, []);
 
   return (
     <PhoneFrame>
-      <RealDashboardScene scrollProgress={scrollProgress} onReady={() => setDashboardReady(true)} />
+      {demoDataReady ? (
+        <RealDashboardScene scrollProgress={scrollProgress} onReady={() => setDashboardReady(true)} />
+      ) : (
+        <section
+          className={`${styles.scenePanel} ${styles.scenePanelSingle} ${styles.sceneDashboard}`}
+          data-light-scope="dashboard-v3"
+          aria-hidden
+        />
+      )}
     </PhoneFrame>
   );
 }


### PR DESCRIPTION
### Motivation
- Prevent dashboard components in the Hero phone lab from issuing real/backend-auth requests on first mount (which produced visible error/fallback states) by ensuring demo mode is active before the real dashboard scene mounts.

### Description
- Add a local `demoDataReady` flag in `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx` and only mount the `RealDashboardScene` after calling `setDashboardDemoModeEnabled(true)`, leaving the real `DemoDashboardOverviewScene`/`DashboardOverview` and smooth scroll logic unchanged.

### Testing
- Ran the workspace type check with `npm --workspace apps/web run typecheck`, which failed due to unrelated preexisting TypeScript errors elsewhere in the codebase (no new type errors introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9628b27c833290e9a9422a616e24)