### PR TITLE
fix(web): adjust final splash lockup positioning in HeroPhoneShowcase

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -226,6 +226,8 @@
   border-radius: 30px;
   display: grid;
   place-items: center;
+  box-sizing: border-box;
+  padding-inline: clamp(12px, 5.5%, 18px);
   overflow: hidden;
   background:
     radial-gradient(
@@ -263,11 +265,13 @@
 
 .loopSplashLockup {
   position: relative;
-  width: min(84%, 260px);
+  width: min(100%, 320px);
+  max-width: 100%;
   min-height: 40%;
   --loop-splash-wordmark-width: 188px;
   --loop-splash-lockup-gap: 12px;
   --loop-splash-flower-shift-x: 90px;
+  --loop-splash-wordmark-shift-x: 10px;
 }
 
 .loopSplashFlower {
@@ -290,7 +294,8 @@
   position: absolute;
   top: 50%;
   left: calc(
-    50% - var(--loop-splash-lockup-gap) - var(--loop-splash-wordmark-width)
+    50% - var(--loop-splash-lockup-gap) - var(--loop-splash-wordmark-width) +
+      var(--loop-splash-wordmark-shift-x)
   );
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Prevent the final splash lockup (`INNERBLOOM` + flower) from being visually clipped at the left edge of the phone viewport by nudging the wordmark right while keeping the flower position and animation timings unchanged.

### Description
- Edited `apps/web/src/components/landing/HeroPhoneShowcase.module.css` to add an internal safe area and horizontal padding with `box-sizing: border-box` and `padding-inline: clamp(12px, 5.5%, 18px)` on `.loopSplashScene`.
- Increased the usable lockup width to `width: min(100%, 320px); max-width: 100%;` and added `--loop-splash-wordmark-shift-x: 10px` on `.loopSplashLockup` to allow the full lockup to fit inside the phone.
- Applied the horizontal offset in `.loopSplashWordmark` by updating `left: calc(...)` to include `var(--loop-splash-wordmark-shift-x)`, preserving existing transform/animation rules so timings and flower movement remain unchanged.

### Testing
- Ran `npm run typecheck:web`, which failed due to preexisting TypeScript errors unrelated to the CSS change, so typecheck did not pass. 
- No other automated visual tests were run as the change is CSS-only and intended to be verified visually in the phone showcase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb9a026c88332b6ef5789a0c10e6c)