### PR TITLE
Refine Streaks panel sizing/alignment in hero phone showcase

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -550,6 +550,45 @@
 }
 
 .heroFocusContent
+  :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-top"] > .flex.items-center.justify-center > .inline-flex) {
+  width: 100%;
+  max-width: 12.4rem !important;
+  gap: 0.18rem;
+  padding: 0.18rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      [data-demo-anchor="streaks-top"]
+      > .flex.items-center.justify-center
+      > .inline-flex
+      > button
+  ) {
+  flex: 1 1 0;
+  min-width: 0;
+  gap: 0.18rem;
+  padding: 0.3rem 0.32rem;
+  font-size: 0.5rem;
+  letter-spacing: 0.08em;
+  line-height: 1;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="streaks"]
+      .ib-card
+      [data-demo-anchor="streaks-top"]
+      > .flex.items-center.justify-center
+      > .inline-flex
+      > button
+      > span
+  ) {
+  font-size: 0.54rem;
+}
+
+.heroFocusContent
   :global(
     [data-demo-anchor="streaks"]
       .ib-card
@@ -585,9 +624,9 @@
       [data-demo-anchor="streaks-bottom"]
       article[role="button"]
   ) {
-  min-height: 4rem;
-  padding: 0.42rem 0.52rem;
-  gap: 0.3rem;
+  min-height: 3.32rem;
+  padding: 0.36rem 0.46rem;
+  gap: 0.24rem;
 }
 
 .heroFocusContent
@@ -609,14 +648,15 @@
       .min-w-0.flex-1
       p
   ) {
-  font-size: 0.63rem;
+  font-size: 0.58rem;
+  line-height: 1.2;
 }
 
 .heroFocusContent
   :global(
     [data-demo-anchor="streaks"] .ib-card article[role="button"] > .grid
   ) {
-  gap: 0.35rem 0.55rem;
+  gap: 0.24rem 0.4rem;
 }
 
 .heroFocusContent
@@ -639,9 +679,11 @@
       > div
       + div
   ) {
-  min-width: 4.2rem;
-  align-items: stretch;
-  gap: 0.1rem;
+  min-width: 3.15rem;
+  width: 3.15rem;
+  justify-self: end;
+  align-items: flex-end;
+  gap: 0.06rem;
 }
 
 .heroFocusContent
@@ -654,7 +696,7 @@
       + div
       > .flex
   ) {
-  width: fit-content;
+  width: 100%;
 }
 
 .heroFocusContent
@@ -667,8 +709,8 @@
       + div
       > .flex.items-end
   ) {
-  justify-content: flex-start;
-  gap: 0.12rem;
+  justify-content: flex-end;
+  gap: 0.1rem;
 }
 
 .heroFocusContent
@@ -682,8 +724,9 @@
       > .flex.items-end
       > div
   ) {
-  width: 0.42rem;
-  min-width: 0.42rem;
+  width: 0.36rem;
+  min-width: 0.36rem;
+  border-radius: 0.18rem;
 }
 
 .heroFocusContent
@@ -696,10 +739,10 @@
       + div
       > .flex.items-center
   ) {
-  justify-content: flex-start;
-  gap: 0.12rem;
-  font-size: 0.46rem;
-  letter-spacing: 0.02em;
+  justify-content: flex-end;
+  gap: 0.1rem;
+  font-size: 0.42rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   color: rgba(148, 163, 184, 0.9);
 }
@@ -715,8 +758,8 @@
       > .flex.items-center
       > span
   ) {
-  width: 0.42rem;
-  min-width: 0.42rem;
+  width: 0.36rem;
+  min-width: 0.36rem;
   line-height: 1;
 }
 
@@ -736,9 +779,23 @@
       article[role="button"]
       .ib-streak-fire-chip__inner
   ) {
-  padding: 0.1rem 0.38rem;
+  padding: 0.06rem 0.28rem;
+  font-size: 0.5rem;
+  gap: 0.14rem;
+}
+
+.heroFocusContent
+  :global([data-demo-anchor="streaks"] .ib-card .ib-streak-mode-chip .ib-streak-mode-chip__inner) {
+  padding: 0.2rem 0.44rem;
+  font-size: 0.44rem;
+  letter-spacing: 0.1em;
+  gap: 0.18rem;
+}
+
+.heroFocusContent
+  :global([data-demo-anchor="streaks"] .ib-card [data-demo-anchor="streaks-top"] .text-\[color\:var\(--color-text\)\]) {
   font-size: 0.58rem;
-  gap: 0.2rem;
+  line-height: 1.12;
 }
 
 .sceneDashboard :global(.lg\:grid-cols-12) {


### PR DESCRIPTION
### Motivation
- The phone showcase was downscaled and the Streaks panel UI elements became visually oversized and misaligned, producing clipping (notably the `Soul` tab) and a heavy visual hierarchy that breaks the premium aesthetic.

### Description
- Tweaked only the showcase CSS overrides in `apps/web/src/components/landing/HeroPhoneShowcase.module.css` to compact the Streaks panel without touching backend, copy, loop, splash, or phone sizing.
- Reduced the Body/Mind/Soul segmented tabs footprint by lowering `font-size`, `letter-spacing` and horizontal `padding`, and enforced equal-fit with `flex: 1` + `min-width: 0` so all three tabs (including `Soul`) fit inside the container.
- Made the mode chip (`FLOW · 3×/WEEK`) and the fire chip less prominent by reducing internal padding and font-size to preserve a premium hierarchy at the smaller phone size.
- Compacted task/streak cards by lowering `min-height`, internal `padding` and gaps, reduced helper subtitle sizing, and converted the mini history bars into a fixed-width, right-aligned block so bars and numeric labels align consistently.

### Testing
- Ran TypeScript check with `pnpm -C apps/web exec tsc --noEmit`, which failed due to pre-existing TypeScript errors in the repository unrelated to this CSS-only change.
- Verified the change is CSS-only and limited to `HeroPhoneShowcase.module.css` and did not modify JS/TS logic or copy; visual validation was intended but not runnable in this environment so no runtime screenshots were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8cee9eb48332823851b47b738ee2)