### PR TITLE
Refine hero phone: in-phone top bar, centered achievements carousel, and CTA styling using design tokens

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -1,5 +1,5 @@
 .phoneFrame {
-  --hero-phone-safe-top: 44px;
+  --hero-phone-safe-top: 86px;
   width: min(100%, 342px);
   aspect-ratio: 9 / 18.5;
   border-radius: 42px;
@@ -73,6 +73,70 @@
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.12),
     inset 0 -14px 36px rgba(4, 5, 10, 0.42);
+}
+
+.phoneTopBar {
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 6;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 44px 14px 10px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-surface) 92%, transparent) 0%,
+    color-mix(in srgb, var(--color-surface) 72%, transparent) 80%,
+    transparent 100%
+  );
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--color-border-subtle) 72%, transparent);
+}
+
+.phoneTopBarCopy {
+  min-width: 0;
+}
+
+.phoneTopBarBrand {
+  margin: 0;
+  font-size: 0.47rem;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: 0.23em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-text-subtle) 86%, white 14%);
+}
+
+.phoneTopBarTitle {
+  margin: 0.22rem 0 0;
+  font-family: var(--font-heading);
+  font-size: 0.96rem;
+  font-weight: 600;
+  line-height: 1.08;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+}
+
+.phoneTopBarMenu {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.17rem;
+  align-items: center;
+  justify-content: center;
+  width: 1.95rem;
+  height: 1.95rem;
+  border-radius: 999px;
+  border: 1px solid
+    color-mix(in srgb, var(--color-border-subtle) 90%, transparent);
+  background: color-mix(in srgb, var(--color-overlay-1) 88%, transparent);
+  padding: 0;
+}
+
+.phoneTopBarMenu span {
+  width: 0.78rem;
+  height: 1.25px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-text) 90%, transparent);
 }
 
 .scenePanel {
@@ -177,13 +241,14 @@
 .logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"]) {
   min-height: 0;
   margin-top: 0.25rem;
-  padding-inline: 0.2rem;
+  --hero-logros-card-width: 88%;
+  padding-inline: max(0.2rem, calc((100% - var(--hero-logros-card-width)) / 2));
   gap: 0.42rem;
   align-items: stretch;
 }
 
 .logrosHeroOnly :global([data-demo-anchor="logros-carousel-track"] > button) {
-  width: 88%;
+  width: var(--hero-logros-card-width);
   min-height: 0;
   height: min(21.8rem, 100%);
   padding: 0.72rem;

--- a/apps/web/src/components/landing/HeroPhoneShowcase.tsx
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.tsx
@@ -1,10 +1,23 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
-import { setDashboardDemoModeEnabled } from '../../lib/demoMode';
-import { DemoDashboardOverviewScene } from '../demo/DemoDashboardOverviewScene';
-import { RewardsSection, type RewardsSectionDemoControls } from '../dashboard-v3/RewardsSection';
-import { getDemoLogrosData, getDemoLogrosPreviewByTaskId } from '../../data/demoLogrosData';
-import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
-import styles from './HeroPhoneShowcase.module.css';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { setDashboardDemoModeEnabled } from "../../lib/demoMode";
+import { DemoDashboardOverviewScene } from "../demo/DemoDashboardOverviewScene";
+import {
+  RewardsSection,
+  type RewardsSectionDemoControls,
+} from "../dashboard-v3/RewardsSection";
+import {
+  getDemoLogrosData,
+  getDemoLogrosPreviewByTaskId,
+} from "../../data/demoLogrosData";
+import { usePostLoginLanguage } from "../../i18n/postLoginLanguage";
+import styles from "./HeroPhoneShowcase.module.css";
 
 const INITIAL_TOP_PAUSE_MS = 500;
 const SCROLL_DOWN_DURATION_MS = 4500;
@@ -27,7 +40,11 @@ const HERO_LOOP_DURATION_MS =
   LOGROS_CAROUSEL_DURATION_MS +
   LOGROS_TO_DASHBOARD_DURATION_MS;
 
-const HERO_TASK_SEQUENCE = ['task-water', 'task-dinner-before-22', 'task-gym'] as const;
+const HERO_TASK_SEQUENCE = [
+  "task-water",
+  "task-dinner-before-22",
+  "task-gym",
+] as const;
 const HERO_BODY_CARD_UNLOCKED_1 = HERO_TASK_SEQUENCE[0];
 const HERO_BODY_CARD_UNLOCKED_2 = HERO_TASK_SEQUENCE[1];
 const HERO_BODY_CARD_BLOCKED_1 = HERO_TASK_SEQUENCE[2];
@@ -67,7 +84,7 @@ function resolveDashboardProgress(elapsedInLoop: number) {
   return 0;
 }
 
-type HeroPhase = 'dashboard' | 'to-logros' | 'logros' | 'to-dashboard';
+type HeroPhase = "dashboard" | "to-logros" | "logros" | "to-dashboard";
 
 function useHeroShowcaseTimeline({
   dashboardReady,
@@ -83,7 +100,7 @@ function useHeroShowcaseTimeline({
     dashboardProgress: number;
     trackProgress: number;
   }>({
-    phase: 'dashboard',
+    phase: "dashboard",
     dashboardProgress: 0,
     trackProgress: 0,
   });
@@ -96,7 +113,7 @@ function useHeroShowcaseTimeline({
   useEffect(() => {
     if (!dashboardReady) {
       setTimeline({
-        phase: 'dashboard',
+        phase: "dashboard",
         dashboardProgress: 0,
         trackProgress: 0,
       });
@@ -145,7 +162,7 @@ function useHeroShowcaseTimeline({
 
       if (!logrosReady) {
         setTimeline({
-          phase: 'dashboard',
+          phase: "dashboard",
           dashboardProgress: resolveDashboardProgress(
             dashboardElapsedRef.current,
           ),
@@ -158,7 +175,7 @@ function useHeroShowcaseTimeline({
       const elapsedInLoop = elapsed % HERO_LOOP_DURATION_MS;
       if (elapsedInLoop < DASHBOARD_LOOP_DURATION_MS) {
         setTimeline({
-          phase: 'dashboard',
+          phase: "dashboard",
           dashboardProgress: resolveDashboardProgress(elapsedInLoop),
           trackProgress: 0,
         });
@@ -168,7 +185,7 @@ function useHeroShowcaseTimeline({
       ) {
         const transitionElapsed = elapsedInLoop - DASHBOARD_LOOP_DURATION_MS;
         setTimeline({
-          phase: 'to-logros',
+          phase: "to-logros",
           dashboardProgress: 0,
           trackProgress: smoothProgress(
             transitionElapsed / DASHBOARD_TO_LOGROS_DURATION_MS,
@@ -181,7 +198,7 @@ function useHeroShowcaseTimeline({
           LOGROS_CAROUSEL_DURATION_MS
       ) {
         setTimeline({
-          phase: 'logros',
+          phase: "logros",
           dashboardProgress: 0,
           trackProgress: 1,
         });
@@ -192,7 +209,7 @@ function useHeroShowcaseTimeline({
           DASHBOARD_TO_LOGROS_DURATION_MS -
           LOGROS_CAROUSEL_DURATION_MS;
         setTimeline({
-          phase: 'to-dashboard',
+          phase: "to-dashboard",
           dashboardProgress: 0,
           trackProgress:
             1 -
@@ -208,7 +225,7 @@ function useHeroShowcaseTimeline({
   }, [dashboardReady, isActive, logrosReady]);
 
   return !dashboardReady
-    ? { phase: 'dashboard' as const, dashboardProgress: 0, trackProgress: 0 }
+    ? { phase: "dashboard" as const, dashboardProgress: 0, trackProgress: 0 }
     : timeline;
 }
 
@@ -226,6 +243,27 @@ function PhoneFrame({
       </div>
       <div className={styles.phoneScreen}>{children}</div>
     </div>
+  );
+}
+
+function PhoneTopBar({ sectionTitle }: { sectionTitle: string }) {
+  return (
+    <header className={styles.phoneTopBar}>
+      <div className={styles.phoneTopBarCopy}>
+        <p className={styles.phoneTopBarBrand}>INNERBLOOM</p>
+        <h2 className={styles.phoneTopBarTitle}>{sectionTitle}</h2>
+      </div>
+      <button
+        type="button"
+        className={styles.phoneTopBarMenu}
+        aria-label={`${sectionTitle} menu`}
+        tabIndex={-1}
+      >
+        <span aria-hidden />
+        <span aria-hidden />
+        <span aria-hidden />
+      </button>
+    </header>
   );
 }
 
@@ -300,7 +338,8 @@ function RealDashboardScene({
         );
         let end = Math.max(start, Math.min(maxScroll, endTarget));
 
-        if (end - start < minTravel) end = Math.min(maxScroll, start + minTravel);
+        if (end - start < minTravel)
+          end = Math.min(maxScroll, start + minTravel);
         if (end - start < minTravel) start = Math.max(0, end - minTravel);
         if (end <= start) {
           start = 0;
@@ -341,6 +380,7 @@ function RealDashboardScene({
       className={`${styles.scenePanel} ${styles.sceneDashboard}`}
       data-light-scope="dashboard-v3"
     >
+      <PhoneTopBar sectionTitle="Dashboard" />
       <div ref={viewportRef} className={styles.realViewport}>
         <div
           className={`${styles.mobileDashboardRoot} ${styles.heroFocusViewport}`}
@@ -379,16 +419,16 @@ function HeroLogrosScene({
   const demoConfig = useMemo(
     () => ({
       disableRemote: true,
-      forceAchievementsViewMode: 'carousel' as const,
+      forceAchievementsViewMode: "carousel" as const,
       mockPreviewAchievementByTaskId: getDemoLogrosPreviewByTaskId(language),
       anchors: {
-        shelves: 'logros-shelves',
-        growthCalibration: 'logros-growth-calibration',
-        carouselTrack: 'logros-carousel-track',
-        carouselStructure: 'logros-carousel-structure',
-        pillarSelector: 'logros-pillar-selector',
-        achievedCard: 'logros-achieved-card',
-        blockedCard: 'logros-blocked-card',
+        shelves: "logros-shelves",
+        growthCalibration: "logros-growth-calibration",
+        carouselTrack: "logros-carousel-track",
+        carouselStructure: "logros-carousel-structure",
+        pillarSelector: "logros-pillar-selector",
+        achievedCard: "logros-achieved-card",
+        blockedCard: "logros-blocked-card",
         achievedCardTaskId: HERO_BODY_CARD_UNLOCKED_1,
         blockedCardTaskId: HERO_BODY_CARD_BLOCKED_1,
       },
@@ -424,7 +464,7 @@ function HeroLogrosScene({
         '[data-demo-anchor="logros-carousel-track"]',
       );
       const cards = track?.querySelectorAll<HTMLElement>(
-        '[data-achievement-carousel-index]',
+        "[data-achievement-carousel-index]",
       );
 
       if (!sceneRoot || !controls || !track || !cards) {
@@ -433,7 +473,7 @@ function HeroLogrosScene({
 
       if (!readinessResolvedRef.current) {
         controls.closeAllOverlays();
-        controls.selectPillar('BODY');
+        controls.selectPillar("BODY");
         controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
         readinessResolvedRef.current = true;
       }
@@ -496,6 +536,9 @@ function HeroLogrosScene({
       className={`${styles.scenePanel} ${styles.sceneLogros}`}
       data-light-scope="dashboard-v3"
     >
+      <PhoneTopBar
+        sectionTitle={language === "es" ? "Logros" : "Achievements"}
+      />
       <div className={styles.logrosViewport}>
         <div className={styles.logrosHeroOnly}>
           <RewardsSection
@@ -521,7 +564,7 @@ export function HeroPhoneShowcase() {
     logrosReady,
     isActive: isHeroActive,
   });
-  const previousPhaseRef = useRef<HeroPhase>('dashboard');
+  const previousPhaseRef = useRef<HeroPhase>("dashboard");
 
   useEffect(() => {
     setDashboardDemoModeEnabled(true);
@@ -533,7 +576,7 @@ export function HeroPhoneShowcase() {
   }, []);
 
   useEffect(() => {
-    if (previousPhaseRef.current !== 'logros' && phase === 'logros') {
+    if (previousPhaseRef.current !== "logros" && phase === "logros") {
       setLogrosCycleKey((value) => value + 1);
     }
     previousPhaseRef.current = phase;
@@ -541,7 +584,7 @@ export function HeroPhoneShowcase() {
 
   useEffect(() => {
     const target = phoneFrameRef.current;
-    if (!target || typeof IntersectionObserver === 'undefined') {
+    if (!target || typeof IntersectionObserver === "undefined") {
       return;
     }
 
@@ -568,7 +611,7 @@ export function HeroPhoneShowcase() {
             onReady={() => setDashboardReady(true)}
           />
           <HeroLogrosScene
-            isActive={isHeroActive && phase === 'logros'}
+            isActive={isHeroActive && phase === "logros"}
             cycleKey={logrosCycleKey}
             onReady={() => setLogrosReady(true)}
           />

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -414,19 +414,14 @@
 }
 
 .landing .journey-cta {
-  border: 1px solid color-mix(in srgb, #c4cfff 32%, rgba(255, 255, 255, 0.42));
+  border: 0;
   padding-inline: clamp(1.15rem, 1.4vw, 1.5rem);
   min-width: 0;
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--accent) 74%, #b8b8ff 26%),
-      color-mix(in srgb, var(--accent-2) 70%, #8fd3ff 30%)
-    );
-  color: #f9fbff;
+  background: var(--gradient-innerbloom);
+  color: #111827;
   box-shadow:
-    0 11px 26px rgba(54, 66, 146, 0.34),
-    0 1px 0 rgba(255, 255, 255, 0.32) inset;
+    var(--shadow-innerbloom-cta),
+    0 1px 0 rgba(255, 255, 255, 0.28) inset;
   transition:
     transform 170ms ease,
     filter 170ms ease,
@@ -441,8 +436,8 @@
   transform: translateY(-1px);
   filter: saturate(1.06) brightness(1.03);
   box-shadow:
-    0 14px 30px rgba(57, 68, 150, 0.4),
-    0 1px 0 rgba(255, 255, 255, 0.38) inset;
+    0 16px 34px rgba(167, 112, 239, 0.32),
+    0 1px 0 rgba(255, 255, 255, 0.34) inset;
 }
 
 .landing .hero-actions {
@@ -461,8 +456,16 @@
   padding: 0.46rem 0.92rem;
   border-radius: 999px;
   border: 1px solid
-    color-mix(in srgb, var(--accent-2) 38%, rgba(186, 212, 255, 0.26));
-  background: color-mix(in srgb, var(--accent-2) 8%, rgba(255, 255, 255, 0.02));
+    color-mix(
+      in srgb,
+      var(--color-accent-secondary) 62%,
+      rgba(139, 92, 246, 0.18)
+    );
+  background: color-mix(
+    in srgb,
+    var(--color-accent-secondary) 10%,
+    rgba(255, 255, 255, 0.01)
+  );
   color: color-mix(in srgb, var(--ink) 86%, #fff 14%);
   text-decoration: none;
   font-family: var(--font-body);
@@ -481,21 +484,22 @@
   transform: translateY(-1px);
   background: color-mix(
     in srgb,
-    var(--accent-2) 14%,
+    var(--color-accent-secondary) 15%,
     rgba(255, 255, 255, 0.04)
   );
   border-color: color-mix(
     in srgb,
-    var(--accent-2) 58%,
-    rgba(186, 212, 255, 0.52)
+    var(--color-accent-secondary) 84%,
+    rgba(139, 92, 246, 0.34)
   );
   box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--accent-2) 24%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--color-accent-secondary) 24%, transparent),
     0 12px 28px rgba(10, 20, 48, 0.34);
 }
 
 .landing .hero-demo-cta:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent-2) 78%, #fff 22%);
+  outline: 2px solid
+    color-mix(in srgb, var(--color-accent-secondary) 78%, #fff 22%);
   outline-offset: 2px;
 }
 
@@ -540,7 +544,6 @@
   color: rgba(186, 201, 229, 0.88);
   text-align: center;
 }
-
 
 .landing .concept-term {
   font-family: var(--font-concept);
@@ -707,8 +710,16 @@
 .landing .card--hero-glass {
   border-color: rgba(235, 244, 255, 0.5);
   background:
-    radial-gradient(130% 124% at 14% 12%, rgba(255, 255, 255, 0.2), transparent 58%),
-    linear-gradient(135deg, rgba(248, 236, 255, 0.17), rgba(214, 233, 255, 0.13));
+    radial-gradient(
+      130% 124% at 14% 12%,
+      rgba(255, 255, 255, 0.2),
+      transparent 58%
+    ),
+    linear-gradient(
+      135deg,
+      rgba(248, 236, 255, 0.17),
+      rgba(214, 233, 255, 0.13)
+    );
   box-shadow:
     0 22px 48px rgba(42, 24, 84, 0.24),
     inset 0 1px 0 rgba(255, 255, 255, 0.62);
@@ -979,7 +990,6 @@
   border-left: 3px solid var(--flow);
 }
 
-
 .landing .mode-evolve {
   border-left: 3px solid var(--evolve);
 }
@@ -1064,7 +1074,11 @@
   align-self: start;
   flex-shrink: 0;
   border-radius: 999px;
-  background: linear-gradient(140deg, rgba(210, 162, 255, 0.42), rgba(248, 203, 189, 0.34));
+  background: linear-gradient(
+    140deg,
+    rgba(210, 162, 255, 0.42),
+    rgba(248, 203, 189, 0.34)
+  );
   border: 1px solid rgba(246, 229, 255, 0.44);
   padding: 7px 13px 6px;
   font-size: 0.74rem;
@@ -1326,7 +1340,7 @@
 }
 
 .landing .visible-scene-region--balance::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: -9px 24px 11px -15px;
   border-top-left-radius: 30px;
@@ -1345,7 +1359,7 @@
 }
 
 .landing .visible-scene-region--balance::after {
-  content: '';
+  content: "";
   position: absolute;
   inset: -10px 23px 10px -16px;
   border: 1px solid rgba(112, 126, 196, 0.28);
@@ -1430,7 +1444,7 @@
 }
 
 .landing .visible-inner-contour::after {
-  content: '';
+  content: "";
   position: absolute;
   inset: -1px;
   border-radius: inherit;
@@ -1460,7 +1474,7 @@
 }
 
 .landing .visible-inner-contour--emotion::after {
-  content: '';
+  content: "";
 }
 
 .landing .visible-scene-fragment--radar {
@@ -2077,8 +2091,16 @@
   --pricing-chip-ink: rgba(28, 18, 39, 0.94);
   --pricing-card-border: rgba(113, 83, 139, 0.36);
   --pricing-card-bg:
-    radial-gradient(120% 110% at 12% 16%, rgba(255, 255, 255, 0.28), transparent 58%),
-    linear-gradient(145deg, rgba(247, 233, 255, 0.26), rgba(214, 229, 255, 0.22));
+    radial-gradient(
+      120% 110% at 12% 16%,
+      rgba(255, 255, 255, 0.28),
+      transparent 58%
+    ),
+    linear-gradient(
+      145deg,
+      rgba(247, 233, 255, 0.26),
+      rgba(214, 229, 255, 0.22)
+    );
   --pricing-card-shadow:
     0 16px 34px rgba(64, 34, 86, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.52);
 }
@@ -2196,7 +2218,9 @@
   margin-bottom: 12px;
   backdrop-filter: blur(var(--landing-glass-blur));
   box-shadow: var(--landing-glass-shadow);
-  transition: border-color 170ms ease, background-color 170ms ease;
+  transition:
+    border-color 170ms ease,
+    background-color 170ms ease;
 }
 
 .landing .faq summary {
@@ -2219,8 +2243,16 @@
 .landing .faq details[open] {
   border-color: rgba(227, 209, 255, 0.48);
   background:
-    radial-gradient(122% 112% at 14% 10%, rgba(255, 255, 255, 0.16), transparent 58%),
-    linear-gradient(136deg, rgba(242, 232, 255, 0.14), rgba(214, 231, 255, 0.12));
+    radial-gradient(
+      122% 112% at 14% 10%,
+      rgba(255, 255, 255, 0.16),
+      transparent 58%
+    ),
+    linear-gradient(
+      136deg,
+      rgba(242, 232, 255, 0.14),
+      rgba(214, 231, 255, 0.12)
+    );
 }
 
 .landing .footer {
@@ -2554,6 +2586,10 @@
     align-items: center;
     justify-content: flex-start;
     flex-wrap: wrap;
+  }
+
+  .landing .hero-actions.hero-actions--single {
+    justify-content: center;
   }
 
   .landing .hero-actions .journey-cta {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -1,21 +1,41 @@
-import { Fragment, useEffect, useRef, useState, type CSSProperties, type KeyboardEvent, type TouchEvent } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { useAuth } from '@clerk/clerk-react';
-import { OFFICIAL_DESIGN_TOKENS, OFFICIAL_LANDING_CSS_VARIABLES } from '../content/officialDesignTokens';
-import { OFFICIAL_LANDING_CONTENT, type Language } from '../content/officialLandingContent';
-import { buildLocalizedAuthPath, resolveAuthLanguage } from '../lib/authLanguage';
-import { buildDemoModeSelectUrl } from '../lib/demoEntry';
-import PremiumTimeline from '../components/PremiumTimeline';
-import { AdaptiveText } from '../components/landing/AdaptiveText';
-import { CookieConsentBanner } from '../components/landing/CookieConsentBanner';
-import { useLandingAnalytics } from '../components/landing/useLandingAnalytics';
-import { HeroPhoneShowcase } from '../components/landing/HeroPhoneShowcase';
-import { LabsWeeklyRhythmSystemSection } from '../components/labs/LabsWeeklyRhythmSystemSection';
-import { buildOnboardingPath } from '../onboarding/i18n';
-import { usePostLoginLanguage } from '../i18n/postLoginLanguage';
-import { persistCookieConsentState, readCookieConsentState } from '../lib/cookieConsent';
-import { SHOW_LANDING_PRICING } from '../config/releaseFlags';
-import './Landing.css';
+import {
+  Fragment,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type TouchEvent,
+} from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useAuth } from "@clerk/clerk-react";
+import {
+  OFFICIAL_DESIGN_TOKENS,
+  OFFICIAL_LANDING_CSS_VARIABLES,
+} from "../content/officialDesignTokens";
+import {
+  OFFICIAL_LANDING_CONTENT,
+  type Language,
+} from "../content/officialLandingContent";
+import {
+  buildLocalizedAuthPath,
+  resolveAuthLanguage,
+} from "../lib/authLanguage";
+import { buildDemoModeSelectUrl } from "../lib/demoEntry";
+import PremiumTimeline from "../components/PremiumTimeline";
+import { AdaptiveText } from "../components/landing/AdaptiveText";
+import { CookieConsentBanner } from "../components/landing/CookieConsentBanner";
+import { useLandingAnalytics } from "../components/landing/useLandingAnalytics";
+import { HeroPhoneShowcase } from "../components/landing/HeroPhoneShowcase";
+import { LabsWeeklyRhythmSystemSection } from "../components/labs/LabsWeeklyRhythmSystemSection";
+import { buildOnboardingPath } from "../onboarding/i18n";
+import { usePostLoginLanguage } from "../i18n/postLoginLanguage";
+import {
+  persistCookieConsentState,
+  readCookieConsentState,
+} from "../lib/cookieConsent";
+import { SHOW_LANDING_PRICING } from "../config/releaseFlags";
+import "./Landing.css";
 
 type LandingGradientOption = {
   id: string;
@@ -26,35 +46,40 @@ type LandingGradientOption = {
 };
 
 const GRADIENT_LABELS: Record<string, { es: string; en: string }> = {
-  curiosity_blue: { es: 'Curiosity Blue', en: 'Curiosity Blue' },
-  endless_river: { es: 'Endless River', en: 'Endless River' },
-  amethyst: { es: 'Amethyst', en: 'Amethyst' },
-  dirty_fog: { es: 'Dirty Fog', en: 'Dirty Fog' },
-  purple_paradise: { es: 'Purple Paradise', en: 'Purple Paradise' },
-  color_1: { es: 'Color 1', en: 'Color 1' },
-  color_2: { es: 'Color 2', en: 'Color 2' },
-  purple_love: { es: 'Purple Love', en: 'Purple Love' },
-  afternoon: { es: 'Afternoon', en: 'Afternoon' },
-  purple_afternoon: { es: 'Purple Afternoon', en: 'Purple Afternoon' },
+  curiosity_blue: { es: "Curiosity Blue", en: "Curiosity Blue" },
+  endless_river: { es: "Endless River", en: "Endless River" },
+  amethyst: { es: "Amethyst", en: "Amethyst" },
+  dirty_fog: { es: "Dirty Fog", en: "Dirty Fog" },
+  purple_paradise: { es: "Purple Paradise", en: "Purple Paradise" },
+  color_1: { es: "Color 1", en: "Color 1" },
+  color_2: { es: "Color 2", en: "Color 2" },
+  purple_love: { es: "Purple Love", en: "Purple Love" },
+  afternoon: { es: "Afternoon", en: "Afternoon" },
+  purple_afternoon: { es: "Purple Afternoon", en: "Purple Afternoon" },
 };
 
-const LANDING_GRADIENTS: LandingGradientOption[] = OFFICIAL_DESIGN_TOKENS.gradients
-  .filter((gradient) => gradient.type === 'linear' && gradient.stops.length >= 2)
-  .map((gradient) => {
-    const label = GRADIENT_LABELS[gradient.name]
-      ?? { es: gradient.name.replace(/_/g, ' '), en: gradient.name.replace(/_/g, ' ') };
+const LANDING_GRADIENTS: LandingGradientOption[] =
+  OFFICIAL_DESIGN_TOKENS.gradients
+    .filter(
+      (gradient) => gradient.type === "linear" && gradient.stops.length >= 2,
+    )
+    .map((gradient) => {
+      const label = GRADIENT_LABELS[gradient.name] ?? {
+        es: gradient.name.replace(/_/g, " "),
+        en: gradient.name.replace(/_/g, " "),
+      };
 
-    return {
-      id: gradient.name,
-      label,
-      angle: gradient.angle,
-      a: gradient.stops[0],
-      b: gradient.stops[1],
-    };
-  });
+      return {
+        id: gradient.name,
+        label,
+        angle: gradient.angle,
+        a: gradient.stops[0],
+        b: gradient.stops[1],
+      };
+    });
 
-const LANDING_GRADIENT_STORAGE_KEY = 'ib:official-landing-gradient';
-const OFFICIAL_DEFAULT_GRADIENT_ID = 'purple_afternoon';
+const LANDING_GRADIENT_STORAGE_KEY = "ib:official-landing-gradient";
+const OFFICIAL_DEFAULT_GRADIENT_ID = "purple_afternoon";
 const SHOW_GRADIENT_SELECTOR = false;
 
 type ModeVisual = {
@@ -65,86 +90,90 @@ type ModeVisual = {
   avatarLabel: string;
 };
 
-const MODE_VISUALS: Record<Language, Record<'low' | 'chill' | 'flow' | 'evolve', ModeVisual>> = {
+const MODE_VISUALS: Record<
+  Language,
+  Record<"low" | "chill" | "flow" | "evolve", ModeVisual>
+> = {
   en: {
     low: {
-      avatarVideo: '/avatars/low-basic.mp4',
-      avatarImage: '/LowMood.jpg',
-      thumbImage: '/LowVertical.png',
-      avatarAlt: 'Red Cat avatar in Innerbloom.',
-      avatarLabel: 'Aligned with your energy'
+      avatarVideo: "/avatars/low-basic.mp4",
+      avatarImage: "/LowMood.jpg",
+      thumbImage: "/LowVertical.png",
+      avatarAlt: "Red Cat avatar in Innerbloom.",
+      avatarLabel: "Aligned with your energy",
     },
     chill: {
-      avatarVideo: '/avatars/chill-basic.mp4',
-      avatarImage: '/Chill-Mood.jpg',
-      thumbImage: '/ChillVertical.png',
-      avatarAlt: 'Green Bear avatar in Innerbloom.',
-      avatarLabel: 'Aligned with your energy'
+      avatarVideo: "/avatars/chill-basic.mp4",
+      avatarImage: "/Chill-Mood.jpg",
+      thumbImage: "/ChillVertical.png",
+      avatarAlt: "Green Bear avatar in Innerbloom.",
+      avatarLabel: "Aligned with your energy",
     },
     flow: {
-      avatarVideo: '/avatars/flow-basic.mp4',
-      avatarImage: '/FlowMood.jpg',
-      thumbImage: '/FlowVertical.png',
-      avatarAlt: 'Blue Amphibian avatar in Innerbloom.',
-      avatarLabel: 'Aligned with your energy'
+      avatarVideo: "/avatars/flow-basic.mp4",
+      avatarImage: "/FlowMood.jpg",
+      thumbImage: "/FlowVertical.png",
+      avatarAlt: "Blue Amphibian avatar in Innerbloom.",
+      avatarLabel: "Aligned with your energy",
     },
     evolve: {
-      avatarVideo: '/avatars/evolve-basic.mp4',
-      avatarImage: '/Evolve-Mood.jpg',
-      thumbImage: '/EvolveVertical.png',
-      avatarAlt: 'Violet Owl avatar in Innerbloom.',
-      avatarLabel: 'Aligned with your energy'
-    }
+      avatarVideo: "/avatars/evolve-basic.mp4",
+      avatarImage: "/Evolve-Mood.jpg",
+      thumbImage: "/EvolveVertical.png",
+      avatarAlt: "Violet Owl avatar in Innerbloom.",
+      avatarLabel: "Aligned with your energy",
+    },
   },
   es: {
     low: {
-      avatarVideo: '/avatars/low-basic.mp4',
-      avatarImage: '/LowMood.jpg',
-      thumbImage: '/LowVertical.png',
-      avatarAlt: 'Avatar Red Cat dentro de Innerbloom.',
-      avatarLabel: 'Alineado a tu energía'
+      avatarVideo: "/avatars/low-basic.mp4",
+      avatarImage: "/LowMood.jpg",
+      thumbImage: "/LowVertical.png",
+      avatarAlt: "Avatar Red Cat dentro de Innerbloom.",
+      avatarLabel: "Alineado a tu energía",
     },
     chill: {
-      avatarVideo: '/avatars/chill-basic.mp4',
-      avatarImage: '/Chill-Mood.jpg',
-      thumbImage: '/ChillVertical.png',
-      avatarAlt: 'Avatar Green Bear dentro de Innerbloom.',
-      avatarLabel: 'Alineado a tu energía'
+      avatarVideo: "/avatars/chill-basic.mp4",
+      avatarImage: "/Chill-Mood.jpg",
+      thumbImage: "/ChillVertical.png",
+      avatarAlt: "Avatar Green Bear dentro de Innerbloom.",
+      avatarLabel: "Alineado a tu energía",
     },
     flow: {
-      avatarVideo: '/avatars/flow-basic.mp4',
-      avatarImage: '/FlowMood.jpg',
-      thumbImage: '/FlowVertical.png',
-      avatarAlt: 'Avatar Blue Amphibian dentro de Innerbloom.',
-      avatarLabel: 'Alineado a tu energía'
+      avatarVideo: "/avatars/flow-basic.mp4",
+      avatarImage: "/FlowMood.jpg",
+      thumbImage: "/FlowVertical.png",
+      avatarAlt: "Avatar Blue Amphibian dentro de Innerbloom.",
+      avatarLabel: "Alineado a tu energía",
     },
     evolve: {
-      avatarVideo: '/avatars/evolve-basic.mp4',
-      avatarImage: '/Evolve-Mood.jpg',
-      thumbImage: '/EvolveVertical.png',
-      avatarAlt: 'Avatar Violet Owl dentro de Innerbloom.',
-      avatarLabel: 'Alineado a tu energía'
-    }
-  }
+      avatarVideo: "/avatars/evolve-basic.mp4",
+      avatarImage: "/Evolve-Mood.jpg",
+      thumbImage: "/EvolveVertical.png",
+      avatarAlt: "Avatar Violet Owl dentro de Innerbloom.",
+      avatarLabel: "Alineado a tu energía",
+    },
+  },
 };
 
 const buttonBaseClasses =
-  'inline-flex items-center justify-center whitespace-nowrap rounded-full px-6 py-3 font-display text-sm font-semibold tracking-tight transition duration-150 ease-out active:translate-y-[1px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white';
+  "inline-flex items-center justify-center whitespace-nowrap rounded-full px-6 py-3 font-display text-sm font-semibold tracking-tight transition duration-150 ease-out active:translate-y-[1px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white";
 
 const buttonVariants = {
-  primary: 'ib-primary-button',
-  ghost: `${buttonBaseClasses} border border-transparent bg-transparent text-text-subtle hover:bg-white/10 hover:text-white`
+  primary: "ib-primary-button",
+  ghost: `${buttonBaseClasses} border border-transparent bg-transparent text-text-subtle hover:bg-white/10 hover:text-white`,
 };
 
-const buttonClasses = (variant: keyof typeof buttonVariants = 'primary') => buttonVariants[variant];
+const buttonClasses = (variant: keyof typeof buttonVariants = "primary") =>
+  buttonVariants[variant];
 
 const PILLAR_EXAMPLES_LABEL: Record<Language, string> = {
-  es: 'Tareas sugeridas:',
-  en: 'Suggested tasks:'
+  es: "Tareas sugeridas:",
+  en: "Suggested tasks:",
 };
 
 function renderMultilineText(text: string) {
-  return text.split('\n').map((line, index) => (
+  return text.split("\n").map((line, index) => (
     <Fragment key={`${line}-${index}`}>
       {index > 0 ? <br /> : null}
       {line}
@@ -156,28 +185,176 @@ function splitPillarCopy(copy: string, language: Language) {
   const examplesLabel = PILLAR_EXAMPLES_LABEL[language];
   const [definitionPart, examplesPart] = copy.split(examplesLabel);
   const definition = definitionPart?.trim() ?? copy;
-  const examples = (examplesPart ?? '')
-    .split('•')
+  const examples = (examplesPart ?? "")
+    .split("•")
     .map((item) => item.trim())
     .filter(Boolean);
 
   return { definition, examples };
 }
 
-const EMOTION_HEATMAP_ROWS: Array<Array<'calm' | 'happy' | 'focus' | 'stress' | 'neutral'>> = [
-  ['calm', 'happy', 'calm', 'happy', 'neutral', 'calm', 'focus', 'calm', 'happy', 'calm', 'neutral', 'focus', 'calm', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral'],
-  ['calm', 'focus', 'calm', 'neutral', 'happy', 'neutral', 'calm', 'focus', 'calm', 'happy', 'focus', 'stress', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral'],
-  ['calm', 'focus', 'neutral', 'happy', 'happy', 'neutral', 'focus', 'calm', 'focus', 'calm', 'focus', 'stress', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral'],
-  ['calm', 'focus', 'neutral', 'focus', 'neutral', 'neutral', 'focus', 'focus', 'focus', 'focus', 'calm', 'stress', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral'],
-  ['focus', 'neutral', 'neutral', 'neutral', 'calm', 'happy', 'focus', 'neutral', 'focus', 'focus', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral'],
-  ['focus', 'calm', 'neutral', 'calm', 'focus', 'neutral', 'focus', 'happy', 'focus', 'calm', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral'],
-  ['calm', 'calm', 'neutral', 'neutral', 'focus', 'focus', 'happy', 'focus', 'calm', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral', 'neutral'],
+const EMOTION_HEATMAP_ROWS: Array<
+  Array<"calm" | "happy" | "focus" | "stress" | "neutral">
+> = [
+  [
+    "calm",
+    "happy",
+    "calm",
+    "happy",
+    "neutral",
+    "calm",
+    "focus",
+    "calm",
+    "happy",
+    "calm",
+    "neutral",
+    "focus",
+    "calm",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+  ],
+  [
+    "calm",
+    "focus",
+    "calm",
+    "neutral",
+    "happy",
+    "neutral",
+    "calm",
+    "focus",
+    "calm",
+    "happy",
+    "focus",
+    "stress",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+  ],
+  [
+    "calm",
+    "focus",
+    "neutral",
+    "happy",
+    "happy",
+    "neutral",
+    "focus",
+    "calm",
+    "focus",
+    "calm",
+    "focus",
+    "stress",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+  ],
+  [
+    "calm",
+    "focus",
+    "neutral",
+    "focus",
+    "neutral",
+    "neutral",
+    "focus",
+    "focus",
+    "focus",
+    "focus",
+    "calm",
+    "stress",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+  ],
+  [
+    "focus",
+    "neutral",
+    "neutral",
+    "neutral",
+    "calm",
+    "happy",
+    "focus",
+    "neutral",
+    "focus",
+    "focus",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+  ],
+  [
+    "focus",
+    "calm",
+    "neutral",
+    "calm",
+    "focus",
+    "neutral",
+    "focus",
+    "happy",
+    "focus",
+    "calm",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+  ],
+  [
+    "calm",
+    "calm",
+    "neutral",
+    "neutral",
+    "focus",
+    "focus",
+    "happy",
+    "focus",
+    "calm",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+    "neutral",
+  ],
 ];
 
-function LanguageDropdown({ value, onChange }: { value: Language; onChange: (language: Language) => void }) {
+function LanguageDropdown({
+  value,
+  onChange,
+}: {
+  value: Language;
+  onChange: (language: Language) => void;
+}) {
   const options: { code: Language; label: string }[] = [
-    { code: 'en', label: 'EN' },
-    { code: 'es', label: 'ES' }
+    { code: "en", label: "EN" },
+    { code: "es", label: "ES" },
   ];
 
   const [isOpen, setIsOpen] = useState(false);
@@ -185,16 +362,20 @@ function LanguageDropdown({ value, onChange }: { value: Language; onChange: (lan
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
         setIsOpen(false);
       }
     }
 
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const currentOption = options.find((option) => option.code === value) ?? options[0];
+  const currentOption =
+    options.find((option) => option.code === value) ?? options[0];
 
   function handleSelect(language: Language) {
     onChange(language);
@@ -202,7 +383,12 @@ function LanguageDropdown({ value, onChange }: { value: Language; onChange: (lan
   }
 
   return (
-    <div ref={dropdownRef} className="lang-toggle" role="group" aria-label="Language selector">
+    <div
+      ref={dropdownRef}
+      className="lang-toggle"
+      role="group"
+      aria-label="Language selector"
+    >
       <button
         type="button"
         className="lang-button"
@@ -223,7 +409,7 @@ function LanguageDropdown({ value, onChange }: { value: Language; onChange: (lan
             type="button"
             role="option"
             aria-selected={value === option.code}
-            className={value === option.code ? 'active' : ''}
+            className={value === option.code ? "active" : ""}
             onClick={() => handleSelect(option.code)}
           >
             {option.label}
@@ -241,31 +427,43 @@ export default function LandingPage() {
   const navigate = useNavigate();
   const isSignedIn = Boolean(userId);
   const [language, setLanguage] = useState<Language>(() =>
-    typeof window !== 'undefined' ? resolveAuthLanguage(window.location.search) : 'es'
+    typeof window !== "undefined"
+      ? resolveAuthLanguage(window.location.search)
+      : "es",
   );
   const [gradientId, setGradientId] = useState<string>(() => {
-    const fallbackGradientId = LANDING_GRADIENTS[0]?.id ?? '';
-    const officialGradient = LANDING_GRADIENTS.find((option) => option.id === OFFICIAL_DEFAULT_GRADIENT_ID);
+    const fallbackGradientId = LANDING_GRADIENTS[0]?.id ?? "";
+    const officialGradient = LANDING_GRADIENTS.find(
+      (option) => option.id === OFFICIAL_DEFAULT_GRADIENT_ID,
+    );
     const officialGradientId = officialGradient?.id ?? fallbackGradientId;
 
-    if (typeof window === 'undefined') return officialGradientId;
+    if (typeof window === "undefined") return officialGradientId;
 
     if (!SHOW_GRADIENT_SELECTOR) {
       return officialGradientId;
     }
 
-    const storedGradientId = window.localStorage.getItem(LANDING_GRADIENT_STORAGE_KEY);
-    const storedGradient = LANDING_GRADIENTS.find((option) => option.id === storedGradientId);
+    const storedGradientId = window.localStorage.getItem(
+      LANDING_GRADIENT_STORAGE_KEY,
+    );
+    const storedGradient = LANDING_GRADIENTS.find(
+      (option) => option.id === storedGradientId,
+    );
     return storedGradient?.id ?? officialGradientId;
   });
   const copy = OFFICIAL_LANDING_CONTENT[language];
-  const visibleNavLinks = copy.navLinks.filter((link) => !/^\/demo$/i.test(link.href) && !/^#?demo$/i.test(link.href));
-  const selectedGradient = LANDING_GRADIENTS.find((option) => option.id === gradientId) ?? LANDING_GRADIENTS[0];
+  const visibleNavLinks = copy.navLinks.filter(
+    (link) => !/^\/demo$/i.test(link.href) && !/^#?demo$/i.test(link.href),
+  );
+  const selectedGradient =
+    LANDING_GRADIENTS.find((option) => option.id === gradientId) ??
+    LANDING_GRADIENTS[0];
   const landingStyle = {
     ...(OFFICIAL_LANDING_CSS_VARIABLES as CSSProperties),
-    '--bg-angle': selectedGradient.angle,
-    '--bg-a': selectedGradient.a,
-    '--bg-b': selectedGradient.b,
+    "--bg-angle": selectedGradient.angle,
+    "--bg-a": selectedGradient.a,
+    "--bg-b": selectedGradient.b,
   } as CSSProperties;
   const [activeSlide, setActiveSlide] = useState(0);
   const [paused, setPaused] = useState(false);
@@ -273,9 +471,11 @@ export default function LandingPage() {
   const [isModesInView, setIsModesInView] = useState(false);
   const [hasModeInteracted, setHasModeInteracted] = useState(false);
   const initialCookieConsentStateRef = useRef(readCookieConsentState());
-  const [analyticsConsent, setAnalyticsConsent] = useState(() => initialCookieConsentStateRef.current.analytics);
+  const [analyticsConsent, setAnalyticsConsent] = useState(
+    () => initialCookieConsentStateRef.current.analytics,
+  );
   const [isCookiePanelOpen, setIsCookiePanelOpen] = useState(
-    () => initialCookieConsentStateRef.current.analytics === 'unset'
+    () => initialCookieConsentStateRef.current.analytics === "unset",
   );
   const modesSectionRef = useRef<HTMLElement | null>(null);
   const modeThumbTouchStartXRef = useRef<number | null>(null);
@@ -285,7 +485,10 @@ export default function LandingPage() {
   const activeMode = copy.modes.items[activeModeIndex] ?? copy.modes.items[0];
   const activeVisual = MODE_VISUALS[language][activeMode.id];
   useEffect(() => {
-    console.info('[landing][ga4-debug] cookie consent read on load', initialCookieConsentStateRef.current);
+    console.info(
+      "[landing][ga4-debug] cookie consent read on load",
+      initialCookieConsentStateRef.current,
+    );
   }, []);
 
   useEffect(() => {
@@ -320,7 +523,7 @@ export default function LandingPage() {
 
   useEffect(() => {
     const elements = Array.from(
-      document.querySelectorAll<HTMLElement>('.reveal-on-scroll')
+      document.querySelectorAll<HTMLElement>(".reveal-on-scroll"),
     );
 
     if (!elements.length) {
@@ -328,12 +531,12 @@ export default function LandingPage() {
     }
 
     const prefersReducedMotion = window.matchMedia(
-      '(prefers-reduced-motion: reduce)'
+      "(prefers-reduced-motion: reduce)",
     ).matches;
 
     if (prefersReducedMotion) {
       elements.forEach((element) => {
-        element.classList.add('is-visible');
+        element.classList.add("is-visible");
       });
       return;
     }
@@ -342,12 +545,12 @@ export default function LandingPage() {
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            entry.target.classList.add('is-visible');
+            entry.target.classList.add("is-visible");
             observer.unobserve(entry.target);
           }
         });
       },
-      { threshold: 0.15, rootMargin: '0px 0px -10%' }
+      { threshold: 0.15, rootMargin: "0px 0px -10%" },
     );
 
     elements.forEach((element) => observer.observe(element));
@@ -366,7 +569,7 @@ export default function LandingPage() {
       ([entry]) => {
         setIsModesInView(entry.isIntersecting);
       },
-      { threshold: 0.35 }
+      { threshold: 0.35 },
     );
 
     observer.observe(sectionElement);
@@ -375,9 +578,16 @@ export default function LandingPage() {
   }, []);
 
   useEffect(() => {
-    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
 
-    if (prefersReducedMotion || hasModeInteracted || !isModesInView || modeCount <= 1) {
+    if (
+      prefersReducedMotion ||
+      hasModeInteracted ||
+      !isModesInView ||
+      modeCount <= 1
+    ) {
       return;
     }
 
@@ -393,11 +603,11 @@ export default function LandingPage() {
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'ArrowLeft') {
+    if (event.key === "ArrowLeft") {
       event.preventDefault();
       goToSlide(activeSlide - 1);
     }
-    if (event.key === 'ArrowRight') {
+    if (event.key === "ArrowRight") {
       event.preventDefault();
       goToSlide(activeSlide + 1);
     }
@@ -416,23 +626,26 @@ export default function LandingPage() {
     selectMode(index);
   };
 
-  const handleModeThumbKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+  const handleModeThumbKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
     const { key } = event;
 
-    if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+    if (key === "Enter" || key === " " || key === "Spacebar") {
       event.preventDefault();
       handleModeSelect(index);
       return;
     }
 
-    if (key === 'ArrowUp' || key === 'ArrowLeft') {
+    if (key === "ArrowUp" || key === "ArrowLeft") {
       event.preventDefault();
       stopModesAutoplay();
       selectMode(index - 1);
       return;
     }
 
-    if (key === 'ArrowDown' || key === 'ArrowRight') {
+    if (key === "ArrowDown" || key === "ArrowRight") {
       event.preventDefault();
       stopModesAutoplay();
       selectMode(index + 1);
@@ -460,22 +673,22 @@ export default function LandingPage() {
   };
 
   const faqJsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'FAQPage',
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
     inLanguage: language,
     mainEntity: copy.faq.items.map((item) => ({
-      '@type': 'Question',
+      "@type": "Question",
       name: item.question,
       acceptedAnswer: {
-        '@type': 'Answer',
-        text: item.answer
-      }
-    }))
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
   };
 
-  const handleAnalyticsConsent = (nextDecision: 'accepted' | 'rejected') => {
+  const handleAnalyticsConsent = (nextDecision: "accepted" | "rejected") => {
     const nextState = persistCookieConsentState(nextDecision);
-    console.info('[landing][ga4-debug] cookie consent updated', {
+    console.info("[landing][ga4-debug] cookie consent updated", {
       nextDecision,
       persistedState: nextState,
     });
@@ -483,14 +696,15 @@ export default function LandingPage() {
     setIsCookiePanelOpen(false);
   };
 
-
   return (
     <div className="landing" style={landingStyle}>
       <header className="nav">
         <Link
           className="brand"
-          to={buildLocalizedAuthPath('/', language)}
-          aria-label={language === 'es' ? 'Innerbloom — inicio' : 'Innerbloom — home'}
+          to={buildLocalizedAuthPath("/", language)}
+          aria-label={
+            language === "es" ? "Innerbloom — inicio" : "Innerbloom — home"
+          }
         >
           <span className="brand-text">Innerbloom</span>
           <img
@@ -513,12 +727,18 @@ export default function LandingPage() {
         <div className="nav-actions">
           {SHOW_GRADIENT_SELECTOR ? (
             <label className="gradient-select-wrapper">
-              <span className="visually-hidden">{language === 'es' ? 'Seleccionar fondo' : 'Select background'}</span>
+              <span className="visually-hidden">
+                {language === "es" ? "Seleccionar fondo" : "Select background"}
+              </span>
               <select
                 className="gradient-select"
                 value={gradientId}
                 onChange={(event) => setGradientId(event.target.value)}
-                aria-label={language === 'es' ? 'Selector de fondo' : 'Background selector'}
+                aria-label={
+                  language === "es"
+                    ? "Selector de fondo"
+                    : "Background selector"
+                }
               >
                 {LANDING_GRADIENTS.map((option) => (
                   <option key={option.id} value={option.id}>
@@ -536,10 +756,10 @@ export default function LandingPage() {
           ) : (
             <>
               <Link
-                className={`${buttonClasses('ghost')} nav-auth-button`}
+                className={`${buttonClasses("ghost")} nav-auth-button`}
                 data-analytics-cta="login"
                 data-analytics-location="nav"
-                to={buildLocalizedAuthPath('/login', language)}
+                to={buildLocalizedAuthPath("/login", language)}
               >
                 {copy.auth.login}
               </Link>
@@ -547,7 +767,7 @@ export default function LandingPage() {
                 className={`${buttonClasses()} nav-auth-button`}
                 data-analytics-cta="create_account"
                 data-analytics-location="nav"
-                to={buildLocalizedAuthPath('/sign-up', language)}
+                to={buildLocalizedAuthPath("/sign-up", language)}
               >
                 {copy.auth.signup}
               </Link>
@@ -557,18 +777,23 @@ export default function LandingPage() {
       </header>
 
       <main>
-        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+        />
         <section className="hero reveal-on-scroll" id="overview">
           <div className="hero-grid">
             <div className="hero-copy">
               <h1>
-                {copy.hero.titleLead}{' '}
+                {copy.hero.titleLead}{" "}
                 <span className="grad">{copy.hero.titleHighlight}</span>
               </h1>
-              <p className="sub">
-                {copy.hero.subtitle}
-              </p>
-              <div className="mt-6 flex flex-wrap items-center justify-center gap-3 hero-actions">
+              <p className="sub">{copy.hero.subtitle}</p>
+              <div
+                className={`mt-6 flex flex-wrap items-center justify-center gap-3 hero-actions ${
+                  isSignedIn ? "hero-actions--single" : ""
+                }`}
+              >
                 {isSignedIn ? (
                   <Link className={buttonClasses()} to="/dashboard">
                     {copy.auth.dashboard}
@@ -587,7 +812,10 @@ export default function LandingPage() {
                       className="hero-demo-cta"
                       data-analytics-cta="guided_demo"
                       data-analytics-location="hero"
-                      to={buildDemoModeSelectUrl({ language, source: 'landing' })}
+                      to={buildDemoModeSelectUrl({
+                        language,
+                        source: "landing",
+                      })}
                     >
                       <span>{copy.auth.guidedDemo}</span>
                     </Link>
@@ -602,18 +830,26 @@ export default function LandingPage() {
           </div>
         </section>
 
-        <section className="truth-problem section-pad reveal-on-scroll" id="why">
+        <section
+          className="truth-problem section-pad reveal-on-scroll"
+          id="why"
+        >
           <div className="container narrow truth-problem-section">
             <p className="truth-problem-kicker">
-              {language === 'es' ? 'EL PROBLEMA REAL' : 'THE REAL PROBLEM'}
+              {language === "es" ? "EL PROBLEMA REAL" : "THE REAL PROBLEM"}
             </p>
 
-            <AdaptiveText as="h2" className="truth-problem-title truth-problem-title--outside">
+            <AdaptiveText
+              as="h2"
+              className="truth-problem-title truth-problem-title--outside"
+            >
               {copy.problem.title}
             </AdaptiveText>
 
             <div className="truth-problem-shell truth-problem-shell--body-only">
-              <AdaptiveText as="p" className="section-sub truth-problem-body">{renderMultilineText(copy.problem.body)}</AdaptiveText>
+              <AdaptiveText as="p" className="section-sub truth-problem-body">
+                {renderMultilineText(copy.problem.body)}
+              </AdaptiveText>
             </div>
           </div>
         </section>
@@ -623,7 +859,9 @@ export default function LandingPage() {
             <div className="how-heading">
               <p className="how-kicker">{copy.how.kicker}</p>
               <AdaptiveText as="h2">{copy.how.title}</AdaptiveText>
-              <AdaptiveText as="p" className="section-sub how-intro">{copy.how.intro}</AdaptiveText>
+              <AdaptiveText as="p" className="section-sub how-intro">
+                {copy.how.intro}
+              </AdaptiveText>
             </div>
             <PremiumTimeline
               steps={copy.how.steps}
@@ -633,12 +871,19 @@ export default function LandingPage() {
           </div>
         </section>
 
-        <section className="feature-showcase section-pad reveal-on-scroll" id="demo">
+        <section
+          className="feature-showcase section-pad reveal-on-scroll"
+          id="demo"
+        >
           <div className="container narrow">
             <div className="visible-progress-top">
               <div className="visible-progress-copy">
-                <AdaptiveText as="h2" className="demo-title">{copy.demo.title}</AdaptiveText>
-                <AdaptiveText as="p" className="demo-sub">{renderMultilineText(copy.demo.text)}</AdaptiveText>
+                <AdaptiveText as="h2" className="demo-title">
+                  {copy.demo.title}
+                </AdaptiveText>
+                <AdaptiveText as="p" className="demo-sub">
+                  {renderMultilineText(copy.demo.text)}
+                </AdaptiveText>
               </div>
 
               <div className="visible-progress-module" aria-hidden>
@@ -647,46 +892,195 @@ export default function LandingPage() {
                     <div className="visible-scene-region visible-scene-region--balance visible-scene-fragment visible-scene-fragment--radar">
                       <div className="visible-canvas-header">
                         <p className="visible-canvas-title">BALANCE</p>
-                        <span className="visible-canvas-chip">Predominio Body</span>
+                        <span className="visible-canvas-chip">
+                          Predominio Body
+                        </span>
                       </div>
                       <div className="visible-radar-shell">
                         <div className="visible-balance-radar-wrap">
-                          <svg className="visible-balance-radar" viewBox="0 0 420 420" aria-hidden>
+                          <svg
+                            className="visible-balance-radar"
+                            viewBox="0 0 420 420"
+                            aria-hidden
+                          >
                             <defs>
-                              <radialGradient id="visible-balance-radar-shape-fill" cx="42%" cy="32%" r="72%">
-                                <stop offset="0%" stopColor="rgba(243, 247, 255, 0.52)" />
-                                <stop offset="100%" stopColor="rgba(189, 205, 243, 0.18)" />
+                              <radialGradient
+                                id="visible-balance-radar-shape-fill"
+                                cx="42%"
+                                cy="32%"
+                                r="72%"
+                              >
+                                <stop
+                                  offset="0%"
+                                  stopColor="rgba(243, 247, 255, 0.52)"
+                                />
+                                <stop
+                                  offset="100%"
+                                  stopColor="rgba(189, 205, 243, 0.18)"
+                                />
                               </radialGradient>
-                              <radialGradient id="visible-balance-radar-inner-fill" cx="50%" cy="42%" r="68%">
-                                <stop offset="0%" stopColor="rgba(226, 236, 255, 0.3)" />
-                                <stop offset="100%" stopColor="rgba(179, 197, 240, 0.08)" />
+                              <radialGradient
+                                id="visible-balance-radar-inner-fill"
+                                cx="50%"
+                                cy="42%"
+                                r="68%"
+                              >
+                                <stop
+                                  offset="0%"
+                                  stopColor="rgba(226, 236, 255, 0.3)"
+                                />
+                                <stop
+                                  offset="100%"
+                                  stopColor="rgba(179, 197, 240, 0.08)"
+                                />
                               </radialGradient>
                             </defs>
-                            <circle className="visible-balance-radar-glow" cx="210" cy="210" r="186" />
-                            <polygon className="visible-balance-radar-ring" points="210.0,40.0 295.0,62.8 357.2,125.0 380.0,210.0 357.2,295.0 295.0,357.2 210.0,380.0 125.0,357.2 62.8,295.0 40.0,210.0 62.8,125.0 125.0,62.8" />
-                            <polygon className="visible-balance-radar-ring" points="210.0,80.0 275.0,97.4 322.6,145.0 340.0,210.0 322.6,275.0 275.0,322.6 210.0,340.0 145.0,322.6 97.4,275.0 80.0,210.0 97.4,145.0 145.0,97.4" />
-                            <polygon className="visible-balance-radar-ring" points="210.0,118.0 256.0,130.3 289.7,164.0 302.0,210.0 289.7,256.0 256.0,289.7 210.0,302.0 164.0,289.7 130.3,256.0 118.0,210.0 130.3,164.0 164.0,130.3" />
-                            <polygon className="visible-balance-radar-ring" points="210.0,154.0 238.0,161.5 258.5,182.0 266.0,210.0 258.5,238.0 238.0,258.5 210.0,266.0 182.0,258.5 161.5,238.0 154.0,210.0 161.5,182.0 182.0,161.5" />
-                            <line className="visible-balance-radar-axis" x1="210" y1="40" x2="210" y2="380" />
-                            <line className="visible-balance-radar-axis" x1="295" y1="62.8" x2="125" y2="357.2" />
-                            <line className="visible-balance-radar-axis" x1="357.2" y1="125" x2="62.8" y2="295" />
-                            <line className="visible-balance-radar-axis" x1="380" y1="210" x2="40" y2="210" />
-                            <line className="visible-balance-radar-axis" x1="357.2" y1="295" x2="62.8" y2="125" />
-                            <line className="visible-balance-radar-axis" x1="295" y1="357.2" x2="125" y2="62.8" />
-                            <path className="visible-balance-radar-pillar visible-balance-radar-pillar--soul" d="M 323.1 344.8 A 176 176 0 0 1 50.5 284.4" />
-                            <path className="visible-balance-radar-pillar visible-balance-radar-pillar--mind" d="M 50.5 284.4 A 176 176 0 0 1 104.1 69.4" />
-                            <path className="visible-balance-radar-pillar visible-balance-radar-pillar--body" d="M 104.1 69.4 A 176 176 0 0 1 323.1 344.8" />
-                            <polygon className="visible-balance-radar-shape visible-balance-radar-shape--outer" points="210.0,144.3 264.4,115.8 321.9,145.4 309.7,210.0 284.6,253.1 280.8,332.7 210.0,280.3 170.3,278.7 159.0,239.5 40.0,210.0 133.4,165.8 157.9,119.7" />
-                            <polygon className="visible-balance-radar-shape visible-balance-radar-shape--inner" points="210.0,159.7 251.6,137.9 295.6,160.6 286.3,210.0 267.0,242.9 264.2,303.8 210.0,263.7 179.7,262.5 171.0,232.5 80.0,210.0 151.5,176.2 170.1,140.9" />
-                            <circle className="visible-balance-radar-core" cx="210" cy="210" r="9" />
-                            <text className="visible-balance-radar-value" x="28" y="208">777</text>
-                            <text className="visible-balance-radar-value" x="252" y="84">483</text>
-                            <text className="visible-balance-radar-value" x="286" y="336">517</text>
-                            <text className="visible-balance-radar-value" x="132" y="236">251</text>
-                            <text className="visible-balance-radar-value" x="141" y="122">456</text>
-                            <text className="visible-balance-radar-value" x="270" y="158">414</text>
-                            <text className="visible-balance-radar-value" x="288" y="192">378</text>
-                            <text className="visible-balance-radar-value" x="118" y="172">252</text>
+                            <circle
+                              className="visible-balance-radar-glow"
+                              cx="210"
+                              cy="210"
+                              r="186"
+                            />
+                            <polygon
+                              className="visible-balance-radar-ring"
+                              points="210.0,40.0 295.0,62.8 357.2,125.0 380.0,210.0 357.2,295.0 295.0,357.2 210.0,380.0 125.0,357.2 62.8,295.0 40.0,210.0 62.8,125.0 125.0,62.8"
+                            />
+                            <polygon
+                              className="visible-balance-radar-ring"
+                              points="210.0,80.0 275.0,97.4 322.6,145.0 340.0,210.0 322.6,275.0 275.0,322.6 210.0,340.0 145.0,322.6 97.4,275.0 80.0,210.0 97.4,145.0 145.0,97.4"
+                            />
+                            <polygon
+                              className="visible-balance-radar-ring"
+                              points="210.0,118.0 256.0,130.3 289.7,164.0 302.0,210.0 289.7,256.0 256.0,289.7 210.0,302.0 164.0,289.7 130.3,256.0 118.0,210.0 130.3,164.0 164.0,130.3"
+                            />
+                            <polygon
+                              className="visible-balance-radar-ring"
+                              points="210.0,154.0 238.0,161.5 258.5,182.0 266.0,210.0 258.5,238.0 238.0,258.5 210.0,266.0 182.0,258.5 161.5,238.0 154.0,210.0 161.5,182.0 182.0,161.5"
+                            />
+                            <line
+                              className="visible-balance-radar-axis"
+                              x1="210"
+                              y1="40"
+                              x2="210"
+                              y2="380"
+                            />
+                            <line
+                              className="visible-balance-radar-axis"
+                              x1="295"
+                              y1="62.8"
+                              x2="125"
+                              y2="357.2"
+                            />
+                            <line
+                              className="visible-balance-radar-axis"
+                              x1="357.2"
+                              y1="125"
+                              x2="62.8"
+                              y2="295"
+                            />
+                            <line
+                              className="visible-balance-radar-axis"
+                              x1="380"
+                              y1="210"
+                              x2="40"
+                              y2="210"
+                            />
+                            <line
+                              className="visible-balance-radar-axis"
+                              x1="357.2"
+                              y1="295"
+                              x2="62.8"
+                              y2="125"
+                            />
+                            <line
+                              className="visible-balance-radar-axis"
+                              x1="295"
+                              y1="357.2"
+                              x2="125"
+                              y2="62.8"
+                            />
+                            <path
+                              className="visible-balance-radar-pillar visible-balance-radar-pillar--soul"
+                              d="M 323.1 344.8 A 176 176 0 0 1 50.5 284.4"
+                            />
+                            <path
+                              className="visible-balance-radar-pillar visible-balance-radar-pillar--mind"
+                              d="M 50.5 284.4 A 176 176 0 0 1 104.1 69.4"
+                            />
+                            <path
+                              className="visible-balance-radar-pillar visible-balance-radar-pillar--body"
+                              d="M 104.1 69.4 A 176 176 0 0 1 323.1 344.8"
+                            />
+                            <polygon
+                              className="visible-balance-radar-shape visible-balance-radar-shape--outer"
+                              points="210.0,144.3 264.4,115.8 321.9,145.4 309.7,210.0 284.6,253.1 280.8,332.7 210.0,280.3 170.3,278.7 159.0,239.5 40.0,210.0 133.4,165.8 157.9,119.7"
+                            />
+                            <polygon
+                              className="visible-balance-radar-shape visible-balance-radar-shape--inner"
+                              points="210.0,159.7 251.6,137.9 295.6,160.6 286.3,210.0 267.0,242.9 264.2,303.8 210.0,263.7 179.7,262.5 171.0,232.5 80.0,210.0 151.5,176.2 170.1,140.9"
+                            />
+                            <circle
+                              className="visible-balance-radar-core"
+                              cx="210"
+                              cy="210"
+                              r="9"
+                            />
+                            <text
+                              className="visible-balance-radar-value"
+                              x="28"
+                              y="208"
+                            >
+                              777
+                            </text>
+                            <text
+                              className="visible-balance-radar-value"
+                              x="252"
+                              y="84"
+                            >
+                              483
+                            </text>
+                            <text
+                              className="visible-balance-radar-value"
+                              x="286"
+                              y="336"
+                            >
+                              517
+                            </text>
+                            <text
+                              className="visible-balance-radar-value"
+                              x="132"
+                              y="236"
+                            >
+                              251
+                            </text>
+                            <text
+                              className="visible-balance-radar-value"
+                              x="141"
+                              y="122"
+                            >
+                              456
+                            </text>
+                            <text
+                              className="visible-balance-radar-value"
+                              x="270"
+                              y="158"
+                            >
+                              414
+                            </text>
+                            <text
+                              className="visible-balance-radar-value"
+                              x="288"
+                              y="192"
+                            >
+                              378
+                            </text>
+                            <text
+                              className="visible-balance-radar-value"
+                              x="118"
+                              y="172"
+                            >
+                              252
+                            </text>
                           </svg>
                         </div>
                       </div>
@@ -715,12 +1109,20 @@ export default function LandingPage() {
                       </div>
                       <div className="visible-emotion-grid">
                         {EMOTION_HEATMAP_ROWS.map((row, rowIndex) => (
-                          <div className="visible-emotion-grid-row" key={`emotion-row-${rowIndex}`}>
+                          <div
+                            className="visible-emotion-grid-row"
+                            key={`emotion-row-${rowIndex}`}
+                          >
                             {row.map((emotion, cellIndex) => (
                               <span
                                 key={`emotion-cell-${rowIndex}-${cellIndex}`}
                                 className={`visible-emotion-cell visible-emotion-cell--${emotion}`}
-                                style={{ '--emotion-order': rowIndex * 19 + cellIndex } as CSSProperties}
+                                style={
+                                  {
+                                    "--emotion-order":
+                                      rowIndex * 19 + cellIndex,
+                                  } as CSSProperties
+                                }
                               />
                             ))}
                           </div>
@@ -736,9 +1138,15 @@ export default function LandingPage() {
                       <div className="visible-canvas-header visible-canvas-header--streaks">
                         <p className="visible-canvas-title">STREAKS</p>
                         <span className="visible-canvas-info">i</span>
-                        <span className="visible-canvas-chip visible-canvas-chip--flow">FLOW · 3M</span>
+                        <span className="visible-canvas-chip visible-canvas-chip--flow">
+                          FLOW · 3M
+                        </span>
                       </div>
-                      <div className="visible-streak-pillars" role="tablist" aria-label="Pilares">
+                      <div
+                        className="visible-streak-pillars"
+                        role="tablist"
+                        aria-label="Pilares"
+                      >
                         <span className="is-active">🫀 BODY</span>
                         <span>🧠 MIND</span>
                         <span>🏵️ SOUL</span>
@@ -792,7 +1200,7 @@ export default function LandingPage() {
                   className={buttonClasses()}
                   data-analytics-cta="guided_demo"
                   data-analytics-location="feature"
-                  to={buildDemoModeSelectUrl({ language, source: 'landing' })}
+                  to={buildDemoModeSelectUrl({ language, source: "landing" })}
                 >
                   {copy.demo.cta}
                 </Link>
@@ -804,28 +1212,48 @@ export default function LandingPage() {
         <section className="why section-pad reveal-on-scroll" id="pillars">
           <div className="container narrow">
             <p className="section-kicker">{copy.pillars.kicker}</p>
-            <AdaptiveText as="h2" className="pillars-title">{copy.pillars.title}</AdaptiveText>
-            <AdaptiveText as="p" className="section-sub pillars-intro">{copy.pillars.intro}</AdaptiveText>
+            <AdaptiveText as="h2" className="pillars-title">
+              {copy.pillars.title}
+            </AdaptiveText>
+            <AdaptiveText as="p" className="section-sub pillars-intro">
+              {copy.pillars.intro}
+            </AdaptiveText>
             <div className="cards grid-3">
               {copy.pillars.items.map((pillar, index) => {
-                const { definition, examples } = splitPillarCopy(pillar.copy, language);
+                const { definition, examples } = splitPillarCopy(
+                  pillar.copy,
+                  language,
+                );
                 return (
                   <article
                     className="card card--hero-glass pillar-card fade-item"
                     key={pillar.title}
-                    style={{ '--delay': `${index * 90}ms` } as CSSProperties}
+                    style={{ "--delay": `${index * 90}ms` } as CSSProperties}
                   >
                     <h3 className="pillar-heading">
-                      <span className="pillar-emoji" aria-hidden>{pillar.emoji}</span>
-                      <span className="concept-term concept-term--pillar">{pillar.title}</span>
+                      <span className="pillar-emoji" aria-hidden>
+                        {pillar.emoji}
+                      </span>
+                      <span className="concept-term concept-term--pillar">
+                        {pillar.title}
+                      </span>
                     </h3>
                     <p className="pillar-definition">{definition}</p>
                     {examples.length > 0 ? (
-                      <div className="pillar-examples" aria-label={PILLAR_EXAMPLES_LABEL[language]}>
-                        <span className="pillar-examples-label">{PILLAR_EXAMPLES_LABEL[language]}</span>
+                      <div
+                        className="pillar-examples"
+                        aria-label={PILLAR_EXAMPLES_LABEL[language]}
+                      >
+                        <span className="pillar-examples-label">
+                          {PILLAR_EXAMPLES_LABEL[language]}
+                        </span>
                         <div className="pillar-chips" role="list">
                           {examples.map((example) => (
-                            <span key={example} className="pillar-chip" role="listitem">
+                            <span
+                              key={example}
+                              className="pillar-chip"
+                              role="listitem"
+                            >
                               {example}
                             </span>
                           ))}
@@ -836,30 +1264,47 @@ export default function LandingPage() {
                 );
               })}
             </div>
-            <AdaptiveText as="p" className="section-sub highlight">{copy.pillars.highlight}</AdaptiveText>
+            <AdaptiveText as="p" className="section-sub highlight">
+              {copy.pillars.highlight}
+            </AdaptiveText>
           </div>
         </section>
 
         <section className="section-pad reveal-on-scroll" id="rhythms">
           <div className="container">
-            <LabsWeeklyRhythmSystemSection language={language} headingAlignment="center" />
+            <LabsWeeklyRhythmSystemSection
+              language={language}
+              headingAlignment="center"
+            />
           </div>
         </section>
 
-        <section ref={modesSectionRef} className="modes section-pad reveal-on-scroll" id="modes">
+        <section
+          ref={modesSectionRef}
+          className="modes section-pad reveal-on-scroll"
+          id="modes"
+        >
           <div className="container">
             <p className="section-kicker">{copy.modes.kicker}</p>
-            <AdaptiveText as="h2" className="modes-title">{copy.modes.title}</AdaptiveText>
-            <AdaptiveText as="p" className="section-sub modes-intro">{copy.modes.intro}</AdaptiveText>
+            <AdaptiveText as="h2" className="modes-title">
+              {copy.modes.title}
+            </AdaptiveText>
+            <AdaptiveText as="p" className="section-sub modes-intro">
+              {copy.modes.intro}
+            </AdaptiveText>
             <div
               className="modes-carousel"
               aria-live="polite"
-              style={{ '--mode-count': copy.modes.items.length } as CSSProperties}
+              style={
+                { "--mode-count": copy.modes.items.length } as CSSProperties
+              }
             >
               <div
                 className="mode-thumbs"
                 role="listbox"
-                aria-label={language === 'es' ? 'Elegir avatar' : 'Choose avatar'}
+                aria-label={
+                  language === "es" ? "Elegir avatar" : "Choose avatar"
+                }
                 onTouchStart={handleModeThumbTouchStart}
                 onTouchEnd={handleModeThumbTouchEnd}
               >
@@ -873,9 +1318,11 @@ export default function LandingPage() {
                       role="option"
                       aria-label={mode.title}
                       aria-selected={isActive}
-                      className={`mode-thumb ${isActive ? 'is-active' : ''}`}
+                      className={`mode-thumb ${isActive ? "is-active" : ""}`}
                       onClick={() => handleModeSelect(index)}
-                      onKeyDown={(event) => handleModeThumbKeyDown(event, index)}
+                      onKeyDown={(event) =>
+                        handleModeThumbKeyDown(event, index)
+                      }
                     >
                       <img src={visual.thumbImage} alt="" aria-hidden />
                     </button>
@@ -883,7 +1330,9 @@ export default function LandingPage() {
                 })}
               </div>
 
-              <article className={`card card--hero-glass mode mode-main mode-${activeMode.id} fade-item`}>
+              <article
+                className={`card card--hero-glass mode mode-main mode-${activeMode.id} fade-item`}
+              >
                 <header className="mode-header">
                   <div className="mode-title">{activeMode.title}</div>
                 </header>
@@ -898,7 +1347,9 @@ export default function LandingPage() {
                     playsInline
                     aria-label={activeVisual.avatarAlt}
                   />
-                  <figcaption className="mode-media-caption">{activeVisual.avatarLabel}</figcaption>
+                  <figcaption className="mode-media-caption">
+                    {activeVisual.avatarLabel}
+                  </figcaption>
                 </figure>
                 <p className="mode-avatar-copy">{activeMode.goal}</p>
               </article>
@@ -906,10 +1357,15 @@ export default function LandingPage() {
           </div>
         </section>
 
-        <section className="testimonials section-pad reveal-on-scroll" id="testimonials">
+        <section
+          className="testimonials section-pad reveal-on-scroll"
+          id="testimonials"
+        >
           <div className="container">
             <AdaptiveText as="h2">{copy.testimonials.title}</AdaptiveText>
-            <AdaptiveText as="p" className="section-sub">{copy.testimonials.intro}</AdaptiveText>
+            <AdaptiveText as="p" className="section-sub">
+              {copy.testimonials.intro}
+            </AdaptiveText>
             <div
               className="slider"
               id="testi-slider"
@@ -921,7 +1377,10 @@ export default function LandingPage() {
               onFocus={() => setPaused(true)}
               onBlur={() => setPaused(false)}
             >
-              <div className="slider-track" style={{ transform: `translateX(-${activeSlide * 100}%)` }}>
+              <div
+                className="slider-track"
+                style={{ transform: `translateX(-${activeSlide * 100}%)` }}
+              >
                 {copy.testimonials.items.map((testimonial, index) => (
                   <figure
                     className="testi"
@@ -929,7 +1388,7 @@ export default function LandingPage() {
                     role="group"
                     id={`slide-${index + 1}`}
                     aria-label={
-                      language === 'es'
+                      language === "es"
                         ? `${index + 1} de ${testimonialCount}`
                         : `${index + 1} of ${testimonialCount}`
                     }
@@ -955,7 +1414,11 @@ export default function LandingPage() {
               >
                 ›
               </button>
-              <div className="slider-dots" role="tablist" aria-label={copy.testimonials.groupLabel}>
+              <div
+                className="slider-dots"
+                role="tablist"
+                aria-label={copy.testimonials.groupLabel}
+              >
                 {copy.testimonials.items.map((testimonial, index) => (
                   <button
                     key={testimonial.author}
@@ -986,20 +1449,29 @@ export default function LandingPage() {
         </section>
 
         {SHOW_LANDING_PRICING ? (
-          <section className="pricing section-pad reveal-on-scroll" id="pricing">
+          <section
+            className="pricing section-pad reveal-on-scroll"
+            id="pricing"
+          >
             <div className="container">
               <AdaptiveText as="h2">{copy.pricing.title}</AdaptiveText>
-              <AdaptiveText as="p" className="section-sub">{copy.pricing.intro}</AdaptiveText>
-              <p className="pricing-trial-highlight">{copy.pricing.trialHighlight}</p>
+              <AdaptiveText as="p" className="section-sub">
+                {copy.pricing.intro}
+              </AdaptiveText>
+              <p className="pricing-trial-highlight">
+                {copy.pricing.trialHighlight}
+              </p>
               <p className="pricing-tax-note">{copy.pricing.taxNote}</p>
               <div className="pricing-grid">
                 {copy.pricing.plans.map((plan, index) => (
                   <article
                     className="card pricing-card fade-item"
                     key={plan.id}
-                    style={{ '--delay': `${index * 90}ms` } as CSSProperties}
+                    style={{ "--delay": `${index * 90}ms` } as CSSProperties}
                   >
-                    {plan.id === 'YEAR' ? <span className="pricing-best-deal-chip">best deal</span> : null}
+                    {plan.id === "YEAR" ? (
+                      <span className="pricing-best-deal-chip">best deal</span>
+                    ) : null}
                     <p className="pricing-plan-name">{plan.name}</p>
                     <p className="pricing-plan-detail">{plan.detail}</p>
                     <p className="pricing-plan-price">{plan.price}</p>
@@ -1013,7 +1485,9 @@ export default function LandingPage() {
         <section className="next section-pad reveal-on-scroll">
           <div className="container narrow center">
             <AdaptiveText as="h2">{copy.next.title}</AdaptiveText>
-            <AdaptiveText as="p" className="section-sub">{copy.next.intro}</AdaptiveText>
+            <AdaptiveText as="p" className="section-sub">
+              {copy.next.intro}
+            </AdaptiveText>
             <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
               {isSignedIn ? (
                 <Link className={buttonClasses()} to="/dashboard">
@@ -1043,10 +1517,18 @@ export default function LandingPage() {
             <Link to="/dashboard">Dashboard</Link>
           ) : (
             <>
-              <Link data-analytics-cta="login" data-analytics-location="footer" to={buildLocalizedAuthPath('/login', language)}>
+              <Link
+                data-analytics-cta="login"
+                data-analytics-location="footer"
+                to={buildLocalizedAuthPath("/login", language)}
+              >
                 {copy.auth.login}
               </Link>
-              <Link data-analytics-cta="create_account" data-analytics-location="footer" to={buildLocalizedAuthPath('/sign-up', language)}>
+              <Link
+                data-analytics-cta="create_account"
+                data-analytics-location="footer"
+                to={buildLocalizedAuthPath("/sign-up", language)}
+              >
                 {copy.auth.signup}
               </Link>
             </>
@@ -1060,7 +1542,7 @@ export default function LandingPage() {
             className="footer-cookies-link"
             onClick={() => setIsCookiePanelOpen(true)}
           >
-            {language === 'es' ? 'Cookies' : 'Cookies'}
+            {language === "es" ? "Cookies" : "Cookies"}
           </button>
           <a
             className="footer-community-link"
@@ -1083,9 +1565,9 @@ export default function LandingPage() {
       <CookieConsentBanner
         language={language}
         isOpen={isCookiePanelOpen}
-        hasDecision={analyticsConsent !== 'unset'}
-        onAccept={() => handleAnalyticsConsent('accepted')}
-        onReject={() => handleAnalyticsConsent('rejected')}
+        hasDecision={analyticsConsent !== "unset"}
+        onAccept={() => handleAnalyticsConsent("accepted")}
+        onReject={() => handleAnalyticsConsent("rejected")}
         onClose={() => setIsCookiePanelOpen(false)}
       />
     </div>


### PR DESCRIPTION
### Motivation
- Make the landing hero phone showcase look and behave more like the real app by embedding the app top bar inside the phone and using existing design tokens for CTAs and gradients. 
- Fix visual/layout issues in the achievements carousel and CTA alignment so the hero reads as premium and consistent with the design system. 

### Description
- Added an in-phone top bar component injected into both Dashboard and Logros scenes with brand label `INNERBLOOM`, section title and a hamburger menu, and increased the phone safe-top so internal content is pushed below the bar (files changed: `HeroPhoneShowcase.tsx`, `HeroPhoneShowcase.module.css`).
- Adjusted the Logros carousel viewport to center the active card by introducing `--hero-logros-card-width` and computed lateral padding so the active item snaps/visually aligns to the phone center (changed in `HeroPhoneShowcase.module.css`).
- Re-styled hero CTAs to reuse official tokens: primary CTA (`Create my adaptive plan`) now uses the official `--gradient-innerbloom` and `--shadow-innerbloom-cta` and has no outline/border, and the secondary `Demos` CTA uses the repo violet token (`--color-accent-secondary`) for border/hover/focus states (changed in `Landing.css` and `Landing.tsx`).
- Centered the single logged-in CTA (`Go to dashboard`) on desktop via a `hero-actions--single` layout variant and small markup change in `Landing.tsx`/`Landing.css` so the logged-in state visually reads as a single primary action.

### Testing
- `pnpm --filter web exec prettier --write` on the modified files: succeeded. 
- `pnpm --filter web exec prettier --check` on the modified files: succeeded.
- `pnpm --filter web exec tsc --noEmit`: attempted and failed due to pre-existing unrelated TypeScript errors elsewhere in the project (not introduced by these changes). 
- `pnpm --filter web exec eslint` was attempted but failed in this environment due to ESLint configuration/runtime warnings; lint fix was not required for the scoped changes and Prettier formatting was applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebbd7ba1388332836d507204512ef3)