### PR TITLE
Ajuste: mejorar legibilidad de task cards en hero y añadir pausa final al loop de scroll

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -284,8 +284,8 @@
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-top"] article[role="button"]),
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-bottom"] article[role="button"]) {
   min-height: 4rem;
-  padding: 0.38rem 0.5rem;
-  gap: 0.22rem;
+  padding: 0.42rem 0.52rem;
+  gap: 0.3rem;
 }
 
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] .text-sm.font-medium) {
@@ -295,6 +295,45 @@
 
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] .min-w-0.flex-1 p) {
   font-size: 0.63rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid) {
+  gap: 0.35rem 0.55rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div:first-child) {
+  min-width: 0;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div) {
+  min-width: 4.8rem;
+  align-items: stretch;
+  gap: 0.14rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-end) {
+  justify-content: space-between;
+  gap: 0.2rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-end > div) {
+  width: 0.42rem;
+  min-width: 0.42rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-center) {
+  justify-content: space-between;
+  gap: 0.2rem;
+  font-size: 0.46rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-center > span) {
+  width: 0.42rem;
+  min-width: 0.42rem;
+  line-height: 1;
 }
 
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] .h-2\.5),

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -7,10 +7,15 @@ import styles from './HeroPhoneShowcaseLabPage.module.css';
 
 const INITIAL_TOP_PAUSE_MS = 500;
 const SCROLL_DOWN_DURATION_MS = 4500;
+const LOOP_BOTTOM_PAUSE_MS = 950;
 const RESET_TO_TOP_DURATION_MS = 300;
 const LOOP_TOP_PAUSE_MS = 350;
 const LOOP_DURATION_MS =
-  INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + RESET_TO_TOP_DURATION_MS + LOOP_TOP_PAUSE_MS;
+  INITIAL_TOP_PAUSE_MS +
+  SCROLL_DOWN_DURATION_MS +
+  LOOP_BOTTOM_PAUSE_MS +
+  RESET_TO_TOP_DURATION_MS +
+  LOOP_TOP_PAUSE_MS;
 
 function smoothProgress(progress: number) {
   return progress * progress * (3 - 2 * progress);
@@ -37,12 +42,14 @@ function useDashboardScrollProgress(isReady: boolean) {
       } else if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS) {
         const downElapsed = elapsedInLoop - INITIAL_TOP_PAUSE_MS;
         setProgress(smoothProgress(downElapsed / SCROLL_DOWN_DURATION_MS));
+      } else if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS) {
+        setProgress(1);
       } else if (
         elapsedInLoop <
-        INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + RESET_TO_TOP_DURATION_MS
+        INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS + RESET_TO_TOP_DURATION_MS
       ) {
         const resetElapsed =
-          elapsedInLoop - INITIAL_TOP_PAUSE_MS - SCROLL_DOWN_DURATION_MS;
+          elapsedInLoop - INITIAL_TOP_PAUSE_MS - SCROLL_DOWN_DURATION_MS - LOOP_BOTTOM_PAUSE_MS;
         setProgress(1 - resetElapsed / RESET_TO_TOP_DURATION_MS);
       } else {
         setProgress(0);


### PR DESCRIPTION
### Motivation
- Corregir el solapamiento de números/labels/barras en las task cards del panel de Streaks cuando se muestra en la vista hero móvil. 
- Mantener el comportamiento actual de scroll (misma velocidad de bajada y reset) pero introducir una permanencia más larga en el fondo antes de volver arriba.

### Description
- Reajusté el micro-layout de las task cards solo en el scope hero (`.heroFocusContent [data-demo-anchor="streaks"]`) cambiando `padding`, `gap` y la distribución del grid para dar espacio reservado al mini-chart y al footer sin agrandar las cards; esto reduce la tipografía/footprint de labels y evita solapamientos (ver `> .grid` y selectores nuevos para la columna del mini-chart). (archivo: `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`)
- Reservé un `min-width` para la columna del mini-chart y forcé `justify-content: space-between` en los bloques de barras/labels para separar visualmente números, barras y labels, manteniendo la estética y el tamaño compacto. (archivo: `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`)
- Añadí una pausa explícita al final del recorrido de la animación de scroll introduciendo la constante `LOOP_BOTTOM_PAUSE_MS = 950` y una fase `setProgress(1)` justo después de la bajada, y ajusté el cálculo de `LOOP_DURATION_MS` y del reset para respetar esa pausa sin tocar la velocidad de bajada ni la pausa inicial. (archivo: `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`)
- Archivos tocados: `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`, `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`.

### Testing
- Ejecuté la comprobación TypeScript con `pnpm -C apps/web exec tsc --noEmit --pretty false` y el comando falló por errores TypeScript preexistentes en partes no relacionadas del repo (auth, preview achievement, tests), por lo que no hubo errores reportados por las líneas modificadas; el cambio de CSS/TSX es local y compiló sin introducir errores nuevos en esos archivos.
- No se añadieron o modificaron tests automatizados; verificación funcional pendiente por revisión visual en la vista `/labs/hero-phone-showcase` en entorno de desarrollo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2b2e052c83329e9b73b5827cb1cf)