### PR TITLE
Refina el splash de cierre del Hero Phone Showcase con lockup premium

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -172,14 +172,153 @@
   border-radius: 30px;
   display: grid;
   place-items: center;
-  background: var(--hero-purple-afternoon, #000c40);
+  overflow: hidden;
+  background:
+    radial-gradient(
+      140% 96% at 50% 130%,
+      rgba(104, 78, 189, 0.2),
+      transparent 58%
+    ),
+    radial-gradient(
+      85% 75% at 50% -10%,
+      rgba(88, 68, 161, 0.16),
+      transparent 74%
+    ),
+    linear-gradient(180deg, #06060b 0%, #030307 100%);
   z-index: 9;
 }
 
+.loopSplashDepthGlow {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(
+      circle at 50% 44%,
+      rgba(188, 147, 255, 0.22),
+      rgba(114, 82, 206, 0.11) 18%,
+      transparent 45%
+    ),
+    radial-gradient(
+      90% 70% at 52% 100%,
+      rgba(76, 55, 142, 0.26),
+      transparent 80%
+    );
+  opacity: 0;
+  animation: loopSplashGlow 1300ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.loopSplashLockup {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  width: 80%;
+  min-height: 38%;
+}
+
 .loopSplashFlower {
-  width: clamp(74px, 32%, 108px);
+  width: clamp(72px, 30%, 102px);
   height: auto;
-  filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.35));
+  z-index: 1;
+  transform-origin: center center;
+  transform: translateX(0) scale(0.22) rotate(-28deg);
+  opacity: 0;
+  filter:
+    drop-shadow(0 14px 26px rgba(0, 0, 0, 0.45))
+    drop-shadow(0 0 18px rgba(165, 119, 236, 0.28));
+  animation: loopSplashFlower 1300ms cubic-bezier(0.23, 1, 0.32, 1) forwards;
+}
+
+.loopSplashWordmark {
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  margin-left: 0;
+  max-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font-size: clamp(0.56rem, 0.82vw, 0.72rem);
+  font-weight: 700;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+  color: rgba(244, 239, 255, 0.96);
+  text-shadow:
+    0 0 12px rgba(187, 147, 255, 0.23),
+    0 0 1px rgba(255, 255, 255, 0.4);
+  animation: loopSplashWordmarkReveal 1300ms cubic-bezier(0.22, 1, 0.36, 1)
+    forwards;
+}
+
+.loopSplashWordmarkLetter {
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(4px);
+  animation: loopSplashLetterIn 220ms ease-out forwards;
+  animation-delay: calc(600ms + var(--letter-delay, 0ms));
+}
+
+@keyframes loopSplashGlow {
+  0% {
+    opacity: 0;
+  }
+
+  35% {
+    opacity: 0.9;
+  }
+
+  100% {
+    opacity: 0.6;
+  }
+}
+
+@keyframes loopSplashFlower {
+  0% {
+    opacity: 0;
+    transform: translateX(0) scale(0.22) rotate(-28deg);
+  }
+
+  38% {
+    opacity: 1;
+    transform: translateX(0) scale(1.02) rotate(8deg);
+  }
+
+  58% {
+    opacity: 1;
+    transform: translateX(0) scale(1) rotate(0deg);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(-50px) scale(0.92) rotate(0deg);
+  }
+}
+
+@keyframes loopSplashWordmarkReveal {
+  0%,
+  52% {
+    max-width: 0;
+    margin-left: 0;
+    opacity: 0;
+  }
+
+  100% {
+    max-width: 190px;
+    margin-left: 12px;
+    opacity: 1;
+  }
+}
+
+@keyframes loopSplashLetterIn {
+  0% {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .sceneTrack {

--- a/apps/web/src/components/landing/HeroPhoneShowcase.tsx
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.tsx
@@ -310,15 +310,31 @@ function RealDashboardScene({
 }
 
 function LoopSplashScene() {
+  const brandCharacters = "INNERBLOOM".split("");
+
   return (
     <section className={styles.loopSplashScene} aria-hidden>
-      <img
-        src="/IB-COLOR-LOGO.png"
-        alt=""
-        className={styles.loopSplashFlower}
-        loading="eager"
-        decoding="async"
-      />
+      <div className={styles.loopSplashDepthGlow} />
+      <div className={styles.loopSplashLockup}>
+        <img
+          src="/IB-COLOR-LOGO.png"
+          alt=""
+          className={styles.loopSplashFlower}
+          loading="eager"
+          decoding="async"
+        />
+        <p className={styles.loopSplashWordmark}>
+          {brandCharacters.map((character, index) => (
+            <span
+              key={`${character}-${index}`}
+              className={styles.loopSplashWordmarkLetter}
+              style={{ "--letter-delay": `${index * 28}ms` } as CSSProperties}
+            >
+              {character}
+            </span>
+          ))}
+        </p>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Mejorar la pantalla splash final del hero phone showcase para que se sienta más premium y evitar el look azul plano actual.
- Usar el asset real de la flor Innerbloom y crear una entrada con escala + rotación que termine formando un lockup con el wordmark.
- Mantener la lógica de loop existente y las restricciones (no tocar backend, CTAs, H1, ni añadir assets nuevos). 

### Description
- `HeroPhoneShowcase.tsx`: reemplacé el contenido simple del splash por `LoopSplashScene` que renderiza una profundidad violeta, la flor (`/IB-COLOR-LOGO.png`) y el wordmark segmentado en letras con delays CSS para aparición letra por letra.
- `HeroPhoneShowcase.module.css`: añadí un fondo oscuro premium (negro/casi negro) con glow violeta sutil, estilos para el lockup y animaciones clave (`loopSplashGlow`, `loopSplashFlower`, `loopSplashWordmarkReveal`, `loopSplashLetterIn`) que implementan la entrada scale+rotate de la flor y la transición de la flor hacia la posición del logo.
- Conservo el timing global del loop (splash duration = `1300ms`) y la detección de `prefers-reduced-motion` ya existente para respetar accesibilidad.
- No se añadieron assets nuevos y no se modificó backend, CTAs ni H1.

### Testing
- Ejecuté `pnpm --filter web build` y la compilación de frontend completó correctamente (build OK).
- Ejecuté la suite de tests con `pnpm --filter web test -- --runInBand`; el comando corrió pero el repo tiene fallas preexistentes en suites no relacionadas con este cambio (mocks/providers/hooks), por lo que no todos los tests quedaron verdes (fallos existentes, no introducidos por este cambio).
- Intenté ejecutar `eslint` en el archivo y un `vitest` dirigido; `eslint` no pudo ejecutarse por la configuración del entorno y el `vitest` dirigido no encontró tests para este componente en el repo (ambos problemas de entorno, no del cambio de UI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8e73b2188332903f288020de63ae)