### PR TITLE
feat(web): usar Labs phone showcase en el hero de la landing

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -1,0 +1,234 @@
+.root {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.phoneFrame {
+  --hero-phone-safe-top: 44px;
+  width: min(100%, 342px);
+  aspect-ratio: 9 / 18.5;
+  border-radius: 42px;
+  background: linear-gradient(160deg, #2d2738 0%, #0b0d13 55%, #111c2f 100%);
+  padding: 10px;
+  box-shadow:
+    0 26px 72px rgba(8, 8, 18, 0.6),
+    0 8px 24px rgba(84, 61, 142, 0.2),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.16),
+    inset 0 -8px 16px rgba(0, 0, 0, 0.34);
+  transform: perspective(1300px) rotateY(-1.35deg) rotateX(0.4deg);
+  transform-origin: center center;
+  position: relative;
+}
+
+.phoneIsland {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: clamp(92px, 38%, 124px);
+  height: 28px;
+  border-radius: 999px;
+  background: radial-gradient(circle at 68% 42%, rgba(49, 57, 74, 0.88) 0, rgba(8, 10, 16, 0.96) 58%, #020307 100%);
+  box-shadow:
+    inset 0 1px 1px rgba(255, 255, 255, 0.14),
+    inset 0 -1px 2px rgba(0, 0, 0, 0.52),
+    0 2px 4px rgba(0, 0, 0, 0.45);
+  z-index: 5;
+  pointer-events: none;
+}
+
+.phoneIslandLens {
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  transform: translateY(-50%);
+  border-radius: 999px;
+  background: radial-gradient(circle at 32% 30%, rgba(127, 140, 176, 0.72), rgba(24, 30, 43, 0.18) 42%, rgba(6, 8, 14, 0.92));
+}
+
+.phoneScreen {
+  height: 100%;
+  border-radius: 30px;
+  overflow: hidden;
+  background: #050816;
+  border: 1px solid rgba(216, 194, 246, 0.24);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 -14px 36px rgba(4, 5, 10, 0.48);
+}
+
+.scenePanel {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+  background: #050816;
+}
+
+.sceneTrack {
+  width: 200%;
+  height: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  transition: transform 0ms linear;
+  will-change: transform;
+}
+
+.sceneDashboard,
+.sceneLogros {
+  width: 100%;
+  height: 100%;
+}
+
+.realViewport {
+  position: absolute;
+  inset: var(--hero-phone-safe-top) 0 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
+  pointer-events: none;
+  touch-action: none;
+  user-select: none;
+}
+
+.realViewport::-webkit-scrollbar {
+  display: none;
+}
+
+.mobileDashboardRoot {
+  min-height: 100%;
+  width: 100%;
+  padding: 16px 12px 108px;
+  box-sizing: border-box;
+}
+
+.heroFocusViewport {
+  padding-bottom: 88px;
+}
+
+.heroFocusContent > :global(.space-y-6) > :first-child {
+  display: none !important;
+}
+
+.heroFocusContent :global([data-demo-anchor='daily-energy']),
+.heroFocusContent :global([data-demo-anchor='daily-cultivation']),
+.heroFocusContent :global([data-demo-anchor='moderation']),
+.heroFocusContent :global([data-demo-anchor='balance']) {
+  display: none !important;
+}
+
+.heroFocusContent :global(.order-1),
+.heroFocusContent :global(.order-3 > :not([data-demo-anchor='emotion-chart'])),
+.heroFocusContent :global(.order-4 > :not([data-demo-anchor='streaks'])) {
+  display: none !important;
+}
+
+.logrosViewport {
+  position: absolute;
+  inset: var(--hero-phone-safe-top) 0 0;
+  overflow: hidden;
+  display: flex;
+  padding: 10px 8px 10px;
+  background: radial-gradient(circle at 20% 12%, rgba(120, 140, 255, 0.15), transparent 48%), #060a16;
+}
+
+.logrosHeroOnly {
+  height: 100%;
+  width: 100%;
+}
+
+.logrosHeroOnly :global(.ib-card) {
+  height: 100%;
+  min-height: 0;
+}
+
+.logrosHeroOnly :global(.ib-card > header),
+.logrosHeroOnly :global(.ib-card > [class*='rightSlot']) {
+  display: none !important;
+}
+
+.logrosHeroOnly :global(.ib-card > .relative) {
+  height: 100%;
+  padding: 0.4rem 0.3rem 0.5rem !important;
+  gap: 0.4rem !important;
+}
+
+.logrosHeroOnly :global([data-demo-anchor='logros-growth-calibration']),
+.logrosHeroOnly :global([data-demo-anchor='weekly-wrapped-shelf']),
+.logrosHeroOnly :global([data-demo-anchor='monthly-wrapped-shelf']) {
+  display: none !important;
+}
+
+.logrosHeroOnly :global([data-demo-anchor='logros-shelves']) {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.logrosHeroOnly :global([data-demo-anchor='logros-carousel-structure']) {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+  min-height: 0;
+  gap: 0.28rem;
+}
+
+.logrosHeroOnly :global([data-demo-anchor='logros-pillar-selector']) {
+  margin: 0 !important;
+  padding-top: 0.1rem;
+}
+
+.logrosHeroOnly :global([data-demo-anchor='logros-carousel-track']) {
+  min-height: 0;
+  margin-top: 0.25rem;
+  padding-inline: 0.2rem;
+  gap: 0.42rem;
+  align-items: stretch;
+}
+
+.logrosHeroOnly :global([data-demo-anchor='logros-carousel-track'] > button) {
+  width: 88%;
+  min-height: 0;
+  height: min(21.8rem, 100%);
+  padding: 0.72rem;
+  border-radius: 1.1rem;
+}
+
+.logrosHeroOnly :global([data-demo-anchor='logros-carousel-track'] > button .text-lg) {
+  font-size: 0.86rem;
+}
+
+.logrosHeroOnly :global([data-demo-anchor='logros-carousel-structure'] > .flex.items-center) {
+  display: none !important;
+}
+
+.logrosHeroOnly :global(.ib-light-elevated-surface--emerald) {
+  padding: 0.6rem !important;
+}
+
+.logrosHeroOnly :global(.ib-light-elevated-surface--emerald .mt-3.grid.gap-3.sm\:grid-cols-2) {
+  margin-top: 0.5rem;
+  gap: 0.45rem;
+  grid-template-columns: 1fr !important;
+}
+
+.logrosHeroOnly :global(.ib-light-elevated-surface--emerald .mt-3.grid.gap-3.sm\:grid-cols-2 > :nth-child(n + 2)) {
+  display: none !important;
+}
+
+.logrosHeroOnly :global(.ib-light-elevated-surface--emerald button) {
+  padding: 0.55rem !important;
+}
+
+.logrosHeroOnly :global(.ib-light-elevated-surface--indigo) {
+  display: none !important;
+}
+
+@media (max-width: 900px) {
+  .phoneFrame {
+    width: min(100%, 320px);
+  }
+}

--- a/apps/web/src/components/landing/HeroPhoneShowcase.tsx
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.tsx
@@ -1,0 +1,385 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { setDashboardDemoModeEnabled } from '../../lib/demoMode';
+import { DemoDashboardOverviewScene } from '../demo/DemoDashboardOverviewScene';
+import { RewardsSection, type RewardsSectionDemoControls } from '../dashboard-v3/RewardsSection';
+import { getDemoLogrosData, getDemoLogrosPreviewByTaskId } from '../../data/demoLogrosData';
+import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
+import styles from './HeroPhoneShowcase.module.css';
+
+const INITIAL_TOP_PAUSE_MS = 500;
+const SCROLL_DOWN_DURATION_MS = 4500;
+const LOOP_BOTTOM_PAUSE_MS = 950;
+const RESET_TO_TOP_DURATION_MS = 300;
+const LOOP_TOP_PAUSE_MS = 350;
+const DASHBOARD_LOOP_DURATION_MS =
+  INITIAL_TOP_PAUSE_MS +
+  SCROLL_DOWN_DURATION_MS +
+  LOOP_BOTTOM_PAUSE_MS +
+  RESET_TO_TOP_DURATION_MS +
+  LOOP_TOP_PAUSE_MS;
+
+const DASHBOARD_TO_LOGROS_DURATION_MS = 820;
+const LOGROS_CAROUSEL_DURATION_MS = 5800;
+const LOGROS_TO_DASHBOARD_DURATION_MS = 820;
+const HERO_LOOP_DURATION_MS =
+  DASHBOARD_LOOP_DURATION_MS +
+  DASHBOARD_TO_LOGROS_DURATION_MS +
+  LOGROS_CAROUSEL_DURATION_MS +
+  LOGROS_TO_DASHBOARD_DURATION_MS;
+
+const HERO_TASK_SEQUENCE = ['task-water', 'task-dinner-before-22', 'task-gym'] as const;
+const HERO_BODY_CARD_UNLOCKED_1 = HERO_TASK_SEQUENCE[0];
+const HERO_BODY_CARD_UNLOCKED_2 = HERO_TASK_SEQUENCE[1];
+const HERO_BODY_CARD_BLOCKED_1 = HERO_TASK_SEQUENCE[2];
+
+function smoothProgress(progress: number) {
+  return progress * progress * (3 - 2 * progress);
+}
+
+function resolveDashboardProgress(elapsedInLoop: number) {
+  if (elapsedInLoop < INITIAL_TOP_PAUSE_MS) return 0;
+
+  if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS) {
+    const downElapsed = elapsedInLoop - INITIAL_TOP_PAUSE_MS;
+    return smoothProgress(downElapsed / SCROLL_DOWN_DURATION_MS);
+  }
+
+  if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS) {
+    return 1;
+  }
+
+  if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS + RESET_TO_TOP_DURATION_MS) {
+    const resetElapsed = elapsedInLoop - INITIAL_TOP_PAUSE_MS - SCROLL_DOWN_DURATION_MS - LOOP_BOTTOM_PAUSE_MS;
+    return 1 - resetElapsed / RESET_TO_TOP_DURATION_MS;
+  }
+
+  return 0;
+}
+
+type HeroPhase = 'dashboard' | 'to-logros' | 'logros' | 'to-dashboard';
+
+function useHeroShowcaseTimeline({ dashboardReady, logrosReady }: { dashboardReady: boolean; logrosReady: boolean }) {
+  const [timeline, setTimeline] = useState<{
+    phase: HeroPhase;
+    dashboardProgress: number;
+    trackProgress: number;
+  }>({
+    phase: 'dashboard',
+    dashboardProgress: 0,
+    trackProgress: 0,
+  });
+
+  const startedAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!dashboardReady) {
+      setTimeline({ phase: 'dashboard', dashboardProgress: 0, trackProgress: 0 });
+      startedAtRef.current = null;
+      return;
+    }
+
+    let rafId = 0;
+    const tick = (now: number) => {
+      const startedAt = startedAtRef.current ?? now;
+      if (startedAtRef.current == null) {
+        startedAtRef.current = now;
+      }
+      const elapsed = Math.max(0, now - startedAt);
+      const dashboardElapsed = elapsed % DASHBOARD_LOOP_DURATION_MS;
+
+      if (!logrosReady) {
+        setTimeline({
+          phase: 'dashboard',
+          dashboardProgress: resolveDashboardProgress(dashboardElapsed),
+          trackProgress: 0,
+        });
+        rafId = window.requestAnimationFrame(tick);
+        return;
+      }
+
+      const elapsedInLoop = elapsed % HERO_LOOP_DURATION_MS;
+      if (elapsedInLoop < DASHBOARD_LOOP_DURATION_MS) {
+        setTimeline({
+          phase: 'dashboard',
+          dashboardProgress: resolveDashboardProgress(elapsedInLoop),
+          trackProgress: 0,
+        });
+      } else if (elapsedInLoop < DASHBOARD_LOOP_DURATION_MS + DASHBOARD_TO_LOGROS_DURATION_MS) {
+        const transitionElapsed = elapsedInLoop - DASHBOARD_LOOP_DURATION_MS;
+        setTimeline({
+          phase: 'to-logros',
+          dashboardProgress: 0,
+          trackProgress: smoothProgress(transitionElapsed / DASHBOARD_TO_LOGROS_DURATION_MS),
+        });
+      } else if (elapsedInLoop < DASHBOARD_LOOP_DURATION_MS + DASHBOARD_TO_LOGROS_DURATION_MS + LOGROS_CAROUSEL_DURATION_MS) {
+        setTimeline({ phase: 'logros', dashboardProgress: 0, trackProgress: 1 });
+      } else {
+        const transitionElapsed = elapsedInLoop - DASHBOARD_LOOP_DURATION_MS - DASHBOARD_TO_LOGROS_DURATION_MS - LOGROS_CAROUSEL_DURATION_MS;
+        setTimeline({
+          phase: 'to-dashboard',
+          dashboardProgress: 0,
+          trackProgress: 1 - smoothProgress(transitionElapsed / LOGROS_TO_DASHBOARD_DURATION_MS),
+        });
+      }
+
+      rafId = window.requestAnimationFrame(tick);
+    };
+
+    rafId = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(rafId);
+  }, [dashboardReady, logrosReady]);
+
+  return !dashboardReady
+    ? { phase: 'dashboard' as const, dashboardProgress: 0, trackProgress: 0 }
+    : timeline;
+}
+
+function PhoneFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className={styles.phoneFrame}>
+      <div className={styles.phoneIsland} aria-hidden>
+        <span className={styles.phoneIslandLens} />
+      </div>
+      <div className={styles.phoneScreen}>{children}</div>
+    </div>
+  );
+}
+
+function RealDashboardScene({ scrollProgress, onReady }: { scrollProgress: number; onReady: () => void }) {
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const readyReportedRef = useRef(false);
+  const scrollRangeRef = useRef({ start: 0, end: 0 });
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const { start, end } = scrollRangeRef.current;
+    viewport.scrollTop = start + (end - start) * scrollProgress;
+  }, [scrollProgress]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || readyReportedRef.current) return;
+
+    let intervalId = 0;
+    let attempts = 0;
+    const maxAttempts = 45;
+
+    const reportReady = () => {
+      if (readyReportedRef.current) return;
+      readyReportedRef.current = true;
+      onReady();
+    };
+
+    const resolveIfReady = () => {
+      attempts += 1;
+      const overallProgress = viewport.querySelector<HTMLElement>('[data-demo-anchor="overall-progress"]');
+      const emotionChart = viewport.querySelector<HTMLElement>('[data-demo-anchor="emotion-chart"]');
+      const streaks = viewport.querySelector<HTMLElement>('[data-demo-anchor="streaks"]');
+      if (!overallProgress || !emotionChart || !streaks) return false;
+
+      const viewportRect = viewport.getBoundingClientRect();
+      const resolveTop = (element: HTMLElement) => element.getBoundingClientRect().top - viewportRect.top + viewport.scrollTop;
+
+      const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+      if (maxScroll > 0) {
+        const overallTop = resolveTop(overallProgress);
+        const emotionTop = resolveTop(emotionChart);
+        const streakTop = resolveTop(streaks);
+        const minTravel = Math.max(Math.min(viewport.clientHeight * 0.58, maxScroll), Math.min(160, maxScroll));
+
+        let start = Math.max(0, Math.min(maxScroll, overallTop - 18));
+        const endTarget = Math.max(emotionTop - viewport.clientHeight * 0.38, streakTop - viewport.clientHeight * 0.14);
+        let end = Math.max(start, Math.min(maxScroll, endTarget));
+
+        if (end - start < minTravel) end = Math.min(maxScroll, start + minTravel);
+        if (end - start < minTravel) start = Math.max(0, end - minTravel);
+        if (end <= start) {
+          start = 0;
+          end = maxScroll;
+        }
+
+        scrollRangeRef.current = { start, end };
+        viewport.scrollTop = start;
+        reportReady();
+        return true;
+      }
+
+      if (attempts >= maxAttempts && maxScroll > 0) {
+        scrollRangeRef.current = { start: 0, end: maxScroll };
+        reportReady();
+        return true;
+      }
+
+      return false;
+    };
+
+    if (!resolveIfReady()) {
+      intervalId = window.setInterval(() => {
+        if (resolveIfReady()) window.clearInterval(intervalId);
+      }, 80);
+    }
+
+    return () => {
+      if (intervalId) window.clearInterval(intervalId);
+    };
+  }, [onReady]);
+
+  return (
+    <section className={`${styles.scenePanel} ${styles.sceneDashboard}`} data-light-scope="dashboard-v3">
+      <div ref={viewportRef} className={styles.realViewport}>
+        <div className={`${styles.mobileDashboardRoot} ${styles.heroFocusViewport}`}>
+          <div className={styles.heroFocusContent}>
+            <DemoDashboardOverviewScene gameMode="flow" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function HeroLogrosScene({ isActive, cycleKey, onReady }: { isActive: boolean; cycleKey: number; onReady: () => void }) {
+  const { language } = usePostLoginLanguage();
+  const sceneRef = useRef<HTMLElement | null>(null);
+  const controlsRef = useRef<RewardsSectionDemoControls | null>(null);
+  const [sceneReady, setSceneReady] = useState(false);
+  const readyReportedRef = useRef(false);
+
+  const demoConfig = useMemo(
+    () => ({
+      disableRemote: true,
+      forceAchievementsViewMode: 'carousel' as const,
+      mockPreviewAchievementByTaskId: getDemoLogrosPreviewByTaskId(language),
+      anchors: {
+        shelves: 'logros-shelves',
+        growthCalibration: 'logros-growth-calibration',
+        carouselTrack: 'logros-carousel-track',
+        carouselStructure: 'logros-carousel-structure',
+        pillarSelector: 'logros-pillar-selector',
+        achievedCard: 'logros-achieved-card',
+        blockedCard: 'logros-blocked-card',
+        achievedCardTaskId: HERO_BODY_CARD_UNLOCKED_1,
+        blockedCardTaskId: HERO_BODY_CARD_BLOCKED_1,
+      },
+      controls: {
+        onReady: (controls: RewardsSectionDemoControls) => {
+          controlsRef.current = controls;
+        },
+      },
+    }),
+    [language],
+  );
+
+  useEffect(() => {
+    let intervalId = 0;
+    let attempts = 0;
+    const maxAttempts = 14;
+
+    const markReady = () => {
+      setSceneReady(true);
+      if (readyReportedRef.current) return;
+      readyReportedRef.current = true;
+      onReady();
+    };
+
+    const resolveTrackReady = () => {
+      attempts += 1;
+      const sceneRoot = sceneRef.current;
+      const controls = controlsRef.current;
+      const track = sceneRoot?.querySelector<HTMLElement>('[data-demo-anchor="logros-carousel-track"]');
+      const cards = track?.querySelectorAll<HTMLElement>('[data-achievement-carousel-index]');
+
+      if (!sceneRoot || !controls || !track || !cards) return false;
+
+      controls.closeAllOverlays();
+      controls.selectPillar('BODY');
+      controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
+
+      if (cards.length >= 2 || (attempts >= maxAttempts && cards.length >= 1)) {
+        markReady();
+        return true;
+      }
+
+      return false;
+    };
+
+    if (!resolveTrackReady()) {
+      intervalId = window.setInterval(() => {
+        if (resolveTrackReady()) window.clearInterval(intervalId);
+      }, 80);
+    }
+
+    return () => {
+      if (intervalId) window.clearInterval(intervalId);
+    };
+  }, [onReady]);
+
+  useEffect(() => {
+    if (!isActive || !sceneReady) return;
+    const controls = controlsRef.current;
+    if (!controls) return;
+
+    controls.closeAllOverlays();
+    controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
+
+    const segment = LOGROS_CAROUSEL_DURATION_MS / 3;
+    const t1 = window.setTimeout(() => controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_2), segment * 0.9);
+    const t2 = window.setTimeout(() => controls.focusCarouselCard(HERO_BODY_CARD_BLOCKED_1), segment * 1.95);
+
+    return () => {
+      window.clearTimeout(t1);
+      window.clearTimeout(t2);
+    };
+  }, [cycleKey, isActive, sceneReady]);
+
+  return (
+    <section ref={sceneRef} className={`${styles.scenePanel} ${styles.sceneLogros}`} data-light-scope="dashboard-v3">
+      <div className={styles.logrosViewport}>
+        <div className={styles.logrosHeroOnly}>
+          <RewardsSection userId="" initialData={getDemoLogrosData(language)} demoConfig={demoConfig} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function HeroPhoneShowcase() {
+  const [dashboardReady, setDashboardReady] = useState(false);
+  const [logrosReady, setLogrosReady] = useState(false);
+  const [demoDataReady, setDemoDataReady] = useState(false);
+  const [logrosCycleKey, setLogrosCycleKey] = useState(0);
+  const { phase, dashboardProgress, trackProgress } = useHeroShowcaseTimeline({ dashboardReady, logrosReady });
+  const previousPhaseRef = useRef<HeroPhase>('dashboard');
+
+  useEffect(() => {
+    setDashboardDemoModeEnabled(true);
+    setDemoDataReady(true);
+    return () => {
+      setDemoDataReady(false);
+      setDashboardDemoModeEnabled(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (previousPhaseRef.current !== 'logros' && phase === 'logros') {
+      setLogrosCycleKey((value) => value + 1);
+    }
+    previousPhaseRef.current = phase;
+  }, [phase]);
+
+  return (
+    <div className={styles.root}>
+      <PhoneFrame>
+        {demoDataReady ? (
+          <div className={styles.sceneTrack} style={{ transform: `translate3d(${-50 * trackProgress}%, 0, 0)` }}>
+            <RealDashboardScene scrollProgress={dashboardProgress} onReady={() => setDashboardReady(true)} />
+            <HeroLogrosScene isActive={phase === 'logros'} cycleKey={logrosCycleKey} onReady={() => setLogrosReady(true)} />
+          </div>
+        ) : (
+          <section className={`${styles.scenePanel} ${styles.sceneDashboard}`} data-light-scope="dashboard-v3" aria-hidden />
+        )}
+      </PhoneFrame>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -83,7 +83,7 @@
   --chill: #34d399;
   --flow: #38bdf8;
   --evolve: #8b5cf6;
-  --hero-size: min(480px, 80vw);
+  --hero-size: min(420px, 42vw);
   position: relative;
   min-height: 100vh;
   overflow-x: hidden;
@@ -373,15 +373,16 @@
   margin: 0 auto;
   padding: 56px 18px;
   display: grid;
-  grid-template-columns: 1.1fr var(--hero-size);
+  grid-template-columns: minmax(0, 1.08fr) minmax(280px, var(--hero-size));
   gap: 40px;
   align-items: center;
 }
 
 .landing .hero h1 {
   font-size: clamp(2.25rem, 2vw + 2rem, 3.5rem);
-  line-height: 1.1;
-  font-weight: 900;
+  line-height: 1.06;
+  font-weight: 560;
+  letter-spacing: -0.028em;
   margin: 0 0 16px;
 }
 
@@ -425,7 +426,7 @@
   position: relative;
   border: var(--conic-border) solid transparent;
   padding-inline: 2.4rem;
-  min-width: min(320px, 80%);
+  min-width: min(320px, 88vw);
   background:
     linear-gradient(#8b5cf6, #8b5cf6) padding-box,
     conic-gradient(
@@ -504,20 +505,13 @@
 }
 
 .landing .hero-media {
-  width: var(--hero-size);
-  height: var(--hero-size);
-  aspect-ratio: 1 / 1;
+  width: min(100%, var(--hero-size));
+  min-height: clamp(540px, 64vh, 700px);
   position: relative;
-  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin-left: auto;
-  border-radius: 16px;
-  border: 1px solid var(--line);
-  background: linear-gradient(
-    180deg,
-    rgba(15, 23, 42, 0.65),
-    rgba(17, 28, 51, 0.4)
-  );
-  box-shadow: 0 24px 70px rgba(12, 18, 34, 0.55);
   animation: float 18s ease-in-out infinite;
   will-change: transform;
 }
@@ -2531,6 +2525,8 @@
   }
 
   .landing .hero-media {
+    width: min(100%, 360px);
+    min-height: auto;
     margin: 0 auto;
   }
 
@@ -2568,6 +2564,25 @@
 
   .landing .demo-title {
     font-size: clamp(1.55rem, 3.4vw, 2.05rem);
+  }
+}
+
+@media (min-width: 1025px) {
+  .landing .hero-actions {
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .landing .hero-actions .journey-cta {
+    min-width: 0;
+  }
+
+  .landing .hero-cta-note {
+    margin-left: 0;
+    margin-right: 0;
+    text-align: left;
   }
 }
 

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -9,6 +9,7 @@ import PremiumTimeline from '../components/PremiumTimeline';
 import { AdaptiveText } from '../components/landing/AdaptiveText';
 import { CookieConsentBanner } from '../components/landing/CookieConsentBanner';
 import { useLandingAnalytics } from '../components/landing/useLandingAnalytics';
+import { HeroPhoneShowcase } from '../components/landing/HeroPhoneShowcase';
 import { LabsWeeklyRhythmSystemSection } from '../components/labs/LabsWeeklyRhythmSystemSection';
 import { buildOnboardingPath } from '../onboarding/i18n';
 import { usePostLoginLanguage } from '../i18n/postLoginLanguage';
@@ -598,15 +599,8 @@ export default function LandingPage() {
               </div>
               <p className="tiny hero-cta-note">{copy.hero.note}</p>
             </div>
-            <div className="hero-media">
-              <img
-                src="/nene.png"
-                alt={copy.hero.alt}
-                className="hero-img"
-                width={1200}
-                height={1200}
-                loading="eager"
-              />
+            <div className="hero-media" aria-label={copy.hero.alt}>
+              <HeroPhoneShowcase />
             </div>
           </div>
         </section>


### PR DESCRIPTION
### Motivation
- Sustituir el asset estático del hero (`/nene.png`) por el phone showcase animado ya existente en Labs para dar una imagen más premium sin rediseñar la landing.  
- Mantener intactos copy, fondo, navbar y el resto de secciones; solo cambiar el bloque visual del hero y ajustes de tipografía/layout necesarios para integrarlo.  
- Mejorar la presencia del H1 y la disposición de CTAs en desktop para que el hero se sienta más fino y equilibrado con el teléfono vertical.

### Description
- Added: `apps/web/src/components/landing/HeroPhoneShowcase.tsx` que contiene la lógica del loop/dashboard↔logros y el frame del teléfono reutilizado desde Labs, y `HeroPhoneShowcase.module.css` con estilos encapsulados del phone frame y escenas.  
- Replaced the hero image in `apps/web/src/pages/Landing.tsx` by importing and rendering `<HeroPhoneShowcase />` inside `.hero-media`, keeping the original `copy` and structure.  
- Adjusted `apps/web/src/pages/Landing.css` to better fit a vertical phone: updated `--hero-size`, changed `.hero-grid` columns, transformed `.hero-media` from a square image box to a centered vertical container with `min-height` to highlight the phone.  
- Refined hero H1 visuals by changing `.landing .hero h1` to `font-weight: 560`, `line-height: 1.06` and tighter `letter-spacing`, while preserving the `.grad` text gradient.  
- Kept mobile-first stacking of CTAs and added a desktop media query (`@media (min-width: 1025px)`) to lay out `.hero-actions` in a row and relax the primary CTA `min-width` so buttons can sit side-by-side on web.

### Testing
- Ejecuté `npm run typecheck:web` as a validation step, which failed due to existing TypeScript errors unrelated to these changes (errors live elsewhere in the repo and were not introduced by this PR).  
- No other automated tests were run in this branch; visual/functional behavior should be verified in-browser (hero now renders the animated phone component and CTAs align on desktop per the added media query).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb829748f08332aafd5ddd101f04ce)