### PR TITLE
Fix landing hero Logros scroll jump by restoring demo controls contract

### DIFF
--- a/apps/web/src/components/dashboard-v3/RewardsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/RewardsSection.tsx
@@ -77,6 +77,7 @@ interface RewardsSectionProps {
     anchors?: RewardsSectionProps["demoAnchors"];
     controls?: {
       onReady?: (controls: RewardsSectionDemoControls) => void;
+      preventPageScrollOnProgrammaticFocus?: boolean;
     };
   };
   demoStepId?: string | null;
@@ -277,6 +278,9 @@ export function RewardsSection({
         disableRemote={resolvedDisableRemote}
         mockPreviewAchievementByTaskId={resolvedMockPreviewAchievementByTaskId}
         onDemoControlsReady={demoConfig?.controls?.onReady}
+        preventPageScrollOnProgrammaticFocus={
+          demoConfig?.controls?.preventPageScrollOnProgrammaticFocus
+        }
         onToggleMaintained={async (habit, enabled) => {
           if (resolvedDisableRemote) {
             return;
@@ -930,6 +934,7 @@ function AchievedShelf({
   mockPreviewAchievementByTaskId,
   demoAnchors,
   onDemoControlsReady,
+  preventPageScrollOnProgrammaticFocus,
   demoStepId,
 }: {
   groups: RewardsHistorySummary["habitAchievements"]["achievedByPillar"];
@@ -946,6 +951,7 @@ function AchievedShelf({
   >;
   demoAnchors?: RewardsSectionProps["demoAnchors"];
   onDemoControlsReady?: (controls: RewardsSectionDemoControls) => void;
+  preventPageScrollOnProgrammaticFocus?: boolean;
   demoStepId?: string | null;
 }) {
   const [activeHabitId, setActiveHabitId] = useState<string | null>(null);
@@ -1085,9 +1091,17 @@ function AchievedShelf({
       if (!targetCard) {
         return;
       }
-      if (typeof targetCard.scrollIntoView === "function") {
+      const behavior = prefersReducedMotion ? "auto" : "smooth";
+      if (preventPageScrollOnProgrammaticFocus) {
+        const centeredLeft =
+          targetCard.offsetLeft - (track.clientWidth - targetCard.clientWidth) / 2;
+        track.scrollTo({
+          left: Math.max(0, centeredLeft),
+          behavior,
+        });
+      } else if (typeof targetCard.scrollIntoView === "function") {
         targetCard.scrollIntoView({
-          behavior: prefersReducedMotion ? "auto" : "smooth",
+          behavior,
           inline: "center",
           block: "nearest",
         });
@@ -1098,6 +1112,7 @@ function AchievedShelf({
       activePillarHabits.length,
       carouselTrackRef,
       prefersReducedMotion,
+      preventPageScrollOnProgrammaticFocus,
       setActiveCarouselIndex,
     ],
   );

--- a/apps/web/src/components/landing/HeroPhoneShowcase.tsx
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { setDashboardDemoModeEnabled } from '../../lib/demoMode';
 import { DemoDashboardOverviewScene } from '../demo/DemoDashboardOverviewScene';
 import { RewardsSection, type RewardsSectionDemoControls } from '../dashboard-v3/RewardsSection';
@@ -72,9 +72,11 @@ type HeroPhase = 'dashboard' | 'to-logros' | 'logros' | 'to-dashboard';
 function useHeroShowcaseTimeline({
   dashboardReady,
   logrosReady,
+  isActive,
 }: {
   dashboardReady: boolean;
   logrosReady: boolean;
+  isActive: boolean;
 }) {
   const [timeline, setTimeline] = useState<{
     phase: HeroPhase;
@@ -89,6 +91,7 @@ function useHeroShowcaseTimeline({
   const lastNowRef = useRef<number | null>(null);
   const dashboardElapsedRef = useRef(0);
   const wasLogrosReadyRef = useRef(logrosReady);
+  const pausedAtRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (!dashboardReady) {
@@ -101,6 +104,7 @@ function useHeroShowcaseTimeline({
       lastNowRef.current = null;
       dashboardElapsedRef.current = 0;
       wasLogrosReadyRef.current = logrosReady;
+      pausedAtRef.current = null;
       return;
     }
 
@@ -108,6 +112,17 @@ function useHeroShowcaseTimeline({
     const now = performance.now();
     if (startedAtRef.current == null) {
       startedAtRef.current = now;
+    }
+    if (isActive) {
+      if (pausedAtRef.current != null && startedAtRef.current != null) {
+        startedAtRef.current += now - pausedAtRef.current;
+      }
+      pausedAtRef.current = null;
+    } else {
+      if (pausedAtRef.current == null) {
+        pausedAtRef.current = now;
+      }
+      return;
     }
     if (
       wasLogrosReadyRef.current !== logrosReady &&
@@ -190,16 +205,22 @@ function useHeroShowcaseTimeline({
 
     rafId = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(rafId);
-  }, [dashboardReady, logrosReady]);
+  }, [dashboardReady, isActive, logrosReady]);
 
   return !dashboardReady
     ? { phase: 'dashboard' as const, dashboardProgress: 0, trackProgress: 0 }
     : timeline;
 }
 
-function PhoneFrame({ children }: { children: ReactNode }) {
+function PhoneFrame({
+  children,
+  frameRef,
+}: {
+  children: ReactNode;
+  frameRef?: RefObject<HTMLDivElement | null>;
+}) {
   return (
-    <div className={styles.phoneFrame}>
+    <div ref={frameRef} className={styles.phoneFrame}>
       <div className={styles.phoneIsland} aria-hidden>
         <span className={styles.phoneIslandLens} />
       </div>
@@ -372,6 +393,7 @@ function HeroLogrosScene({
         blockedCardTaskId: HERO_BODY_CARD_BLOCKED_1,
       },
       controls: {
+        preventPageScrollOnProgrammaticFocus: true,
         onReady: (controls: RewardsSectionDemoControls) => {
           controlsRef.current = controls;
           setControlsReady(true);
@@ -492,9 +514,12 @@ export function HeroPhoneShowcase() {
   const [logrosReady, setLogrosReady] = useState(false);
   const [demoDataReady, setDemoDataReady] = useState(false);
   const [logrosCycleKey, setLogrosCycleKey] = useState(0);
+  const [isHeroActive, setIsHeroActive] = useState(true);
+  const phoneFrameRef = useRef<HTMLDivElement | null>(null);
   const { phase, dashboardProgress, trackProgress } = useHeroShowcaseTimeline({
     dashboardReady,
     logrosReady,
+    isActive: isHeroActive,
   });
   const previousPhaseRef = useRef<HeroPhase>('dashboard');
 
@@ -514,8 +539,25 @@ export function HeroPhoneShowcase() {
     previousPhaseRef.current = phase;
   }, [phase]);
 
+  useEffect(() => {
+    const target = phoneFrameRef.current;
+    if (!target || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsHeroActive(entry.isIntersecting && entry.intersectionRatio > 0.35);
+      },
+      { threshold: [0, 0.35, 1] },
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <PhoneFrame>
+    <PhoneFrame frameRef={phoneFrameRef}>
       {demoDataReady ? (
         <div
           className={styles.sceneTrack}
@@ -526,7 +568,7 @@ export function HeroPhoneShowcase() {
             onReady={() => setDashboardReady(true)}
           />
           <HeroLogrosScene
-            isActive={phase === 'logros'}
+            isActive={isHeroActive && phase === 'logros'}
             cycleKey={logrosCycleKey}
             onReady={() => setLogrosReady(true)}
           />


### PR DESCRIPTION
### Motivation
- A revert left HeroPhoneShowcase still setting `preventPageScrollOnProgrammaticFocus` while `RewardsSection` no longer accepted or propagated it, breaking the contract between the hero and the Achieved shelf and causing the page to jump when the carousel used `scrollIntoView()` on loop re-entry. 
- The goal is to prevent the carousel from moving the global page scroll while keeping the visual layout and animations unchanged and to avoid firing Logros timers/actions while the hero is offscreen.

### Description
- Restored `preventPageScrollOnProgrammaticFocus?: boolean` to `RewardsSectionProps[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba43a30ac8332a72b55aae9cab19f)