### PR TITLE
Require maintained lifecycle status before cloning tasks on edit

### DIFF
--- a/apps/api/src/services/user-tasks.service.ts
+++ b/apps/api/src/services/user-tasks.service.ts
@@ -115,7 +115,11 @@ async function resolveXpBase(difficultyId: number | null | undefined): Promise<n
 const emptyUpdateMessage = 'At least one property must be provided';
 const EDIT_CONTINUITY_DAYS = 35;
 
-function shouldCloneTaskOnEdit(createdAt: string, now: Date): boolean {
+function shouldCloneTaskOnEdit(createdAt: string, lifecycleStatus: string | null | undefined, now: Date): boolean {
+  if (lifecycleStatus !== 'achievement_maintained') {
+    return false;
+  }
+
   const created = new Date(createdAt);
   const boundary = new Date(created.getTime());
   boundary.setUTCDate(boundary.getUTCDate() + EDIT_CONTINUITY_DAYS);
@@ -184,7 +188,7 @@ export async function updateUserTaskRow(
     throw new HttpError(404, 'task_not_found', 'Task not found');
   }
 
-  const shouldClone = shouldCloneTaskOnEdit(currentTask.created_at, new Date());
+  const shouldClone = shouldCloneTaskOnEdit(currentTask.created_at, currentTask.lifecycle_status, new Date());
   if (shouldClone) {
     const nextTaskId = randomUUID();
     const nextTitle = payload.title ?? currentTask.task;


### PR DESCRIPTION
### Motivation
- Prevent normal task updates from entering the clone flow simply because a task is older than the continuity threshold, which was causing 500 errors during task update tests.

### Description
- Update `shouldCloneTaskOnEdit` to accept a `lifecycleStatus` argument and only return true when `lifecycleStatus === 'achievement_maintained'`, and pass `currentTask.lifecycle_status` into the clone decision during `updateUserTaskRow` in `apps/api/src/services/user-tasks.service.ts`.

### Testing
- Ran `cd apps/api && npx vitest run src/controllers/tasks/update-user-task.test.ts` and all tests in that file passed (5 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1659fc988332ae8c5b3ed1d9cf66)