### PR TITLE
Unify guided overlay visuals/motion and fix Logros contextual exit

### DIFF
--- a/apps/web/src/components/demo/GuidedDemoOverlay.tsx
+++ b/apps/web/src/components/demo/GuidedDemoOverlay.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useMemo, useState, type PointerEvent as ReactPointerEvent } from 'react';
 import { DEMO_GUIDED_STEPS, type DemoLanguage, type GuidedStep } from '../../config/demoGuidedTour';
+import {
+  GUIDED_OVERLAY_FRAME_CLASS,
+  GUIDED_OVERLAY_MASK_CLASS,
+  GUIDED_OVERLAY_PANEL_BASE_CLASS,
+  GUIDED_OVERLAY_SLICE_CLASS,
+} from './guidedOverlayFoundation';
 
 type Props = {
   language: DemoLanguage;
@@ -176,7 +182,7 @@ export function GuidedDemoOverlay({
 }: Props) {
   const [stepIndex, setStepIndex] = useState(0);
   const [isTransitioningStep, setIsTransitioningStep] = useState(true);
-  const [isInteractionLocked, setIsInteractionLocked] = useState(false);
+  const [isInteractionLocked] = useState(true);
   const [targetRect, setTargetRect] = useState<Rect | null>(null);
   const [viewport, setViewport] = useState({ width: window.innerWidth, height: window.innerHeight });
   const step = steps[stepIndex];
@@ -186,20 +192,11 @@ export function GuidedDemoOverlay({
   const isLogrosModalStep = LABS_LOGROS_MODAL_STEP_IDS.has(step.id);
   const isCompactMobile = viewport.width <= 390 || viewport.height <= 740;
 
-  const lockManualScroll = () => {
-    setIsInteractionLocked(true);
-  };
-
-  const unlockManualScroll = () => {
-    setIsInteractionLocked(false);
-  };
-
   const goToStep = (nextIndex: number) => {
     const boundedIndex = clamp(nextIndex, 0, steps.length - 1);
     if (boundedIndex === stepIndex) {
       return;
     }
-    unlockManualScroll();
     setIsTransitioningStep(true);
     setStepIndex(boundedIndex);
   };
@@ -257,7 +254,6 @@ export function GuidedDemoOverlay({
     if (!step?.targetSelector) {
       setTargetRect(null);
       void waitForLayoutSettle(1).then(() => {
-        lockManualScroll();
         setIsTransitioningStep(false);
       });
       return;
@@ -271,7 +267,6 @@ export function GuidedDemoOverlay({
       }
       const target = document.querySelector(selector) as HTMLElement | null;
       if (!target) {
-        setTargetRect(null);
         return;
       }
       const targetRect = target.getBoundingClientRect();
@@ -397,7 +392,6 @@ export function GuidedDemoOverlay({
         return;
       }
       updateRect();
-      lockManualScroll();
       setIsTransitioningStep(false);
     };
 
@@ -414,7 +408,6 @@ export function GuidedDemoOverlay({
     }, 220);
     const handleResize = () => {
       setViewport({ width: window.innerWidth, height: window.innerHeight });
-      unlockManualScroll();
       setIsTransitioningStep(true);
       void runStepAlignment(2);
     };
@@ -541,8 +534,6 @@ export function GuidedDemoOverlay({
   const primaryButtonClass = `ib-primary-button !min-h-0 !px-4 !py-2 !font-semibold !text-xs !uppercase !tracking-[0.16em] focus-visible:ring-offset-[color:var(--color-surface-elevated)] ${walkthroughButtonSizeClass}`;
   const tertiaryButtonClass = `ml-auto inline-flex items-center justify-center rounded-full border border-[color:var(--color-border-subtle)]/70 font-semibold uppercase tracking-[0.14em] text-[color:var(--color-text-muted)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/35 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-surface-elevated)] ${walkthroughButtonSizeClass}`;
   const overlayZClass = isDailyQuestStep ? 'z-[10020]' : 'z-[520]';
-  const overlayMaskClass = 'bg-slate-950/88 backdrop-blur-[6px] backdrop-saturate-[0.82]';
-
   const goToPreviousStep = () => {
     if (canGoBack && !isTransitioningStep) {
       goToStep(stepIndex - 1);
@@ -590,13 +581,16 @@ export function GuidedDemoOverlay({
     >
       {targetRect ? (
         <>
-          <div className={`absolute left-0 right-0 top-0 ${overlayMaskClass}`} style={{ height: targetRect.top }} />
           <div
-            className={`absolute left-0 ${overlayMaskClass}`}
+            className={`absolute left-0 right-0 top-0 ${GUIDED_OVERLAY_MASK_CLASS} ${GUIDED_OVERLAY_SLICE_CLASS}`}
+            style={{ height: targetRect.top }}
+          />
+          <div
+            className={`absolute left-0 ${GUIDED_OVERLAY_MASK_CLASS} ${GUIDED_OVERLAY_SLICE_CLASS}`}
             style={{ top: targetRect.top, width: targetRect.left, height: targetRect.height }}
           />
           <div
-            className={`absolute right-0 ${overlayMaskClass}`}
+            className={`absolute right-0 ${GUIDED_OVERLAY_MASK_CLASS} ${GUIDED_OVERLAY_SLICE_CLASS}`}
             style={{
               top: targetRect.top,
               width: Math.max(0, viewport.width - (targetRect.left + targetRect.width)),
@@ -604,23 +598,23 @@ export function GuidedDemoOverlay({
             }}
           />
           <div
-            className={`absolute bottom-0 left-0 right-0 ${overlayMaskClass}`}
+            className={`absolute bottom-0 left-0 right-0 ${GUIDED_OVERLAY_MASK_CLASS} ${GUIDED_OVERLAY_SLICE_CLASS}`}
             style={{ top: targetRect.top + targetRect.height }}
           />
         </>
       ) : (
-        <div className={`absolute inset-0 ${overlayMaskClass}`} />
+        <div className={`absolute inset-0 ${GUIDED_OVERLAY_MASK_CLASS} ${GUIDED_OVERLAY_SLICE_CLASS}`} />
       )}
 
       {targetRect ? (
         <div
-          className="pointer-events-none absolute rounded-2xl border border-violet-200/70 shadow-[0_0_0_1px_rgba(255,255,255,0.3),0_0_0_9999px_rgba(2,6,23,0.28),0_0_52px_rgba(139,92,246,0.42)] transition-all"
+          className={GUIDED_OVERLAY_FRAME_CLASS}
           style={{ top: targetRect.top, left: targetRect.left, width: targetRect.width, height: targetRect.height }}
         />
       ) : null}
 
       <aside
-        className={`guided-demo-panel pointer-events-auto absolute rounded-2xl border border-violet-200/60 bg-slate-950/92 text-[color:var(--color-text)] shadow-[0_24px_60px_rgba(2,6,23,0.55)] backdrop-blur-xl ${isCompactMobile ? 'p-3' : 'p-4'} ${isIntroModalStep ? 'max-w-lg overflow-hidden border-white/20 bg-[#0a133d]/92 text-center text-white shadow-[0_0_45px_rgba(79,70,229,0.22)]' : ''}`}
+        className={`guided-demo-panel pointer-events-auto absolute ${GUIDED_OVERLAY_PANEL_BASE_CLASS} ${isCompactMobile ? 'p-3' : 'p-4'} ${isIntroModalStep ? 'max-w-lg overflow-hidden border-white/20 bg-[#0a133d]/92 text-center text-white shadow-[0_0_45px_rgba(79,70,229,0.22)]' : ''} transition-all duration-500 ease-out`}
         style={tooltipStyle}
       >
         {isIntroModalStep ? (

--- a/apps/web/src/components/demo/guidedOverlayFoundation.ts
+++ b/apps/web/src/components/demo/guidedOverlayFoundation.ts
@@ -1,0 +1,11 @@
+export const GUIDED_OVERLAY_MASK_CLASS =
+  'bg-slate-950/88 backdrop-blur-[6px] backdrop-saturate-[0.82]';
+
+export const GUIDED_OVERLAY_SLICE_CLASS =
+  'transition-all duration-500 ease-out';
+
+export const GUIDED_OVERLAY_FRAME_CLASS =
+  'pointer-events-none absolute rounded-2xl border border-violet-200/70 shadow-[0_0_0_1px_rgba(255,255,255,0.3),0_0_0_9999px_rgba(2,6,23,0.28),0_0_52px_rgba(139,92,246,0.42)] transition-all duration-500 ease-out';
+
+export const GUIDED_OVERLAY_PANEL_BASE_CLASS =
+  'rounded-3xl border border-white/10 bg-[color:var(--color-surface-elevated)] text-[color:var(--color-slate-100)] shadow-[0_24px_65px_rgba(2,6,23,0.72)] backdrop-blur-xl';

--- a/apps/web/src/pages/labs/LogrosDemoPage.tsx
+++ b/apps/web/src/pages/labs/LogrosDemoPage.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { useAuth } from '@clerk/clerk-react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { GuidedDemoOverlay } from '../../components/demo/GuidedDemoOverlay';
 import { RewardsSection, type RewardsSectionDemoControls } from '../../components/dashboard-v3/RewardsSection';
+import { DASHBOARD_PATH } from '../../config/auth';
 import { LABS_LOGROS_GUIDED_STEPS } from '../../config/labsLogrosGuidedTour';
 import { getDemoLogrosData, getDemoLogrosPreviewByTaskId } from '../../data/demoLogrosData';
 import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
-import { getPublicDemoHubPath } from '../../lib/demoEntry';
+import { getPublicDemoHubPath, resolveDemoEntryContext } from '../../lib/demoEntry';
 
 const DEMO_ANCHORS = {
   shelves: 'logros-shelves',
@@ -30,8 +32,16 @@ const DEMO_ANCHORS = {
 
 export default function LabsLogrosDemoPage() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { userId } = useAuth();
   const { language } = usePostLoginLanguage();
+  const demoContext = resolveDemoEntryContext(location.search);
   const demoHubPath = getPublicDemoHubPath(location.search);
+  const dashboardPath = useMemo(() => {
+    const raw = DASHBOARD_PATH || '/dashboard-v3';
+    const normalized = raw.startsWith('/') ? raw : `/${raw}`;
+    return normalized.replace(/\/+$/, '') || '/dashboard-v3';
+  }, []);
   const [showGuidedTour, setShowGuidedTour] = useState(true);
   const [activeStepId, setActiveStepId] = useState<string | null>(LABS_LOGROS_GUIDED_STEPS[0]?.id ?? null);
   const demoControlsRef = useRef<RewardsSectionDemoControls | null>(null);
@@ -94,6 +104,15 @@ export default function LabsLogrosDemoPage() {
     }
   }, []);
 
+  const handleDemoExit = useCallback(() => {
+    const shouldReturnToDashboard = Boolean(userId) && (demoContext.fromOnboarding || demoContext.source === 'internal');
+    if (shouldReturnToDashboard) {
+      navigate(dashboardPath, { state: { scrollToTopOnEnter: true, source: 'demo', focusSection: 'logros' } });
+      return;
+    }
+    navigate(demoHubPath);
+  }, [dashboardPath, demoContext.fromOnboarding, demoContext.source, demoHubPath, navigate, userId]);
+
   return (
     <div className="min-h-screen bg-transparent" data-light-scope="dashboard-v3" data-labs-logros-step={activeStepId ?? undefined}>
       <header className="sticky top-0 z-40 border-b border-[color:var(--glass-border)] bg-[image:var(--glass-bg)] px-3 py-3 backdrop-blur-xl md:px-6">
@@ -103,8 +122,14 @@ export default function LabsLogrosDemoPage() {
             <h1 className="font-display text-[1.05rem] font-semibold text-[color:var(--color-text)] md:text-xl">{language === 'es' ? 'Logros' : 'Achievements'}</h1>
           </div>
           <Link
-            to={demoHubPath}
-            aria-label={language === 'es' ? 'Cerrar demo de Logros y volver al hub público' : 'Close Achievements demo and return to the public hub'}
+            to={demoContext.fromOnboarding || demoContext.source === 'internal' ? dashboardPath : demoHubPath}
+            onClick={(event) => {
+              event.preventDefault();
+              handleDemoExit();
+            }}
+            aria-label={language === 'es'
+              ? 'Cerrar demo de Logros'
+              : 'Close Achievements demo'}
             className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[color:var(--glass-border)] bg-[color:var(--color-surface-soft)] text-lg font-semibold leading-none text-[color:var(--color-text)] transition-colors hover:bg-[color:var(--color-surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-bg)]"
           >
             <span aria-hidden>×</span>

--- a/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
+++ b/apps/web/src/pages/labs/editor-guide/EditorGuideOverlay.tsx
@@ -6,6 +6,12 @@ import {
   type EditorGuideStepId,
   getEditorGuideSteps,
 } from "./guideConfig";
+import {
+  GUIDED_OVERLAY_FRAME_CLASS,
+  GUIDED_OVERLAY_MASK_CLASS,
+  GUIDED_OVERLAY_PANEL_BASE_CLASS,
+  GUIDED_OVERLAY_SLICE_CLASS,
+} from "../../../components/demo/guidedOverlayFoundation";
 
 type Rect = { top: number; left: number; width: number; height: number };
 type ModalCoreFocusPhase = "overview" | "detail";
@@ -73,13 +79,27 @@ export function EditorGuideOverlay({
     const body = document.body;
     const prevHtmlOverflow = html.style.overflow;
     const prevBodyOverflow = body.style.overflow;
+    const prevHtmlOverscrollBehavior = html.style.overscrollBehavior;
+    const prevBodyOverscrollBehavior = body.style.overscrollBehavior;
 
     html.style.overflow = "hidden";
     body.style.overflow = "hidden";
+    html.style.overscrollBehavior = "none";
+    body.style.overscrollBehavior = "none";
+
+    const preventManualScroll = (event: WheelEvent | TouchEvent) => {
+      event.preventDefault();
+    };
+    window.addEventListener("wheel", preventManualScroll, { passive: false });
+    window.addEventListener("touchmove", preventManualScroll, { passive: false });
 
     return () => {
+      window.removeEventListener("wheel", preventManualScroll);
+      window.removeEventListener("touchmove", preventManualScroll);
       html.style.overflow = prevHtmlOverflow;
       body.style.overflow = prevBodyOverflow;
+      html.style.overscrollBehavior = prevHtmlOverscrollBehavior;
+      body.style.overscrollBehavior = prevBodyOverscrollBehavior;
     };
   }, [isOpen]);
 
@@ -196,8 +216,6 @@ export function EditorGuideOverlay({
     : { aria: "Guide", back: "Previous", skip: "Skip", finish: "Finish", next: "Next", label: "Guide" };
 
   const nextLabel = isLast ? copy.finish : copy.next;
-  const maskedOverlayClass =
-    "bg-slate-950/88 backdrop-blur-[6px] backdrop-saturate-[0.82]";
 
   const frame = useMemo(() => {
     if (!targetRect) {
@@ -227,15 +245,15 @@ export function EditorGuideOverlay({
       {frame && !isWheelStep ? (
         <>
           <div
-            className={`absolute left-0 right-0 top-0 ${maskedOverlayClass} transition-all duration-500`}
+            className={`absolute left-0 right-0 top-0 ${GUIDED_OVERLAY_MASK_CLASS} ${GUIDED_OVERLAY_SLICE_CLASS}`}
             style={{ height: frame.top }}
           />
           <div
-            className={`absolute left-0 ${maskedOverlayClass} transition-all duration-500`}
+            className={`absolute left-0 ${GUIDED_OVERLAY_MASK_CLASS} ${GUIDED_OVERLAY_SLICE_CLASS}`}
             style={{ top: frame.top, width: frame.left, height: frame.height }}
           />
           <div
-            className={`absolute right-0 ${maskedOverlayClass} transition-all duration-500`}
+            className={`absolute right-0 ${GUIDED_OVERLAY_MASK_CLASS} ${GUIDED_OVERLAY_SLICE_CLASS}`}
             style={{
               top: frame.top,
               left: frame.left + frame.width,
@@ -243,11 +261,11 @@ export function EditorGuideOverlay({
             }}
           />
           <div
-            className={`absolute left-0 right-0 ${maskedOverlayClass} transition-all duration-500`}
+            className={`absolute left-0 right-0 ${GUIDED_OVERLAY_MASK_CLASS} ${GUIDED_OVERLAY_SLICE_CLASS}`}
             style={{ top: frame.top + frame.height, bottom: 0 }}
           />
           <div
-            className="pointer-events-none absolute rounded-2xl border border-violet-200/70 shadow-[0_0_0_1px_rgba(255,255,255,0.3),0_0_0_9999px_rgba(2,6,23,0.28),0_0_52px_rgba(139,92,246,0.42)] transition-all duration-500"
+            className={GUIDED_OVERLAY_FRAME_CLASS}
             style={{
               top: frame.top,
               left: frame.left,
@@ -257,11 +275,11 @@ export function EditorGuideOverlay({
           />
         </>
       ) : (
-        <div className={`absolute inset-0 ${maskedOverlayClass}`} />
+        <div className={`absolute inset-0 ${GUIDED_OVERLAY_MASK_CLASS}`} />
       )}
 
       <section
-        className={`editor-guide-panel absolute left-1/2 flex w-[min(calc(100vw-1.5rem),42rem)] -translate-x-1/2 flex-col rounded-3xl border border-white/10 bg-[color:var(--color-surface-elevated)] px-5 py-4 text-[color:var(--color-slate-100)] shadow-[0_24px_65px_rgba(2,6,23,0.72)] ${
+        className={`editor-guide-panel absolute left-1/2 flex w-[min(calc(100vw-1.5rem),42rem)] -translate-x-1/2 flex-col px-5 py-4 ${GUIDED_OVERLAY_PANEL_BASE_CLASS} ${
           panelPlacement === "top"
             ? "top-3 md:top-6"
             : panelPlacement === "center"


### PR DESCRIPTION
### Motivation
- Alinear Dashboard y Logros con el lenguaje visual, timing y suavidad de la guía del Editor y corregir el comportamiento de salida de Logros según contexto de entrada.
- Evitar saltos bruscos al cambiar de step y bloquear el scroll manual mientras una attention window está activa, manteniendo el scroll programático para alineación.

### Description
- Extraje una capa visual compartida `guidedOverlayFoundation.ts` con clases reutilizables para máscara, slices, foco y panel (misma máscara premium, blur, frame violeta/blanco y `transition-all duration-500 ease-out`).
- Apliqué esas clases en `GuidedDemoOverlay.tsx` y `EditorGuideOverlay.tsx` para homogeneizar slices, frame y panel y lograr interpolación suave entre pasos.
- Hice el bloqueo de scroll manual consistente: añadí overscroll/ wheel/ touch prevention en `EditorGuideOverlay` y mantuve bloqueo programático estable en `GuidedDemoOverlay` (evita interacción manual mientras la guía está activa).
- Corregí la `X` de Logros para resolver contexto con `resolveDemoEntryContext(location.search)` y usar `handleDemoExit()` que decide entre volver al hub público o al dashboard real según `demoContext` y `userId`, replicando la lógica de Dashboard.
- Pequeña mejora de estabilidad: el overlay ya no invalidará inmediatamente el foco cuando el target está momentáneamente ausente durante mutaciones, evitando flashes/saltos entre pasos.

### Testing
- Ejecuté `npm run typecheck:web` para validar tipos del workspace web, y la tarea falló con errores TypeScript preexistentes no relacionados con este cambio (errores en `runtimeAuth.tsx`, `PreviewAchievementCard` y fixtures de tests).  
- No se añadieron tests unitarios en este PR; los cambios son visuales/UX y afectan componentes de UI (se probó revisión de código y consistencia de clases en los archivos modificados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4e3e63b08332a1565b31271402ea)