### PR TITLE
Refinar hero phone showcase: cards más compactas y Emotion Chart con continuidad temporal

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2135,20 +2135,74 @@ function normalizeEmotionDate(raw: unknown): string | null {
   return null;
 }
 
+function addDaysIso(isoDate: string, days: number): string {
+  const [year, month, day] = isoDate.split('-').map((part) => Number(part));
+  const date = new Date(year, month - 1, day);
+  date.setDate(date.getDate() + days);
+  return formatDateKey(date);
+}
+
+function buildContiguousDemoEmotionSnapshots(): EmotionSnapshot[] {
+  const segments: Array<{ start: string; mood: EmotionSnapshot['mood']; days: number }> = [
+    { start: '2025-10-01', mood: 'Calma', days: 4 },
+    { start: '2025-10-06', mood: 'Motivación', days: 5 },
+    { start: '2025-10-11', mood: 'Felicidad', days: 3 },
+    { start: '2025-10-15', mood: 'Cansancio', days: 2 },
+    { start: '2025-10-17', mood: 'Calma', days: 4 },
+    { start: '2025-10-22', mood: 'Motivación', days: 6 },
+    { start: '2025-10-28', mood: 'Ansiedad', days: 2 },
+    { start: '2025-10-30', mood: 'Calma', days: 5 },
+    { start: '2025-11-05', mood: 'Felicidad', days: 4 },
+    { start: '2025-11-09', mood: 'Motivación', days: 6 },
+    { start: '2025-11-16', mood: 'Frustración', days: 3 },
+    { start: '2025-11-19', mood: 'Calma', days: 5 },
+    { start: '2025-11-24', mood: 'Motivación', days: 6 },
+    { start: '2025-12-01', mood: 'Cansancio', days: 3 },
+    { start: '2025-12-04', mood: 'Felicidad', days: 4 },
+    { start: '2025-12-08', mood: 'Motivación', days: 5 },
+    { start: '2025-12-14', mood: 'Tristeza', days: 2 },
+    { start: '2025-12-16', mood: 'Calma', days: 5 },
+    { start: '2025-12-21', mood: 'Motivación', days: 6 },
+    { start: '2025-12-28', mood: 'Felicidad', days: 4 },
+    { start: '2026-01-01', mood: 'Calma', days: 4 },
+    { start: '2026-01-05', mood: 'Motivación', days: 6 },
+    { start: '2026-01-12', mood: 'Ansiedad', days: 2 },
+    { start: '2026-01-14', mood: 'Calma', days: 4 },
+    { start: '2026-01-18', mood: 'Motivación', days: 6 },
+    { start: '2026-01-25', mood: 'Felicidad', days: 4 },
+    { start: '2026-01-29', mood: 'Calma', days: 4 },
+    { start: '2026-02-02', mood: 'Motivación', days: 6 },
+    { start: '2026-02-09', mood: 'Frustración', days: 2 },
+    { start: '2026-02-11', mood: 'Calma', days: 4 },
+    { start: '2026-02-15', mood: 'Motivación', days: 5 },
+    { start: '2026-02-21', mood: 'Felicidad', days: 3 },
+    { start: '2026-02-24', mood: 'Calma', days: 3 },
+    { start: '2026-02-27', mood: 'Motivación', days: 5 },
+    { start: '2026-03-04', mood: 'Cansancio', days: 2 },
+    { start: '2026-03-06', mood: 'Calma', days: 3 },
+    { start: '2026-03-09', mood: 'Motivación', days: 5 },
+    { start: '2026-03-14', mood: 'Felicidad', days: 4 },
+    { start: '2026-03-18', mood: 'Calma', days: 3 },
+    { start: '2026-03-21', mood: 'Motivación', days: 4 },
+  ];
+
+  const snapshots: EmotionSnapshot[] = [];
+
+  for (const segment of segments) {
+    for (let offset = 0; offset < segment.days; offset += 1) {
+      snapshots.push({
+        date: addDaysIso(segment.start, offset),
+        mood: segment.mood,
+      });
+    }
+  }
+
+  return snapshots;
+}
+
 export async function getEmotions(userId: string, params: EmotionQuery = {}): Promise<EmotionSnapshot[]> {
   if (isDashboardDemoModeEnabled()) {
-    return [
-      { date: '2025-10-03', mood: 'Calma' }, { date: '2025-10-08', mood: 'Motivación' },
-      { date: '2025-10-14', mood: 'Felicidad' }, { date: '2025-10-20', mood: 'Tristeza' },
-      { date: '2025-10-24', mood: 'Motivación' }, { date: '2025-11-02', mood: 'Calma' },
-      { date: '2025-11-11', mood: 'Frustración' }, { date: '2025-11-20', mood: 'Ansiedad' },
-      { date: '2025-12-02', mood: 'Cansancio' }, { date: '2025-12-10', mood: 'Felicidad' },
-      { date: '2025-12-19', mood: 'Motivación' }, { date: '2026-01-03', mood: 'Calma' },
-      { date: '2026-01-09', mood: 'Cansancio' }, { date: '2026-01-17', mood: 'Motivación' },
-      { date: '2026-01-25', mood: 'Felicidad' }, { date: '2026-02-05', mood: 'Calma' },
-      { date: '2026-02-14', mood: 'Motivación' }, { date: '2026-02-23', mood: 'Ansiedad' },
-      { date: '2026-03-01', mood: 'Motivación' },
-    ];
+    return buildContiguousDemoEmotionSnapshots();
   }
   const response = await getAuthorizedJson<
     EmotionLogResponse | EmotionLogEntry[] | { emotions?: unknown; days?: unknown }

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -209,6 +209,68 @@
   font-size: 10px;
 }
 
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card > .relative),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card > .relative) {
+  padding: 0.45rem 0.55rem 0.6rem;
+  gap: 0.7rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card header),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card header) {
+  gap: 0.45rem 0.6rem;
+  padding-top: 0.15rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card header h3),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card header h3) {
+  font-size: 0.72rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card header p),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card header p) {
+  font-size: 0.62rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card > .relative > .flex.flex-col.gap-4),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card > .relative > .flex.flex-col.gap-4) {
+  gap: 0.65rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card .emotion-highlight-indicator) {
+  width: 1.95rem;
+  height: 1.95rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="summary"] .summary-inner) {
+  padding: 0.55rem 0.65rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="heatmap"]) {
+  --emotion-heatmap-min-h: 0px;
+}
+
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="heatmap"] .emotion-chart-surface) {
+  padding: 0.35rem 0.45rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-top"]),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-bottom"]) {
+  row-gap: 0.6rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-top"] > section),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-bottom"] > section) {
+  row-gap: 0.55rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card .grid.grid-cols-1.gap-3) {
+  gap: 0.45rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [class*="rounded-ib-md"]) {
+  min-height: 4.65rem;
+}
+
 .sceneDashboard :global(.lg\:grid-cols-12) {
   grid-template-columns: minmax(0, 1fr) !important;
 }


### PR DESCRIPTION
### Motivation
- Mejorar la presentación del hero phone sin alterar el framing ni la arquitectura existente. 
- Conseguir que las cards dentro del mock móvil (especialmente Emotion Chart y Streaks) se parezcan más a la realidad reduciendo ligeramente altura/padding/espaciado vertical. 
- Evitar el patrón visual tipo “confeti” en el Emotion Chart reemplazando el mock por una secuencia con continuidad temporal y agrupaciones naturales.

### Description
- Ajusté estilos del hero-safe para compactar verticalmente las cards `Emotion Chart` y `Streaks` reduciendo `padding`, `gap`, tamaños de título/subtítulo y padding interno de componentes de resumen (`apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`).
- Reduje padding del surface del heatmap y ajusté el tamaño del indicador de emoción para mantener legibilidad sin “aplastar” contenido.
- Reemplacé el mock demo de emociones dispersas por una generación determinística por segmentos contiguos (`buildContiguousDemoEmotionSnapshots`) que crea runs de días consecutivos por emoción, y añadí el helper `addDaysIso` para construir fechas; `getEmotions` en modo demo ahora usa esta secuencia (`apps/web/src/lib/api.ts`).
- Cambios quirúrgicos y localizados que mantienen los componentes reales y la lógica existente del dashboard intacta.

### Testing
- Ejecuté `pnpm -C apps/web exec eslint src/pages/labs/HeroPhoneShowcaseLabPage.module.css src/lib/api.ts`, que falló por la configuración local de ESLint v9 (ausencia de `eslint.config.*`) en este entorno de ejecución; los cambios CSS/JS aplicados son mínimos y no introducen reglas nuevas.
- Ejecuté `pnpm -w exec tsc -p apps/web/tsconfig.json --noEmit`, que falló por errores TypeScript preexistentes en otras áreas del repo no relacionadas con estos cambios; la generación de snapshots demo y los ajustes CSS no presentan errores locales detectables por inspección.

Archivos tocados
- `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`
- `apps/web/src/lib/api.ts`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb22ec48ec8332ab6f1fe7eed35f52)