### PR TITLE
Restore hero phone autoplay and fix Logros readiness & visibility

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -210,7 +210,10 @@
   gap: 0.45rem !important;
 }
 
-.logrosHeroOnly :global(.ib-card > .relative > :not([data-demo-anchor])) {
+.logrosHeroOnly
+  :global(
+    .ib-card > .relative > :not([data-demo-anchor="logros-shelves"])
+  ) {
   display: none !important;
 }
 
@@ -257,6 +260,9 @@
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
+  pointer-events: none;
+  touch-action: none;
+  user-select: none;
 }
 
 .realViewport::-webkit-scrollbar {

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -285,6 +285,7 @@ function HeroLogrosScene({
   const controlsRef = useRef<RewardsSectionDemoControls | null>(null);
   const [sceneReady, setSceneReady] = useState(false);
   const readyReportedRef = useRef(false);
+  const readinessResolvedRef = useRef(false);
 
   const demoConfig = useMemo(
     () => ({
@@ -292,9 +293,11 @@ function HeroLogrosScene({
       forceAchievementsViewMode: "carousel" as const,
       mockPreviewAchievementByTaskId: getDemoLogrosPreviewByTaskId(language),
       anchors: {
+        shelves: "logros-shelves",
         carouselTrack: "logros-carousel-track",
         carouselStructure: "logros-carousel-structure",
         pillarSelector: "logros-pillar-selector",
+        achievedCard: "logros-achieved-card",
         achievedCardTaskId: HERO_BODY_CARD_UNLOCKED_1,
         blockedCardTaskId: HERO_BODY_CARD_BLOCKED_1,
       },
@@ -311,24 +314,67 @@ function HeroLogrosScene({
     let intervalId = 0;
 
     const resolveTrackReady = () => {
+      const sceneRoot = document.querySelector<HTMLElement>(
+        `.${styles.sceneLogros}`,
+      );
       const controls = controlsRef.current;
-      const track = document.querySelector<HTMLElement>(
+      const track = sceneRoot?.querySelector<HTMLElement>(
         '[data-demo-anchor="logros-carousel-track"]',
+      );
+      const pillarSelector = sceneRoot?.querySelector<HTMLElement>(
+        '[data-demo-anchor="logros-pillar-selector"]',
       );
       const cards = track?.querySelectorAll<HTMLElement>(
         "[data-achievement-carousel-index]",
       );
+      const firstCard = sceneRoot?.querySelector<HTMLElement>(
+        '[data-demo-anchor="logros-achieved-card"]',
+      );
+      const blockedCard = sceneRoot?.querySelector<HTMLElement>(
+        '[data-demo-anchor="logros-blocked-card"]',
+      );
+      const isBodySelected = Boolean(
+        pillarSelector?.querySelector<HTMLElement>(
+          '[role="tab"][aria-selected="true"]',
+        )?.textContent?.toLowerCase().includes("body") ||
+          pillarSelector?.querySelector<HTMLElement>(
+            '[role="tab"][aria-selected="true"]',
+          )?.textContent
+            ?.toLowerCase()
+            .includes("cuerpo"),
+      );
 
-      if (!controls || !track || !cards || cards.length < 3) {
+      if (
+        !controls ||
+        !track ||
+        !cards ||
+        cards.length < 3 ||
+        !firstCard ||
+        !blockedCard
+      ) {
         return false;
       }
 
-      const firstCard = cards[0];
       const trackRect = track.getBoundingClientRect();
       const firstRect = firstCard.getBoundingClientRect();
       const hasLayout =
         trackRect.width > 0 && firstRect.width > 0 && firstRect.height > 0;
       if (!hasLayout) {
+        return false;
+      }
+
+      if (!readinessResolvedRef.current) {
+        controls.closeAllOverlays();
+        controls.selectPillar("BODY");
+        controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
+        readinessResolvedRef.current = true;
+        return false;
+      }
+
+      const horizontallyVisible =
+        firstRect.right > trackRect.left + 8 &&
+        firstRect.left < trackRect.right - 8;
+      if (!isBodySelected || !horizontallyVisible) {
         return false;
       }
 
@@ -366,7 +412,6 @@ function HeroLogrosScene({
     }
 
     controls.closeAllOverlays();
-    controls.selectPillar("BODY");
     controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
 
     const segment = LOGROS_CAROUSEL_DURATION_MS / 3;


### PR DESCRIPTION
### Motivation
- El hero phone debía reproducir automáticamente el dashboard y luego transicionar a la escena de Logros mostrando el carrusel BODY; ese flujo quedó roto porque el dashboard permitía scroll manual y la escena de Logros quedaba renderizada pero oculta/without readiness.
- Hay que asegurar que el loop principal no avance a la escena de Logros hasta que ésta esté realmente lista (controles disponibles, pilar BODY seleccionado y la primera card visible), manteniendo componentes reales y datos mock existentes.

### Description
- Bloqueo de interacción manual del viewport móvil para restaurar autoplay del dashboard añadiendo `pointer-events: none`, `touch-action: none` y `user-select: none` sobre `.realViewport` en `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`.
- Ajuste de la regla hero-only que ocultaba demasiado: el selector dejó de esconder el contenedor del estante/carrusel y ahora preserva `data-demo-anchor="logros-shelves"` para que la estructura del RewardsSection permanezca montada (`apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`).
- Fortaleza de la readiness de Logros en `HeroLogrosScene` (`apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx`): se añadió un `readinessResolvedRef` y una comprobación que espera (1) `controls` disponibles, (2) `track` y al menos 3 `cards`, (3) anclas clave (`achieved` y `blocked`), (4) layout con tamaños positivos, (5) que el pilar BODY esté seleccionado y (6) que la primera BODY card esté horizontalmente visible antes de marcar escena como ready y llamar a `onReady()`.
- Se inyectaron anchors adicionales en `demoConfig` (`shelves`, `achievedCard`) y se fuerza `disableRemote: true` y `forceAchievementsViewMode: 'carousel'` para que el comportamiento sea determinista y el foco programático (`selectPillar('BODY')` + `focusCarouselCard(...)`) funcione correctamente en el timing esperado.
- Mantengo la secuencia real del carrusel: primera card desbloqueada (`task-water`) → segunda desbloqueada (`task-dinner-before-22`) → bloqueada (`task-gym`) mediante los timeouts existentes (sin introducir UI fake ni tocar backend/auth).
- Archivos modificados: `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx` y `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`.

### Testing
- Ejecuté el chequeo de tipos en `apps/web` con `pnpm -C apps/web exec tsc --noEmit`; la ejecución falló por errores de tipo preexistentes en el repositorio (errores relacionados con Clerk exports, `PreviewAchievementCard` test types y otros), los cuales no son introducidos por este cambio, por lo que no fue posible un `tsc --noEmit` limpio en este entorno. Failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb429a6de48332b834ffcb7c5648ce)