### PR TITLE
Polish hero phone showcase: show real headers, center Logros card, and apply Innerbloom CTA styles

### DIFF
--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css
@@ -64,6 +64,10 @@
   margin-top: 1.6rem;
 }
 
+.ctaRowSingle {
+  justify-content: center;
+}
+
 .primaryCta,
 .secondaryCta {
   display: inline-flex;
@@ -77,15 +81,16 @@
 }
 
 .primaryCta {
-  background: linear-gradient(135deg, #9a78f6, #6f84f7);
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, var(--color-accent-primary), var(--color-accent-secondary));
   color: #fbfbff;
-  box-shadow: 0 8px 24px rgba(116, 107, 216, 0.36);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--color-accent-primary) 34%, transparent);
 }
 
 .secondaryCta {
-  border: 1px solid rgba(220, 216, 243, 0.24);
-  color: rgba(243, 239, 255, 0.92);
-  background: rgba(255, 245, 236, 0.03);
+  border: 1px solid color-mix(in srgb, var(--color-accent-primary) 58%, transparent);
+  color: color-mix(in srgb, var(--color-accent-primary) 72%, white);
+  background: color-mix(in srgb, var(--color-accent-primary) 14%, transparent);
 }
 
 .visualCol {
@@ -187,7 +192,7 @@
   inset: var(--hero-phone-safe-top) 0 0;
   overflow: hidden;
   display: flex;
-  padding: 10px 8px 10px;
+  padding: 8px 8px 10px;
   background:
     radial-gradient(
       circle at 20% 12%,
@@ -207,15 +212,15 @@
   min-height: 0;
 }
 
-.logrosHeroOnly :global(.ib-card > header),
-.logrosHeroOnly :global(.ib-card > [class*="rightSlot"]) {
-  display: none !important;
-}
-
 .logrosHeroOnly :global(.ib-card > .relative) {
   height: 100%;
-  padding: 0.4rem 0.3rem 0.5rem !important;
-  gap: 0.4rem !important;
+  padding: 0.45rem 0.35rem 0.5rem !important;
+  gap: 0.42rem !important;
+}
+
+.logrosHeroOnly :global(.ib-card > .relative > header) {
+  padding-top: 0.18rem;
+  padding-inline: 0.35rem;
 }
 
 .logrosHeroOnly :global([data-demo-anchor="logros-growth-calibration"]),
@@ -243,15 +248,16 @@
 }
 
 .logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"]) {
+  --hero-logros-card-width: min(86%, 16.8rem);
   min-height: 0;
-  margin-top: 0.25rem;
-  padding-inline: 0.2rem;
-  gap: 0.42rem;
+  margin-top: 0.22rem;
+  padding-inline: max(0.35rem, calc((100% - var(--hero-logros-card-width)) / 2));
+  gap: 0.56rem;
   align-items: stretch;
 }
 
 .logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"] > button) {
-  width: 88%;
+  width: var(--hero-logros-card-width);
   min-height: 0;
   height: min(21.8rem, 100%);
   padding: 0.72rem;
@@ -320,10 +326,6 @@
   display: none !important;
 }
 
-.heroFocusContent > :global(.space-y-6) > :first-child {
-  display: none !important;
-}
-
 .heroFocusContent :global([data-demo-anchor="daily-energy"]),
 .heroFocusContent :global([data-demo-anchor="daily-cultivation"]),
 .heroFocusContent :global([data-demo-anchor="moderation"]),
@@ -339,6 +341,7 @@
 
 .heroFocusViewport {
   padding-bottom: 88px;
+  padding-top: 6px;
 }
 
 .heroFocusContent

--- a/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
+++ b/apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useAuth } from "@clerk/clerk-react";
 import { Link } from "react-router-dom";
 import { setDashboardDemoModeEnabled } from "../../lib/demoMode";
 import { DemoDashboardOverviewScene } from "../../components/demo/DemoDashboardOverviewScene";
@@ -678,6 +679,13 @@ function HeroPhoneShowcase() {
 }
 
 export default function HeroPhoneShowcaseLabPage() {
+  const { userId } = useAuth();
+  const isSignedIn = Boolean(userId);
+
+  const primaryCta = isSignedIn
+    ? { label: "Go to dashboard", to: "/dashboard" }
+    : { label: "Comenzar ahora", to: "/onboarding" };
+
   return (
     <main className={styles.page}>
       <section className={styles.hero}>
@@ -691,13 +699,19 @@ export default function HeroPhoneShowcaseLabPage() {
             manteniendo el recorrido actual y sumando una escena de carrusel
             BODY en loop horizontal premium.
           </p>
-          <div className={styles.ctaRow}>
-            <Link className={styles.primaryCta} to="/onboarding">
-              Comenzar ahora
+          <div
+            className={`${styles.ctaRow} ${
+              isSignedIn ? styles.ctaRowSingle : ""
+            }`}
+          >
+            <Link className={styles.primaryCta} to={primaryCta.to}>
+              {primaryCta.label}
             </Link>
-            <a className={styles.secondaryCta} href="/landing-v2#highlights">
-              Ver dashboard
-            </a>
+            {!isSignedIn ? (
+              <a className={styles.secondaryCta} href="/landing-v2#highlights">
+                Demos
+              </a>
+            ) : null}
           </div>
         </div>
 


### PR DESCRIPTION
### Motivation

- Hacer que la representación dentro del mock de teléfono sea más fiel al producto real mostrando el header superior en Dashboard y en Logros, y que el hero se vea más premium y consistente con los tokens del repo.
- Corregir la posición visual del card activo del carrusel de Logros para que esté centrado en el viewport del teléfono.
- Alinear los CTAs del hero con la colorimetría de Innerbloom y centrar el botón único `Go to dashboard` cuando el usuario está logueado.

### Description

- Archivos modificados: `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.tsx` y `apps/web/src/pages/labs/HeroPhoneShowcaseLabPage.module.css`.
- Restauré el header real dentro del teléfono quitando reglas que lo ocultaban y ajusté offsets para evitar solapes; las reglas eliminadas o reemplazadas son las que escondían el bloque superior del dashboard y el header/rightSlot de `RewardsSection` en la escena Logros.
- Centré la card activa del carrusel de Logros añadiendo `--hero-logros-card-width`, calculando `padding-inline` del track para que el card activo quede centrado y usando ese ancho en los botones/cards del track; también ajusté `gap` y sizing para el hero mobile view.
- Actualicé los CTAs del hero para usar tokens existentes de Innerbloom: la `primaryCta` ahora usa `linear-gradient(135deg, var(--color-accent-primary), var(--color-accent-secondary))` y un `box-shadow` más sutil; la `secondaryCta` (antes celeste) ahora usa tratamiento violeta basado en `--color-accent-primary`; añadí `.ctaRowSingle` para centrar el CTA cuando solo hay un botón.
- Añadí render condicional para CTAs en `HeroPhoneShowcaseLabPage.tsx` usando `useAuth()` so: si el usuario está logueado el CTA principal es `Go to dashboard` y se centra, y si no lo está el secundario aparece como `Demos`.
- Cambios CSS/JS concretos aplicados (resumen): eliminada la regla `.heroFocusContent > :global(.space-y-6) > :first-child { display: none !important; }`; eliminada la regla que ocultaba headers en Logros `.logrosHeroOnly :global(.ib-card > header), .logrosHeroOnly :global(.ib-card > [class*="rightSlot"]) { display: none !important; }`; ajustado `.logrosHeroOnly :global(.ib-card > .relative)` padding/gap y añadido `.logrosHeroOnly :global(.ib-card > .relative > header)`; añadido `--hero-logros-card-width` y centrado del track mediante `padding-inline: max(0.35rem, calc((100% - var(--hero-logros-card-width)) / 2))`; botones/cards del track ahora usan `width: var(--hero-logros-card-width)`; `logrosViewport` padding reducido de `10px` a `8px`; `.heroFocusViewport` recibió `padding-top: 6px`; añadida `.ctaRowSingle { justify-content: center; }`; `.primaryCta` y `.secondaryCta` actualizadas para usar color tokens.

### Testing

- Ejecuté `pnpm -C apps/web run typecheck` y la comprobación de TypeScript falló por errores globales del repo que no están relacionados con estos cambios; la falla es preexistente y no fue causada por las modificaciones aquí.
- Intenté `pnpm -C apps/web exec eslint ...` y la ejecución falló por la configuración local de ESLint (el runner no encontró `eslint.config.*` en este entorno), por lo que no se pudo obtener un linter limpio en este paso.
- No se ejecutaron tests unitarios nuevos; los cambios fueron diseñados para ser exclusivamente visuales en el hero (CSS + pequeño ajuste de render de CTA) y las verificaciones automáticas disponibles en este entorno indicaron fallos globales no relacionados con los ficheros modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb5afd42883328787b1664971dc22)