### PR TITLE
Adjust hero phone showcase scale and add end-of-loop Purple Afternoon splash

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -1,6 +1,6 @@
 .phoneFrame {
   --hero-phone-safe-top: 74px;
-  width: min(100%, 342px);
+  width: min(100%, 306px);
   aspect-ratio: 9 / 18.5;
   border-radius: 42px;
   background: linear-gradient(160deg, #2d2738 0%, #0b0d13 55%, #111c2f 100%);
@@ -13,6 +13,14 @@
   transform: perspective(1300px) rotateY(-1.35deg) rotateX(0.4deg);
   transform-origin: center center;
   position: relative;
+}
+
+.phoneScreenBackground {
+  position: absolute;
+  inset: 10px;
+  border-radius: 30px;
+  background: var(--hero-purple-afternoon, #000c40);
+  pointer-events: none;
 }
 
 .phoneIsland {
@@ -156,6 +164,22 @@
       transparent 58%
     ),
     linear-gradient(180deg, #10172d 0%, #090f22 100%);
+}
+
+.loopSplashScene {
+  position: absolute;
+  inset: 10px;
+  border-radius: 30px;
+  display: grid;
+  place-items: center;
+  background: var(--hero-purple-afternoon, #000c40);
+  z-index: 9;
+}
+
+.loopSplashFlower {
+  width: clamp(74px, 32%, 108px);
+  height: auto;
+  filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.35));
 }
 
 .sceneTrack {
@@ -768,7 +792,7 @@
   }
 
   .phoneFrame {
-    width: min(100%, 340px);
+    width: min(100%, 300px);
     transform: none;
   }
 }

--- a/apps/web/src/components/landing/HeroPhoneShowcase.tsx
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.tsx
@@ -2,22 +2,26 @@ import {
   useEffect,
   useRef,
   useState,
+  type CSSProperties,
   type ReactNode,
   type RefObject,
 } from "react";
 import { setDashboardDemoModeEnabled } from "../../lib/demoMode";
+import { OFFICIAL_DESIGN_TOKENS } from "../../content/officialDesignTokens";
 import { DemoDashboardOverviewScene } from "../demo/DemoDashboardOverviewScene";
 import styles from "./HeroPhoneShowcase.module.css";
 
 const INITIAL_TOP_PAUSE_MS = 500;
 const SCROLL_DOWN_DURATION_MS = 4500;
-const LOOP_BOTTOM_PAUSE_MS = 950;
+const LOOP_BOTTOM_PAUSE_MS = 1600;
+const LOOP_SPLASH_DURATION_MS = 1300;
 const RESET_TO_TOP_DURATION_MS = 300;
 const LOOP_TOP_PAUSE_MS = 350;
 const DASHBOARD_LOOP_DURATION_MS =
   INITIAL_TOP_PAUSE_MS +
   SCROLL_DOWN_DURATION_MS +
   LOOP_BOTTOM_PAUSE_MS +
+  LOOP_SPLASH_DURATION_MS +
   RESET_TO_TOP_DURATION_MS +
   LOOP_TOP_PAUSE_MS;
 
@@ -44,32 +48,49 @@ function resolveDashboardProgress(elapsedInLoop: number) {
     INITIAL_TOP_PAUSE_MS +
       SCROLL_DOWN_DURATION_MS +
       LOOP_BOTTOM_PAUSE_MS +
+      LOOP_SPLASH_DURATION_MS
+  ) {
+    return 0;
+  }
+  if (
+    elapsedInLoop <
+    INITIAL_TOP_PAUSE_MS +
+      SCROLL_DOWN_DURATION_MS +
+      LOOP_BOTTOM_PAUSE_MS +
+      LOOP_SPLASH_DURATION_MS +
       RESET_TO_TOP_DURATION_MS
   ) {
     const resetElapsed =
       elapsedInLoop -
       INITIAL_TOP_PAUSE_MS -
       SCROLL_DOWN_DURATION_MS -
-      LOOP_BOTTOM_PAUSE_MS;
+      LOOP_BOTTOM_PAUSE_MS -
+      LOOP_SPLASH_DURATION_MS;
     return 1 - resetElapsed / RESET_TO_TOP_DURATION_MS;
   }
   return 0;
 }
 
+type HeroShowcasePhase = "dashboard" | "splash";
+
 function useHeroShowcaseTimeline({
   dashboardReady,
   isActive,
+  reducedMotion,
 }: {
   dashboardReady: boolean;
   isActive: boolean;
+  reducedMotion: boolean;
 }) {
   const [dashboardProgress, setDashboardProgress] = useState(0);
+  const [phase, setPhase] = useState<HeroShowcasePhase>("dashboard");
   const startedAtRef = useRef<number | null>(null);
   const pausedAtRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!dashboardReady) {
+    if (!dashboardReady || reducedMotion) {
       setDashboardProgress(0);
+      setPhase("dashboard");
       startedAtRef.current = null;
       pausedAtRef.current = null;
       return;
@@ -97,15 +118,26 @@ function useHeroShowcaseTimeline({
       const startedAt = startedAtRef.current ?? currentNow;
       const elapsed = Math.max(0, currentNow - startedAt);
       const elapsedInLoop = elapsed % DASHBOARD_LOOP_DURATION_MS;
+      const splashStart =
+        INITIAL_TOP_PAUSE_MS + SCROLL_DOWN_DURATION_MS + LOOP_BOTTOM_PAUSE_MS;
+      const splashEnd = splashStart + LOOP_SPLASH_DURATION_MS;
+      const nextPhase: HeroShowcasePhase =
+        elapsedInLoop >= splashStart && elapsedInLoop < splashEnd
+          ? "splash"
+          : "dashboard";
+      setPhase(nextPhase);
       setDashboardProgress(resolveDashboardProgress(elapsedInLoop));
       rafId = window.requestAnimationFrame(tick);
     };
 
     rafId = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(rafId);
-  }, [dashboardReady, isActive]);
+  }, [dashboardReady, isActive, reducedMotion]);
 
-  return !dashboardReady ? 0 : dashboardProgress;
+  return {
+    dashboardProgress: !dashboardReady || reducedMotion ? 0 : dashboardProgress,
+    phase: !dashboardReady || reducedMotion ? "dashboard" : phase,
+  };
 }
 
 function PhoneFrame({
@@ -145,6 +177,13 @@ function PhoneTopBar({ sectionTitle }: { sectionTitle: string }) {
     </header>
   );
 }
+
+const purpleAfternoon =
+  OFFICIAL_DESIGN_TOKENS.gradients.find(
+    (gradient) => gradient.name === "purple_afternoon",
+  ) ?? OFFICIAL_DESIGN_TOKENS.gradients[0];
+const purpleAfternoonSolid =
+  purpleAfternoon.stops[0]?.trim().split(" ")[0] ?? "#000c40";
 
 function RealDashboardScene({
   scrollProgress,
@@ -270,15 +309,41 @@ function RealDashboardScene({
   );
 }
 
+function LoopSplashScene() {
+  return (
+    <section className={styles.loopSplashScene} aria-hidden>
+      <img
+        src="/IB-COLOR-LOGO.png"
+        alt=""
+        className={styles.loopSplashFlower}
+        loading="eager"
+        decoding="async"
+      />
+    </section>
+  );
+}
+
 export function HeroPhoneShowcase() {
   const [dashboardReady, setDashboardReady] = useState(false);
   const [demoDataReady, setDemoDataReady] = useState(false);
   const [isHeroActive, setIsHeroActive] = useState(true);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const phoneFrameRef = useRef<HTMLDivElement | null>(null);
-  const dashboardProgress = useHeroShowcaseTimeline({
+  const { dashboardProgress, phase } = useHeroShowcaseTimeline({
     dashboardReady,
     isActive: isHeroActive,
+    reducedMotion: prefersReducedMotion,
   });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function")
+      return;
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => setPrefersReducedMotion(media.matches);
+    sync();
+    media.addEventListener("change", sync);
+    return () => media.removeEventListener("change", sync);
+  }, []);
 
   useEffect(() => {
     setDashboardDemoModeEnabled(true);
@@ -308,6 +373,10 @@ export function HeroPhoneShowcase() {
 
   return (
     <PhoneFrame frameRef={phoneFrameRef}>
+      <div
+        className={styles.phoneScreenBackground}
+        style={{ "--hero-purple-afternoon": purpleAfternoonSolid } as CSSProperties}
+      />
       {demoDataReady ? (
         <RealDashboardScene
           scrollProgress={dashboardProgress}
@@ -320,6 +389,7 @@ export function HeroPhoneShowcase() {
           aria-hidden
         />
       )}
+      {phase === "splash" ? <LoopSplashScene /> : null}
     </PhoneFrame>
   );
 }


### PR DESCRIPTION
### Motivation
- Make the hero phone less visually dominant on desktop by reducing the device frame while keeping proportions and responsive behavior.
- Provide a clear end-of-loop visual that reads as a premium interstitial, using existing brand assets and tokens (no invented colors or images).
- Respect `prefers-reduced-motion` and keep the loop scoped to dashboard + splash only.

### Description
- Updated `apps/web/src/components/landing/HeroPhoneShowcase.module.css` to reduce the phone frame width from `342px` to `306px` (desktop) and the responsive breakpoint size from `340px` to `300px`, and added CSS for the splash background and centered flower (`.loopSplashScene`, `.loopSplashFlower`, `.phoneScreenBackground`).
- Updated `apps/web/src/components/landing/HeroPhoneShowcase.tsx` to extend the timeline: increased bottom pause and added a dedicated splash phase, added `LoopSplashScene` which renders the real flower asset, and wired `prefers-reduced-motion` into the timeline hook so motion is minimized when the user requests reduced motion.
- Timeline now is: initial top pause `500ms` → scroll down `4500ms` → bottom pause `1600ms` → splash/interstitial `1300ms` → reset `300ms` → top pause `350ms` (loop restarts).
- Uses existing repo asset `/IB-COLOR-LOGO.png` for the splash flower and the official design token `purple_afternoon` (dark stop `#000c40`) as the splash background color; reads the token from `OFFICIAL_DESIGN_TOKENS` rather than inventing new values.
- Changes are limited to the hero showcase component and its CSS; no backend, copy, CTA, H1, or achievement loop reactivation was made.

### Testing
- Built the web app with `pnpm -C apps/web build` which succeeded (production build completed). 
- Ran type checking with `pnpm -C apps/web typecheck` which failed due to pre-existing, unrelated TypeScript errors elsewhere in the codebase and not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8572417883329915815ceb635f6b)