### PR TITLE
Hero phone: loop de scroll continuo y enfoque hero-safe del dashboard

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -147,6 +147,28 @@
   box-sizing: border-box;
 }
 
+
+.heroFocusContent > :global(.space-y-6) > :first-child {
+  display: none !important;
+}
+
+.heroFocusContent :global([data-demo-anchor="daily-energy"]),
+.heroFocusContent :global([data-demo-anchor="daily-cultivation"]),
+.heroFocusContent :global([data-demo-anchor="moderation"]),
+.heroFocusContent :global([data-demo-anchor="balance"]) {
+  display: none !important;
+}
+
+.heroFocusContent :global(.order-1),
+.heroFocusContent :global(.order-3 > :not([data-demo-anchor="emotion-chart"])),
+.heroFocusContent :global(.order-4 > :not([data-demo-anchor="streaks"])) {
+  display: none !important;
+}
+
+.heroFocusViewport {
+  padding-bottom: 88px;
+}
+
 .sceneDashboard :global(.lg\:grid-cols-12) {
   grid-template-columns: minmax(0, 1fr) !important;
 }

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -5,13 +5,15 @@ import { setDashboardDemoModeEnabled } from '../../lib/demoMode';
 import { DemoDashboardOverviewScene } from '../../components/demo/DemoDashboardOverviewScene';
 import styles from './HeroPhoneShowcaseLabPage.module.css';
 
-const INITIAL_PAUSE_MS = 400;
-const SCROLL_DURATION_MS = 3000;
+const INITIAL_TOP_PAUSE_MS = 500;
+const SCROLL_DOWN_DURATION_MS = 3000;
+const RESET_TO_TOP_DURATION_MS = 300;
+const LOOP_TOP_PAUSE_MS = 350;
+const LOOP_DURATION_MS =
+  INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + RESET_TO_TOP_DURATION_MS + LOOP_TOP_PAUSE_MS;
 
-function easeInOut(progress: number) {
-  return progress < 0.5
-    ? 4 * progress * progress * progress
-    : 1 - Math.pow(-2 * progress + 2, 3) / 2;
+function smoothProgress(progress: number) {
+  return progress * progress * (3 - 2 * progress);
 }
 
 function useDashboardScrollProgress(isReady: boolean) {
@@ -25,24 +27,35 @@ function useDashboardScrollProgress(isReady: boolean) {
     }
 
     let rafId = 0;
-    const start = performance.now();
+    const startedAt = performance.now();
 
     const tick = (now: number) => {
-      const elapsed = now - start;
-      const movementElapsed = Math.max(0, elapsed - INITIAL_PAUSE_MS);
-      const nextProgress = Math.min(1, movementElapsed / SCROLL_DURATION_MS);
-      setProgress(nextProgress);
+      const elapsedInLoop = (now - startedAt) % LOOP_DURATION_MS;
 
-      if (nextProgress < 1) {
-        rafId = window.requestAnimationFrame(tick);
+      if (elapsedInLoop < INITIAL_TOP_PAUSE_MS) {
+        setProgress(0);
+      } else if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS) {
+        const downElapsed = elapsedInLoop - INITIAL_TOP_PAUSE_MS;
+        setProgress(smoothProgress(downElapsed / SCROLL_DOWN_DURATION_MS));
+      } else if (
+        elapsedInLoop <
+        INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + RESET_TO_TOP_DURATION_MS
+      ) {
+        const resetElapsed =
+          elapsedInLoop - INITIAL_TOP_PAUSE_MS - SCROLL_DOWN_DURATION_MS;
+        setProgress(1 - resetElapsed / RESET_TO_TOP_DURATION_MS);
+      } else {
+        setProgress(0);
       }
+
+      rafId = window.requestAnimationFrame(tick);
     };
 
     rafId = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(rafId);
   }, [isReady, prefersReducedMotion]);
 
-  return prefersReducedMotion || !isReady ? 0 : easeInOut(progress);
+  return prefersReducedMotion || !isReady ? 0 : progress;
 }
 
 function PhoneFrame({ children }: { children: ReactNode }) {
@@ -127,8 +140,10 @@ function RealDashboardScene({
       data-light-scope="dashboard-v3"
     >
       <div ref={viewportRef} className={styles.realViewport}>
-        <div className={styles.mobileDashboardRoot}>
-          <DemoDashboardOverviewScene gameMode="flow" />
+        <div className={`${styles.mobileDashboardRoot} ${styles.heroFocusViewport}`}>
+          <div className={styles.heroFocusContent}>
+            <DemoDashboardOverviewScene gameMode="flow" />
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Enfocar la demo del dashboard dentro del marco de teléfono mostrando solo las señales clave (Overall Progress, Avatar, Emotion Chart, Streaks) y exponer un recorrido suave y premium en loop para el hero showcase.
- Evitar rehacer la UI ni tocar datos reales, usando los componentes reales del dashboard y los datos mock ya existentes.

### Description
- Implementé un loop de scroll controlado en `useDashboardScrollProgress` con fases explícitas: pausa arriba `500ms`, bajada suave `3000ms` (`smoothProgress`), reset rápido arriba `300ms`, pausa breve arriba `350ms`, repitiendo continuamente con `requestAnimationFrame` y respetando `prefers-reduced-motion`.
- Añadí un contenedor hero-safe (`heroFocusViewport` / `heroFocusContent`) alrededor de `DemoDashboardOverviewScene` y apliqué reglas CSS específicas para ocultar secciones no deseadas usando selectores sobre `data-demo-anchor` y órdenes de layout, manteniendo `Overall Progress` + `Avatar` arriba, luego `Emotion Chart`, luego `Streaks`.
- No se modificaron los componentes del dashboard ni la fuente de datos; la variante se logra mediante composición y CSS scoped en la página de laboratorio.
- Archivos modificados: `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx` y `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`.

### Testing
- Ejecuté `pnpm -C apps/web exec eslint` sobre los archivos tocados y la invocación falló por configuración de ESLint del repositorio (no se encontró `eslint.config.*`).
- Ejecuté `pnpm -C apps/web exec tsc --noEmit` y el chequeo TypeScript falló por errores preexistentes en múltiples ficheros fuera del alcance de este cambio; no son errores introducidos por esta PR.
- Local runtime validation steps done in code: el hook de preparación detecta anclas `data-demo-anchor` (`overall-progress`, `emotion-chart`, `streaks`) y calcula el rango de scroll antes de iniciar el loop; `prefers-reduced-motion` detiene la animación si aplica.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1b3266f08332b6e9e759737c508b)