### PR TITLE
Fix contextual exit for Logros demo close button

### DIFF
--- a/apps/web/src/components/dashboard-v3/RewardsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/RewardsSection.tsx
@@ -211,7 +211,7 @@ export function RewardsSection({
         <div className="flex items-center gap-2">
           {!resolvedDisableRemote ? (
             <a
-              href="/labs/logros"
+              href={`/labs/logros?${new URLSearchParams({ lang: language, source: 'internal' }).toString()}`}
               title={
                 language === "es"
                   ? "Ver demo guiada de Logros"

--- a/apps/web/src/pages/labs/LogrosDemoPage.tsx
+++ b/apps/web/src/pages/labs/LogrosDemoPage.tsx
@@ -104,14 +104,15 @@ export default function LabsLogrosDemoPage() {
     }
   }, []);
 
+  const shouldReturnToDashboard = Boolean(userId) && (demoContext.fromOnboarding || demoContext.source === 'internal');
+
   const handleDemoExit = useCallback(() => {
-    const shouldReturnToDashboard = Boolean(userId) && (demoContext.fromOnboarding || demoContext.source === 'internal');
     if (shouldReturnToDashboard) {
       navigate(dashboardPath, { state: { scrollToTopOnEnter: true, source: 'demo', focusSection: 'logros' } });
       return;
     }
     navigate(demoHubPath);
-  }, [dashboardPath, demoContext.fromOnboarding, demoContext.source, demoHubPath, navigate, userId]);
+  }, [dashboardPath, demoHubPath, navigate, shouldReturnToDashboard]);
 
   return (
     <div className="min-h-screen bg-transparent" data-light-scope="dashboard-v3" data-labs-logros-step={activeStepId ?? undefined}>
@@ -122,7 +123,7 @@ export default function LabsLogrosDemoPage() {
             <h1 className="font-display text-[1.05rem] font-semibold text-[color:var(--color-text)] md:text-xl">{language === 'es' ? 'Logros' : 'Achievements'}</h1>
           </div>
           <Link
-            to={demoContext.fromOnboarding || demoContext.source === 'internal' ? dashboardPath : demoHubPath}
+            to={shouldReturnToDashboard ? dashboardPath : demoHubPath}
             onClick={(event) => {
               event.preventDefault();
               handleDemoExit();


### PR DESCRIPTION
### Motivation
- The Logros demo close (`X`) always fell back to the public demo hub because the demo entry lacked contextual query params when opened from the real dashboard, causing `resolveDemoEntryContext(...)` to treat the source as `landing`. 
- The goal is to match the contextual exit logic used by `DemoDashboard.tsx` so logged-in/internal/onboarding flows return to the real dashboard and public flows still return to the demo hub. 

### Description
- Added a `shouldReturnToDashboard` boolean in `apps/web/src/pages/labs/LogrosDemoPage.tsx` computed as `Boolean(userId) && (demoContext.fromOnboarding || demoContext.source === 'internal')` and used it in a `handleDemoExit()` callback to conditionally `navigate()` either to `dashboardPath` (with state `{ scrollToTopOnEnter: true, source: 'demo', focusSection: 'logros' }`) or to `demoHubPath` for public demos. 
- Updated the `Link` close button in `LogrosDemoPage.tsx` to use the `shouldReturnToDashboard` condition instead of an always-public fallback. 
- Ensured in-dashboard entry points carry context by updating the RewardsSection demo link in `apps/web/src/components/dashboard-v3/RewardsSection.tsx` to include query params (`lang` and `source=internal`) when linking to the Logros demo. 

### Testing
- Ran project type-check with `pnpm -C apps/web typecheck`, which failed due to existing, repo-wide TypeScript errors unrelated to this change. 
- Verified by code inspection that `LogrosDemoPage` now mirrors the contextual exit pattern from `DemoDashboard.tsx` and that the internal dashboard link to the demo includes `source=internal` so `resolveDemoEntryContext(...)` will detect internal/session entries correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9d805c1483328486da4f3365f43a)