### PR TITLE
Polish landing hero CTAs, swap nav auth order, and refine phone showcase backdrop

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -1,98 +1,3 @@
-.page {
-  min-height: 100vh;
-  padding: clamp(1.4rem, 2.8vw, 3rem);
-  color: #f2f1fb;
-  background:
-    radial-gradient(
-      circle at 80% 10%,
-      rgba(153, 111, 244, 0.2),
-      transparent 37%
-    ),
-    radial-gradient(
-      circle at 17% 13%,
-      rgba(117, 142, 252, 0.16),
-      transparent 33%
-    ),
-    radial-gradient(
-      circle at 52% 82%,
-      rgba(253, 173, 124, 0.08),
-      transparent 52%
-    ),
-    linear-gradient(180deg, #0f0f19 0%, #0a0a12 100%);
-}
-
-.hero {
-  max-width: 1180px;
-  margin: 0 auto;
-  min-height: calc(100vh - 3rem);
-  display: grid;
-  gap: clamp(1.3rem, 3vw, 2.6rem);
-  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 390px);
-  align-items: center;
-}
-
-.copyCol h1 {
-  margin: 0;
-  font-size: clamp(2rem, 5vw, 3.7rem);
-  line-height: 1.04;
-  letter-spacing: -0.03em;
-}
-
-.copyCol h1 span {
-  color: #c8a6ff;
-}
-
-.copyCol > p {
-  margin: 0.95rem 0 0;
-  max-width: 55ch;
-  color: rgba(237, 236, 250, 0.84);
-  line-height: 1.6;
-}
-
-.kicker {
-  margin: 0 0 1rem;
-  font-size: 0.72rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(236, 205, 183, 0.72);
-}
-
-.ctaRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.8rem;
-  margin-top: 1.6rem;
-}
-
-.primaryCta,
-.secondaryCta {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 44px;
-  padding: 0.72rem 1.2rem;
-  border-radius: 999px;
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.primaryCta {
-  background: linear-gradient(135deg, #9a78f6, #6f84f7);
-  color: #fbfbff;
-  box-shadow: 0 8px 24px rgba(116, 107, 216, 0.36);
-}
-
-.secondaryCta {
-  border: 1px solid rgba(220, 216, 243, 0.24);
-  color: rgba(243, 239, 255, 0.92);
-  background: rgba(255, 245, 236, 0.03);
-}
-
-.visualCol {
-  display: flex;
-  justify-content: center;
-}
-
 .phoneFrame {
   --hero-phone-safe-top: 44px;
   width: min(100%, 342px);
@@ -152,11 +57,22 @@
   height: 100%;
   border-radius: 30px;
   overflow: hidden;
-  background: #050816;
+  background:
+    radial-gradient(
+      130% 100% at 18% 8%,
+      rgba(128, 118, 238, 0.22),
+      transparent 46%
+    ),
+    radial-gradient(
+      120% 110% at 84% 102%,
+      rgba(84, 136, 232, 0.17),
+      transparent 58%
+    ),
+    linear-gradient(170deg, #11162a 0%, #090f22 60%, #0a1226 100%);
   border: 1px solid rgba(216, 194, 246, 0.24);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    inset 0 -14px 36px rgba(4, 5, 10, 0.48);
+    inset 0 -14px 36px rgba(4, 5, 10, 0.42);
 }
 
 .scenePanel {
@@ -164,7 +80,18 @@
   height: 100%;
   position: relative;
   overflow: hidden;
-  background: #050816;
+  background:
+    radial-gradient(
+      120% 88% at 14% 0%,
+      rgba(139, 126, 255, 0.16),
+      transparent 52%
+    ),
+    radial-gradient(
+      115% 96% at 94% 100%,
+      rgba(82, 139, 237, 0.12),
+      transparent 58%
+    ),
+    linear-gradient(180deg, #10172d 0%, #090f22 100%);
 }
 
 .sceneTrack {
@@ -190,11 +117,16 @@
   padding: 10px 8px 10px;
   background:
     radial-gradient(
-      circle at 20% 12%,
-      rgba(120, 140, 255, 0.15),
-      transparent 48%
+      circle at 20% 10%,
+      rgba(133, 143, 255, 0.2),
+      transparent 46%
     ),
-    #060a16;
+    radial-gradient(
+      circle at 78% 92%,
+      rgba(102, 144, 232, 0.14),
+      transparent 52%
+    ),
+    linear-gradient(180deg, #0f1730 0%, #0a1125 100%);
 }
 
 .logrosHeroOnly {

--- a/apps/web/src/content/officialLandingContent.ts
+++ b/apps/web/src/content/officialLandingContent.ts
@@ -279,7 +279,7 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
       signup: 'Crear cuenta',
       login: 'Iniciar sesión',
       startJourney: 'Crear mi plan adaptativo',
-      guidedDemo: 'Ver demo guiada'
+      guidedDemo: 'Demos'
     },
     footer: { copyright: '©️ Gamification Journey', faq: 'FAQ' }
   },
@@ -516,7 +516,7 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
       signup: 'Create account',
       login: 'Log in',
       startJourney: 'Create my adaptive plan',
-      guidedDemo: 'See guided demo'
+      guidedDemo: 'Demos'
     },
     footer: { copyright: '©️ Gamification Journey', faq: 'FAQ' }
   }

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -413,36 +413,36 @@
   font-weight: 500;
 }
 
-@property --conic-angle {
-  syntax: "<angle>";
-  inherits: false;
-  initial-value: 0deg;
-}
-
 .landing .journey-cta {
-  --conic-angle: 0deg;
-  --conic-border: 2px;
-  --conic-duration: 4s;
-  position: relative;
-  border: var(--conic-border) solid transparent;
-  padding-inline: 2.4rem;
-  min-width: min(320px, 88vw);
+  border: 1px solid color-mix(in srgb, #c4cfff 32%, rgba(255, 255, 255, 0.42));
+  padding-inline: clamp(1.15rem, 1.4vw, 1.5rem);
+  min-width: 0;
   background:
-    linear-gradient(#8b5cf6, #8b5cf6) padding-box,
-    conic-gradient(
-        from var(--conic-angle),
-        rgba(255, 255, 255, 0.95),
-        rgba(255, 255, 255, 0.45),
-        rgba(255, 255, 255, 0.85),
-        rgba(255, 255, 255, 0.35),
-        rgba(255, 255, 255, 0.95)
-      )
-      border-box;
-  animation: conic-spin var(--conic-duration) linear infinite;
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--accent) 74%, #b8b8ff 26%),
+      color-mix(in srgb, var(--accent-2) 70%, #8fd3ff 30%)
+    );
+  color: #f9fbff;
+  box-shadow:
+    0 11px 26px rgba(54, 66, 146, 0.34),
+    0 1px 0 rgba(255, 255, 255, 0.32) inset;
+  transition:
+    transform 170ms ease,
+    filter 170ms ease,
+    box-shadow 210ms ease;
 }
 
 .landing .hero-actions .journey-cta {
   flex: 0 1 auto;
+}
+
+.landing .journey-cta:hover {
+  transform: translateY(-1px);
+  filter: saturate(1.06) brightness(1.03);
+  box-shadow:
+    0 14px 30px rgba(57, 68, 150, 0.4),
+    0 1px 0 rgba(255, 255, 255, 0.38) inset;
 }
 
 .landing .hero-actions {
@@ -456,20 +456,20 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.42rem;
-  min-height: 30px;
-  padding: 0.4rem 1.02rem;
-  border-radius: 14px;
+  gap: 0.28rem;
+  min-height: 36px;
+  padding: 0.46rem 0.92rem;
+  border-radius: 999px;
   border: 1px solid
-    color-mix(in srgb, var(--accent-2) 48%, rgba(186, 212, 255, 0.45));
-  background: color-mix(in srgb, var(--accent-2) 9%, rgba(255, 255, 255, 0.03));
-  color: color-mix(in srgb, var(--ink) 94%, #fff 6%);
+    color-mix(in srgb, var(--accent-2) 38%, rgba(186, 212, 255, 0.26));
+  background: color-mix(in srgb, var(--accent-2) 8%, rgba(255, 255, 255, 0.02));
+  color: color-mix(in srgb, var(--ink) 86%, #fff 14%);
   text-decoration: none;
   font-family: var(--font-body);
-  font-size: 0.83rem;
-  font-weight: 650;
+  font-size: 0.78rem;
+  font-weight: 620;
   letter-spacing: 0.01em;
-  box-shadow: 0 10px 26px rgba(8, 18, 44, 0.28);
+  box-shadow: 0 7px 18px rgba(8, 18, 44, 0.24);
   transition:
     transform 160ms ease,
     background-color 160ms ease,
@@ -497,11 +497,6 @@
 .landing .hero-demo-cta:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent-2) 78%, #fff 22%);
   outline-offset: 2px;
-}
-
-.landing .hero-demo-cta-icon {
-  font-size: 0.64rem;
-  opacity: 0.92;
 }
 
 .landing .hero-media {
@@ -2482,12 +2477,6 @@
   }
 }
 
-@keyframes conic-spin {
-  to {
-    --conic-angle: 360deg;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .landing::before,
   .landing::after,
@@ -2524,10 +2513,9 @@
   }
 
   .landing .hero-demo-cta {
-    min-height: 28px;
-    padding: 0.38rem 0.95rem;
-    font-size: 0.8rem;
-    border-radius: 13px;
+    min-height: 34px;
+    padding: 0.42rem 0.88rem;
+    font-size: 0.75rem;
   }
 
   .landing .visible-progress-top {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -537,19 +537,19 @@ export default function LandingPage() {
             <>
               <Link
                 className={`${buttonClasses('ghost')} nav-auth-button`}
-                data-analytics-cta="create_account"
-                data-analytics-location="nav"
-                to={buildLocalizedAuthPath('/sign-up', language)}
-              >
-                {copy.auth.signup}
-              </Link>
-              <Link
-                className={`${buttonClasses()} nav-auth-button`}
                 data-analytics-cta="login"
                 data-analytics-location="nav"
                 to={buildLocalizedAuthPath('/login', language)}
               >
                 {copy.auth.login}
+              </Link>
+              <Link
+                className={`${buttonClasses()} nav-auth-button`}
+                data-analytics-cta="create_account"
+                data-analytics-location="nav"
+                to={buildLocalizedAuthPath('/sign-up', language)}
+              >
+                {copy.auth.signup}
               </Link>
             </>
           )}
@@ -589,9 +589,6 @@ export default function LandingPage() {
                       data-analytics-location="hero"
                       to={buildDemoModeSelectUrl({ language, source: 'landing' })}
                     >
-                      <span className="hero-demo-cta-icon" aria-hidden>
-                        ▶
-                      </span>
                       <span>{copy.auth.guidedDemo}</span>
                     </Link>
                   </>


### PR DESCRIPTION
### Motivation
- Apply a focused visual polish to the official landing hero so CTAs match the lab `HeroPhoneShowcase` look and the phone preview breathes more (de-emphasize flat black slab).
- Swap the nav auth action emphasis so `Create account` is the filled primary action and `Log in` is the ghost/secondary action.

### Description
- Updated hero copy source so guided-demo CTA reads `Demos` in both `es` and `en` by editing `apps/web/src/content/officialLandingContent.ts`.
- Reworked hero primary CTA visual by replacing the animated conic `journey-cta` treatment with a premium gradient pill (smaller min-width, gradient violet/blue, soft shadow, hover/focus retained) in `apps/web/src/pages/Landing.css`.
- Adjusted hero secondary CTA styling to be more compact and genuinely secondary and removed the play icon from the markup in `apps/web/src/pages/Landing.tsx` and `apps/web/src/pages/Landing.css`.
- Inverted top-nav auth actions in `apps/web/src/pages/Landing.tsx` so `Log in` is the ghost/quiet link and `Create account` is the filled button, preserving `to` routes and `data-analytics-*` attributes.
- Improved phone interior backgrounds inside `HeroPhoneShowcase` by updating `.phoneScreen`, `.scenePanel` and `.logrosViewport` with subtle navy/indigo layers and radial accents to add depth and separation in `apps/web/src/components/landing/HeroPhoneShowcase.module.css`.
- Performed a small cleanup in `HeroPhoneShowcase.module.css` removing unused lab scaffolding styles duplicated from the lab page.
- Preserved navigation, analytics attributes and existing CTA destinations throughout (no routing or analytics logic changed).

### Testing
- Ran typecheck for the web workspace: `npm run typecheck:web` (this command failed due to pre-existing TypeScript errors unrelated to the landing/CSS changes; no landing-specific TypeScript code was added that would cause these failures).
- Verified via static diff that `data-analytics-cta` and `data-analytics-location` attributes and `to` paths for hero and nav links were preserved or reassigned correctly after swapping the auth buttons.

Files touched:
- `apps/web/src/pages/Landing.tsx` (nav auth order, removed demo play icon)
- `apps/web/src/pages/Landing.css` (new `journey-cta` pill, updated `hero-demo-cta` styles, removed conic animation)
- `apps/web/src/content/officialLandingContent.ts` (guided demo copy -> `Demos`)
- `apps/web/src/components/landing/HeroPhoneShowcase.module.css` (phone interior background updates, small cleanup)

Notes:
- The visual change intentionally replaces the previous conic-border look; if other places rely on old `journey-cta` visual, they will now inherit the new pill styling on purpose to keep consistency rather than duplicating styles.
- No navigation routes or analytics events were removed or re-routed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebacbfd9908332b822026bba068f74)