### PR TITLE
Ajusta framing del Hero Phone Showcase y extiende duración del scroll un 50%

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -169,6 +169,46 @@
   padding-bottom: 88px;
 }
 
+.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card > .relative) {
+  gap: 0.7rem;
+  padding: 0.4rem 0.45rem 0.6rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card header) {
+  gap: 0.5rem;
+  padding-top: 0.2rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card header h3) {
+  font-size: 0.7rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card header [class*="inline-flex"]) {
+  transform: scale(0.94);
+  transform-origin: top right;
+}
+
+.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card .text-4xl) {
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card .text-\[2\.5em\]) {
+  font-size: 2.05em;
+}
+
+.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card .space-y-3) {
+  row-gap: 0.5rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card .h-6) {
+  height: 1.2rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card [role="progressbar"] span) {
+  font-size: 10px;
+}
+
 .sceneDashboard :global(.lg\:grid-cols-12) {
   grid-template-columns: minmax(0, 1fr) !important;
 }

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -6,7 +6,7 @@ import { DemoDashboardOverviewScene } from '../../components/demo/DemoDashboardO
 import styles from './HeroPhoneShowcaseLabPage.module.css';
 
 const INITIAL_TOP_PAUSE_MS = 500;
-const SCROLL_DOWN_DURATION_MS = 3000;
+const SCROLL_DOWN_DURATION_MS = 4500;
 const RESET_TO_TOP_DURATION_MS = 300;
 const LOOP_TOP_PAUSE_MS = 350;
 const LOOP_DURATION_MS =
@@ -109,7 +109,7 @@ function RealDashboardScene({
       const start = Math.max(0, Math.min(maxScroll, overallTop - 18));
       const endTarget = Math.max(
         emotionTop - viewport.clientHeight * 0.42,
-        streakTop - viewport.clientHeight * 0.28,
+        streakTop - viewport.clientHeight * 0.16,
       );
       const end = Math.max(start, Math.min(maxScroll, endTarget));
 


### PR DESCRIPTION
### Motivation
- Mejorar el encuadre del hero mobile para que el bloque de **Overall Progress** consuma menos altura visual sin perder información (avatar, GP, nivel, barra de progreso). 
- Hacer que el panel de **Streaks** sea más visible en el recorrido de demo (header + selector BODY/MIND/SOUL + más contenido útil) gracias a un ajuste de framing, sin mostrar todo el panel ni reestructurar la UI. 
- Mantener la misma sensación de movimiento pero alargar la duración de la animación de scroll en un 50% conservando pausa inicial, easing y loop. 

### Description
- Incrementé `SCROLL_DOWN_DURATION_MS` de `3000` a `4500` ms para alargar la fase de bajada 50% y así mantener la misma suavidad pero más tiempo total (`apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`).
- Ajusté el cálculo del target final del scroll para priorizar la visibilidad de Streaks cambiando el offset de `streakTop - viewport.clientHeight * 0.28` a `streakTop - viewport.clientHeight * 0.16`, para que el header y el selector queden más a la vista (`apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`).
- Añadí overrides CSS fuertemente acotados al scope del hero (selectores dentro de `.heroFocusContent` apuntando a `[data-demo-anchor="overall-progress"]`) para compactar spacing interno, tamaños de tipografía y altura de la barra de progreso sin tocar el resto del dashboard ni los datos (`apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`).
- Cambios intencionalmente quirúrgicos y localizados: no se modificó la arquitectura, los mocks, ni se añadieron secciones nuevas; solo ajuste de timing, framing y scoping visual del card de métricas.

### Testing
- Se ejecutó `npm run typecheck:web` y falló por errores de TypeScript preexistentes en otros módulos no relacionados con estos cambios, por lo que no pasó la comprobación de `tsc` (fallo preexistente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1ed9b08483329c33481cc108c7fa)