### PR TITLE
Fix hero splash motion and compact Emotion Chart legend on mobile

### DIFF
--- a/apps/web/src/components/dashboard-v3/EmotionChartCard.tsx
+++ b/apps/web/src/components/dashboard-v3/EmotionChartCard.tsx
@@ -890,14 +890,27 @@ export function EmotionChartCard({ userId }: EmotionChartCardProps) {
 
       {(!showSkeleton && !showError && !showEmpty) || hasRecordedEmotion ? (
         <div className="flex flex-col gap-5">
-          <div className="flex flex-wrap gap-4 text-xs text-[color:var(--color-text-subtle)]">
+          <div
+            className="flex flex-wrap gap-4 text-xs text-[color:var(--color-text-subtle)]"
+            data-emotion-card="legend"
+          >
             {LEGEND.map((item) => (
-              <div key={getEmotionLabel(item.name, language)} className="flex items-center gap-2">
+              <div
+                key={getEmotionLabel(item.name, language)}
+                className="flex items-center gap-2"
+                data-emotion-card="legend-item"
+              >
                 <span
                   className="h-4 w-4 rounded-md border border-[color:var(--color-border-subtle)]"
+                  data-emotion-card="legend-swatch"
                   style={{ backgroundColor: item.color }}
                 />
-                <span className="font-medium text-[color:var(--color-text)]">{getEmotionLabel(item.name, language)}</span>
+                <span
+                  className="font-medium text-[color:var(--color-text)]"
+                  data-emotion-card="legend-label"
+                >
+                  {getEmotionLabel(item.name, language)}
+                </span>
               </div>
             ))}
           </div>

--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -263,33 +263,39 @@
 
 .loopSplashLockup {
   position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
-  width: 80%;
-  min-height: 38%;
+  width: min(84%, 260px);
+  min-height: 40%;
+  --loop-splash-wordmark-width: 188px;
+  --loop-splash-lockup-gap: 12px;
+  --loop-splash-flower-shift-x: 90px;
 }
 
 .loopSplashFlower {
-  width: clamp(72px, 30%, 102px);
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: clamp(72px, 30%, 98px);
   height: auto;
-  z-index: 1;
+  z-index: 2;
   transform-origin: center center;
-  transform: translateX(0) scale(0.22) rotate(-28deg);
+  transform: translate(-50%, -50%) scale(0.24) rotate(-18deg);
   opacity: 0;
   filter:
     drop-shadow(0 14px 26px rgba(0, 0, 0, 0.45))
     drop-shadow(0 0 18px rgba(165, 119, 236, 0.28));
-  animation: loopSplashFlower 3900ms cubic-bezier(0.23, 1, 0.32, 1) forwards;
+  animation: loopSplashFlower 3900ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 .loopSplashWordmark {
+  position: absolute;
+  top: 50%;
+  left: calc(
+    50% - var(--loop-splash-lockup-gap) - var(--loop-splash-wordmark-width)
+  );
   display: inline-flex;
   align-items: center;
   margin: 0;
-  margin-left: 0;
-  max-width: 0;
+  width: var(--loop-splash-wordmark-width);
   overflow: hidden;
   white-space: nowrap;
   font-size: clamp(0.73rem, 1.06vw, 0.94rem);
@@ -300,6 +306,9 @@
   text-shadow:
     0 0 12px rgba(187, 147, 255, 0.23),
     0 0 1px rgba(255, 255, 255, 0.4);
+  opacity: 0;
+  clip-path: inset(0 100% 0 0);
+  transform: translateY(-50%);
   animation: loopSplashWordmarkReveal 3900ms cubic-bezier(0.22, 1, 0.36, 1)
     forwards;
 }
@@ -308,8 +317,8 @@
   display: inline-block;
   opacity: 0;
   transform: translateY(4px);
-  animation: loopSplashLetterIn 300ms ease-out forwards;
-  animation-delay: calc(1680ms + var(--letter-delay, 0ms));
+  animation: loopSplashLetterIn 340ms ease-out forwards;
+  animation-delay: calc(1320ms + var(--letter-delay, 0ms));
 }
 
 @keyframes loopSplashGlow {
@@ -329,42 +338,43 @@
 @keyframes loopSplashFlower {
   0% {
     opacity: 0;
-    transform: translateX(0) scale(0.22) rotate(-28deg);
+    transform: translate(-50%, -50%) scale(0.24) rotate(-18deg);
   }
 
-  24% {
+  18% {
     opacity: 1;
-    transform: translateX(0) scale(1.015) rotate(7deg);
+    transform: translate(-50%, -50%) scale(1.01) rotate(2deg);
   }
 
-  52% {
+  44% {
     opacity: 1;
-    transform: translateX(0) scale(1) rotate(0deg);
+    transform: translate(-50%, -50%) scale(1) rotate(0deg);
   }
 
   100% {
     opacity: 1;
-    transform: translateX(52px) scale(0.92) rotate(0deg);
+    transform: translate(
+        calc(-50% + var(--loop-splash-flower-shift-x)),
+        -50%
+      )
+      scale(0.92) rotate(0deg);
   }
 }
 
 @keyframes loopSplashWordmarkReveal {
   0%,
-  44% {
-    max-width: 0;
-    margin-left: 0;
+  28% {
+    clip-path: inset(0 100% 0 0);
     opacity: 0;
   }
 
-  70% {
-    max-width: 190px;
-    margin-left: 12px;
+  74% {
+    clip-path: inset(0 0 0 0);
     opacity: 1;
   }
 
   100% {
-    max-width: 190px;
-    margin-left: 12px;
+    clip-path: inset(0 0 0 0);
     opacity: 1;
   }
 }
@@ -784,6 +794,41 @@
   ) {
   font-size: 0.66rem;
   line-height: 1.2;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="legend"]
+  ) {
+  gap: 0.28rem 0.52rem;
+  font-size: 0.45rem;
+  line-height: 1.1;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="legend-item"]
+  ) {
+  gap: 0.22rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"]
+      .ib-card
+      [data-emotion-card="legend-swatch"]
+  ) {
+  width: 0.56rem;
+  height: 0.56rem;
+  border-radius: 0.16rem;
+}
+
+.heroFocusContent
+  :global(
+    [data-demo-anchor="emotion-chart"] .ib-card [data-emotion-card="legend-label"]
+  ) {
+  font-size: 0.45rem;
+  line-height: 1.1;
 }
 
 .heroFocusContent


### PR DESCRIPTION
### Motivation
- Ensure the final Innerbloom splash lockup is visually stable and premium by removing the current left-then-right flower motion and preventing the flower from crossing the wordmark. 
- Make the `Emotion Chart` legend compact on mobile inside the hero phone showcase so it no longer inflates the dashboard card height. 
- Apply changes only at the hero phone showcase / mobile dashboard scope and avoid touching backend logic.

### Description
- Reworked the splash lockup layout and keyframes in `apps/web/src/components/landing/HeroPhoneShowcase.module.css` so the flower starts centered and performs a single rightward translation into the final lockup, and the wordmark is revealed left-to-right while the flower moves (no pre-movement to the left and no overlap). 
- Converted flower and wordmark to absolutely positioned elements inside the lockup, introduced layout variables (`--loop-splash-wordmark-width`, `--loop-splash-lockup-gap`, `--loop-splash-flower-shift-x`) and adjusted `@keyframes loopSplashFlower` to produce one rightward translation only. 
- Replaced the previous wordmark expansion with a left-to-right reveal using `clip-path` + per-letter entrance timing so the text is revealed progressively while the flower translates. 
- Added stable styling hooks to the Emotion Chart legend in `apps/web/src/components/dashboard-v3/EmotionChartCard.tsx` via `data-emotion-card` attributes and reduced legend visual footprint by ~40% in the hero/mobile scope (swatch size, label font-size and spacing) in `HeroPhoneShowcase.module.css` using the existing `.heroFocusContent` scope so desktop/outside-showcase styling is not affected.
- Files changed: `apps/web/src/components/landing/HeroPhoneShowcase.module.css` and `apps/web/src/components/dashboard-v3/EmotionChartCard.tsx`.
- Breakpoints / scope: the legend size reductions are scoped to the hero phone showcase via `.heroFocusContent :global([data-demo-anchor="emotion-chart"])` (i.e. applied inside the embedded phone/dashboard viewport) rather than a global media query, preserving desktop visuals.

### Testing
- Ran the repository typecheck with `pnpm -C apps/web typecheck`, which failed due to pre-existing TypeScript errors in the repository unrelated to these changes. 
- No other automated tests were run in this PR; visual/QA should be validated in a browser to confirm timing and that the flower only moves right and does not overlap the wordmark.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb56de32c8332a5298fdac1701a16)