### PR TITLE
Polish hero phone showcase: compact mobile progress, splash timing, and premium phone frame

### DIFF
--- a/apps/web/src/components/dashboard-v3/MetricHeader.tsx
+++ b/apps/web/src/components/dashboard-v3/MetricHeader.tsx
@@ -96,17 +96,17 @@ export function MetricHeader({
       className="ib-metric-header-card"
       title={t("dashboard.metricHeader.title")}
       rightSlot={
-        <div className="flex items-start justify-end gap-2 sm:gap-3 -mt-1">
-          {chipStyle ? <GameModeChip {...chipStyle} /> : null}
+        <div className="metric-header-right-slot flex items-center justify-end gap-1.5 sm:gap-2.5 -mt-0.5">
           <InfoDotTarget
             id="xpLevel"
             placement="left"
-            className="inline-flex items-center"
+            className="metric-header-info-dot inline-flex items-center"
           >
             <span className="sr-only">
               {t("dashboard.metricHeader.infoAria")}
             </span>
           </InfoDotTarget>
+          {chipStyle ? <GameModeChip {...chipStyle} /> : null}
         </div>
       }
       subtitle={subtitle}
@@ -165,7 +165,7 @@ export function MetricHeader({
           </div>
 
           <div className="space-y-3">
-            <DashboardMeta className="tracking-[0.02em] text-[color:var(--color-text)]">
+            <DashboardMeta className="text-left tracking-[0.02em] text-[color:var(--color-text)]">
               {t("dashboard.metricHeader.progress")}
             </DashboardMeta>
             <div

--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -3,16 +3,67 @@
   width: min(100%, 306px);
   aspect-ratio: 9 / 18.5;
   border-radius: 42px;
-  background: linear-gradient(160deg, #2d2738 0%, #0b0d13 55%, #111c2f 100%);
+  background:
+    linear-gradient(
+      148deg,
+      color-mix(in srgb, #d8deea 26%, #2a2d35 74%) 0%,
+      #101217 36%,
+      #0a0d12 70%,
+      color-mix(in srgb, #4c5462 22%, #0b0d11 78%) 100%
+    );
   padding: 10px;
   box-shadow:
     0 26px 72px rgba(8, 8, 18, 0.6),
     0 8px 24px rgba(84, 61, 142, 0.2),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.16),
-    inset 0 -8px 16px rgba(0, 0, 0, 0.34);
+    inset 0 0 0 1px rgba(255, 255, 255, 0.26),
+    inset 0 0 0 2px rgba(121, 131, 150, 0.2),
+    inset 0 -10px 18px rgba(0, 0, 0, 0.4);
   transform: perspective(1300px) rotateY(-1.35deg) rotateX(0.4deg);
   transform-origin: center center;
   position: relative;
+}
+
+.phoneFrame::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 41px;
+  pointer-events: none;
+  background:
+    linear-gradient(
+      90deg,
+      rgba(214, 225, 239, 0.18) 0%,
+      rgba(214, 225, 239, 0.02) 14%,
+      rgba(30, 34, 44, 0.14) 28%,
+      rgba(208, 216, 230, 0.04) 50%,
+      rgba(30, 34, 44, 0.14) 72%,
+      rgba(214, 225, 239, 0.02) 86%,
+      rgba(214, 225, 239, 0.18) 100%
+    );
+  mix-blend-mode: screen;
+}
+
+.phoneFrame::after {
+  content: "";
+  position: absolute;
+  top: 26%;
+  right: -1.5px;
+  width: 2.5px;
+  height: 20%;
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(220, 229, 241, 0.52) 0%,
+    rgba(118, 127, 145, 0.4) 58%,
+    rgba(24, 27, 35, 0.7) 100%
+  );
+  box-shadow:
+    0 0 0 0.3px rgba(232, 238, 249, 0.2),
+    0 5px 0 0 rgba(123, 132, 151, 0.7),
+    0 14px 0 0 rgba(123, 132, 151, 0.68),
+    0 23px 0 0 rgba(123, 132, 151, 0.66);
+  opacity: 0.8;
+  pointer-events: none;
 }
 
 .phoneScreenBackground {
@@ -102,6 +153,9 @@
 }
 
 .phoneTopBarCopy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   min-width: 0;
 }
 
@@ -118,7 +172,7 @@
 .phoneTopBarCopy .phoneTopBarTitle {
   margin: 0.02rem 0 0;
   font-family: var(--font-heading);
-  font-size: 0.44rem;
+  font-size: 0.53rem;
   font-weight: 600;
   line-height: 1;
   letter-spacing: -0.01em;
@@ -204,7 +258,7 @@
       transparent 80%
     );
   opacity: 0;
-  animation: loopSplashGlow 1300ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: loopSplashGlow 3900ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 .loopSplashLockup {
@@ -227,7 +281,7 @@
   filter:
     drop-shadow(0 14px 26px rgba(0, 0, 0, 0.45))
     drop-shadow(0 0 18px rgba(165, 119, 236, 0.28));
-  animation: loopSplashFlower 1300ms cubic-bezier(0.23, 1, 0.32, 1) forwards;
+  animation: loopSplashFlower 3900ms cubic-bezier(0.23, 1, 0.32, 1) forwards;
 }
 
 .loopSplashWordmark {
@@ -238,7 +292,7 @@
   max-width: 0;
   overflow: hidden;
   white-space: nowrap;
-  font-size: clamp(0.56rem, 0.82vw, 0.72rem);
+  font-size: clamp(0.73rem, 1.06vw, 0.94rem);
   font-weight: 700;
   letter-spacing: 0.17em;
   text-transform: uppercase;
@@ -246,7 +300,7 @@
   text-shadow:
     0 0 12px rgba(187, 147, 255, 0.23),
     0 0 1px rgba(255, 255, 255, 0.4);
-  animation: loopSplashWordmarkReveal 1300ms cubic-bezier(0.22, 1, 0.36, 1)
+  animation: loopSplashWordmarkReveal 3900ms cubic-bezier(0.22, 1, 0.36, 1)
     forwards;
 }
 
@@ -254,8 +308,8 @@
   display: inline-block;
   opacity: 0;
   transform: translateY(4px);
-  animation: loopSplashLetterIn 220ms ease-out forwards;
-  animation-delay: calc(600ms + var(--letter-delay, 0ms));
+  animation: loopSplashLetterIn 300ms ease-out forwards;
+  animation-delay: calc(1680ms + var(--letter-delay, 0ms));
 }
 
 @keyframes loopSplashGlow {
@@ -278,28 +332,34 @@
     transform: translateX(0) scale(0.22) rotate(-28deg);
   }
 
-  38% {
+  24% {
     opacity: 1;
-    transform: translateX(0) scale(1.02) rotate(8deg);
+    transform: translateX(0) scale(1.015) rotate(7deg);
   }
 
-  58% {
+  52% {
     opacity: 1;
     transform: translateX(0) scale(1) rotate(0deg);
   }
 
   100% {
     opacity: 1;
-    transform: translateX(-50px) scale(0.92) rotate(0deg);
+    transform: translateX(52px) scale(0.92) rotate(0deg);
   }
 }
 
 @keyframes loopSplashWordmarkReveal {
   0%,
-  52% {
+  44% {
     max-width: 0;
     margin-left: 0;
     opacity: 0;
+  }
+
+  70% {
+    max-width: 190px;
+    margin-left: 12px;
+    opacity: 1;
   }
 
   100% {
@@ -511,6 +571,9 @@
 
 .heroFocusContent
   :global([data-demo-anchor="overall-progress"] .ib-metric-header-card header) {
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
   padding-top: 0.2rem;
 }
@@ -527,10 +590,73 @@
     [data-demo-anchor="overall-progress"]
       .ib-metric-header-card
       header
-      [class*="inline-flex"]
+      .metric-header-right-slot
   ) {
-  transform: scale(0.94);
-  transform-origin: top right;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.34rem;
+  margin-top: 0;
+  white-space: nowrap;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      header
+      .metric-header-info-dot
+  ) {
+  --info-dot-size: 14px;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      header
+      .metric-header-info-dot
+  ) {
+  gap: 0.2rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      header
+      .metric-header-info-dot
+      .info-dot__button
+  ) {
+  font-size: 10px;
+  border-width: 0.8px;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      header
+      .metric-header-right-slot
+      .ib-game-mode-chip__inner
+  ) {
+  gap: 0.24rem;
+  padding: 0.1rem 0.4rem;
+  font-size: 7px;
+  letter-spacing: 0.1em;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="overall-progress"]
+      .ib-metric-header-card
+      header
+      .metric-header-right-slot
+      .ib-game-mode-chip__inner
+      > span:first-child
+  ) {
+  width: 0.24rem;
+  height: 0.24rem;
 }
 
 .heroFocusContent

--- a/apps/web/src/components/landing/HeroPhoneShowcase.tsx
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.tsx
@@ -14,7 +14,7 @@ import styles from "./HeroPhoneShowcase.module.css";
 const INITIAL_TOP_PAUSE_MS = 500;
 const SCROLL_DOWN_DURATION_MS = 4500;
 const LOOP_BOTTOM_PAUSE_MS = 1600;
-const LOOP_SPLASH_DURATION_MS = 1300;
+const LOOP_SPLASH_DURATION_MS = 3900;
 const RESET_TO_TOP_DURATION_MS = 300;
 const LOOP_TOP_PAUSE_MS = 350;
 const DASHBOARD_LOOP_DURATION_MS =
@@ -328,7 +328,7 @@ function LoopSplashScene() {
             <span
               key={`${character}-${index}`}
               className={styles.loopSplashWordmarkLetter}
-              style={{ "--letter-delay": `${index * 28}ms` } as CSSProperties}
+              style={{ "--letter-delay": `${index * 92}ms` } as CSSProperties}
             >
               {character}
             </span>


### PR DESCRIPTION
### Motivation
- Make the landing hero phone showcase look more compact and premium on mobile without touching backend or copy. 
- Keep dashboard cards and mobile/desktop responsiveness intact while fixing layout wrap issues and improving the final splash choreography. 

### Description
- Updated `MetricHeader` (`apps/web/src/components/dashboard-v3/MetricHeader.tsx`) to reflow the right slot as a single `info dot + FLOW chip` group and force the `Progress` label to `text-left`. 
- Adjusted hero timeline constants and per-letter reveal pacing in `HeroPhoneShowcase` (`apps/web/src/components/landing/HeroPhoneShowcase.tsx`) by tripling the splash duration and increasing per-letter delays. 
- Overhauled phone shell visuals and mobile-top-bar sizing in `HeroPhoneShowcase.module.css` (`apps/web/src/components/landing/HeroPhoneShowcase.module.css`) to add graphite/silver side highlights, a subtle side-button cue, larger left-aligned `Dashboard` text (~+20%), and other cosmetic refinements. 
- Compacted the `OVERALL PROGRESS` mobile header via CSS: prevent wrapping, align items center, justify-between, reduce `info-dot` and `ib-game-mode-chip` inner sizing/padding to keep title left and controls on one line. 

### Testing
- Ran lint attempt: `pnpm --filter web exec eslint src/components/landing/HeroPhoneShowcase.tsx src/components/landing/HeroPhoneShowcase.module.css src/components/dashboard-v3/MetricHeader.tsx`, which failed due to repository ESLint v9 flat-config migration/setup (failure is environmental, not caused by these edits). 
- Ran typecheck: `pnpm --filter web run typecheck`, which failed due to pre-existing TypeScript errors unrelated to the modified files; the updated files do not introduce new TS signatures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9e0fe1ac8332b496ad515efdfccc)