### PR TITLE
Arreglar readiness y framing de la escena Logros en HeroPhoneShowcase

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -205,54 +205,49 @@
 }
 
 .logrosHeroOnly :global(.ib-card > .relative) {
-  padding: 0.35rem 0.35rem 0.45rem !important;
-  gap: 0.65rem !important;
+  height: 100%;
+  padding: 0.25rem 0.25rem 0.5rem !important;
+  gap: 0.45rem !important;
 }
 
-.logrosHeroOnly
-  :global(.ib-card > .relative > .space-y-3:first-child > [role="tablist"]) {
+.logrosHeroOnly :global(.ib-card > .relative > :not([data-demo-anchor])) {
   display: none !important;
 }
 
-.logrosHeroOnly
-  :global(
-    .ib-card
-      > .relative
-      > .space-y-3:first-child
-      [data-demo-anchor="logros-carousel-track"]
-  ) {
-  margin-top: 0.1rem;
-  padding-inline: 0.15rem;
-  gap: 0.7rem;
+.logrosHeroOnly :global([data-demo-anchor="logros-carousel-structure"]) {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+  min-height: 0;
+}
+
+.logrosHeroOnly :global([data-demo-anchor="logros-pillar-selector"]) {
+  margin: 0 !important;
+}
+
+.logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"]) {
+  min-height: 0;
+  margin-top: 0.2rem;
+  padding-inline: 0.2rem;
+  gap: 0.55rem;
+  align-items: stretch;
+}
+
+.logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"] > button) {
+  width: 86%;
+  min-height: 0;
+  height: 24.4rem;
+  padding: 0.75rem;
+  border-radius: 1.1rem;
 }
 
 .logrosHeroOnly
-  :global(
-    .ib-card
-      > .relative
-      > .space-y-3:first-child
-      [data-demo-anchor="logros-carousel-track"]
-      > button
-  ) {
-  width: 92%;
-  height: 25.2rem;
-  padding: 0.85rem;
-  border-radius: 1.3rem;
+  :global([data-demo-anchor="logros-carousel-track"] > button .text-lg) {
+  font-size: 0.86rem;
 }
 
 .logrosHeroOnly
-  :global(
-    .ib-card
-      > .relative
-      > .space-y-3:first-child
-      [data-demo-anchor="logros-carousel-track"]
-      > button
-      .text-lg
-  ) {
-  font-size: 0.93rem;
-}
-
-.logrosHeroOnly :global(.ib-card > .relative > :not(.space-y-3:first-child)) {
+  :global([data-demo-anchor="logros-carousel-structure"] > .flex.items-center) {
   display: none !important;
 }
 .realViewport {

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -40,6 +40,9 @@ const HERO_TASK_SEQUENCE = [
   "task-dinner-before-22",
   "task-gym",
 ] as const;
+const HERO_BODY_CARD_UNLOCKED_1 = HERO_TASK_SEQUENCE[0];
+const HERO_BODY_CARD_UNLOCKED_2 = HERO_TASK_SEQUENCE[1];
+const HERO_BODY_CARD_BLOCKED_1 = HERO_TASK_SEQUENCE[2];
 
 function smoothProgress(progress: number) {
   return progress * progress * (3 - 2 * progress);
@@ -272,12 +275,16 @@ function RealDashboardScene({
 function HeroLogrosScene({
   isActive,
   cycleKey,
+  onReady,
 }: {
   isActive: boolean;
   cycleKey: number;
+  onReady: () => void;
 }) {
   const { language } = usePostLoginLanguage();
   const controlsRef = useRef<RewardsSectionDemoControls | null>(null);
+  const [sceneReady, setSceneReady] = useState(false);
+  const readyReportedRef = useRef(false);
 
   const demoConfig = useMemo(
     () => ({
@@ -286,8 +293,10 @@ function HeroLogrosScene({
       mockPreviewAchievementByTaskId: getDemoLogrosPreviewByTaskId(language),
       anchors: {
         carouselTrack: "logros-carousel-track",
-        achievedCardTaskId: HERO_TASK_SEQUENCE[0],
-        blockedCardTaskId: HERO_TASK_SEQUENCE[2],
+        carouselStructure: "logros-carousel-structure",
+        pillarSelector: "logros-pillar-selector",
+        achievedCardTaskId: HERO_BODY_CARD_UNLOCKED_1,
+        blockedCardTaskId: HERO_BODY_CARD_BLOCKED_1,
       },
       controls: {
         onReady: (controls: RewardsSectionDemoControls) => {
@@ -299,7 +308,55 @@ function HeroLogrosScene({
   );
 
   useEffect(() => {
-    if (!isActive) {
+    let intervalId = 0;
+
+    const resolveTrackReady = () => {
+      const controls = controlsRef.current;
+      const track = document.querySelector<HTMLElement>(
+        '[data-demo-anchor="logros-carousel-track"]',
+      );
+      const cards = track?.querySelectorAll<HTMLElement>(
+        "[data-achievement-carousel-index]",
+      );
+
+      if (!controls || !track || !cards || cards.length < 3) {
+        return false;
+      }
+
+      const firstCard = cards[0];
+      const trackRect = track.getBoundingClientRect();
+      const firstRect = firstCard.getBoundingClientRect();
+      const hasLayout =
+        trackRect.width > 0 && firstRect.width > 0 && firstRect.height > 0;
+      if (!hasLayout) {
+        return false;
+      }
+
+      setSceneReady(true);
+      if (!readyReportedRef.current) {
+        readyReportedRef.current = true;
+        onReady();
+      }
+      return true;
+    };
+
+    if (!resolveTrackReady()) {
+      intervalId = window.setInterval(() => {
+        if (resolveTrackReady()) {
+          window.clearInterval(intervalId);
+        }
+      }, 80);
+    }
+
+    return () => {
+      if (intervalId) {
+        window.clearInterval(intervalId);
+      }
+    };
+  }, [onReady]);
+
+  useEffect(() => {
+    if (!isActive || !sceneReady) {
       return;
     }
 
@@ -310,15 +367,15 @@ function HeroLogrosScene({
 
     controls.closeAllOverlays();
     controls.selectPillar("BODY");
-    controls.focusCarouselCard(HERO_TASK_SEQUENCE[0]);
+    controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
 
     const segment = LOGROS_CAROUSEL_DURATION_MS / 3;
     const t1 = window.setTimeout(
-      () => controls.focusCarouselCard(HERO_TASK_SEQUENCE[1]),
+      () => controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_2),
       segment * 0.9,
     );
     const t2 = window.setTimeout(
-      () => controls.focusCarouselCard(HERO_TASK_SEQUENCE[2]),
+      () => controls.focusCarouselCard(HERO_BODY_CARD_BLOCKED_1),
       segment * 1.95,
     );
 
@@ -326,7 +383,7 @@ function HeroLogrosScene({
       window.clearTimeout(t1);
       window.clearTimeout(t2);
     };
-  }, [cycleKey, isActive]);
+  }, [cycleKey, isActive, sceneReady]);
 
   return (
     <section
@@ -348,10 +405,11 @@ function HeroLogrosScene({
 
 function HeroPhoneShowcase() {
   const [dashboardReady, setDashboardReady] = useState(false);
+  const [logrosReady, setLogrosReady] = useState(false);
   const [demoDataReady, setDemoDataReady] = useState(false);
   const [logrosCycleKey, setLogrosCycleKey] = useState(0);
   const { phase, dashboardProgress, trackProgress } =
-    useHeroShowcaseTimeline(dashboardReady);
+    useHeroShowcaseTimeline(dashboardReady && logrosReady);
   const previousPhaseRef = useRef<HeroPhase>("dashboard");
 
   useEffect(() => {
@@ -384,6 +442,7 @@ function HeroPhoneShowcase() {
           <HeroLogrosScene
             isActive={phase === "logros"}
             cycleKey={logrosCycleKey}
+            onReady={() => setLogrosReady(true)}
           />
         </div>
       ) : (


### PR DESCRIPTION
### Motivation
- La transición hero → Logros entraba antes de que el carrusel estuviera montado, dejando la vista del móvil mayormente vacía; se necesita un ready state específico para Logros y un encuadre CSS menos agresivo. 
- También había riesgo de que los controles (`selectPillar` / `focusCarouselCard`) se ejecutaran antes de que el track/cards existieran, por lo que la secuencia de foco debe hacerse sólo cuando la escena esté realmente lista.

### Description
- Añadí un readiness propio en `HeroLogrosScene` que comprueba `controlsRef.current`, la presencia del track (`[data-demo-anchor="logros-carousel-track"]`), al menos 3 cards y dimensiones de layout antes de reportar listo y llamar a la UI global. (`apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`).
- El timeline del hero ahora espera ambas señales (`dashboardReady && logrosReady`) en `useHeroShowcaseTimeline` antes de iniciar la transición a Logros para evitar frames vacíos. (`HeroPhoneShowcaseLabPage.tsx`).
- Hice robusta la secuencia de controles: explicitado constants para los task ids BODY y la secuencia de foco `task-water` → `task-dinner-before-22` → `task-gym`, ejecutada sólo cuando `isActive && sceneReady`. (`HeroPhoneShowcaseLabPage.tsx`).
- Reescribí `.logrosHeroOnly` en `HeroPhoneShowcaseLabPage.module.css` para usar los `data-demo-anchor` semánticos (`logros-carousel-structure`, `logros-pillar-selector`, `logros-carousel-track`), reducir padding/recortes y asegurar que el carrusel sea el elemento central dentro del phone viewport; removí selectores estructurales frágiles que ocultaban el body. (`HeroPhoneShowcaseLabPage.module.css`).
- Archivos tocados: `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx` y `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`.

### Testing
- Ejecuté el linter con `pnpm -C apps/web exec eslint src/pages/labs/HeroPhoneShowcaseLabPage.tsx` y falló por ausencia de `eslint.config.*` en el entorno, error de configuración global no introducido por este cambio (falla externa). 
- Ejecuté `pnpm -C apps/web run typecheck` y falló con múltiples errores TypeScript preexistentes en otras áreas del repo; estos errores no fueron introducidos por esta PR y no afectaron la lógica de readiness ni el CSS aplicado. 
- No se añadieron tests unitarios nuevos; los cambios son focales a montaje/UX y CSS y requieren validación visual en un entorno de navegador.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb39ee331c8332a5b38767e4636ba3)