### PR TITLE
Redesign achievement habit preview card with animated premium visuals

### DIFF
--- a/apps/web/src/components/dashboard-v3/PreviewAchievementCard.tsx
+++ b/apps/web/src/components/dashboard-v3/PreviewAchievementCard.tsx
@@ -28,18 +28,21 @@ type MonthNodeProps = {
 const statusConfig = {
   fragile: {
     label: { es: 'Hábito frágil', en: 'Fragile habit' },
-    chip: 'bg-rose-300 text-rose-950',
-    ring: 'stroke-rose-300',
+    chip: 'border border-rose-200/30 bg-gradient-to-r from-rose-300/90 to-rose-200/80 text-rose-950 shadow-[0_8px_24px_rgba(251,113,133,0.22)]',
+    ringColor: '#fb7185',
+    ringGradientStop: '#fda4af',
   },
   building: {
     label: { es: 'Hábito en construcción', en: 'Habit in progress' },
-    chip: 'bg-amber-300 text-amber-950',
-    ring: 'stroke-amber-300',
+    chip: 'border border-amber-100/30 bg-gradient-to-r from-amber-300/90 to-yellow-200/85 text-amber-950 shadow-[0_8px_24px_rgba(251,191,36,0.2)]',
+    ringColor: '#fbbf24',
+    ringGradientStop: '#fde68a',
   },
   strong: {
     label: { es: 'Hábito fuerte', en: 'Strong habit' },
-    chip: 'bg-emerald-300 text-emerald-950',
-    ring: 'stroke-emerald-300',
+    chip: 'border border-emerald-100/30 bg-gradient-to-r from-emerald-300/92 to-teal-200/85 text-emerald-950 shadow-[0_8px_24px_rgba(74,222,128,0.24)]',
+    ringColor: '#6ee7b7',
+    ringGradientStop: '#99f6e4',
   },
 } as const;
 
@@ -98,16 +101,16 @@ function normalizeRecentMonths(recentMonths: PreviewAchievement['recentMonths'])
 function getMonthTone(state: string | null | undefined): string {
   const normalized = String(state ?? '').toLowerCase();
   if (normalized === 'strong' || normalized === 'valid' || normalized === 'achieved') {
-    return 'bg-emerald-300/90 text-emerald-950';
+    return 'bg-gradient-to-br from-emerald-300/95 to-emerald-200/75 text-emerald-950 shadow-[0_6px_18px_rgba(16,185,129,0.25)]';
   }
   if (normalized === 'building' || normalized === 'pending' || normalized === 'weak' || normalized === 'floor_only') {
-    return 'bg-amber-300/85 text-amber-950';
+    return 'bg-gradient-to-br from-amber-300/92 to-yellow-200/72 text-amber-950 shadow-[0_6px_18px_rgba(245,158,11,0.24)]';
   }
   if (normalized.startsWith('projected')) {
-    return 'bg-violet-300/35 text-violet-100';
+    return 'bg-gradient-to-br from-violet-300/45 to-indigo-300/30 text-violet-100 shadow-[0_8px_24px_rgba(139,92,246,0.25)]';
   }
   if (normalized === 'invalid' || normalized === 'bad' || normalized === 'locked') {
-    return 'bg-rose-300/80 text-rose-950';
+    return 'bg-gradient-to-br from-rose-300/88 to-rose-200/68 text-rose-950 shadow-[0_6px_18px_rgba(244,63,94,0.22)]';
   }
   return 'bg-white/10 text-[color:var(--color-slate-300)]';
 }
@@ -128,38 +131,30 @@ function getMonthMetric(value: number | null | undefined): string {
 }
 
 function RecentMonthNode({ entry, language, compact = false }: MonthNodeProps) {
-  const isProjected = entry.projected;
   const monthSymbol = getMonthSymbol(entry.state);
   return (
     <div
       key={`${entry.key}-${entry.value ?? 0}`}
       data-testid="recent-month-item"
       className={cx(
-        'flex shrink-0 flex-col items-center gap-0 py-0',
-        compact ? 'h-[3.25rem] w-[2.5rem] sm:h-[3.45rem] sm:w-[2.75rem]' : 'h-[4.35rem] w-[3.35rem] sm:h-[4.55rem] sm:w-[3.55rem]',
+        'flex shrink-0 flex-col items-center gap-1 py-0',
+        compact ? 'h-[3.8rem] w-[2.5rem] sm:h-[4rem] sm:w-[2.75rem]' : 'h-[4.8rem] w-[3.35rem] sm:h-[4.95rem] sm:w-[3.55rem]',
       )}
     >
       <div
         data-testid="recent-month-node"
         className={cx(
           compact
-            ? 'relative inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold leading-none shadow-[0_6px_16px_rgba(5,10,35,0.35)] sm:h-7 sm:w-7 sm:text-sm'
-            : 'relative inline-flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold leading-none shadow-[0_6px_16px_rgba(5,10,35,0.35)] sm:h-9 sm:w-9 sm:text-base',
+            ? 'relative inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold leading-none shadow-[0_8px_20px_rgba(5,10,35,0.4)] sm:h-7 sm:w-7 sm:text-sm'
+            : 'relative inline-flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold leading-none shadow-[0_8px_20px_rgba(5,10,35,0.4)] sm:h-9 sm:w-9 sm:text-base',
           getMonthTone(entry.state),
         )}
         aria-label={`${entry.periodKey ?? 'unknown'}-${entry.state ?? 'unknown'}`}
         data-month-symbol={monthSymbol}
       >
-        {isProjected ? (
-          <span
-            aria-hidden
-            className="inline-flex h-3.5 w-3.5 animate-[spin_4.8s_linear_infinite] rounded-full border-[1.5px] border-white/14 border-t-white/80 border-r-white/45 sm:h-[0.95rem] sm:w-[0.95rem]"
-          />
-        ) : (
-          monthSymbol
-        )}
+        {monthSymbol}
       </div>
-      <span className={cx('text-[color:var(--color-slate-300)]', compact ? 'text-[9px]' : 'text-[10px]')} data-testid="recent-month-label">
+      <span className={cx('text-[color:var(--color-slate-300)] leading-none', compact ? 'text-[9px]' : 'text-[10px]')} data-testid="recent-month-label">
         {entry.periodKey ? monthLabel(entry.periodKey, language) : language === 'es' ? 'Sin mes' : 'No month'}
       </span>
       <span
@@ -197,13 +192,16 @@ export function PreviewAchievementCard({
   const groupedMonths = hasGroupedWindow ? orderedRecentMonths.slice(lastThreeStart, lastThreeEnd) : [];
   const shouldCenterRecentTimeline = orderedRecentMonths.length <= 5;
   const shouldUseOverflowTrack = orderedRecentMonths.length > 5;
+  const [animatedScore, setAnimatedScore] = useState(0);
+  const ringGradientId = useId();
+  const ringGlowId = useId();
 
   const ring = useMemo(() => {
-    const radius = 47;
+    const radius = 46;
     const circumference = 2 * Math.PI * radius;
-    const offset = circumference * (1 - score / 100);
+    const offset = circumference * (1 - animatedScore / 100);
     return { radius, circumference, offset };
-  }, [score]);
+  }, [animatedScore]);
 
   const [isScoreTooltipOpen, setIsScoreTooltipOpen] = useState(false);
   const scoreTooltipId = useId();
@@ -211,11 +209,38 @@ export function PreviewAchievementCard({
   const scoreMarkerTop = `${Math.max(0, Math.min(100, 100 - score))}%`;
   const groupedProjectedMonth = groupedMonths.find((entry) => entry.projected);
   const windowTitle = language === 'es' ? 'Ventana activa' : 'Active window';
+  const projectionNote =
+    groupedProjectedMonth || orderedRecentMonths.some((entry) => entry.projected)
+      ? previewAchievement.currentMonth?.expectedTargetSoFar != null && previewAchievement.currentMonth.expectedTargetSoFar <= 1
+        ? language === 'es'
+          ? '~ estimación temprana'
+          : '~ early estimate'
+        : language === 'es'
+          ? '~ proyectado al ritmo actual'
+          : '~ projected at current pace'
+      : null;
   const rangeLabels = {
     strong: language === 'es' ? 'fuerte' : 'strong',
     building: language === 'es' ? 'en construcción' : 'building',
     fragile: language === 'es' ? 'frágil' : 'fragile',
   } as const;
+
+  useEffect(() => {
+    let frame = 0;
+    let start = 0;
+    const durationMs = 900;
+    setAnimatedScore(0);
+    const tick = (timestamp: number) => {
+      if (start === 0) start = timestamp;
+      const progress = Math.min(1, (timestamp - start) / durationMs);
+      // Cubic-out easing keeps the first half energetic and settles gently near the final score.
+      const eased = 1 - (1 - progress) ** 3;
+      setAnimatedScore(Math.round(score * eased));
+      if (progress < 1) frame = window.requestAnimationFrame(tick);
+    };
+    frame = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(frame);
+  }, [score]);
 
   useEffect(() => {
     if (!isScoreTooltipOpen) return;
@@ -257,49 +282,72 @@ export function PreviewAchievementCard({
             </p>
           )}
         </div>
-        <div className="mx-auto flex shrink-0 flex-col items-center" data-tour-anchor="achievement-preview-overview">
+        <div className="mx-auto flex w-full shrink-0 flex-col items-center" data-tour-anchor="achievement-preview-overview">
           <span className={cx('inline-flex items-center rounded-full font-semibold', isCompact ? 'px-2.5 py-0.5 text-[11px]' : 'px-3 py-1 text-xs', tone.chip)}>
             {tone.label[language]}
           </span>
-          <div className={cx('mt-2 flex items-center justify-center', isCompact ? 'gap-1.5 sm:gap-2.5' : 'gap-2.5 sm:gap-3.5')} data-testid="score-block" data-tour-anchor="achievement-preview-score">
-            <div className="relative" ref={scoreTooltipRef}>
+          <div
+            className={cx(
+              'mt-2 flex w-full items-center justify-center md:col-start-2 md:justify-self-center',
+              isCompact ? 'gap-2 sm:gap-2.5' : 'gap-3 sm:gap-4',
+              'flex-wrap sm:flex-nowrap',
+            )}
+            data-testid="score-block"
+            data-tour-anchor="achievement-preview-score"
+          >
+            <div className="relative shrink-0" ref={scoreTooltipRef}>
               <svg
-                className={isCompact ? 'h-24 w-24 sm:h-28 sm:w-28' : 'h-32 w-32 sm:h-36 sm:w-36'}
+                className={isCompact ? 'h-20 w-20 sm:h-24 sm:w-24' : 'h-24 w-24 sm:h-28 sm:w-28'}
                 viewBox="0 0 120 120"
                 role="img"
                 aria-label={`preview achievement score ${score}`}
                 data-testid="score-donut"
               >
+                <defs>
+                  <linearGradient id={ringGradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+                    <stop offset="0%" stopColor={tone.ringGradientStop} />
+                    <stop offset="100%" stopColor={tone.ringColor} />
+                  </linearGradient>
+                  <filter id={ringGlowId} x="-40%" y="-40%" width="180%" height="180%">
+                    <feDropShadow dx="0" dy="0" stdDeviation="2.5" floodColor={tone.ringColor} floodOpacity="0.32" />
+                  </filter>
+                </defs>
                 <circle
                   cx="60"
                   cy="60"
                   r={ring.radius}
-                  strokeWidth={11}
-                  className="fill-none stroke-[color:var(--color-border-subtle)]"
+                  strokeWidth={10}
+                  className="fill-none"
+                  stroke="rgba(79,70,229,0.2)"
                 />
                 <circle
                   cx="60"
                   cy="60"
                   r={ring.radius}
-                  strokeWidth={11}
+                  strokeWidth={10}
                   strokeDasharray={`${ring.circumference} ${ring.circumference}`}
                   strokeDashoffset={ring.offset}
-                  className={cx('fill-none transition-[stroke-dashoffset] duration-500 ease-out', tone.ring)}
+                  className="fill-none transition-[stroke-dashoffset] duration-500 ease-out"
                   strokeLinecap="round"
+                  stroke={`url(#${ringGradientId})`}
+                  filter={`url(#${ringGlowId})`}
                   transform="rotate(-90 60 60)"
                 />
-                <text x="60" y="56" textAnchor="middle" dominantBaseline="middle" className="fill-[color:var(--color-text)] text-[26px] font-semibold">
-                  {score}
-                </text>
               </svg>
-              <div className="absolute left-1/2 top-[58%] inline-flex -translate-x-1/2 items-center gap-1 text-[10px] text-[color:var(--color-slate-400)]">
-                <span className="font-semibold uppercase tracking-[0.12em] text-[color:var(--color-slate-300)]">{scoreLabel}</span>
+              <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+                <span className="text-[30px] font-semibold leading-none text-[color:var(--color-text)] sm:text-[32px]">{score}</span>
+                <span data-testid="score-affordance" className="mt-2 inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-slate-300)]">
+                  <span className="font-semibold">{scoreLabel}</span>
+                  <span className="sr-only">{language === 'es' ? 'fuerza actual del hábito' : 'current habit strength'}</span>
+                </span>
+              </div>
+              <div className="absolute left-1/2 top-[67%] inline-flex -translate-x-1/2 items-center gap-1 text-[10px] text-[color:var(--color-slate-400)]">
                 <button
                   type="button"
                   onClick={() => setIsScoreTooltipOpen((prev) => !prev)}
                   onFocus={() => setIsScoreTooltipOpen(true)}
                   aria-label={language === 'es' ? 'Qué significa este score' : 'What this score means'}
-                  className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-white/65 bg-[rgba(14,20,40,0.88)] text-[9px] font-semibold text-white shadow-[0_8px_20px_rgba(8,12,24,0.55)] backdrop-blur-xl"
+                  className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-white/65 bg-white/20 text-[9px] font-semibold text-white shadow-[0_8px_20px_rgba(8,12,24,0.55)] backdrop-blur-xl"
                   data-testid="score-info-dot"
                   aria-describedby={isScoreTooltipOpen ? scoreTooltipId : undefined}
                 >
@@ -318,28 +366,32 @@ export function PreviewAchievementCard({
                 </div>
               )}
             </div>
-            <div className={cx('relative flex items-center', isCompact ? 'h-24 sm:h-28' : 'h-32 sm:h-36')} data-testid="score-range-rail" data-tour-anchor="achievement-preview-scale">
-              <div className={cx('relative h-full', isCompact ? 'w-[4.1rem]' : 'w-[5.35rem]')}>
-                <div className="absolute bottom-1 left-2.5 top-1 w-3 overflow-hidden rounded-full">
+            <div
+              className={cx('relative flex items-center rounded-xl border border-white/10 bg-white/[0.02] px-2 py-2', isCompact ? 'h-24 sm:h-28' : 'h-32 sm:h-36')}
+              data-testid="score-range-rail"
+              data-tour-anchor="achievement-preview-scale"
+            >
+              <div className={cx('relative h-full', isCompact ? 'w-[3.9rem]' : 'w-[4.5rem]')}>
+                <div className="absolute bottom-1 left-1.5 top-1 w-2 overflow-hidden rounded-full bg-[rgba(79,70,229,0.18)]">
                   <button
                     type="button"
-                    className="absolute inset-x-0 top-0 h-[20%] bg-emerald-300/95 focus:outline-none"
+                    className="absolute inset-x-0 top-0 h-[20%] bg-gradient-to-b from-emerald-200/90 to-emerald-300/75 focus:outline-none"
                     aria-label={rangeLabels.strong}
                   />
                   <button
                     type="button"
-                    className="absolute inset-x-0 top-[20%] h-[30%] bg-amber-300/95 focus:outline-none"
+                    className="absolute inset-x-0 top-[20%] h-[30%] bg-gradient-to-b from-amber-200/90 to-amber-300/75 focus:outline-none"
                     aria-label={rangeLabels.building}
                   />
                   <button
                     type="button"
-                    className="absolute inset-x-0 bottom-0 h-[50%] bg-rose-300/95 focus:outline-none"
+                    className="absolute inset-x-0 bottom-0 h-[50%] bg-gradient-to-b from-rose-200/85 to-rose-300/78 focus:outline-none"
                     aria-label={rangeLabels.fragile}
                   />
-                  <span className="absolute inset-x-0 top-[20%] h-px bg-white/35" />
-                  <span className="absolute inset-x-0 top-[50%] h-px bg-white/35" />
+                  <span className="absolute inset-x-0 top-[20%] h-px bg-white/45" />
+                  <span className="absolute inset-x-0 top-[50%] h-px bg-white/45" />
                   <span
-                    className="pointer-events-none absolute inset-x-0 h-0.5 bg-white shadow-[0_0_0_1px_rgba(10,14,26,0.45)] transition-all duration-500 ease-out"
+                    className="pointer-events-none absolute -inset-x-0.5 h-0.5 rounded-full bg-white shadow-[0_0_0_1px_rgba(10,14,26,0.4),0_0_12px_rgba(255,255,255,0.45)] transition-all duration-500 ease-out"
                     style={{ top: scoreMarkerTop }}
                     aria-hidden
                   />
@@ -348,13 +400,13 @@ export function PreviewAchievementCard({
                 <span className="absolute left-0 top-[20%] -translate-y-1/2 text-[8px] text-[color:var(--color-slate-300)]">80</span>
                 <span className="absolute left-0 top-[50%] -translate-y-1/2 text-[8px] text-[color:var(--color-slate-300)]">50</span>
                 <span className="absolute left-0 bottom-0 text-[8px] text-[color:var(--color-slate-500)]">0</span>
-                <span className={cx('absolute top-[2%] text-left text-[9px] font-medium leading-none text-[color:var(--color-slate-300)]', isCompact ? 'left-[2.95rem]' : 'left-[3.44rem]')}>
+                <span className={cx('absolute top-[3%] text-left text-[9px] font-medium leading-none text-[color:var(--color-slate-300)]', isCompact ? 'left-[2.25rem]' : 'left-[2.6rem]')}>
                   {rangeLabels.strong}
                 </span>
-                <span className={cx('absolute top-[50%] -translate-y-1/2 text-left text-[9px] font-medium leading-none text-[color:var(--color-slate-300)]', isCompact ? 'left-[2.95rem]' : 'left-[3.44rem]')}>
+                <span className={cx('absolute top-[50%] -translate-y-1/2 text-left text-[9px] font-medium leading-none text-[color:var(--color-slate-300)]', isCompact ? 'left-[2.25rem]' : 'left-[2.6rem]')}>
                   {rangeLabels.building}
                 </span>
-                <span className={cx('absolute bottom-[2%] text-left text-[9px] font-medium leading-none text-[color:var(--color-slate-300)]', isCompact ? 'left-[2.95rem]' : 'left-[3.44rem]')}>
+                <span className={cx('absolute bottom-[3%] text-left text-[9px] font-medium leading-none text-[color:var(--color-slate-300)]', isCompact ? 'left-[2.25rem]' : 'left-[2.6rem]')}>
                   {rangeLabels.fragile}
                 </span>
               </div>
@@ -370,6 +422,7 @@ export function PreviewAchievementCard({
               <p className={cx('font-semibold uppercase tracking-[0.08em] text-[color:var(--color-slate-100)]', isCompact ? 'text-[13px]' : 'text-sm')}>
                 {language === 'es' ? 'Resultado últimos meses' : 'Last months result'}
               </p>
+              {language === 'es' && <span className="sr-only">Historial reciente</span>}
               <details className="group relative" data-testid="timeline-legend">
                 <summary
                   className="inline-flex h-4 w-4 cursor-pointer list-none items-center justify-center rounded-full border border-white/40 bg-white/20 text-[10px] font-semibold leading-none text-white shadow-sm transition-colors hover:bg-white/30"
@@ -382,11 +435,11 @@ export function PreviewAchievementCard({
                   <p>{language === 'es' ? '✓ = mes fuerte' : '✓ = strong month'}</p>
                   <p>{language === 'es' ? '• = en construcción' : '• = building'}</p>
                   <p>{language === 'es' ? '✕ = mes débil' : '✕ = weak month'}</p>
-                  <p>{language === 'es' ? '↻ = mes proyectado en curso' : '↻ = projected month in progress'}</p>
+                  <p>{language === 'es' ? '~ = proyectado al ritmo actual' : '~ = projected at current pace'}</p>
                 </div>
               </details>
             </div>
-            <div className="w-full overflow-x-auto pb-4" data-testid="recent-timeline" data-tour-anchor="achievement-preview-months">
+            <div className="w-full overflow-x-auto pb-2 pt-1" data-testid="recent-timeline" data-tour-anchor="achievement-preview-months">
               <div
                 className={cx(
                   'flex items-end gap-1 md:gap-1.5',
@@ -399,38 +452,30 @@ export function PreviewAchievementCard({
                   <RecentMonthNode key={`${entry.key}-${entry.value ?? 0}`} entry={entry} language={language} compact={isCompact} />
                 ))}
                 {hasGroupedWindow && (
-                  <div className="flex flex-col items-center">
+                  <div className="relative flex items-end rounded-xl bg-white/5 px-1.5 pb-1 pt-4">
+                    <span className="pointer-events-none absolute inset-0 rounded-xl border border-violet-200/20 bg-violet-400/8 shadow-[0_0_24px_rgba(129,140,248,0.16)]" />
+                    <p className="absolute left-2 top-1 text-[8px] font-medium uppercase tracking-[0.1em] text-[color:var(--color-slate-400)]">{windowTitle}</p>
                     <div
-                      className={cx('flex flex-col items-center rounded-xl border border-[color:var(--color-border-soft)] pb-2', isCompact ? 'px-1 pt-0.5 md:px-1.5' : 'px-1.5 pt-0.3 md:px-2')}
+                      className="relative flex items-end gap-1 rounded-xl bg-white/5 md:gap-1.5"
                       data-testid="seal-window-group"
                       data-window-start={lastThreeStart}
                       data-window-end={lastThreeEnd - 1}
                       data-tour-anchor="achievement-preview-active-window"
                     >
-                      <p className={cx('text-center font-semibold uppercase tracking-[0.08em] text-[color:var(--color-slate-100)]', isCompact ? 'text-[12px]' : 'text-sm')}>{windowTitle}</p>
-                      <div className="flex items-end gap-1 md:gap-1.5" data-testid="seal-window-track">
-                        {groupedMonths.map((entry) => (
-                          <RecentMonthNode key={`${entry.key}-${entry.value ?? 0}`} entry={entry} language={language} compact={isCompact} />
-                        ))}
-                      </div>
+                      {groupedMonths.map((entry) => (
+                        <RecentMonthNode key={`${entry.key}-${entry.value ?? 0}`} entry={entry} language={language} compact={isCompact} />
+                      ))}
                     </div>
-                    {groupedProjectedMonth && (
-                      <div className="mt-1 flex items-start gap-1 md:gap-1.5" data-testid="projected-month-label-row">
-                        {groupedMonths.map((entry, index) => (
-                          <span key={`${entry.key}-projected-indicator`} className={cx('text-center text-[9px] leading-none text-[color:var(--color-slate-400)]', isCompact ? 'w-[2.5rem] sm:w-[2.75rem]' : 'w-[3.35rem] sm:w-[3.55rem]')}>
-                            {entry.projected && index === groupedMonths.length - 1
-                              ? language === 'es'
-                                ? 'proyectado'
-                                : 'projected'
-                              : '\u00A0'}
-                          </span>
-                        ))}
-                      </div>
-                    )}
+                    {groupedProjectedMonth && <span className="absolute -bottom-3 right-2 text-[9px] text-[color:var(--color-slate-400)]">{language === 'es' ? 'proyectado' : 'projected'}</span>}
                   </div>
                 )}
               </div>
             </div>
+            {projectionNote && (
+              <p className="mt-1 text-[10px] text-[color:var(--color-slate-400)]" data-testid="recent-timeline-projection-note">
+                {projectionNote}
+              </p>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
### Motivation
- Refresh the “Desarrollo del hábito” preview to feel premium, modern, and aligned with Innerbloom’s dark universe while preserving existing semantics and behavior. 
- Replace the flat static donut and clunky rail/timeline with a softer animated visualization that reads well inside the current achievement card size.

### Description
- Implemented a premium animated SVG progress ring that animates 0→score on mount using `requestAnimationFrame`, uses `strokeLinecap="round"`, a two-stop gradient stroke and a restrained glow, and preserves center content (score number, `SCORE` label, info button/tooltip); all logic lives in `PreviewAchievementCard.tsx` and uses existing design tokens where available.
- Preserved semantic state colors (`frágil`, `en construcción`, `fuerte`) while upgrading chips and month tokens to subtle gradients, opacity and soft shadows and exposing `ringColor`/`ringGradientStop` per-tone for the ring treatment.
- Rebuilt the vertical status scale into a compact status rail (closer labels, smaller footprint, subtler track) that no longer competes visually with the ring and keeps label proximity tighter.
- Redesigned the recent-months timeline so month tokens are baseline-aligned, the active window uses a translucent highlighted container (not raised tokens), reduced the hierarchy for the window label, and added a single projection note microcopy when appropriate; preserved localization and grouped-window logic.
- Kept accessibility and interactions intact (tooltip behavior, aria labels, readable center content), avoided adding heavy dependencies, and added a small comment explaining the animation easing math.

### Testing
- Ran the component unit tests with `npm --workspace apps/web run test -- src/components/dashboard-v3/__tests__/PreviewAchievementCard.test.tsx --run` and all tests passed (`22 tests` passed).
- Ran workspace typecheck `npm run typecheck:web` which surfaced pre-existing unrelated TypeScript errors elsewhere in the repo and did not block this change.
- No new runtime dependencies were introduced and visual behavior was implemented using React + native SVG/animation logic confined to `apps/web/src/components/dashboard-v3/PreviewAchievementCard.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec899769588332b95b332e50e05bc1)