### PR TITLE
Refine Hero phone showcase layout and stabilize readiness logic for dashboard/logros scenes

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -185,7 +185,8 @@
   position: absolute;
   inset: 0;
   overflow: hidden;
-  padding: 8px 7px 12px;
+  display: flex;
+  padding: 8px 8px 10px;
   background:
     radial-gradient(
       circle at 20% 12%,
@@ -197,6 +198,12 @@
 
 .logrosHeroOnly {
   height: 100%;
+  width: 100%;
+}
+
+.logrosHeroOnly :global(.ib-card) {
+  height: 100%;
+  min-height: 0;
 }
 
 .logrosHeroOnly :global(.ib-card > header),
@@ -230,17 +237,17 @@
 
 .logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"]) {
   min-height: 0;
-  margin-top: 0.2rem;
+  margin-top: 0.25rem;
   padding-inline: 0.2rem;
-  gap: 0.55rem;
+  gap: 0.42rem;
   align-items: stretch;
 }
 
 .logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"] > button) {
-  width: 86%;
+  width: 88%;
   min-height: 0;
-  height: 24.4rem;
-  padding: 0.75rem;
+  height: min(22.4rem, 100%);
+  padding: 0.72rem;
   border-radius: 1.1rem;
 }
 
@@ -256,9 +263,8 @@
 .realViewport {
   position: absolute;
   inset: 0;
-  overflow: auto;
+  overflow: hidden;
   overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
   pointer-events: none;
   touch-action: none;

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { useReducedMotion } from "framer-motion";
 import { setDashboardDemoModeEnabled } from "../../lib/demoMode";
 import { DemoDashboardOverviewScene } from "../../components/demo/DemoDashboardOverviewScene";
 import {
@@ -82,7 +81,6 @@ function resolveDashboardProgress(elapsedInLoop: number) {
 type HeroPhase = "dashboard" | "to-logros" | "logros" | "to-dashboard";
 
 function useHeroShowcaseTimeline(isReady: boolean) {
-  const prefersReducedMotion = useReducedMotion();
   const [timeline, setTimeline] = useState<{
     phase: HeroPhase;
     dashboardProgress: number;
@@ -94,7 +92,7 @@ function useHeroShowcaseTimeline(isReady: boolean) {
   });
 
   useEffect(() => {
-    if (prefersReducedMotion || !isReady) {
+    if (!isReady) {
       setTimeline({
         phase: "dashboard",
         dashboardProgress: 0,
@@ -158,9 +156,9 @@ function useHeroShowcaseTimeline(isReady: boolean) {
 
     rafId = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(rafId);
-  }, [isReady, prefersReducedMotion]);
+  }, [isReady]);
 
-  return prefersReducedMotion || !isReady
+  return !isReady
     ? { phase: "dashboard" as const, dashboardProgress: 0, trackProgress: 0 }
     : timeline;
 }
@@ -223,15 +221,32 @@ function RealDashboardScene({
         0,
         viewport.scrollHeight - viewport.clientHeight,
       );
+      if (maxScroll <= 0) {
+        return false;
+      }
       const overallTop = resolveTop(overallProgress);
       const emotionTop = resolveTop(emotionChart);
       const streakTop = resolveTop(streaks);
-      const start = Math.max(0, Math.min(maxScroll, overallTop - 18));
-      const endTarget = Math.max(
-        emotionTop - viewport.clientHeight * 0.42,
-        streakTop - viewport.clientHeight * 0.16,
+      const minTravel = Math.max(
+        Math.min(viewport.clientHeight * 0.58, maxScroll),
+        Math.min(160, maxScroll),
       );
-      const end = Math.max(start, Math.min(maxScroll, endTarget));
+      let start = Math.max(0, Math.min(maxScroll, overallTop - 18));
+      const endTarget = Math.max(
+        emotionTop - viewport.clientHeight * 0.38,
+        streakTop - viewport.clientHeight * 0.14,
+      );
+      let end = Math.max(start, Math.min(maxScroll, endTarget));
+      if (end - start < minTravel) {
+        end = Math.min(maxScroll, start + minTravel);
+      }
+      if (end - start < minTravel) {
+        start = Math.max(0, end - minTravel);
+      }
+      if (end <= start) {
+        start = 0;
+        end = maxScroll;
+      }
 
       scrollRangeRef.current = { start, end };
       viewport.scrollTop = start;
@@ -282,8 +297,10 @@ function HeroLogrosScene({
   onReady: () => void;
 }) {
   const { language } = usePostLoginLanguage();
+  const sceneRef = useRef<HTMLElement | null>(null);
   const controlsRef = useRef<RewardsSectionDemoControls | null>(null);
   const [sceneReady, setSceneReady] = useState(false);
+  const [controlsReady, setControlsReady] = useState(false);
   const readyReportedRef = useRef(false);
   const readinessResolvedRef = useRef(false);
 
@@ -298,12 +315,14 @@ function HeroLogrosScene({
         carouselStructure: "logros-carousel-structure",
         pillarSelector: "logros-pillar-selector",
         achievedCard: "logros-achieved-card",
+        blockedCard: "logros-blocked-card",
         achievedCardTaskId: HERO_BODY_CARD_UNLOCKED_1,
         blockedCardTaskId: HERO_BODY_CARD_BLOCKED_1,
       },
       controls: {
         onReady: (controls: RewardsSectionDemoControls) => {
           controlsRef.current = controls;
+          setControlsReady(true);
         },
       },
     }),
@@ -314,9 +333,7 @@ function HeroLogrosScene({
     let intervalId = 0;
 
     const resolveTrackReady = () => {
-      const sceneRoot = document.querySelector<HTMLElement>(
-        `.${styles.sceneLogros}`,
-      );
+      const sceneRoot = sceneRef.current;
       const controls = controlsRef.current;
       const track = sceneRoot?.querySelector<HTMLElement>(
         '[data-demo-anchor="logros-carousel-track"]',
@@ -344,14 +361,11 @@ function HeroLogrosScene({
             .includes("cuerpo"),
       );
 
-      if (
-        !controls ||
-        !track ||
-        !cards ||
-        cards.length < 3 ||
-        !firstCard ||
-        !blockedCard
-      ) {
+      if (!sceneRoot || !controlsReady || !controls || !track || !cards) {
+        return false;
+      }
+
+      if (cards.length < 3 || !firstCard || !blockedCard) {
         return false;
       }
 
@@ -374,7 +388,11 @@ function HeroLogrosScene({
       const horizontallyVisible =
         firstRect.right > trackRect.left + 8 &&
         firstRect.left < trackRect.right - 8;
-      if (!isBodySelected || !horizontallyVisible) {
+      const hasFocusableFirstCard =
+        firstCard.matches("button") &&
+        !firstCard.hasAttribute("disabled") &&
+        firstCard.tabIndex >= 0;
+      if (!isBodySelected || !horizontallyVisible || !hasFocusableFirstCard) {
         return false;
       }
 
@@ -399,7 +417,7 @@ function HeroLogrosScene({
         window.clearInterval(intervalId);
       }
     };
-  }, [onReady]);
+  }, [controlsReady, onReady]);
 
   useEffect(() => {
     if (!isActive || !sceneReady) {
@@ -432,6 +450,7 @@ function HeroLogrosScene({
 
   return (
     <section
+      ref={sceneRef}
       className={`${styles.scenePanel} ${styles.sceneLogros}`}
       data-light-scope="dashboard-v3"
     >


### PR DESCRIPTION
### Motivation
- Improve the phone hero visuals and spacing so the Logros and Dashboard demos render consistently across viewport sizes. 
- Make the demo timeline and readiness detection more robust so the showcase starts only when DOM layout and demo controls are fully ready. 
- Remove the reduced-motion gating in the lab timeline so the showcase timeline runs reliably in the lab environment.

### Description
- Tweak CSS in `HeroPhoneShowcaseLabPage.module.css` to adjust paddings, gaps, card dimensions, and viewport behavior, and set `.realViewport` to `overflow: hidden` to avoid scroll artifacts. 
- Add `.logrosHeroOnly` and `.ib-card` height adjustments and refine carousel track/gap/card sizing and margins for tighter hero presentation. 
- In `useHeroShowcaseTimeline` remove the `useReducedMotion` dependency and reduced-motion early-return so the timeline is controlled only by the component readiness flag. 
- In `RealDashboardScene` add a guard for zero `maxScroll` and compute a minimum travel distance (`minTravel`) with fallback adjustments to ensure meaningful `start`/`end` scrollRange values before reporting ready. 
- In `HeroLogrosScene` introduce a `sceneRef`, a `controlsReady` flag set by `demoConfig.controls.onReady`, replace global `querySelector` usage with the local `sceneRef`, and add checks for controls readiness and the first card focusability before marking the scene ready, plus set the section ref.

### Testing
- Ran TypeScript type-check via `yarn tsc` and the build type-check succeeded. 
- Executed the test suite using `yarn test` and all automated tests passed. 
- Performed local verification of the lab page in the browser to confirm layout adjustments and readiness transitions behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb479b01108332aef71ceea2704fd1)