### PR TITLE
Add Logros carousel scene to hero phone loop (real RewardsSection)

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -3,9 +3,21 @@
   padding: clamp(1.4rem, 2.8vw, 3rem);
   color: #f2f1fb;
   background:
-    radial-gradient(circle at 80% 10%, rgba(153, 111, 244, 0.2), transparent 37%),
-    radial-gradient(circle at 17% 13%, rgba(117, 142, 252, 0.16), transparent 33%),
-    radial-gradient(circle at 52% 82%, rgba(253, 173, 124, 0.08), transparent 52%),
+    radial-gradient(
+      circle at 80% 10%,
+      rgba(153, 111, 244, 0.2),
+      transparent 37%
+    ),
+    radial-gradient(
+      circle at 17% 13%,
+      rgba(117, 142, 252, 0.16),
+      transparent 33%
+    ),
+    radial-gradient(
+      circle at 52% 82%,
+      rgba(253, 173, 124, 0.08),
+      transparent 52%
+    ),
     linear-gradient(180deg, #0f0f19 0%, #0a0a12 100%);
 }
 
@@ -84,28 +96,59 @@
 .phoneFrame {
   width: min(100%, 342px);
   aspect-ratio: 9 / 18.5;
-  border-radius: 40px;
-  background: linear-gradient(145deg, #2a2536 0%, #0a0910 48%, #141b30 100%);
+  border-radius: 42px;
+  background: linear-gradient(160deg, #2d2738 0%, #0b0d13 55%, #111c2f 100%);
   padding: 10px;
   box-shadow:
     0 26px 72px rgba(8, 8, 18, 0.6),
     0 8px 24px rgba(84, 61, 142, 0.2),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.12),
-    inset 0 -7px 14px rgba(0, 0, 0, 0.32);
+    inset 0 0 0 1px rgba(255, 255, 255, 0.16),
+    inset 0 -8px 16px rgba(0, 0, 0, 0.34);
   transform: perspective(1200px) rotateY(-5deg) rotateX(1.5deg);
   transform-origin: center right;
+  position: relative;
 }
 
-.phoneNotch {
-  width: 36%;
-  height: 19px;
-  margin: 0 auto 8px;
-  background: linear-gradient(180deg, #05060b, #141724);
-  border-radius: 0 0 14px 14px;
+.phoneIsland {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: clamp(92px, 38%, 124px);
+  height: 28px;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle at 68% 42%,
+    rgba(49, 57, 74, 0.88) 0,
+    rgba(8, 10, 16, 0.96) 58%,
+    #020307 100%
+  );
+  box-shadow:
+    inset 0 1px 1px rgba(255, 255, 255, 0.14),
+    inset 0 -1px 2px rgba(0, 0, 0, 0.52),
+    0 2px 4px rgba(0, 0, 0, 0.45);
+  z-index: 5;
+  pointer-events: none;
+}
+
+.phoneIslandLens {
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  transform: translateY(-50%);
+  border-radius: 999px;
+  background: radial-gradient(
+    circle at 32% 30%,
+    rgba(127, 140, 176, 0.72),
+    rgba(24, 30, 43, 0.18) 42%,
+    rgba(6, 8, 14, 0.92)
+  );
 }
 
 .phoneScreen {
-  height: calc(100% - 27px);
+  height: 100%;
   border-radius: 30px;
   overflow: hidden;
   background: #050816;
@@ -123,9 +166,94 @@
   background: #050816;
 }
 
+.sceneTrack {
+  width: 200%;
+  height: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  transition: transform 0ms linear;
+  will-change: transform;
+}
 
-.scenePanelSingle {
+.sceneDashboard,
+.sceneLogros {
   width: 100%;
+  height: 100%;
+}
+
+.logrosViewport {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  padding: 8px 7px 12px;
+  background:
+    radial-gradient(
+      circle at 20% 12%,
+      rgba(120, 140, 255, 0.15),
+      transparent 48%
+    ),
+    #060a16;
+}
+
+.logrosHeroOnly {
+  height: 100%;
+}
+
+.logrosHeroOnly :global(.ib-card > header),
+.logrosHeroOnly :global(.ib-card > [class*="rightSlot"]) {
+  display: none !important;
+}
+
+.logrosHeroOnly :global(.ib-card > .relative) {
+  padding: 0.35rem 0.35rem 0.45rem !important;
+  gap: 0.65rem !important;
+}
+
+.logrosHeroOnly
+  :global(.ib-card > .relative > .space-y-3:first-child > [role="tablist"]) {
+  display: none !important;
+}
+
+.logrosHeroOnly
+  :global(
+    .ib-card
+      > .relative
+      > .space-y-3:first-child
+      [data-demo-anchor="logros-carousel-track"]
+  ) {
+  margin-top: 0.1rem;
+  padding-inline: 0.15rem;
+  gap: 0.7rem;
+}
+
+.logrosHeroOnly
+  :global(
+    .ib-card
+      > .relative
+      > .space-y-3:first-child
+      [data-demo-anchor="logros-carousel-track"]
+      > button
+  ) {
+  width: 92%;
+  height: 25.2rem;
+  padding: 0.85rem;
+  border-radius: 1.3rem;
+}
+
+.logrosHeroOnly
+  :global(
+    .ib-card
+      > .relative
+      > .space-y-3:first-child
+      [data-demo-anchor="logros-carousel-track"]
+      > button
+      .text-lg
+  ) {
+  font-size: 0.93rem;
+}
+
+.logrosHeroOnly :global(.ib-card > .relative > :not(.space-y-3:first-child)) {
+  display: none !important;
 }
 .realViewport {
   position: absolute;
@@ -146,7 +274,6 @@
   padding: 12px 12px 108px;
   box-sizing: border-box;
 }
-
 
 .heroFocusContent > :global(.space-y-6) > :first-child {
   display: none !important;
@@ -169,47 +296,79 @@
   padding-bottom: 88px;
 }
 
-.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card > .relative) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"] .ib-metric-header-card > .relative
+  ) {
   gap: 0.7rem;
   padding: 0.4rem 0.45rem 0.6rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card header) {
+.heroFocusContent
+  :global([data-demo-anchor="overall-progress"] .ib-metric-header-card header) {
   gap: 0.5rem;
   padding-top: 0.2rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card header h3) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"] .ib-metric-header-card header h3
+  ) {
   font-size: 0.7rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card header [class*="inline-flex"]) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      header
+      [class*="inline-flex"]
+  ) {
   transform: scale(0.94);
   transform-origin: top right;
 }
 
-.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card .text-4xl) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"] .ib-metric-header-card .text-4xl
+  ) {
   font-size: 1.8rem;
   line-height: 1;
 }
 
-.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card .text-\[2\.5em\]) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      .text-\[2\.5em\]
+  ) {
   font-size: 2.05em;
 }
 
-.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card .space-y-3) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"] .ib-metric-header-card .space-y-3
+  ) {
   row-gap: 0.5rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card .h-6) {
+.heroFocusContent
+  :global([data-demo-anchor="overall-progress"] .ib-metric-header-card .h-6) {
   height: 1.2rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="overall-progress"] .ib-metric-header-card [role="progressbar"] span) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      [role="progressbar"]
+      span
+  ) {
   font-size: 10px;
 }
 
-.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card > .relative),
+.heroFocusContent
+  :global([data-demo-anchor="emotion-chart"] .ib-card > .relative),
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card > .relative) {
   padding: 0.45rem 0.55rem 0.6rem;
   gap: 0.7rem;
@@ -221,7 +380,8 @@
   padding-top: 0.15rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card header h3),
+.heroFocusContent
+  :global([data-demo-anchor="emotion-chart"] .ib-card header h3),
 .heroFocusContent :global([data-demo-anchor="streaks"] .ib-card header h3) {
   font-size: 0.72rem;
 }
@@ -231,101 +391,245 @@
   font-size: 0.62rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card > .relative > .flex.flex-col.gap-4),
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card > .relative > .flex.flex-col.gap-4) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      > .relative
+      > .flex.flex-col.gap-4
+  ),
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"] .ib-card > .relative > .flex.flex-col.gap-4
+  ) {
   gap: 0.65rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card .emotion-highlight-indicator) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"] .ib-card .emotion-highlight-indicator
+  ) {
   width: 1.35rem;
   height: 1.35rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="summary"] .summary-inner) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="summary"]
+      .summary-inner
+  ) {
   padding: 0.42rem 0.5rem;
   gap: 0.35rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="summary"] .summary-content) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="summary"]
+      .summary-content
+  ) {
   gap: 0.4rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="summary"] .summary-title) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="summary"]
+      .summary-title
+  ) {
   font-size: 0.7rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="summary"] .summary-description) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="summary"]
+      .summary-description
+  ) {
   font-size: 0.66rem;
   line-height: 1.2;
 }
 
-.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="heatmap"]) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="heatmap"]
+  ) {
   --emotion-heatmap-min-h: 0px;
 }
 
-.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="heatmap"] .emotion-chart-surface) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="heatmap"]
+      .emotion-chart-surface
+  ) {
   padding: 0.35rem 0.45rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-top"]),
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-bottom"]) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-top"]
+  ),
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-bottom"]
+  ) {
   row-gap: 0.6rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-top"] > section),
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-bottom"] > section) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      [data-demo-anchor="streaks-top"]
+      > section
+  ),
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      [data-demo-anchor="streaks-bottom"]
+      > section
+  ) {
   row-gap: 0.55rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card .grid.grid-cols-1.gap-3) {
+.heroFocusContent
+  :global([data-demo-anchor="streaks"] .ib-card .grid.grid-cols-1.gap-3) {
   gap: 0.45rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-top"] article[role="button"]),
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-bottom"] article[role="button"]) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      [data-demo-anchor="streaks-top"]
+      article[role="button"]
+  ),
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      [data-demo-anchor="streaks-bottom"]
+      article[role="button"]
+  ) {
   min-height: 4rem;
   padding: 0.42rem 0.52rem;
   gap: 0.3rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] .text-sm.font-medium) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      .text-sm.font-medium
+  ) {
   font-size: 0.75rem;
   line-height: 1.15;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] .min-w-0.flex-1 p) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      .min-w-0.flex-1
+      p
+  ) {
   font-size: 0.63rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid
+  ) {
   gap: 0.35rem 0.55rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div:first-child) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div:first-child
+  ) {
   min-width: 0;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+  ) {
   min-width: 4.2rem;
   align-items: stretch;
   gap: 0.1rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+      > .flex
+  ) {
   width: fit-content;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-end) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+      > .flex.items-end
+  ) {
   justify-content: flex-start;
   gap: 0.12rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-end > div) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+      > .flex.items-end
+      > div
+  ) {
   width: 0.42rem;
   min-width: 0.42rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-center) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+      > .flex.items-center
+  ) {
   justify-content: flex-start;
   gap: 0.12rem;
   font-size: 0.46rem;
@@ -334,18 +638,38 @@
   color: rgba(148, 163, 184, 0.9);
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid > div + div > .flex.items-center > span) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+      > .flex.items-center
+      > span
+  ) {
   width: 0.42rem;
   min-width: 0.42rem;
   line-height: 1;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] .h-2\.5),
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] .h-2\.5 > div) {
+.heroFocusContent
+  :global([data-demo-anchor="streaks"] .ib-card article[role="button"] .h-2\.5),
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"] .ib-card article[role="button"] .h-2\.5 > div
+  ) {
   height: 0.42rem;
 }
 
-.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card article[role="button"] .ib-streak-fire-chip__inner) {
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      .ib-streak-fire-chip__inner
+  ) {
   padding: 0.1rem 0.38rem;
   font-size: 0.58rem;
   gap: 0.2rem;

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -1,33 +1,102 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { Link } from 'react-router-dom';
-import { useReducedMotion } from 'framer-motion';
-import { setDashboardDemoModeEnabled } from '../../lib/demoMode';
-import { DemoDashboardOverviewScene } from '../../components/demo/DemoDashboardOverviewScene';
-import styles from './HeroPhoneShowcaseLabPage.module.css';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { useReducedMotion } from "framer-motion";
+import { setDashboardDemoModeEnabled } from "../../lib/demoMode";
+import { DemoDashboardOverviewScene } from "../../components/demo/DemoDashboardOverviewScene";
+import {
+  RewardsSection,
+  type RewardsSectionDemoControls,
+} from "../../components/dashboard-v3/RewardsSection";
+import {
+  getDemoLogrosData,
+  getDemoLogrosPreviewByTaskId,
+} from "../../data/demoLogrosData";
+import { usePostLoginLanguage } from "../../i18n/postLoginLanguage";
+import styles from "./HeroPhoneShowcaseLabPage.module.css";
 
 const INITIAL_TOP_PAUSE_MS = 500;
 const SCROLL_DOWN_DURATION_MS = 4500;
 const LOOP_BOTTOM_PAUSE_MS = 950;
 const RESET_TO_TOP_DURATION_MS = 300;
 const LOOP_TOP_PAUSE_MS = 350;
-const LOOP_DURATION_MS =
+const DASHBOARD_LOOP_DURATION_MS =
   INITIAL_TOP_PAUSE_MS +
   SCROLL_DOWN_DURATION_MS +
   LOOP_BOTTOM_PAUSE_MS +
   RESET_TO_TOP_DURATION_MS +
   LOOP_TOP_PAUSE_MS;
 
+const DASHBOARD_TO_LOGROS_DURATION_MS = 820;
+const LOGROS_CAROUSEL_DURATION_MS = 5800;
+const LOGROS_TO_DASHBOARD_DURATION_MS = 820;
+const HERO_LOOP_DURATION_MS =
+  DASHBOARD_LOOP_DURATION_MS +
+  DASHBOARD_TO_LOGROS_DURATION_MS +
+  LOGROS_CAROUSEL_DURATION_MS +
+  LOGROS_TO_DASHBOARD_DURATION_MS;
+
+const HERO_TASK_SEQUENCE = [
+  "task-water",
+  "task-dinner-before-22",
+  "task-gym",
+] as const;
+
 function smoothProgress(progress: number) {
   return progress * progress * (3 - 2 * progress);
 }
 
-function useDashboardScrollProgress(isReady: boolean) {
+function resolveDashboardProgress(elapsedInLoop: number) {
+  if (elapsedInLoop < INITIAL_TOP_PAUSE_MS) {
+    return 0;
+  }
+  if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS) {
+    const downElapsed = elapsedInLoop - INITIAL_TOP_PAUSE_MS;
+    return smoothProgress(downElapsed / SCROLL_DOWN_DURATION_MS);
+  }
+  if (
+    elapsedInLoop <
+    INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS
+  ) {
+    return 1;
+  }
+  if (
+    elapsedInLoop <
+    INITIAL_TOP_PAUSE_MS +
+      SCROLL_DOWN_DURATION_MS +
+      LOOP_BOTTOM_PAUSE_MS +
+      RESET_TO_TOP_DURATION_MS
+  ) {
+    const resetElapsed =
+      elapsedInLoop -
+      INITIAL_TOP_PAUSE_MS -
+      SCROLL_DOWN_DURATION_MS -
+      LOOP_BOTTOM_PAUSE_MS;
+    return 1 - resetElapsed / RESET_TO_TOP_DURATION_MS;
+  }
+  return 0;
+}
+
+type HeroPhase = "dashboard" | "to-logros" | "logros" | "to-dashboard";
+
+function useHeroShowcaseTimeline(isReady: boolean) {
   const prefersReducedMotion = useReducedMotion();
-  const [progress, setProgress] = useState(0);
+  const [timeline, setTimeline] = useState<{
+    phase: HeroPhase;
+    dashboardProgress: number;
+    trackProgress: number;
+  }>({
+    phase: "dashboard",
+    dashboardProgress: 0,
+    trackProgress: 0,
+  });
 
   useEffect(() => {
     if (prefersReducedMotion || !isReady) {
-      setProgress(0);
+      setTimeline({
+        phase: "dashboard",
+        dashboardProgress: 0,
+        trackProgress: 0,
+      });
       return;
     }
 
@@ -35,24 +104,50 @@ function useDashboardScrollProgress(isReady: boolean) {
     const startedAt = performance.now();
 
     const tick = (now: number) => {
-      const elapsedInLoop = (now - startedAt) % LOOP_DURATION_MS;
+      const elapsedInLoop = (now - startedAt) % HERO_LOOP_DURATION_MS;
 
-      if (elapsedInLoop < INITIAL_TOP_PAUSE_MS) {
-        setProgress(0);
-      } else if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS) {
-        const downElapsed = elapsedInLoop - INITIAL_TOP_PAUSE_MS;
-        setProgress(smoothProgress(downElapsed / SCROLL_DOWN_DURATION_MS));
-      } else if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS) {
-        setProgress(1);
+      if (elapsedInLoop < DASHBOARD_LOOP_DURATION_MS) {
+        setTimeline({
+          phase: "dashboard",
+          dashboardProgress: resolveDashboardProgress(elapsedInLoop),
+          trackProgress: 0,
+        });
       } else if (
         elapsedInLoop <
-        INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS + RESET_TO_TOP_DURATION_MS
+        DASHBOARD_LOOP_DURATION_MS + DASHBOARD_TO_LOGROS_DURATION_MS
       ) {
-        const resetElapsed =
-          elapsedInLoop - INITIAL_TOP_PAUSE_MS - SCROLL_DOWN_DURATION_MS - LOOP_BOTTOM_PAUSE_MS;
-        setProgress(1 - resetElapsed / RESET_TO_TOP_DURATION_MS);
+        const transitionElapsed = elapsedInLoop - DASHBOARD_LOOP_DURATION_MS;
+        setTimeline({
+          phase: "to-logros",
+          dashboardProgress: 0,
+          trackProgress: smoothProgress(
+            transitionElapsed / DASHBOARD_TO_LOGROS_DURATION_MS,
+          ),
+        });
+      } else if (
+        elapsedInLoop <
+        DASHBOARD_LOOP_DURATION_MS +
+          DASHBOARD_TO_LOGROS_DURATION_MS +
+          LOGROS_CAROUSEL_DURATION_MS
+      ) {
+        setTimeline({
+          phase: "logros",
+          dashboardProgress: 0,
+          trackProgress: 1,
+        });
       } else {
-        setProgress(0);
+        const transitionElapsed =
+          elapsedInLoop -
+          DASHBOARD_LOOP_DURATION_MS -
+          DASHBOARD_TO_LOGROS_DURATION_MS -
+          LOGROS_CAROUSEL_DURATION_MS;
+        setTimeline({
+          phase: "to-dashboard",
+          dashboardProgress: 0,
+          trackProgress:
+            1 -
+            smoothProgress(transitionElapsed / LOGROS_TO_DASHBOARD_DURATION_MS),
+        });
       }
 
       rafId = window.requestAnimationFrame(tick);
@@ -62,13 +157,17 @@ function useDashboardScrollProgress(isReady: boolean) {
     return () => window.cancelAnimationFrame(rafId);
   }, [isReady, prefersReducedMotion]);
 
-  return prefersReducedMotion || !isReady ? 0 : progress;
+  return prefersReducedMotion || !isReady
+    ? { phase: "dashboard" as const, dashboardProgress: 0, trackProgress: 0 }
+    : timeline;
 }
 
 function PhoneFrame({ children }: { children: ReactNode }) {
   return (
     <div className={styles.phoneFrame}>
-      <div className={styles.phoneNotch} />
+      <div className={styles.phoneIsland} aria-hidden>
+        <span className={styles.phoneIslandLens} />
+      </div>
       <div className={styles.phoneScreen}>{children}</div>
     </div>
   );
@@ -100,16 +199,27 @@ function RealDashboardScene({
     let intervalId = 0;
 
     const resolveIfReady = () => {
-      const overallProgress = viewport.querySelector<HTMLElement>('[data-demo-anchor="overall-progress"]');
-      const emotionChart = viewport.querySelector<HTMLElement>('[data-demo-anchor="emotion-chart"]');
-      const streaks = viewport.querySelector<HTMLElement>('[data-demo-anchor="streaks"]');
+      const overallProgress = viewport.querySelector<HTMLElement>(
+        '[data-demo-anchor="overall-progress"]',
+      );
+      const emotionChart = viewport.querySelector<HTMLElement>(
+        '[data-demo-anchor="emotion-chart"]',
+      );
+      const streaks = viewport.querySelector<HTMLElement>(
+        '[data-demo-anchor="streaks"]',
+      );
       if (!overallProgress || !emotionChart || !streaks) return false;
 
       const viewportRect = viewport.getBoundingClientRect();
       const resolveTop = (element: HTMLElement) =>
-        element.getBoundingClientRect().top - viewportRect.top + viewport.scrollTop;
+        element.getBoundingClientRect().top -
+        viewportRect.top +
+        viewport.scrollTop;
 
-      const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+      const maxScroll = Math.max(
+        0,
+        viewport.scrollHeight - viewport.clientHeight,
+      );
       const overallTop = resolveTop(overallProgress);
       const emotionTop = resolveTop(emotionChart);
       const streakTop = resolveTop(streaks);
@@ -143,11 +253,13 @@ function RealDashboardScene({
 
   return (
     <section
-      className={`${styles.scenePanel} ${styles.scenePanelSingle} ${styles.sceneDashboard}`}
+      className={`${styles.scenePanel} ${styles.sceneDashboard}`}
       data-light-scope="dashboard-v3"
     >
       <div ref={viewportRef} className={styles.realViewport}>
-        <div className={`${styles.mobileDashboardRoot} ${styles.heroFocusViewport}`}>
+        <div
+          className={`${styles.mobileDashboardRoot} ${styles.heroFocusViewport}`}
+        >
           <div className={styles.heroFocusContent}>
             <DemoDashboardOverviewScene gameMode="flow" />
           </div>
@@ -157,10 +269,90 @@ function RealDashboardScene({
   );
 }
 
+function HeroLogrosScene({
+  isActive,
+  cycleKey,
+}: {
+  isActive: boolean;
+  cycleKey: number;
+}) {
+  const { language } = usePostLoginLanguage();
+  const controlsRef = useRef<RewardsSectionDemoControls | null>(null);
+
+  const demoConfig = useMemo(
+    () => ({
+      disableRemote: true,
+      forceAchievementsViewMode: "carousel" as const,
+      mockPreviewAchievementByTaskId: getDemoLogrosPreviewByTaskId(language),
+      anchors: {
+        carouselTrack: "logros-carousel-track",
+        achievedCardTaskId: HERO_TASK_SEQUENCE[0],
+        blockedCardTaskId: HERO_TASK_SEQUENCE[2],
+      },
+      controls: {
+        onReady: (controls: RewardsSectionDemoControls) => {
+          controlsRef.current = controls;
+        },
+      },
+    }),
+    [language],
+  );
+
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    const controls = controlsRef.current;
+    if (!controls) {
+      return;
+    }
+
+    controls.closeAllOverlays();
+    controls.selectPillar("BODY");
+    controls.focusCarouselCard(HERO_TASK_SEQUENCE[0]);
+
+    const segment = LOGROS_CAROUSEL_DURATION_MS / 3;
+    const t1 = window.setTimeout(
+      () => controls.focusCarouselCard(HERO_TASK_SEQUENCE[1]),
+      segment * 0.9,
+    );
+    const t2 = window.setTimeout(
+      () => controls.focusCarouselCard(HERO_TASK_SEQUENCE[2]),
+      segment * 1.95,
+    );
+
+    return () => {
+      window.clearTimeout(t1);
+      window.clearTimeout(t2);
+    };
+  }, [cycleKey, isActive]);
+
+  return (
+    <section
+      className={`${styles.scenePanel} ${styles.sceneLogros}`}
+      data-light-scope="dashboard-v3"
+    >
+      <div className={styles.logrosViewport}>
+        <div className={styles.logrosHeroOnly}>
+          <RewardsSection
+            userId=""
+            initialData={getDemoLogrosData(language)}
+            demoConfig={demoConfig}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function HeroPhoneShowcase() {
   const [dashboardReady, setDashboardReady] = useState(false);
   const [demoDataReady, setDemoDataReady] = useState(false);
-  const scrollProgress = useDashboardScrollProgress(dashboardReady);
+  const [logrosCycleKey, setLogrosCycleKey] = useState(0);
+  const { phase, dashboardProgress, trackProgress } =
+    useHeroShowcaseTimeline(dashboardReady);
+  const previousPhaseRef = useRef<HeroPhase>("dashboard");
 
   useEffect(() => {
     setDashboardDemoModeEnabled(true);
@@ -171,13 +363,32 @@ function HeroPhoneShowcase() {
     };
   }, []);
 
+  useEffect(() => {
+    if (previousPhaseRef.current !== "logros" && phase === "logros") {
+      setLogrosCycleKey((value) => value + 1);
+    }
+    previousPhaseRef.current = phase;
+  }, [phase]);
+
   return (
     <PhoneFrame>
       {demoDataReady ? (
-        <RealDashboardScene scrollProgress={scrollProgress} onReady={() => setDashboardReady(true)} />
+        <div
+          className={styles.sceneTrack}
+          style={{ transform: `translate3d(${-50 * trackProgress}%, 0, 0)` }}
+        >
+          <RealDashboardScene
+            scrollProgress={dashboardProgress}
+            onReady={() => setDashboardReady(true)}
+          />
+          <HeroLogrosScene
+            isActive={phase === "logros"}
+            cycleKey={logrosCycleKey}
+          />
+        </div>
       ) : (
         <section
-          className={`${styles.scenePanel} ${styles.scenePanelSingle} ${styles.sceneDashboard}`}
+          className={`${styles.scenePanel} ${styles.sceneDashboard}`}
           data-light-scope="dashboard-v3"
           aria-hidden
         />
@@ -196,12 +407,17 @@ export default function HeroPhoneShowcaseLabPage() {
             Tu progreso, <span>en tiempo real.</span>
           </h1>
           <p>
-            Iteración del experimento móvil enfocada solo en el dashboard demo, con encuadre deliberado y scroll
-            suave para mostrar señales clave de progreso.
+            Iteración del experimento móvil enfocada en dashboard + logros,
+            manteniendo el recorrido actual y sumando una escena de carrusel
+            BODY en loop horizontal premium.
           </p>
           <div className={styles.ctaRow}>
-            <Link className={styles.primaryCta} to="/onboarding">Comenzar ahora</Link>
-            <a className={styles.secondaryCta} href="/landing-v2#highlights">Ver dashboard</a>
+            <Link className={styles.primaryCta} to="/onboarding">
+              Comenzar ahora
+            </Link>
+            <a className={styles.secondaryCta} href="/landing-v2#highlights">
+              Ver dashboard
+            </a>
           </div>
         </div>
 


### PR DESCRIPTION
### Motivation
- Mantener intacta la escena del dashboard actual y sumar una segunda escena real de Logros dentro del mismo hero sin rehacer la lógica existente.
- Mostrar un carrusel premium de `RewardsSection` en modo demo (mock datos) enfocado en el pillar `BODY` y con una secuencia horizontal controlada.
- Entregar una transición limpia y horizontal entre dashboard y logros, y ajustar el marco del teléfono a un aspecto iOS con Dynamic Island.

### Description
- Añadí un timeline/state-machine `useHeroShowcaseTimeline` y un contenedor de pista horizontal `sceneTrack` que coordina: `dashboard` -> `to-logros` -> `logros` -> `to-dashboard` manteniendo los tiempos del dashboard original. (`HeroPhoneShowcaseLabPage.tsx`).
- Implementé `HeroLogrosScene` que monta el componente real `RewardsSection` en demo mode usando `getDemoLogrosData(language)`, `getDemoLogrosPreviewByTaskId(language)`, `demoConfig.disableRemote = true` y `forceAchievementsViewMode = 'carousel'`, y uso de controles demo para enfocar la secuencia de cards. (`HeroPhoneShowcaseLabPage.tsx`).
- Definí la secuencia hero-safe de tareas BODY `['task-water', 'task-dinner-before-22', 'task-gym']` para mostrar: desbloqueada, desbloqueada, bloqueada, y disparé focos del carrusel en tres pasos durante la fase `logros`. (`HeroPhoneShowcaseLabPage.tsx`, `demoLogrosData.ts` fue reutilizado).
- Añadí estilos hero-safe para ocultar chrome innecesario y priorizar visualmente el carrusel, y reemplacé el notch por `phoneIsland`/`phoneIslandLens` para el efecto Dynamic Island. (`HeroPhoneShowcaseLabPage.module.css`).

### Testing
- Ejecuté `prettier --write` y `prettier --check` sobre los archivos modificados y ambos pasaron correctamente. (éxito)
- Ejecuté `tsc --noEmit` y falló por errores TypeScript preexistentes a nivel de repo que no fueron introducidos por este cambio; el fallo es externo a esta PR. (fallido, no relacionado)
- Intenté `eslint` pero la configuración local provocó error por falta de `eslint.config.*` y no se consideró en este PR; el cambio se dejó formateado por Prettier. (no ejecutado)

Files changed: `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`, `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`.

Notas: la escena del dashboard (`RealDashboardScene`) y sus tiempos base se dejaron intactos y fueron reutilizados dentro del loop global; se hizo commit con mensaje descriptivo para esta integración.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb33d9c274833286acba8cc0796200)