### PR TITLE
Fix Logros hero scene readiness blocking horizontal transition

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -361,6 +361,11 @@ function HeroLogrosScene({
   const [controlsReady, setControlsReady] = useState(false);
   const readyReportedRef = useRef(false);
   const readinessResolvedRef = useRef(false);
+  const onReadyRef = useRef(onReady);
+
+  useEffect(() => {
+    onReadyRef.current = onReady;
+  }, [onReady]);
 
   const demoConfig = useMemo(
     () => ({
@@ -379,6 +384,7 @@ function HeroLogrosScene({
       },
       controls: {
         onReady: (controls: RewardsSectionDemoControls) => {
+          console.info("[hero-logros] controls.onReady fired");
           controlsRef.current = controls;
           setControlsReady(true);
         },
@@ -388,19 +394,25 @@ function HeroLogrosScene({
   );
 
   useEffect(() => {
+    console.info("[hero-logros] HeroLogrosScene mounted");
+  }, []);
+
+  useEffect(() => {
+    if (sceneReady) {
+      console.info("[hero-logros] sceneReady -> true");
+    }
+  }, [sceneReady]);
+
+  useEffect(() => {
     let intervalId = 0;
     let attempts = 0;
-    const maxAttempts = 50;
+    const maxAttempts = 14;
     const markReady = (reason: "strict" | "fallback") => {
       setSceneReady(true);
       if (!readyReportedRef.current) {
         readyReportedRef.current = true;
-        if (reason === "fallback") {
-          console.info("[hero-phone-showcase] logros fallback ready");
-        } else {
-          console.info("[hero-phone-showcase] logros ready");
-        }
-        onReady();
+        console.info("[hero-logros] onReady() call", { reason });
+        onReadyRef.current();
       }
     };
 
@@ -417,76 +429,46 @@ function HeroLogrosScene({
       const cards = track?.querySelectorAll<HTMLElement>(
         "[data-achievement-carousel-index]",
       );
-      const firstCard = sceneRoot?.querySelector<HTMLElement>(
-        '[data-demo-anchor="logros-achieved-card"]',
-      );
-      const blockedCard = sceneRoot?.querySelector<HTMLElement>(
-        '[data-demo-anchor="logros-blocked-card"]',
-      );
-      if (!sceneRoot || !controlsReady || !controls || !track || !cards) {
+
+      if (attempts <= 3 || attempts === maxAttempts) {
+        console.info("[hero-logros] readiness tick", {
+          attempts,
+          hasSceneRoot: Boolean(sceneRoot),
+          controlsReady,
+          hasControls: Boolean(controls),
+          hasTrack: Boolean(track),
+          cards: cards?.length ?? 0,
+        });
+      }
+
+      if (!sceneRoot || !controls || !track || !cards) {
         return false;
       }
 
       if (!readinessResolvedRef.current) {
+        console.info("[hero-logros] initial controls setup");
         controls.closeAllOverlays();
         controls.selectPillar("BODY");
         controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
         readinessResolvedRef.current = true;
-        return false;
       }
 
-      if (!firstCard) {
-        return false;
-      }
-
-      const trackRect = track.getBoundingClientRect();
-      const firstRect = firstCard.getBoundingClientRect();
-      const hasLayout =
-        trackRect.width > 0 && firstRect.width > 0 && firstRect.height > 0;
-      if (!hasLayout) {
-        return false;
-      }
-
-      const selectedTabLabel = pillarSelector
-        ?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]')
-        ?.textContent?.toLowerCase();
-      const isBodySelected = Boolean(
-        selectedTabLabel?.includes("body") || selectedTabLabel?.includes("cuerpo"),
-      );
-
-      const horizontallyVisible =
-        firstRect.right > trackRect.left + 8 &&
-        firstRect.left < trackRect.right - 8;
-      const hasFocusableFirstCard =
-        firstCard.matches("button") &&
-        !firstCard.hasAttribute("disabled") &&
-        firstCard.tabIndex >= 0;
-      const hasMinimumStructure = cards.length >= 2 && Boolean(blockedCard);
-      if (
-        hasMinimumStructure &&
-        isBodySelected &&
-        horizontallyVisible &&
-        hasFocusableFirstCard
-      ) {
+      const hasMinimumStructure = cards.length >= 2;
+      if (hasMinimumStructure) {
         markReady("strict");
         return true;
       }
 
-      if (attempts >= maxAttempts && hasMinimumStructure) {
-        console.info("[hero-phone-showcase] logros readiness fallback", {
+      if (attempts >= maxAttempts && cards.length >= 1) {
+        console.info("[hero-logros] fallback ready after retries", {
           attempts,
           cards: cards.length,
-          isBodySelected,
-          horizontallyVisible,
-          hasFocusableFirstCard,
+          hasPillarSelector: Boolean(pillarSelector),
         });
         markReady("fallback");
         return true;
       }
 
-      if (!hasMinimumStructure) {
-        return false;
-      }
       return false;
     };
 
@@ -503,7 +485,7 @@ function HeroLogrosScene({
         window.clearInterval(intervalId);
       }
     };
-  }, [controlsReady, onReady]);
+  }, [controlsReady]);
 
   useEffect(() => {
     if (!isActive || !sceneReady) {
@@ -589,6 +571,9 @@ function HeroPhoneShowcase() {
   useEffect(() => {
     if (previousPhaseRef.current !== "logros" && phase === "logros") {
       setLogrosCycleKey((value) => value + 1);
+    }
+    if (phase === "to-logros" || phase === "logros") {
+      console.info("[hero-logros] phase", phase, { logrosReady });
     }
     if (previousPhaseRef.current !== phase) {
       console.info("[hero-phone-showcase] phase", phase);


### PR DESCRIPTION
### Motivation
- The Logros horizontal scene could never become active because its readiness gate relied on fragile UI checks and an unstable `onReady` prop, leaving the timeline stuck on the vertical dashboard loop.
- The intent is to allow the hero timeline to advance into the Logros carousel without changing dashboard vertical autoplay, copy, or layout.

### Description
- Simplified `HeroLogrosScene` readiness gate in `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx` to require only `sceneRoot` + `controls` + `logros-carousel-track` + at least 2 rendered cards, with a fallback after ~1.1s when at least 1 card exists.
- Stabilized `onReady` usage by storing it in a ref (`onReadyRef`) so the polling effect is not retriggered by parent re-renders, and removed the `onReady` dependency from the polling effect.
- Kept initial setup calls `controls.closeAllOverlays()`, `controls.selectPillar('BODY')`, and `controls.focusCarouselCard(...)` but made them non-blocking (they run once and no longer block readiness if not perfect on first try).
- Added temporary diagnostic logs prefixed with `[hero-logros]` to trace mount, `controls.onReady`, track/cards detection, `sceneReady` transitions, `onReady()` calls, and timeline phase entries; these logs are easy to remove later.

### Testing
- Ran `npm run typecheck:web` (invokes `tsc --noEmit`) and it failed due to preexisting TypeScript errors elsewhere in the repo unrelated to this change (e.g., `runtimeAuth.tsx`, `PreviewAchievementCard*`, `demoLogrosData.ts`), so no green typecheck could be produced in this environment.
- Verified code compiles locally enough to commit the single-file change and confirmed added debug logs and readiness logic are self-contained to `HeroPhoneShowcaseLabPage.tsx` and do not modify dashboard timings or UI copy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb68dd361883328f782817c5b4759d)