### PR TITLE
Polish hero phone angle and logros safe-area composition

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -94,6 +94,7 @@
 }
 
 .phoneFrame {
+  --hero-phone-safe-top: 44px;
   width: min(100%, 342px);
   aspect-ratio: 9 / 18.5;
   border-radius: 42px;
@@ -104,8 +105,8 @@
     0 8px 24px rgba(84, 61, 142, 0.2),
     inset 0 0 0 1px rgba(255, 255, 255, 0.16),
     inset 0 -8px 16px rgba(0, 0, 0, 0.34);
-  transform: perspective(1200px) rotateY(-5deg) rotateX(1.5deg);
-  transform-origin: center right;
+  transform: perspective(1300px) rotateY(-1.35deg) rotateX(0.4deg);
+  transform-origin: center center;
   position: relative;
 }
 
@@ -183,10 +184,10 @@
 
 .logrosViewport {
   position: absolute;
-  inset: 0;
+  inset: var(--hero-phone-safe-top) 0 0;
   overflow: hidden;
   display: flex;
-  padding: 8px 8px 10px;
+  padding: 10px 8px 10px;
   background:
     radial-gradient(
       circle at 20% 12%,
@@ -213,8 +214,8 @@
 
 .logrosHeroOnly :global(.ib-card > .relative) {
   height: 100%;
-  padding: 0.25rem 0.25rem 0.5rem !important;
-  gap: 0.45rem !important;
+  padding: 0.4rem 0.3rem 0.5rem !important;
+  gap: 0.4rem !important;
 }
 
 .logrosHeroOnly :global([data-demo-anchor="logros-growth-calibration"]),
@@ -233,10 +234,12 @@
   grid-template-rows: auto 1fr;
   height: 100%;
   min-height: 0;
+  gap: 0.28rem;
 }
 
 .logrosHeroOnly :global([data-demo-anchor="logros-pillar-selector"]) {
   margin: 0 !important;
+  padding-top: 0.1rem;
 }
 
 .logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"]) {
@@ -250,7 +253,7 @@
 .logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"] > button) {
   width: 88%;
   min-height: 0;
-  height: min(22.4rem, 100%);
+  height: min(21.8rem, 100%);
   padding: 0.72rem;
   border-radius: 1.1rem;
 }
@@ -266,7 +269,7 @@
 }
 .realViewport {
   position: absolute;
-  inset: 0;
+  inset: var(--hero-phone-safe-top) 0 0;
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior: contain;
@@ -283,8 +286,38 @@
 .mobileDashboardRoot {
   min-height: 100%;
   width: 100%;
-  padding: 12px 12px 108px;
+  padding: 16px 12px 108px;
   box-sizing: border-box;
+}
+
+.logrosHeroOnly :global(.ib-light-elevated-surface--emerald) {
+  padding: 0.6rem !important;
+}
+
+.logrosHeroOnly
+  :global(
+    .ib-light-elevated-surface--emerald .mt-3.grid.gap-3.sm\:grid-cols-2
+  ) {
+  margin-top: 0.5rem;
+  gap: 0.45rem;
+  grid-template-columns: 1fr !important;
+}
+
+.logrosHeroOnly
+  :global(
+    .ib-light-elevated-surface--emerald
+      .mt-3.grid.gap-3.sm\:grid-cols-2
+      > :nth-child(n + 2)
+  ) {
+  display: none !important;
+}
+
+.logrosHeroOnly :global(.ib-light-elevated-surface--emerald button) {
+  padding: 0.55rem !important;
+}
+
+.logrosHeroOnly :global(.ib-light-elevated-surface--indigo) {
+  display: none !important;
 }
 
 .heroFocusContent > :global(.space-y-6) > :first-child {


### PR DESCRIPTION
### Motivation
- El teléfono del hero se percibía torcido por una transformación 3D demasiado agresiva y un origen de transformación desplazado, lo que dañaba la lectura de la pantalla en el showcase.
- El contenido dentro de la pantalla (dashboard y escena de Logros) quedaba demasiado cerca de la Dynamic Island y algunos controles (segmented control) tocaban la isla.
- El bloque de Weekly Wrapped en el hero aparecía aplastado y desproporcionado respecto al carrusel, afectando la jerarquía visual en el viewport pequeño.

### Description
- Reduje la inclinación 3D en `.phoneFrame` cambiando `transform: perspective(1200px) rotateY(-5deg) rotateX(1.5deg)` a `perspective(1300px) rotateY(-1.35deg) rotateX(0.4deg)` y centré el `transform-origin` para que el teléfono se vea más recto y premium manteniendo algo de profundidad.
- Añadí una variable `--hero-phone-safe-top: 44px` y la apliqué a `.logrosViewport` y `.realViewport`, además de aumentar levemente el `padding-top` en `.mobileDashboardRoot` para forzar una safe area superior que evita que la UI choque con la Dynamic Island.
- Ajusté el subtree de Logros scoped al hero (`.logrosHeroOnly`) aligerando padding/gap, reduciendo la altura máxima de las cards del carrusel y añadiendo pequeños offsets en el selector de pilar para mejorar la composición sin tocar la lógica de `RewardsSection`.
- Hice cambios localizados para Weekly Wrapped dentro del hero: aumenté el padding del contenedor emerald, forcé la grilla a 1 columna, escondí los items extra y compacté botones y paddings para que el bloque quede limpio y proporcional dentro del hero sin modificar la implementación global de `RewardsSection`.

### Testing
- Ejecuté `prettier --check apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css` y se detectaron issues de formato antes del arreglo.
- Ejecuté `prettier --write apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css` para aplicar formato y luego `prettier --check` que pasó correctamente.
- No se modificó lógica de autoplay ni datos mock, y no se ejecutaron tests visuales automáticos en este entorno de cambios CSS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7d18bde483329638fecb2a63b305)