### PR TITLE
Compacta spacing del mini chart de Streaks en HeroPhoneShowcase

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -306,14 +306,18 @@
 }
 
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div) {
-  min-width: 4.8rem;
+  min-width: 4.2rem;
   align-items: stretch;
-  gap: 0.14rem;
+  gap: 0.1rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex) {
+  width: fit-content;
 }
 
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-end) {
-  justify-content: space-between;
-  gap: 0.2rem;
+  justify-content: flex-start;
+  gap: 0.12rem;
 }
 
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-end > div) {
@@ -322,8 +326,8 @@
 }
 
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-center) {
-  justify-content: space-between;
-  gap: 0.2rem;
+  justify-content: flex-start;
+  gap: 0.12rem;
   font-size: 0.46rem;
   letter-spacing: 0.02em;
   text-transform: uppercase;


### PR DESCRIPTION
### Motivation
- El mini chart de las task cards en la vista hero muestra las barras verdes demasiado separadas y se busca un aspecto más compacto que haga que las barras se lean como un grupo.
- El cambio debe ser quirúrgico y solo afectar la vista del hero sin tocar la implementación o estilos globales del panel de Streaks.

### Description
- Ajusté selectores acotados bajo `.heroFocusContent` y `[data-demo-anchor="streaks"]` en `HeroPhoneShowcaseLabPage.module.css` para mantener el alcance solo a la vista del hero.
- Reduje el ancho mínimo del contenedor derecho de `min-width: 4.8rem` a `min-width: 4.2rem` y bajé el `gap` interno de `0.14rem` a `0.1rem` para acercar las barras.
- Forcé el subbloque del mini chart a `width: fit-content` y cambié la distribución de `justify-content: space-between` a `justify-content: flex-start` con `gap: 0.12rem` en las filas relevantes para eliminar el espacio sobrante entre barras y labels.
- Archivos modificados: `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css` (solo CSS, sin cambios en `StreaksPanel.tsx` ni en estilos globales).

### Testing
- Ejecuté `npm run typecheck:web`; el comando falló por errores TypeScript preexistentes en otros módulos que no están relacionados con este cambio de CSS.
- Verifiqué el diff y el contenido de `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css` con `git` y `nl` para confirmar los ajustes aplicados y el alcance del selector.
- No se ejecutaron tests visuales automáticos en este entorno; se recomienda revisión visual en el `HeroPhoneShowcase` para confirmar que las barras quedan más juntas como en la referencia.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2ebfdb4c8332ad2e37ab8ac2845a)