### PR TITLE
Refine landing hero: phone showcase loop, phone top bar, H1 gradient and CTA text

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -1,5 +1,5 @@
 .phoneFrame {
-  --hero-phone-safe-top: 86px;
+  --hero-phone-safe-top: 74px;
   width: min(100%, 342px);
   aspect-ratio: 9 / 18.5;
   border-radius: 42px;
@@ -80,9 +80,9 @@
   inset: 0 0 auto;
   z-index: 6;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  padding: 44px 14px 10px;
+  padding: 37px 12px 8px;
   background: linear-gradient(
     180deg,
     color-mix(in srgb, var(--color-surface) 92%, transparent) 0%,
@@ -99,7 +99,7 @@
 
 .phoneTopBarBrand {
   margin: 0;
-  font-size: 0.47rem;
+  font-size: 0.42rem;
   line-height: 1.1;
   font-weight: 700;
   letter-spacing: 0.23em;
@@ -108,11 +108,11 @@
 }
 
 .phoneTopBarTitle {
-  margin: 0.22rem 0 0;
+  margin: 0.08rem 0 0;
   font-family: var(--font-heading);
-  font-size: 0.96rem;
+  font-size: 0.44rem;
   font-weight: 600;
-  line-height: 1.08;
+  line-height: 1.02;
   letter-spacing: -0.01em;
   color: var(--color-text);
 }
@@ -120,11 +120,11 @@
 .phoneTopBarMenu {
   display: inline-flex;
   flex-direction: column;
-  gap: 0.17rem;
+  gap: 0.14rem;
   align-items: center;
   justify-content: center;
-  width: 1.95rem;
-  height: 1.95rem;
+  width: 1.64rem;
+  height: 1.64rem;
   border-radius: 999px;
   border: 1px solid
     color-mix(in srgb, var(--color-border-subtle) 90%, transparent);
@@ -133,7 +133,7 @@
 }
 
 .phoneTopBarMenu span {
-  width: 0.78rem;
+  width: 0.62rem;
   height: 1.25px;
   border-radius: 999px;
   background: color-mix(in srgb, var(--color-text) 90%, transparent);

--- a/apps/web/src/components/landing/HeroPhoneShowcase.tsx
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.tsx
@@ -1,6 +1,5 @@
 import {
   useEffect,
-  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -8,15 +7,6 @@ import {
 } from "react";
 import { setDashboardDemoModeEnabled } from "../../lib/demoMode";
 import { DemoDashboardOverviewScene } from "../demo/DemoDashboardOverviewScene";
-import {
-  RewardsSection,
-  type RewardsSectionDemoControls,
-} from "../dashboard-v3/RewardsSection";
-import {
-  getDemoLogrosData,
-  getDemoLogrosPreviewByTaskId,
-} from "../../data/demoLogrosData";
-import { usePostLoginLanguage } from "../../i18n/postLoginLanguage";
 import styles from "./HeroPhoneShowcase.module.css";
 
 const INITIAL_TOP_PAUSE_MS = 500;
@@ -30,24 +20,6 @@ const DASHBOARD_LOOP_DURATION_MS =
   LOOP_BOTTOM_PAUSE_MS +
   RESET_TO_TOP_DURATION_MS +
   LOOP_TOP_PAUSE_MS;
-
-const DASHBOARD_TO_LOGROS_DURATION_MS = 820;
-const LOGROS_CAROUSEL_DURATION_MS = 5800;
-const LOGROS_TO_DASHBOARD_DURATION_MS = 820;
-const HERO_LOOP_DURATION_MS =
-  DASHBOARD_LOOP_DURATION_MS +
-  DASHBOARD_TO_LOGROS_DURATION_MS +
-  LOGROS_CAROUSEL_DURATION_MS +
-  LOGROS_TO_DASHBOARD_DURATION_MS;
-
-const HERO_TASK_SEQUENCE = [
-  "task-water",
-  "task-dinner-before-22",
-  "task-gym",
-] as const;
-const HERO_BODY_CARD_UNLOCKED_1 = HERO_TASK_SEQUENCE[0];
-const HERO_BODY_CARD_UNLOCKED_2 = HERO_TASK_SEQUENCE[1];
-const HERO_BODY_CARD_BLOCKED_1 = HERO_TASK_SEQUENCE[2];
 
 function smoothProgress(progress: number) {
   return progress * progress * (3 - 2 * progress);
@@ -84,52 +56,30 @@ function resolveDashboardProgress(elapsedInLoop: number) {
   return 0;
 }
 
-type HeroPhase = "dashboard" | "to-logros" | "logros" | "to-dashboard";
-
 function useHeroShowcaseTimeline({
   dashboardReady,
-  logrosReady,
   isActive,
 }: {
   dashboardReady: boolean;
-  logrosReady: boolean;
   isActive: boolean;
 }) {
-  const [timeline, setTimeline] = useState<{
-    phase: HeroPhase;
-    dashboardProgress: number;
-    trackProgress: number;
-  }>({
-    phase: "dashboard",
-    dashboardProgress: 0,
-    trackProgress: 0,
-  });
+  const [dashboardProgress, setDashboardProgress] = useState(0);
   const startedAtRef = useRef<number | null>(null);
-  const lastNowRef = useRef<number | null>(null);
-  const dashboardElapsedRef = useRef(0);
-  const wasLogrosReadyRef = useRef(logrosReady);
   const pausedAtRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (!dashboardReady) {
-      setTimeline({
-        phase: "dashboard",
-        dashboardProgress: 0,
-        trackProgress: 0,
-      });
+      setDashboardProgress(0);
       startedAtRef.current = null;
-      lastNowRef.current = null;
-      dashboardElapsedRef.current = 0;
-      wasLogrosReadyRef.current = logrosReady;
       pausedAtRef.current = null;
       return;
     }
 
-    let rafId = 0;
     const now = performance.now();
     if (startedAtRef.current == null) {
       startedAtRef.current = now;
     }
+
     if (isActive) {
       if (pausedAtRef.current != null && startedAtRef.current != null) {
         startedAtRef.current += now - pausedAtRef.current;
@@ -141,92 +91,21 @@ function useHeroShowcaseTimeline({
       }
       return;
     }
-    if (
-      wasLogrosReadyRef.current !== logrosReady &&
-      startedAtRef.current != null
-    ) {
-      const previousNow = lastNowRef.current ?? now;
-      if (wasLogrosReadyRef.current === false && logrosReady === true) {
-        startedAtRef.current = previousNow - dashboardElapsedRef.current;
-      } else if (wasLogrosReadyRef.current === true && logrosReady === false) {
-        startedAtRef.current = previousNow;
-      }
-      wasLogrosReadyRef.current = logrosReady;
-    }
 
+    let rafId = 0;
     const tick = (currentNow: number) => {
       const startedAt = startedAtRef.current ?? currentNow;
       const elapsed = Math.max(0, currentNow - startedAt);
-      dashboardElapsedRef.current = elapsed % DASHBOARD_LOOP_DURATION_MS;
-      lastNowRef.current = currentNow;
-
-      if (!logrosReady) {
-        setTimeline({
-          phase: "dashboard",
-          dashboardProgress: resolveDashboardProgress(
-            dashboardElapsedRef.current,
-          ),
-          trackProgress: 0,
-        });
-        rafId = window.requestAnimationFrame(tick);
-        return;
-      }
-
-      const elapsedInLoop = elapsed % HERO_LOOP_DURATION_MS;
-      if (elapsedInLoop < DASHBOARD_LOOP_DURATION_MS) {
-        setTimeline({
-          phase: "dashboard",
-          dashboardProgress: resolveDashboardProgress(elapsedInLoop),
-          trackProgress: 0,
-        });
-      } else if (
-        elapsedInLoop <
-        DASHBOARD_LOOP_DURATION_MS + DASHBOARD_TO_LOGROS_DURATION_MS
-      ) {
-        const transitionElapsed = elapsedInLoop - DASHBOARD_LOOP_DURATION_MS;
-        setTimeline({
-          phase: "to-logros",
-          dashboardProgress: 0,
-          trackProgress: smoothProgress(
-            transitionElapsed / DASHBOARD_TO_LOGROS_DURATION_MS,
-          ),
-        });
-      } else if (
-        elapsedInLoop <
-        DASHBOARD_LOOP_DURATION_MS +
-          DASHBOARD_TO_LOGROS_DURATION_MS +
-          LOGROS_CAROUSEL_DURATION_MS
-      ) {
-        setTimeline({
-          phase: "logros",
-          dashboardProgress: 0,
-          trackProgress: 1,
-        });
-      } else {
-        const transitionElapsed =
-          elapsedInLoop -
-          DASHBOARD_LOOP_DURATION_MS -
-          DASHBOARD_TO_LOGROS_DURATION_MS -
-          LOGROS_CAROUSEL_DURATION_MS;
-        setTimeline({
-          phase: "to-dashboard",
-          dashboardProgress: 0,
-          trackProgress:
-            1 -
-            smoothProgress(transitionElapsed / LOGROS_TO_DASHBOARD_DURATION_MS),
-        });
-      }
-
+      const elapsedInLoop = elapsed % DASHBOARD_LOOP_DURATION_MS;
+      setDashboardProgress(resolveDashboardProgress(elapsedInLoop));
       rafId = window.requestAnimationFrame(tick);
     };
 
     rafId = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(rafId);
-  }, [dashboardReady, isActive, logrosReady]);
+  }, [dashboardReady, isActive]);
 
-  return !dashboardReady
-    ? { phase: "dashboard" as const, dashboardProgress: 0, trackProgress: 0 }
-    : timeline;
+  return !dashboardReady ? 0 : dashboardProgress;
 }
 
 function PhoneFrame({
@@ -293,6 +172,7 @@ function RealDashboardScene({
     let intervalId = 0;
     let attempts = 0;
     const maxAttempts = 45;
+
     const reportReady = () => {
       if (readyReportedRef.current) return;
       readyReportedRef.current = true;
@@ -324,7 +204,6 @@ function RealDashboardScene({
       );
       if (maxScroll > 0) {
         const overallTop = resolveTop(overallProgress);
-        const emotionTop = resolveTop(emotionChart);
         const streakTop = resolveTop(streaks);
         const minTravel = Math.max(
           Math.min(viewport.clientHeight * 0.58, maxScroll),
@@ -332,10 +211,7 @@ function RealDashboardScene({
         );
 
         let start = Math.max(0, Math.min(maxScroll, overallTop - 18));
-        const endTarget = Math.max(
-          emotionTop - viewport.clientHeight * 0.38,
-          streakTop - viewport.clientHeight * 0.14,
-        );
+        const endTarget = streakTop - viewport.clientHeight * 0.14;
         let end = Math.max(start, Math.min(maxScroll, endTarget));
 
         if (end - start < minTravel)
@@ -394,177 +270,15 @@ function RealDashboardScene({
   );
 }
 
-function HeroLogrosScene({
-  isActive,
-  cycleKey,
-  onReady,
-}: {
-  isActive: boolean;
-  cycleKey: number;
-  onReady: () => void;
-}) {
-  const { language } = usePostLoginLanguage();
-  const sceneRef = useRef<HTMLElement | null>(null);
-  const controlsRef = useRef<RewardsSectionDemoControls | null>(null);
-  const [sceneReady, setSceneReady] = useState(false);
-  const [controlsReady, setControlsReady] = useState(false);
-  const readyReportedRef = useRef(false);
-  const readinessResolvedRef = useRef(false);
-  const onReadyRef = useRef(onReady);
-
-  useEffect(() => {
-    onReadyRef.current = onReady;
-  }, [onReady]);
-
-  const demoConfig = useMemo(
-    () => ({
-      disableRemote: true,
-      forceAchievementsViewMode: "carousel" as const,
-      mockPreviewAchievementByTaskId: getDemoLogrosPreviewByTaskId(language),
-      anchors: {
-        shelves: "logros-shelves",
-        growthCalibration: "logros-growth-calibration",
-        carouselTrack: "logros-carousel-track",
-        carouselStructure: "logros-carousel-structure",
-        pillarSelector: "logros-pillar-selector",
-        achievedCard: "logros-achieved-card",
-        blockedCard: "logros-blocked-card",
-        achievedCardTaskId: HERO_BODY_CARD_UNLOCKED_1,
-        blockedCardTaskId: HERO_BODY_CARD_BLOCKED_1,
-      },
-      controls: {
-        preventPageScrollOnProgrammaticFocus: true,
-        onReady: (controls: RewardsSectionDemoControls) => {
-          controlsRef.current = controls;
-          setControlsReady(true);
-        },
-      },
-    }),
-    [language],
-  );
-
-  useEffect(() => {
-    let intervalId = 0;
-    let attempts = 0;
-    const maxAttempts = 14;
-
-    const markReady = () => {
-      setSceneReady(true);
-      if (!readyReportedRef.current) {
-        readyReportedRef.current = true;
-        onReadyRef.current();
-      }
-    };
-
-    const resolveTrackReady = () => {
-      attempts += 1;
-      const sceneRoot = sceneRef.current;
-      const controls = controlsRef.current;
-      const track = sceneRoot?.querySelector<HTMLElement>(
-        '[data-demo-anchor="logros-carousel-track"]',
-      );
-      const cards = track?.querySelectorAll<HTMLElement>(
-        "[data-achievement-carousel-index]",
-      );
-
-      if (!sceneRoot || !controls || !track || !cards) {
-        return false;
-      }
-
-      if (!readinessResolvedRef.current) {
-        controls.closeAllOverlays();
-        controls.selectPillar("BODY");
-        controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
-        readinessResolvedRef.current = true;
-      }
-
-      if (cards.length >= 2 || (attempts >= maxAttempts && cards.length >= 1)) {
-        markReady();
-        return true;
-      }
-
-      return false;
-    };
-
-    if (!resolveTrackReady()) {
-      intervalId = window.setInterval(() => {
-        if (resolveTrackReady()) {
-          window.clearInterval(intervalId);
-        }
-      }, 80);
-    }
-
-    return () => {
-      if (intervalId) {
-        window.clearInterval(intervalId);
-      }
-    };
-  }, [controlsReady]);
-
-  useEffect(() => {
-    if (!isActive || !sceneReady) {
-      return;
-    }
-
-    const controls = controlsRef.current;
-    if (!controls) {
-      return;
-    }
-
-    controls.closeAllOverlays();
-    controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_1);
-
-    const segment = LOGROS_CAROUSEL_DURATION_MS / 3;
-    const t1 = window.setTimeout(
-      () => controls.focusCarouselCard(HERO_BODY_CARD_UNLOCKED_2),
-      segment * 0.9,
-    );
-    const t2 = window.setTimeout(
-      () => controls.focusCarouselCard(HERO_BODY_CARD_BLOCKED_1),
-      segment * 1.95,
-    );
-
-    return () => {
-      window.clearTimeout(t1);
-      window.clearTimeout(t2);
-    };
-  }, [cycleKey, isActive, sceneReady]);
-
-  return (
-    <section
-      ref={sceneRef}
-      className={`${styles.scenePanel} ${styles.sceneLogros}`}
-      data-light-scope="dashboard-v3"
-    >
-      <PhoneTopBar
-        sectionTitle={language === "es" ? "Logros" : "Achievements"}
-      />
-      <div className={styles.logrosViewport}>
-        <div className={styles.logrosHeroOnly}>
-          <RewardsSection
-            userId=""
-            initialData={getDemoLogrosData(language)}
-            demoConfig={demoConfig}
-          />
-        </div>
-      </div>
-    </section>
-  );
-}
-
 export function HeroPhoneShowcase() {
   const [dashboardReady, setDashboardReady] = useState(false);
-  const [logrosReady, setLogrosReady] = useState(false);
   const [demoDataReady, setDemoDataReady] = useState(false);
-  const [logrosCycleKey, setLogrosCycleKey] = useState(0);
   const [isHeroActive, setIsHeroActive] = useState(true);
   const phoneFrameRef = useRef<HTMLDivElement | null>(null);
-  const { phase, dashboardProgress, trackProgress } = useHeroShowcaseTimeline({
+  const dashboardProgress = useHeroShowcaseTimeline({
     dashboardReady,
-    logrosReady,
     isActive: isHeroActive,
   });
-  const previousPhaseRef = useRef<HeroPhase>("dashboard");
 
   useEffect(() => {
     setDashboardDemoModeEnabled(true);
@@ -574,13 +288,6 @@ export function HeroPhoneShowcase() {
       setDashboardDemoModeEnabled(false);
     };
   }, []);
-
-  useEffect(() => {
-    if (previousPhaseRef.current !== "logros" && phase === "logros") {
-      setLogrosCycleKey((value) => value + 1);
-    }
-    previousPhaseRef.current = phase;
-  }, [phase]);
 
   useEffect(() => {
     const target = phoneFrameRef.current;
@@ -602,20 +309,10 @@ export function HeroPhoneShowcase() {
   return (
     <PhoneFrame frameRef={phoneFrameRef}>
       {demoDataReady ? (
-        <div
-          className={styles.sceneTrack}
-          style={{ transform: `translate3d(${-50 * trackProgress}%, 0, 0)` }}
-        >
-          <RealDashboardScene
-            scrollProgress={dashboardProgress}
-            onReady={() => setDashboardReady(true)}
-          />
-          <HeroLogrosScene
-            isActive={isHeroActive && phase === "logros"}
-            cycleKey={logrosCycleKey}
-            onReady={() => setLogrosReady(true)}
-          />
-        </div>
+        <RealDashboardScene
+          scrollProgress={dashboardProgress}
+          onReady={() => setDashboardReady(true)}
+        />
       ) : (
         <section
           className={`${styles.scenePanel} ${styles.sceneDashboard}`}

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -387,7 +387,7 @@
 }
 
 .landing .hero h1 .grad {
-  background: linear-gradient(100deg, var(--accent), var(--accent-2));
+  background: var(--gradient-innerbloom);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -418,7 +418,7 @@
   padding-inline: clamp(1.15rem, 1.4vw, 1.5rem);
   min-width: 0;
   background: var(--gradient-innerbloom);
-  color: #111827;
+  color: #ffffff;
   box-shadow:
     var(--shadow-innerbloom-cta),
     0 1px 0 rgba(255, 255, 255, 0.28) inset;


### PR DESCRIPTION
### Motivation
- Improve the hero phone showcase to feel like a realistic premium app header by reducing the oversized “Dashboard” title and tightening top-bar spacing. 
- Simplify the phone showcase loop so it stays entirely inside the Dashboard scene and ends at the Streaks panel (no transition to Achievements). 
- Ensure visual consistency by reusing the official Innerbloom gradient token for the highlighted H1 fragment and make the primary CTA label white for maximum contrast.

### Description
- Simplified the showcase timeline to a single vertical dashboard loop (keeps scrolling down to `streaks` then resets) and removed the achievements/logros scene and associated cross-scene timing logic by pruning the carousel/track logic from `HeroPhoneShowcase` and returning a single `dashboardProgress` value from the timeline hook. 
- Made the phone top bar much more compact by adjusting CSS in `HeroPhoneShowcase.module.css`: reduced `--hero-phone-safe-top`, tightened `padding`, reduced `.phoneTopBarTitle` `font-size`/`line-height` and decreased menu/button sizes so `Dashboard` no longer dominates the phone viewport. 
- Applied the official Innerbloom gradient token to the H1 highlight by switching `.landing .hero h1 .grad` to `var(--gradient-innerbloom)`. 
- Forced the primary CTA `.journey-cta` text color to pure white (`#ffffff`) to ensure legible text over the gradient. 
- Files changed: `apps/web/src/components/landing/HeroPhoneShowcase.tsx`, `apps/web/src/components/landing/HeroPhoneShowcase.module.css`, `apps/web/src/pages/Landing.css`.

### Testing
- Ran TypeScript check in the web app with `pnpm -C apps/web exec tsc --noEmit`, which reported failures from unrelated, pre-existing TypeScript issues across the repo and did not indicate regressions introduced by these focused changes (type errors are repository-wide and predate this PR). (failed — unrelated errors)
- Ran ESLint for the modified file with `pnpm -C apps/web exec eslint src/components/landing/HeroPhoneShowcase.tsx`, which could not run due to the workspace using ESLint v9 without a top-level `eslint.config.*` in this environment. (failed — workspace lint config missing)
- No backend changes, no copy or layout structure changes were made; visual/UX behavior should be validated in-browser (recommended) as the changes are primarily CSS/animation logic edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc17d225083328c172a02d15b08a7)