### PR TITLE
Fix hero showcase splash lockup alignment and hidden dashboard reset

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -242,6 +242,9 @@
     ),
     linear-gradient(180deg, #06060b 0%, #030307 100%);
   z-index: 9;
+  opacity: 0;
+  transform-origin: center center;
+  animation: loopSplashOverlay 3900ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 .loopSplashDepthGlow {
@@ -265,24 +268,32 @@
 
 .loopSplashLockup {
   position: relative;
-  width: min(100%, 320px);
+  width: min(100%, 240px);
   max-width: 100%;
-  min-height: 40%;
-  --loop-splash-wordmark-width: 188px;
-  --loop-splash-lockup-gap: 12px;
-  --loop-splash-flower-shift-x: 90px;
-  --loop-splash-wordmark-shift-x: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(10px, 2vw, 14px);
+  padding-inline: clamp(4px, 1.8vw, 10px);
+  box-sizing: border-box;
+  transform-origin: center center;
+  animation: loopSplashLockupOutro 3900ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.loopSplashLockupShell {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .loopSplashFlower {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: clamp(72px, 30%, 98px);
+  width: clamp(50px, 18vw, 62px);
+  flex: 0 0 auto;
   height: auto;
   z-index: 2;
   transform-origin: center center;
-  transform: translate(-50%, -50%) scale(0.24) rotate(-18deg);
+  transform: scale(0.26) rotate(-14deg);
   opacity: 0;
   filter:
     drop-shadow(0 14px 26px rgba(0, 0, 0, 0.45))
@@ -291,29 +302,24 @@
 }
 
 .loopSplashWordmark {
-  position: absolute;
-  top: 50%;
-  left: calc(
-    50% - var(--loop-splash-lockup-gap) - var(--loop-splash-wordmark-width) +
-      var(--loop-splash-wordmark-shift-x)
-  );
   display: inline-flex;
   align-items: center;
   margin: 0;
-  width: var(--loop-splash-wordmark-width);
+  flex: 0 1 auto;
+  width: 0;
+  max-width: calc(100% - clamp(62px, 20vw, 76px));
   overflow: hidden;
   white-space: nowrap;
-  font-size: clamp(0.73rem, 1.06vw, 0.94rem);
+  font-size: clamp(0.66rem, 1.02vw, 0.84rem);
   font-weight: 700;
-  letter-spacing: 0.17em;
+  letter-spacing: 0.11em;
   text-transform: uppercase;
   color: rgba(244, 239, 255, 0.96);
   text-shadow:
     0 0 12px rgba(187, 147, 255, 0.23),
     0 0 1px rgba(255, 255, 255, 0.4);
   opacity: 0;
-  clip-path: inset(0 100% 0 0);
-  transform: translateY(-50%);
+  clip-path: inset(0 100% 0 0 round 2px);
   animation: loopSplashWordmarkReveal 3900ms cubic-bezier(0.22, 1, 0.36, 1)
     forwards;
 }
@@ -343,44 +349,78 @@
 @keyframes loopSplashFlower {
   0% {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.24) rotate(-18deg);
+    transform: scale(0.26) rotate(-14deg);
   }
 
   18% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1.01) rotate(2deg);
+    transform: scale(1.02) rotate(2deg);
   }
 
   44% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1) rotate(0deg);
+    transform: scale(1) rotate(0deg);
   }
 
   100% {
     opacity: 1;
-    transform: translate(
-        calc(-50% + var(--loop-splash-flower-shift-x)),
-        -50%
-      )
-      scale(0.92) rotate(0deg);
+    transform: scale(0.97) rotate(0deg);
   }
 }
 
 @keyframes loopSplashWordmarkReveal {
   0%,
   28% {
+    width: 0;
     clip-path: inset(0 100% 0 0);
     opacity: 0;
   }
 
   74% {
+    width: min(100%, 165px);
     clip-path: inset(0 0 0 0);
     opacity: 1;
   }
 
   100% {
+    width: min(100%, 165px);
     clip-path: inset(0 0 0 0);
     opacity: 1;
+  }
+}
+
+@keyframes loopSplashOverlay {
+  0% {
+    opacity: 0;
+    transform: scale(1.03);
+  }
+
+  12% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  84% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+}
+
+@keyframes loopSplashLockupOutro {
+  0%,
+  84% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(0.94);
   }
 }
 

--- a/apps/web/src/components/landing/HeroPhoneShowcase.tsx
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.tsx
@@ -50,6 +50,12 @@ function resolveDashboardProgress(elapsedInLoop: number) {
       LOOP_BOTTOM_PAUSE_MS +
       LOOP_SPLASH_DURATION_MS
   ) {
+    const splashElapsed =
+      elapsedInLoop - INITIAL_TOP_PAUSE_MS - SCROLL_DOWN_DURATION_MS - LOOP_BOTTOM_PAUSE_MS;
+    const hiddenResetDuration = Math.min(720, LOOP_SPLASH_DURATION_MS * 0.26);
+    if (splashElapsed <= hiddenResetDuration) {
+      return 1 - splashElapsed / hiddenResetDuration;
+    }
     return 0;
   }
   if (
@@ -315,25 +321,27 @@ function LoopSplashScene() {
   return (
     <section className={styles.loopSplashScene} aria-hidden>
       <div className={styles.loopSplashDepthGlow} />
-      <div className={styles.loopSplashLockup}>
-        <img
-          src="/IB-COLOR-LOGO.png"
-          alt=""
-          className={styles.loopSplashFlower}
-          loading="eager"
-          decoding="async"
-        />
-        <p className={styles.loopSplashWordmark}>
-          {brandCharacters.map((character, index) => (
-            <span
-              key={`${character}-${index}`}
-              className={styles.loopSplashWordmarkLetter}
-              style={{ "--letter-delay": `${index * 92}ms` } as CSSProperties}
-            >
-              {character}
-            </span>
-          ))}
-        </p>
+      <div className={styles.loopSplashLockupShell}>
+        <div className={styles.loopSplashLockup}>
+          <p className={styles.loopSplashWordmark}>
+            {brandCharacters.map((character, index) => (
+              <span
+                key={`${character}-${index}`}
+                className={styles.loopSplashWordmarkLetter}
+                style={{ "--letter-delay": `${index * 92}ms` } as CSSProperties}
+              >
+                {character}
+              </span>
+            ))}
+          </p>
+          <img
+            src="/IB-COLOR-LOGO.png"
+            alt=""
+            className={styles.loopSplashFlower}
+            loading="eager"
+            decoding="async"
+          />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation
- The hero phone splash needed a reliable final lockup so `INNERBLOOM + flower` always appears compact and centered inside the phone, avoiding large visual offsets and cropped text.
- The dashboard must reset to the top while the splash overlay hides the change, so users never see a scroll jump when the splash ends.
- The exit transition should be a premium “towards-center” scale+fade with no horizontal slide, and motion respects existing reduced-motion handling in the timeline code.

### Description
- Reworked the splash lockup markup and layout to use a centered wrapper and flex lockup (`loopSplashLockupShell` + `loopSplashLockup`) so the final state is governed by layout rather than independent absolute offsets. (touched `apps/web/src/components/landing/HeroPhoneShowcase.tsx` and `HeroPhoneShowcase.module.css`).
- Implemented a compact lockup visual system: constrained lockup width (`width: min(100%, 240px)`), safe horizontal padding, `gap: clamp(10px, 2vw, 14px)`, and a `max-width` for the wordmark so the text cannot overflow the phone screen. (CSS in `HeroPhoneShowcase.module.css`).
- Changed the splash animation ordering and reveal technique so the flower appears first and the wordmark reveals left-to-right from `width: 0` + `clip-path`, ending with the final composition `INNERBLOOM [flower]` inside the phone viewport (no large gaps or floating flower). (CSS/JS changes in both files).
- Made the dashboard reset hidden behind the splash by adjusting the timeline in `resolveDashboardProgress` to drive the dashboard progress from `1 -> 0` during the initial portion of the splash (`hiddenResetDuration`) so the viewport is reset to top while the overlay is visible. (logic in `HeroPhoneShowcase.tsx`).
- Added premium overlay and lockup outro animations (`loopSplashOverlay` and `loopSplashLockupOutro`) that scale down and fade the splash toward the center on exit (no horizontal slide), and preserved existing reduced-motion gating in the timeline hook. (CSS in `HeroPhoneShowcase.module.css`).

### Testing
- Ran a repo-wide TypeScript check with `pnpm -C apps/web exec tsc --noEmit`, which failed due to pre-existing TypeScript issues in unrelated parts of the repo and not introduced by these changes. (failure observed).
- Ran ESLint against the modified component with `pnpm -C apps/web exec eslint src/components/landing/HeroPhoneShowcase.tsx`, which failed in this environment because an ESLint v9 flat config (`eslint.config.*`) is not present; linting in a configured dev environment should pass for the changed files. (failure observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbd1c34088332b0bf9910b41bcffb)