### PR TITLE
Restore Labs hero phone showcase behavior in Landing

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -1,5 +1,94 @@
-.root {
-  width: 100%;
+.page {
+  min-height: 100vh;
+  padding: clamp(1.4rem, 2.8vw, 3rem);
+  color: #f2f1fb;
+  background:
+    radial-gradient(
+      circle at 80% 10%,
+      rgba(153, 111, 244, 0.2),
+      transparent 37%
+    ),
+    radial-gradient(
+      circle at 17% 13%,
+      rgba(117, 142, 252, 0.16),
+      transparent 33%
+    ),
+    radial-gradient(
+      circle at 52% 82%,
+      rgba(253, 173, 124, 0.08),
+      transparent 52%
+    ),
+    linear-gradient(180deg, #0f0f19 0%, #0a0a12 100%);
+}
+
+.hero {
+  max-width: 1180px;
+  margin: 0 auto;
+  min-height: calc(100vh - 3rem);
+  display: grid;
+  gap: clamp(1.3rem, 3vw, 2.6rem);
+  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 390px);
+  align-items: center;
+}
+
+.copyCol h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.7rem);
+  line-height: 1.04;
+  letter-spacing: -0.03em;
+}
+
+.copyCol h1 span {
+  color: #c8a6ff;
+}
+
+.copyCol > p {
+  margin: 0.95rem 0 0;
+  max-width: 55ch;
+  color: rgba(237, 236, 250, 0.84);
+  line-height: 1.6;
+}
+
+.kicker {
+  margin: 0 0 1rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(236, 205, 183, 0.72);
+}
+
+.ctaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin-top: 1.6rem;
+}
+
+.primaryCta,
+.secondaryCta {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 44px;
+  padding: 0.72rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.primaryCta {
+  background: linear-gradient(135deg, #9a78f6, #6f84f7);
+  color: #fbfbff;
+  box-shadow: 0 8px 24px rgba(116, 107, 216, 0.36);
+}
+
+.secondaryCta {
+  border: 1px solid rgba(220, 216, 243, 0.24);
+  color: rgba(243, 239, 255, 0.92);
+  background: rgba(255, 245, 236, 0.03);
+}
+
+.visualCol {
   display: flex;
   justify-content: center;
 }
@@ -29,7 +118,12 @@
   width: clamp(92px, 38%, 124px);
   height: 28px;
   border-radius: 999px;
-  background: radial-gradient(circle at 68% 42%, rgba(49, 57, 74, 0.88) 0, rgba(8, 10, 16, 0.96) 58%, #020307 100%);
+  background: radial-gradient(
+    circle at 68% 42%,
+    rgba(49, 57, 74, 0.88) 0,
+    rgba(8, 10, 16, 0.96) 58%,
+    #020307 100%
+  );
   box-shadow:
     inset 0 1px 1px rgba(255, 255, 255, 0.14),
     inset 0 -1px 2px rgba(0, 0, 0, 0.52),
@@ -46,7 +140,12 @@
   height: 10px;
   transform: translateY(-50%);
   border-radius: 999px;
-  background: radial-gradient(circle at 32% 30%, rgba(127, 140, 176, 0.72), rgba(24, 30, 43, 0.18) 42%, rgba(6, 8, 14, 0.92));
+  background: radial-gradient(
+    circle at 32% 30%,
+    rgba(127, 140, 176, 0.72),
+    rgba(24, 30, 43, 0.18) 42%,
+    rgba(6, 8, 14, 0.92)
+  );
 }
 
 .phoneScreen {
@@ -83,6 +182,91 @@
   height: 100%;
 }
 
+.logrosViewport {
+  position: absolute;
+  inset: var(--hero-phone-safe-top) 0 0;
+  overflow: hidden;
+  display: flex;
+  padding: 10px 8px 10px;
+  background:
+    radial-gradient(
+      circle at 20% 12%,
+      rgba(120, 140, 255, 0.15),
+      transparent 48%
+    ),
+    #060a16;
+}
+
+.logrosHeroOnly {
+  height: 100%;
+  width: 100%;
+}
+
+.logrosHeroOnly :global(.ib-card) {
+  height: 100%;
+  min-height: 0;
+}
+
+.logrosHeroOnly :global(.ib-card > header),
+.logrosHeroOnly :global(.ib-card > [class*="rightSlot"]) {
+  display: none !important;
+}
+
+.logrosHeroOnly :global(.ib-card > .relative) {
+  height: 100%;
+  padding: 0.4rem 0.3rem 0.5rem !important;
+  gap: 0.4rem !important;
+}
+
+.logrosHeroOnly :global([data-demo-anchor="logros-growth-calibration"]),
+.logrosHeroOnly :global([data-demo-anchor="weekly-wrapped-shelf"]),
+.logrosHeroOnly :global([data-demo-anchor="monthly-wrapped-shelf"]) {
+  display: none !important;
+}
+
+.logrosHeroOnly :global([data-demo-anchor="logros-shelves"]) {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.logrosHeroOnly :global([data-demo-anchor="logros-carousel-structure"]) {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+  min-height: 0;
+  gap: 0.28rem;
+}
+
+.logrosHeroOnly :global([data-demo-anchor="logros-pillar-selector"]) {
+  margin: 0 !important;
+  padding-top: 0.1rem;
+}
+
+.logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"]) {
+  min-height: 0;
+  margin-top: 0.25rem;
+  padding-inline: 0.2rem;
+  gap: 0.42rem;
+  align-items: stretch;
+}
+
+.logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"] > button) {
+  width: 88%;
+  min-height: 0;
+  height: min(21.8rem, 100%);
+  padding: 0.72rem;
+  border-radius: 1.1rem;
+}
+
+.logrosHeroOnly
+  :global([data-demo-anchor="logros-carousel-track"] > button .text-lg) {
+  font-size: 0.86rem;
+}
+
+.logrosHeroOnly
+  :global([data-demo-anchor="logros-carousel-structure"] > .flex.items-center) {
+  display: none !important;
+}
 .realViewport {
   position: absolute;
   inset: var(--hero-phone-safe-top) 0 0;
@@ -106,116 +290,25 @@
   box-sizing: border-box;
 }
 
-.heroFocusViewport {
-  padding-bottom: 88px;
-}
-
-.heroFocusContent > :global(.space-y-6) > :first-child {
-  display: none !important;
-}
-
-.heroFocusContent :global([data-demo-anchor='daily-energy']),
-.heroFocusContent :global([data-demo-anchor='daily-cultivation']),
-.heroFocusContent :global([data-demo-anchor='moderation']),
-.heroFocusContent :global([data-demo-anchor='balance']) {
-  display: none !important;
-}
-
-.heroFocusContent :global(.order-1),
-.heroFocusContent :global(.order-3 > :not([data-demo-anchor='emotion-chart'])),
-.heroFocusContent :global(.order-4 > :not([data-demo-anchor='streaks'])) {
-  display: none !important;
-}
-
-.logrosViewport {
-  position: absolute;
-  inset: var(--hero-phone-safe-top) 0 0;
-  overflow: hidden;
-  display: flex;
-  padding: 10px 8px 10px;
-  background: radial-gradient(circle at 20% 12%, rgba(120, 140, 255, 0.15), transparent 48%), #060a16;
-}
-
-.logrosHeroOnly {
-  height: 100%;
-  width: 100%;
-}
-
-.logrosHeroOnly :global(.ib-card) {
-  height: 100%;
-  min-height: 0;
-}
-
-.logrosHeroOnly :global(.ib-card > header),
-.logrosHeroOnly :global(.ib-card > [class*='rightSlot']) {
-  display: none !important;
-}
-
-.logrosHeroOnly :global(.ib-card > .relative) {
-  height: 100%;
-  padding: 0.4rem 0.3rem 0.5rem !important;
-  gap: 0.4rem !important;
-}
-
-.logrosHeroOnly :global([data-demo-anchor='logros-growth-calibration']),
-.logrosHeroOnly :global([data-demo-anchor='weekly-wrapped-shelf']),
-.logrosHeroOnly :global([data-demo-anchor='monthly-wrapped-shelf']) {
-  display: none !important;
-}
-
-.logrosHeroOnly :global([data-demo-anchor='logros-shelves']) {
-  flex: 1 1 auto;
-  min-height: 0;
-}
-
-.logrosHeroOnly :global([data-demo-anchor='logros-carousel-structure']) {
-  display: grid;
-  grid-template-rows: auto 1fr;
-  height: 100%;
-  min-height: 0;
-  gap: 0.28rem;
-}
-
-.logrosHeroOnly :global([data-demo-anchor='logros-pillar-selector']) {
-  margin: 0 !important;
-  padding-top: 0.1rem;
-}
-
-.logrosHeroOnly :global([data-demo-anchor='logros-carousel-track']) {
-  min-height: 0;
-  margin-top: 0.25rem;
-  padding-inline: 0.2rem;
-  gap: 0.42rem;
-  align-items: stretch;
-}
-
-.logrosHeroOnly :global([data-demo-anchor='logros-carousel-track'] > button) {
-  width: 88%;
-  min-height: 0;
-  height: min(21.8rem, 100%);
-  padding: 0.72rem;
-  border-radius: 1.1rem;
-}
-
-.logrosHeroOnly :global([data-demo-anchor='logros-carousel-track'] > button .text-lg) {
-  font-size: 0.86rem;
-}
-
-.logrosHeroOnly :global([data-demo-anchor='logros-carousel-structure'] > .flex.items-center) {
-  display: none !important;
-}
-
 .logrosHeroOnly :global(.ib-light-elevated-surface--emerald) {
   padding: 0.6rem !important;
 }
 
-.logrosHeroOnly :global(.ib-light-elevated-surface--emerald .mt-3.grid.gap-3.sm\:grid-cols-2) {
+.logrosHeroOnly
+  :global(
+    .ib-light-elevated-surface--emerald .mt-3.grid.gap-3.sm\:grid-cols-2
+  ) {
   margin-top: 0.5rem;
   gap: 0.45rem;
   grid-template-columns: 1fr !important;
 }
 
-.logrosHeroOnly :global(.ib-light-elevated-surface--emerald .mt-3.grid.gap-3.sm\:grid-cols-2 > :nth-child(n + 2)) {
+.logrosHeroOnly
+  :global(
+    .ib-light-elevated-surface--emerald
+      .mt-3.grid.gap-3.sm\:grid-cols-2
+      > :nth-child(n + 2)
+  ) {
   display: none !important;
 }
 
@@ -227,8 +320,458 @@
   display: none !important;
 }
 
-@media (max-width: 900px) {
+.heroFocusContent > :global(.space-y-6) > :first-child {
+  display: none !important;
+}
+
+.heroFocusContent :global([data-demo-anchor="daily-energy"]),
+.heroFocusContent :global([data-demo-anchor="daily-cultivation"]),
+.heroFocusContent :global([data-demo-anchor="moderation"]),
+.heroFocusContent :global([data-demo-anchor="balance"]) {
+  display: none !important;
+}
+
+.heroFocusContent :global(.order-1),
+.heroFocusContent :global(.order-3 > :not([data-demo-anchor="emotion-chart"])),
+.heroFocusContent :global(.order-4 > :not([data-demo-anchor="streaks"])) {
+  display: none !important;
+}
+
+.heroFocusViewport {
+  padding-bottom: 88px;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"] .ib-metric-header-card > .relative
+  ) {
+  gap: 0.7rem;
+  padding: 0.4rem 0.45rem 0.6rem;
+}
+
+.heroFocusContent
+  :global([data-demo-anchor="overall-progress"] .ib-metric-header-card header) {
+  gap: 0.5rem;
+  padding-top: 0.2rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"] .ib-metric-header-card header h3
+  ) {
+  font-size: 0.7rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      header
+      [class*="inline-flex"]
+  ) {
+  transform: scale(0.94);
+  transform-origin: top right;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"] .ib-metric-header-card .text-4xl
+  ) {
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      .text-\[2\.5em\]
+  ) {
+  font-size: 2.05em;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"] .ib-metric-header-card .space-y-3
+  ) {
+  row-gap: 0.5rem;
+}
+
+.heroFocusContent
+  :global([data-demo-anchor="overall-progress"] .ib-metric-header-card .h-6) {
+  height: 1.2rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      [role="progressbar"]
+      span
+  ) {
+  font-size: 10px;
+}
+
+.heroFocusContent
+  :global([data-demo-anchor="emotion-chart"] .ib-card > .relative),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card > .relative) {
+  padding: 0.45rem 0.55rem 0.6rem;
+  gap: 0.7rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card header),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card header) {
+  gap: 0.45rem 0.6rem;
+  padding-top: 0.15rem;
+}
+
+.heroFocusContent
+  :global([data-demo-anchor="emotion-chart"] .ib-card header h3),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card header h3) {
+  font-size: 0.72rem;
+}
+
+.heroFocusContent :global([data-demo-anchor="emotion-chart"] .ib-card header p),
+.heroFocusContent :global([data-demo-anchor="streaks"] .ib-card header p) {
+  font-size: 0.62rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      > .relative
+      > .flex.flex-col.gap-4
+  ),
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"] .ib-card > .relative > .flex.flex-col.gap-4
+  ) {
+  gap: 0.65rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"] .ib-card .emotion-highlight-indicator
+  ) {
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="summary"]
+      .summary-inner
+  ) {
+  padding: 0.42rem 0.5rem;
+  gap: 0.35rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="summary"]
+      .summary-content
+  ) {
+  gap: 0.4rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="summary"]
+      .summary-title
+  ) {
+  font-size: 0.7rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="summary"]
+      .summary-description
+  ) {
+  font-size: 0.66rem;
+  line-height: 1.2;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="heatmap"]
+  ) {
+  --emotion-heatmap-min-h: 0px;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="heatmap"]
+      .emotion-chart-surface
+  ) {
+  padding: 0.35rem 0.45rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-top"]
+  ),
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-bottom"]
+  ) {
+  row-gap: 0.6rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      [data-demo-anchor="streaks-top"]
+      > section
+  ),
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      [data-demo-anchor="streaks-bottom"]
+      > section
+  ) {
+  row-gap: 0.55rem;
+}
+
+.heroFocusContent
+  :global([data-demo-anchor="streaks"] .ib-card .grid.grid-cols-1.gap-3) {
+  gap: 0.45rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      [data-demo-anchor="streaks-top"]
+      article[role="button"]
+  ),
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      [data-demo-anchor="streaks-bottom"]
+      article[role="button"]
+  ) {
+  min-height: 4rem;
+  padding: 0.42rem 0.52rem;
+  gap: 0.3rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      .text-sm.font-medium
+  ) {
+  font-size: 0.75rem;
+  line-height: 1.15;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      .min-w-0.flex-1
+      p
+  ) {
+  font-size: 0.63rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid
+  ) {
+  gap: 0.35rem 0.55rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div:first-child
+  ) {
+  min-width: 0;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+  ) {
+  min-width: 4.2rem;
+  align-items: stretch;
+  gap: 0.1rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+      > .flex
+  ) {
+  width: fit-content;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+      > .flex.items-end
+  ) {
+  justify-content: flex-start;
+  gap: 0.12rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+      > .flex.items-end
+      > div
+  ) {
+  width: 0.42rem;
+  min-width: 0.42rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+      > .flex.items-center
+  ) {
+  justify-content: flex-start;
+  gap: 0.12rem;
+  font-size: 0.46rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      > .grid
+      > div
+      + div
+      > .flex.items-center
+      > span
+  ) {
+  width: 0.42rem;
+  min-width: 0.42rem;
+  line-height: 1;
+}
+
+.heroFocusContent
+  :global([data-demo-anchor="streaks"] .ib-card article[role="button"] .h-2\.5),
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"] .ib-card article[role="button"] .h-2\.5 > div
+  ) {
+  height: 0.42rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      article[role="button"]
+      .ib-streak-fire-chip__inner
+  ) {
+  padding: 0.1rem 0.38rem;
+  font-size: 0.58rem;
+  gap: 0.2rem;
+}
+
+.sceneDashboard :global(.lg\:grid-cols-12) {
+  grid-template-columns: minmax(0, 1fr) !important;
+}
+
+.sceneDashboard :global(.lg\:col-span-4),
+.sceneDashboard :global(.lg\:col-span-5),
+.sceneDashboard :global(.lg\:col-span-6),
+.sceneDashboard :global(.lg\:col-span-7),
+.sceneDashboard :global(.lg\:col-span-8),
+.sceneDashboard :global(.lg\:col-span-12),
+.sceneDashboard :global(.md\:col-span-2),
+.sceneDashboard :global(.md\:col-span-3),
+.sceneDashboard :global(.md\:col-span-4) {
+  grid-column: span 1 / span 1 !important;
+}
+
+.sceneDashboard :global(.lg\:order-2),
+.sceneDashboard :global(.lg\:order-3),
+.sceneDashboard :global(.lg\:order-4) {
+  order: initial !important;
+}
+
+.sceneDashboard :global(.md\:grid-cols-2),
+.sceneDashboard :global(.md\:grid-cols-3),
+.sceneDashboard :global(.lg\:grid-cols-2),
+.sceneDashboard :global(.lg\:grid-cols-3),
+.sceneDashboard :global(.lg\:grid-cols-4) {
+  grid-template-columns: minmax(0, 1fr) !important;
+}
+
+.sceneDashboard :global(.md\:gap-5),
+.sceneDashboard :global(.lg\:gap-6) {
+  gap: 1rem !important;
+}
+
+.sceneDashboard :global([class*="max-w-"]) {
+  max-width: 100% !important;
+}
+
+@media (max-width: 980px) {
+  .hero {
+    grid-template-columns: 1fr;
+    align-content: start;
+    min-height: unset;
+  }
+
+  .visualCol {
+    justify-content: flex-start;
+  }
+
   .phoneFrame {
-    width: min(100%, 320px);
+    width: min(100%, 340px);
+    transform: none;
   }
 }

--- a/apps/web/src/components/landing/HeroPhoneShowcase.tsx
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.tsx
@@ -37,28 +37,45 @@ function smoothProgress(progress: number) {
 }
 
 function resolveDashboardProgress(elapsedInLoop: number) {
-  if (elapsedInLoop < INITIAL_TOP_PAUSE_MS) return 0;
-
+  if (elapsedInLoop < INITIAL_TOP_PAUSE_MS) {
+    return 0;
+  }
   if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS) {
     const downElapsed = elapsedInLoop - INITIAL_TOP_PAUSE_MS;
     return smoothProgress(downElapsed / SCROLL_DOWN_DURATION_MS);
   }
-
-  if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS) {
+  if (
+    elapsedInLoop <
+    INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS
+  ) {
     return 1;
   }
-
-  if (elapsedInLoop < INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS + RESET_TO_TOP_DURATION_MS) {
-    const resetElapsed = elapsedInLoop - INITIAL_TOP_PAUSE_MS - SCROLL_DOWN_DURATION_MS - LOOP_BOTTOM_PAUSE_MS;
+  if (
+    elapsedInLoop <
+    INITIAL_TOP_PAUSE_MS +
+      SCROLL_DOWN_DURATION_MS +
+      LOOP_BOTTOM_PAUSE_MS +
+      RESET_TO_TOP_DURATION_MS
+  ) {
+    const resetElapsed =
+      elapsedInLoop -
+      INITIAL_TOP_PAUSE_MS -
+      SCROLL_DOWN_DURATION_MS -
+      LOOP_BOTTOM_PAUSE_MS;
     return 1 - resetElapsed / RESET_TO_TOP_DURATION_MS;
   }
-
   return 0;
 }
 
 type HeroPhase = 'dashboard' | 'to-logros' | 'logros' | 'to-dashboard';
 
-function useHeroShowcaseTimeline({ dashboardReady, logrosReady }: { dashboardReady: boolean; logrosReady: boolean }) {
+function useHeroShowcaseTimeline({
+  dashboardReady,
+  logrosReady,
+}: {
+  dashboardReady: boolean;
+  logrosReady: boolean;
+}) {
   const [timeline, setTimeline] = useState<{
     phase: HeroPhase;
     dashboardProgress: number;
@@ -68,29 +85,55 @@ function useHeroShowcaseTimeline({ dashboardReady, logrosReady }: { dashboardRea
     dashboardProgress: 0,
     trackProgress: 0,
   });
-
   const startedAtRef = useRef<number | null>(null);
+  const lastNowRef = useRef<number | null>(null);
+  const dashboardElapsedRef = useRef(0);
+  const wasLogrosReadyRef = useRef(logrosReady);
 
   useEffect(() => {
     if (!dashboardReady) {
-      setTimeline({ phase: 'dashboard', dashboardProgress: 0, trackProgress: 0 });
+      setTimeline({
+        phase: 'dashboard',
+        dashboardProgress: 0,
+        trackProgress: 0,
+      });
       startedAtRef.current = null;
+      lastNowRef.current = null;
+      dashboardElapsedRef.current = 0;
+      wasLogrosReadyRef.current = logrosReady;
       return;
     }
 
     let rafId = 0;
-    const tick = (now: number) => {
-      const startedAt = startedAtRef.current ?? now;
-      if (startedAtRef.current == null) {
-        startedAtRef.current = now;
+    const now = performance.now();
+    if (startedAtRef.current == null) {
+      startedAtRef.current = now;
+    }
+    if (
+      wasLogrosReadyRef.current !== logrosReady &&
+      startedAtRef.current != null
+    ) {
+      const previousNow = lastNowRef.current ?? now;
+      if (wasLogrosReadyRef.current === false && logrosReady === true) {
+        startedAtRef.current = previousNow - dashboardElapsedRef.current;
+      } else if (wasLogrosReadyRef.current === true && logrosReady === false) {
+        startedAtRef.current = previousNow;
       }
-      const elapsed = Math.max(0, now - startedAt);
-      const dashboardElapsed = elapsed % DASHBOARD_LOOP_DURATION_MS;
+      wasLogrosReadyRef.current = logrosReady;
+    }
+
+    const tick = (currentNow: number) => {
+      const startedAt = startedAtRef.current ?? currentNow;
+      const elapsed = Math.max(0, currentNow - startedAt);
+      dashboardElapsedRef.current = elapsed % DASHBOARD_LOOP_DURATION_MS;
+      lastNowRef.current = currentNow;
 
       if (!logrosReady) {
         setTimeline({
           phase: 'dashboard',
-          dashboardProgress: resolveDashboardProgress(dashboardElapsed),
+          dashboardProgress: resolveDashboardProgress(
+            dashboardElapsedRef.current,
+          ),
           trackProgress: 0,
         });
         rafId = window.requestAnimationFrame(tick);
@@ -104,21 +147,41 @@ function useHeroShowcaseTimeline({ dashboardReady, logrosReady }: { dashboardRea
           dashboardProgress: resolveDashboardProgress(elapsedInLoop),
           trackProgress: 0,
         });
-      } else if (elapsedInLoop < DASHBOARD_LOOP_DURATION_MS + DASHBOARD_TO_LOGROS_DURATION_MS) {
+      } else if (
+        elapsedInLoop <
+        DASHBOARD_LOOP_DURATION_MS + DASHBOARD_TO_LOGROS_DURATION_MS
+      ) {
         const transitionElapsed = elapsedInLoop - DASHBOARD_LOOP_DURATION_MS;
         setTimeline({
           phase: 'to-logros',
           dashboardProgress: 0,
-          trackProgress: smoothProgress(transitionElapsed / DASHBOARD_TO_LOGROS_DURATION_MS),
+          trackProgress: smoothProgress(
+            transitionElapsed / DASHBOARD_TO_LOGROS_DURATION_MS,
+          ),
         });
-      } else if (elapsedInLoop < DASHBOARD_LOOP_DURATION_MS + DASHBOARD_TO_LOGROS_DURATION_MS + LOGROS_CAROUSEL_DURATION_MS) {
-        setTimeline({ phase: 'logros', dashboardProgress: 0, trackProgress: 1 });
+      } else if (
+        elapsedInLoop <
+        DASHBOARD_LOOP_DURATION_MS +
+          DASHBOARD_TO_LOGROS_DURATION_MS +
+          LOGROS_CAROUSEL_DURATION_MS
+      ) {
+        setTimeline({
+          phase: 'logros',
+          dashboardProgress: 0,
+          trackProgress: 1,
+        });
       } else {
-        const transitionElapsed = elapsedInLoop - DASHBOARD_LOOP_DURATION_MS - DASHBOARD_TO_LOGROS_DURATION_MS - LOGROS_CAROUSEL_DURATION_MS;
+        const transitionElapsed =
+          elapsedInLoop -
+          DASHBOARD_LOOP_DURATION_MS -
+          DASHBOARD_TO_LOGROS_DURATION_MS -
+          LOGROS_CAROUSEL_DURATION_MS;
         setTimeline({
           phase: 'to-dashboard',
           dashboardProgress: 0,
-          trackProgress: 1 - smoothProgress(transitionElapsed / LOGROS_TO_DASHBOARD_DURATION_MS),
+          trackProgress:
+            1 -
+            smoothProgress(transitionElapsed / LOGROS_TO_DASHBOARD_DURATION_MS),
         });
       }
 
@@ -145,7 +208,13 @@ function PhoneFrame({ children }: { children: ReactNode }) {
   );
 }
 
-function RealDashboardScene({ scrollProgress, onReady }: { scrollProgress: number; onReady: () => void }) {
+function RealDashboardScene({
+  scrollProgress,
+  onReady,
+}: {
+  scrollProgress: number;
+  onReady: () => void;
+}) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const readyReportedRef = useRef(false);
   const scrollRangeRef = useRef({ start: 0, end: 0 });
@@ -165,7 +234,6 @@ function RealDashboardScene({ scrollProgress, onReady }: { scrollProgress: numbe
     let intervalId = 0;
     let attempts = 0;
     const maxAttempts = 45;
-
     const reportReady = () => {
       if (readyReportedRef.current) return;
       readyReportedRef.current = true;
@@ -174,23 +242,41 @@ function RealDashboardScene({ scrollProgress, onReady }: { scrollProgress: numbe
 
     const resolveIfReady = () => {
       attempts += 1;
-      const overallProgress = viewport.querySelector<HTMLElement>('[data-demo-anchor="overall-progress"]');
-      const emotionChart = viewport.querySelector<HTMLElement>('[data-demo-anchor="emotion-chart"]');
-      const streaks = viewport.querySelector<HTMLElement>('[data-demo-anchor="streaks"]');
+      const overallProgress = viewport.querySelector<HTMLElement>(
+        '[data-demo-anchor="overall-progress"]',
+      );
+      const emotionChart = viewport.querySelector<HTMLElement>(
+        '[data-demo-anchor="emotion-chart"]',
+      );
+      const streaks = viewport.querySelector<HTMLElement>(
+        '[data-demo-anchor="streaks"]',
+      );
       if (!overallProgress || !emotionChart || !streaks) return false;
 
       const viewportRect = viewport.getBoundingClientRect();
-      const resolveTop = (element: HTMLElement) => element.getBoundingClientRect().top - viewportRect.top + viewport.scrollTop;
+      const resolveTop = (element: HTMLElement) =>
+        element.getBoundingClientRect().top -
+        viewportRect.top +
+        viewport.scrollTop;
 
-      const maxScroll = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+      const maxScroll = Math.max(
+        0,
+        viewport.scrollHeight - viewport.clientHeight,
+      );
       if (maxScroll > 0) {
         const overallTop = resolveTop(overallProgress);
         const emotionTop = resolveTop(emotionChart);
         const streakTop = resolveTop(streaks);
-        const minTravel = Math.max(Math.min(viewport.clientHeight * 0.58, maxScroll), Math.min(160, maxScroll));
+        const minTravel = Math.max(
+          Math.min(viewport.clientHeight * 0.58, maxScroll),
+          Math.min(160, maxScroll),
+        );
 
         let start = Math.max(0, Math.min(maxScroll, overallTop - 18));
-        const endTarget = Math.max(emotionTop - viewport.clientHeight * 0.38, streakTop - viewport.clientHeight * 0.14);
+        const endTarget = Math.max(
+          emotionTop - viewport.clientHeight * 0.38,
+          streakTop - viewport.clientHeight * 0.14,
+        );
         let end = Math.max(start, Math.min(maxScroll, endTarget));
 
         if (end - start < minTravel) end = Math.min(maxScroll, start + minTravel);
@@ -208,6 +294,7 @@ function RealDashboardScene({ scrollProgress, onReady }: { scrollProgress: numbe
 
       if (attempts >= maxAttempts && maxScroll > 0) {
         scrollRangeRef.current = { start: 0, end: maxScroll };
+        viewport.scrollTop = 0;
         reportReady();
         return true;
       }
@@ -217,7 +304,9 @@ function RealDashboardScene({ scrollProgress, onReady }: { scrollProgress: numbe
 
     if (!resolveIfReady()) {
       intervalId = window.setInterval(() => {
-        if (resolveIfReady()) window.clearInterval(intervalId);
+        if (resolveIfReady()) {
+          window.clearInterval(intervalId);
+        }
       }, 80);
     }
 
@@ -227,9 +316,14 @@ function RealDashboardScene({ scrollProgress, onReady }: { scrollProgress: numbe
   }, [onReady]);
 
   return (
-    <section className={`${styles.scenePanel} ${styles.sceneDashboard}`} data-light-scope="dashboard-v3">
+    <section
+      className={`${styles.scenePanel} ${styles.sceneDashboard}`}
+      data-light-scope="dashboard-v3"
+    >
       <div ref={viewportRef} className={styles.realViewport}>
-        <div className={`${styles.mobileDashboardRoot} ${styles.heroFocusViewport}`}>
+        <div
+          className={`${styles.mobileDashboardRoot} ${styles.heroFocusViewport}`}
+        >
           <div className={styles.heroFocusContent}>
             <DemoDashboardOverviewScene gameMode="flow" />
           </div>
@@ -239,12 +333,27 @@ function RealDashboardScene({ scrollProgress, onReady }: { scrollProgress: numbe
   );
 }
 
-function HeroLogrosScene({ isActive, cycleKey, onReady }: { isActive: boolean; cycleKey: number; onReady: () => void }) {
+function HeroLogrosScene({
+  isActive,
+  cycleKey,
+  onReady,
+}: {
+  isActive: boolean;
+  cycleKey: number;
+  onReady: () => void;
+}) {
   const { language } = usePostLoginLanguage();
   const sceneRef = useRef<HTMLElement | null>(null);
   const controlsRef = useRef<RewardsSectionDemoControls | null>(null);
   const [sceneReady, setSceneReady] = useState(false);
+  const [controlsReady, setControlsReady] = useState(false);
   const readyReportedRef = useRef(false);
+  const readinessResolvedRef = useRef(false);
+  const onReadyRef = useRef(onReady);
+
+  useEffect(() => {
+    onReadyRef.current = onReady;
+  }, [onReady]);
 
   const demoConfig = useMemo(
     () => ({
@@ -265,6 +374,7 @@ function HeroLogrosScene({ isActive, cycleKey, onReady }: { isActive: boolean; c
       controls: {
         onReady: (controls: RewardsSectionDemoControls) => {
           controlsRef.current = controls;
+          setControlsReady(true);
         },
       },
     }),
@@ -278,23 +388,33 @@ function HeroLogrosScene({ isActive, cycleKey, onReady }: { isActive: boolean; c
 
     const markReady = () => {
       setSceneReady(true);
-      if (readyReportedRef.current) return;
-      readyReportedRef.current = true;
-      onReady();
+      if (!readyReportedRef.current) {
+        readyReportedRef.current = true;
+        onReadyRef.current();
+      }
     };
 
     const resolveTrackReady = () => {
       attempts += 1;
       const sceneRoot = sceneRef.current;
       const controls = controlsRef.current;
-      const track = sceneRoot?.querySelector<HTMLElement>('[data-demo-anchor="logros-carousel-track"]');
-      const cards = track?.querySelectorAll<HTMLElement>('[data-achievement-carousel-index]');
+      const track = sceneRoot?.querySelector<HTMLElement>(
+        '[data-demo-anchor="logros-carousel-track"]',
+      );
+      const cards = track?.querySelectorAll<HTMLElement>(
+        '[data-achievement-carousel-index]',
+      );
 
-      if (!sceneRoot || !controls || !track || !cards) return false;
+      if (!sceneRoot || !controls || !track || !cards) {
+        return false;
+      }
 
-      controls.closeAllOverlays();
-      controls.selectPillar('BODY');
-      controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
+      if (!readinessResolvedRef.current) {
+        controls.closeAllOverlays();
+        controls.selectPillar('BODY');
+        controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
+        readinessResolvedRef.current = true;
+      }
 
       if (cards.length >= 2 || (attempts >= maxAttempts && cards.length >= 1)) {
         markReady();
@@ -306,26 +426,41 @@ function HeroLogrosScene({ isActive, cycleKey, onReady }: { isActive: boolean; c
 
     if (!resolveTrackReady()) {
       intervalId = window.setInterval(() => {
-        if (resolveTrackReady()) window.clearInterval(intervalId);
+        if (resolveTrackReady()) {
+          window.clearInterval(intervalId);
+        }
       }, 80);
     }
 
     return () => {
-      if (intervalId) window.clearInterval(intervalId);
+      if (intervalId) {
+        window.clearInterval(intervalId);
+      }
     };
-  }, [onReady]);
+  }, [controlsReady]);
 
   useEffect(() => {
-    if (!isActive || !sceneReady) return;
+    if (!isActive || !sceneReady) {
+      return;
+    }
+
     const controls = controlsRef.current;
-    if (!controls) return;
+    if (!controls) {
+      return;
+    }
 
     controls.closeAllOverlays();
     controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
 
     const segment = LOGROS_CAROUSEL_DURATION_MS / 3;
-    const t1 = window.setTimeout(() => controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_2), segment * 0.9);
-    const t2 = window.setTimeout(() => controls.focusCarouselCard(HERO_BODY_CARD_BLOCKED_1), segment * 1.95);
+    const t1 = window.setTimeout(
+      () => controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_2),
+      segment * 0.9,
+    );
+    const t2 = window.setTimeout(
+      () => controls.focusCarouselCard(HERO_BODY_CARD_BLOCKED_1),
+      segment * 1.95,
+    );
 
     return () => {
       window.clearTimeout(t1);
@@ -334,10 +469,18 @@ function HeroLogrosScene({ isActive, cycleKey, onReady }: { isActive: boolean; c
   }, [cycleKey, isActive, sceneReady]);
 
   return (
-    <section ref={sceneRef} className={`${styles.scenePanel} ${styles.sceneLogros}`} data-light-scope="dashboard-v3">
+    <section
+      ref={sceneRef}
+      className={`${styles.scenePanel} ${styles.sceneLogros}`}
+      data-light-scope="dashboard-v3"
+    >
       <div className={styles.logrosViewport}>
         <div className={styles.logrosHeroOnly}>
-          <RewardsSection userId="" initialData={getDemoLogrosData(language)} demoConfig={demoConfig} />
+          <RewardsSection
+            userId=""
+            initialData={getDemoLogrosData(language)}
+            demoConfig={demoConfig}
+          />
         </div>
       </div>
     </section>
@@ -349,7 +492,10 @@ export function HeroPhoneShowcase() {
   const [logrosReady, setLogrosReady] = useState(false);
   const [demoDataReady, setDemoDataReady] = useState(false);
   const [logrosCycleKey, setLogrosCycleKey] = useState(0);
-  const { phase, dashboardProgress, trackProgress } = useHeroShowcaseTimeline({ dashboardReady, logrosReady });
+  const { phase, dashboardProgress, trackProgress } = useHeroShowcaseTimeline({
+    dashboardReady,
+    logrosReady,
+  });
   const previousPhaseRef = useRef<HeroPhase>('dashboard');
 
   useEffect(() => {
@@ -369,17 +515,29 @@ export function HeroPhoneShowcase() {
   }, [phase]);
 
   return (
-    <div className={styles.root}>
-      <PhoneFrame>
-        {demoDataReady ? (
-          <div className={styles.sceneTrack} style={{ transform: `translate3d(${-50 * trackProgress}%, 0, 0)` }}>
-            <RealDashboardScene scrollProgress={dashboardProgress} onReady={() => setDashboardReady(true)} />
-            <HeroLogrosScene isActive={phase === 'logros'} cycleKey={logrosCycleKey} onReady={() => setLogrosReady(true)} />
-          </div>
-        ) : (
-          <section className={`${styles.scenePanel} ${styles.sceneDashboard}`} data-light-scope="dashboard-v3" aria-hidden />
-        )}
-      </PhoneFrame>
-    </div>
+    <PhoneFrame>
+      {demoDataReady ? (
+        <div
+          className={styles.sceneTrack}
+          style={{ transform: `translate3d(${-50 * trackProgress}%, 0, 0)` }}
+        >
+          <RealDashboardScene
+            scrollProgress={dashboardProgress}
+            onReady={() => setDashboardReady(true)}
+          />
+          <HeroLogrosScene
+            isActive={phase === 'logros'}
+            cycleKey={logrosCycleKey}
+            onReady={() => setLogrosReady(true)}
+          />
+        </div>
+      ) : (
+        <section
+          className={`${styles.scenePanel} ${styles.sceneDashboard}`}
+          data-light-scope="dashboard-v3"
+          aria-hidden
+        />
+      )}
+    </PhoneFrame>
   );
 }

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -373,7 +373,7 @@
   margin: 0 auto;
   padding: 56px 18px;
   display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(280px, var(--hero-size));
+  grid-template-columns: minmax(0, 1.03fr) minmax(320px, var(--hero-size));
   gap: 40px;
   align-items: center;
 }
@@ -505,24 +505,16 @@
 }
 
 .landing .hero-media {
-  width: min(100%, var(--hero-size));
-  min-height: clamp(540px, 64vh, 700px);
+  width: min(100%, 420px);
+  min-height: clamp(560px, 68vh, 740px);
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: center;
-  margin-left: auto;
+  justify-content: flex-end;
+  margin-left: clamp(6px, 1.8vw, 28px);
   animation: float 18s ease-in-out infinite;
   will-change: transform;
-}
-
-.landing .hero-img {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: 50% 12%;
+  overflow: visible;
 }
 
 .landing section h2 {
@@ -2528,6 +2520,7 @@
     width: min(100%, 360px);
     min-height: auto;
     margin: 0 auto;
+    justify-content: center;
   }
 
   .landing .hero-demo-cta {


### PR DESCRIPTION
### Motivation
- Restore the exact Labs hero phone showcase behavior inside the landing page so the phone dashboard and Logros scene render and respond identically to `/labs/hero-phone-showcase` without manual visual re-interpretation. 
- Ensure the showcase is an encapsulated component that does not rely on `.hero-media`/`.hero-img` image-frame styles and does not leak invisible layout artifacts into the phone viewport. 
- Move the phone slightly to the right on desktop while preserving mobile-first responsive behavior and keeping existing landing copy, background and typography.

### Description
- Introduced a landing copy of the Labs implementation by adding `apps/web/src/components/landing/HeroPhoneShowcase.tsx` which reuses the Labs timeline/scene orchestration (dashboard ↔ logros, readiness logic, carousel focus sequence). 
- Restored the Labs CSS scoped to the showcase by copying and adapting `HeroPhoneShowcaseLabPage.module.css` into `apps/web/src/components/landing/HeroPhoneShowcase.module.css`, including critical `.sceneDashboard :global(...)` overrides that force a single-column mobile-like dashboard inside the phone, neutralize `col-span`/`order-*`, constrain `grid-cols-*`, reduce gaps and enforce `max-width:100%`. 
- Fixed Logros composition by reintroducing the hero-scoped rules that hide unnecessary wrappers/headers, constrain carousel track/cards sizing and remove elements that were invisible but still occupying layout. 
- Updated `apps/web/src/pages/Landing.css` to stop treating the hero media as a square image frame by removing the `.hero-img` framing and turning `.hero-media` into a vertical phone container, adjusting `hero-grid` columns, setting `.hero-media` width/min-height/overflow/justify alignment and adding a controlled `margin-left` so the phone is nudged right on desktop while centering on smaller screens.

### Testing
- Ran TypeScript check with `pnpm -C apps/web exec tsc --noEmit`, which failed but the failures are pre-existing repository-wide TypeScript issues not introduced by this change. 
- Ran ESLint on the modified files with `pnpm -C apps/web exec eslint src/components/landing/HeroPhoneShowcase.tsx src/pages/Landing.tsx`, which could not run successfully in this environment due to missing `eslint.config.*` (ESLint v9 migration issue) rather than issues in the new code. 
- No automated visual/regression tests were available in this environment; manual verification instructions are to load the landing and compare against `/labs/hero-phone-showcase` to confirm dashboard single-column behavior, Logros carousel sizing/stability, no invisible elements occupying layout, and phone alignment on desktop.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9b491ffc83329d9457d064a1b6ee)