### PR TITLE
Rebuild landing “You’re not the problem” section with code-driven visual flow

### DIFF
--- a/apps/web/src/content/officialLandingContent.ts
+++ b/apps/web/src/content/officialLandingContent.ts
@@ -24,7 +24,7 @@ export type LandingCopy = {
     note: string;
     alt: string;
   };
-  problem: { title: string; body: string };
+  problem: { title: string; left: string; right: string };
   pillars: { kicker: string; title: string; intro: string; highlightLeadIn: string; highlight: string; items: Pillar[] };
   modes: { kicker: string; title: string; intro: string; items: Mode[] };
   how: { kicker: string; title: string; intro: string; closingLine: string; steps: HowTimelineStep[] };
@@ -58,8 +58,10 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
     },
     problem: {
       title: 'El problema no sos vos.',
-      body:
-        'La mayoría de las apps de hábitos asumen que aparece la misma versión de vos todos los días.\nMisma energía. Mismo foco. Misma disciplina.\n\nPero la vida cambia.\nEntonces tu sistema también debería cambiar con vos.'
+      left:
+        'La mayoría de las apps de hábitos están diseñadas para una versión de vos que no existe:\n\nsiempre con la misma energía,\nel mismo foco y la misma disciplina.',
+      right:
+        'Pero la vida cambia. Y cuando\nel sistema no cambia con vos,\n\nno se siente que el sistema falló:\nse siente que fallaste vos.'
     },
     pillars: {
       kicker: 'PROGRESO EN EQUILIBRIO',
@@ -295,8 +297,10 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
     },
     problem: {
       title: 'You’re not the problem.',
-      body:
-        'Most habit apps assume the same version of you shows up every day.\nSame energy. Same focus. Same discipline.\n\nBut real life changes.\nSo your system should change with you.'
+      left:
+        'Most habit apps are designed\nfor a version of you that doesn’t exist:\n\nalways with the same energy,\nthe same focus, and the same discipline.',
+      right:
+        'But life changes. And when\nthe system doesn’t change with you,\n\nit doesn’t feel like the system failed—\nit feels like you did.'
     },
     pillars: {
       kicker: 'PROGRESS IN BALANCE',

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -563,7 +563,12 @@
 
 .landing .truth-problem {
   position: relative;
+  overflow: hidden;
   padding: clamp(78px, 8.8vw, 116px) 0 clamp(58px, 6.9vw, 90px);
+  background:
+    radial-gradient(circle at 22% 82%, rgba(24, 52, 118, 0.42), transparent 56%),
+    radial-gradient(circle at 86% 18%, rgba(68, 38, 132, 0.36), transparent 60%),
+    linear-gradient(165deg, rgba(8, 12, 34, 0.96), rgba(9, 16, 45, 0.98) 42%, rgba(13, 17, 42, 0.98));
 }
 
 .landing .truth-problem-section {
@@ -593,111 +598,250 @@
 }
 
 .landing .truth-problem-title--outside {
-  max-width: 19ch;
+  max-width: 11ch;
   margin-bottom: 0;
-  font-size: clamp(1.78rem, 1.35vw + 1.34rem, 2.36rem);
-}
-
-.landing .problem-flow-visual {
+  font-size: clamp(2.25rem, 2.5vw + 1.2rem, 4.35rem);
+  line-height: 1.02;
   position: relative;
-  width: min(1040px, 100%);
-  margin: clamp(8px, 2vw, 16px) auto clamp(2px, 0.6vw, 8px);
+  z-index: 3;
+}
+
+.landing .problem-visual-stage {
+  position: relative;
+  width: clamp(1100px, 88vw, 1360px);
+  height: clamp(350px, 38vw, 510px);
+  margin: clamp(-40px, -4vw, -12px) auto clamp(0px, 0.4vw, 12px);
+  transform: rotate(-5deg);
   pointer-events: none;
+  z-index: 1;
+  -webkit-mask-image: radial-gradient(ellipse 80% 74% at 52% 56%, #000 56%, rgba(0, 0, 0, 0.82) 72%, transparent 100%);
+  mask-image: radial-gradient(ellipse 80% 74% at 52% 56%, #000 56%, rgba(0, 0, 0, 0.82) 72%, transparent 100%);
 }
 
-.landing .problem-flow-visual img {
-  width: 100%;
-  display: block;
-  opacity: 0.72;
-  mix-blend-mode: screen;
-  filter: saturate(1.08) contrast(1.04);
-  -webkit-mask-image: radial-gradient(
-    ellipse 80% 62% at center,
-    #000 42%,
-    rgba(0, 0, 0, 0.74) 66%,
-    rgba(0, 0, 0, 0.38) 82%,
-    transparent 100%
-  );
-  mask-image: radial-gradient(
-    ellipse 80% 62% at center,
-    #000 42%,
-    rgba(0, 0, 0, 0.74) 66%,
-    rgba(0, 0, 0, 0.38) 82%,
-    transparent 100%
-  );
+.landing .problem-grid {
+  position: absolute;
+  left: 3.2%;
+  bottom: 8%;
+  width: clamp(260px, 27vw, 420px);
+  aspect-ratio: 1.18 / 1;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: clamp(4px, 0.5vw, 7px);
+  padding: clamp(12px, 1.3vw, 16px);
+  border-radius: 14px;
+  border: 1px solid rgba(129, 171, 255, 0.22);
+  background:
+    linear-gradient(160deg, rgba(17, 28, 58, 0.7), rgba(9, 15, 40, 0.34)),
+    radial-gradient(circle at 18% 15%, rgba(102, 159, 255, 0.18), transparent 54%);
+  box-shadow: inset 0 1px 0 rgba(211, 232, 255, 0.12), 0 28px 36px rgba(3, 8, 22, 0.36);
+  transform: perspective(700px) rotateY(13deg) rotateX(4deg) skew(-2deg, -3deg);
+  transform-origin: left center;
+  overflow: hidden;
 }
 
-.landing .problem-flow-visual::after {
+.landing .problem-grid::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(
-      circle at 77% 48%,
-      rgba(255, 202, 175, 0.22),
-      transparent 46%
-    ),
-    linear-gradient(
-      90deg,
-      rgba(8, 20, 68, 0.42),
-      rgba(11, 14, 47, 0.1) 36%,
-      rgba(24, 14, 55, 0.2) 72%,
-      rgba(10, 15, 40, 0.44)
-    );
+  background: linear-gradient(120deg, rgba(114, 166, 255, 0.18), transparent 42%, rgba(255, 168, 148, 0.14) 92%);
   mix-blend-mode: screen;
-  opacity: 0.82;
-  -webkit-mask-image: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(0, 0, 0, 0.92) 14%,
-    #000 50%,
-    rgba(0, 0, 0, 0.9) 86%,
-    transparent 100%
-  );
-  mask-image: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(0, 0, 0, 0.92) 14%,
-    #000 50%,
-    rgba(0, 0, 0, 0.9) 86%,
-    transparent 100%
-  );
+  opacity: 0.66;
 }
 
-.landing .section-sub.truth-problem-body {
-  margin: 0 auto;
-  max-width: min(720px, 92%);
-  color: color-mix(in srgb, var(--ink) 88%, #e6dcff 12%);
+.landing .problem-grid-cell {
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(142, 186, 255, 0.2);
+  border-radius: 4px;
+  color: rgba(177, 228, 243, 0.5);
+  font-size: clamp(0.55rem, 0.38vw, 0.7rem);
+  line-height: 1;
+  background: rgba(15, 26, 52, 0.36);
+}
+
+.landing .problem-flow-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.landing .problem-flow-svg .flow-band {
+  fill: none;
+  stroke-linecap: round;
+  mix-blend-mode: screen;
+}
+
+.landing .problem-flow-svg .band-1 {
+  stroke-width: 56;
+  opacity: 0.72;
+}
+
+.landing .problem-flow-svg .band-2 {
+  stroke-width: 34;
+  opacity: 0.62;
+}
+
+.landing .problem-flow-svg .band-3 {
+  stroke-width: 22;
+  opacity: 0.54;
+}
+
+.landing .problem-flow {
+  position: absolute;
+  inset: 0;
+}
+
+.landing .problem-flow .flow-band {
+  position: absolute;
+  left: 10%;
+  right: 2%;
+  border-radius: 999px;
+  mix-blend-mode: screen;
+  filter: blur(0.2px);
+}
+
+.landing .problem-flow .band-1 {
+  top: 46%;
+  height: clamp(34px, 3.1vw, 46px);
+  transform: translateY(-50%) rotate(-18deg);
+  background: linear-gradient(90deg, rgba(125, 182, 255, 0.1), rgba(135, 216, 239, 0.36), rgba(176, 147, 255, 0.24));
+}
+
+.landing .problem-flow .band-2 {
+  top: 54%;
+  height: clamp(22px, 2.2vw, 32px);
+  transform: translateY(-50%) rotate(-18deg);
+  background: linear-gradient(90deg, rgba(116, 171, 255, 0.06), rgba(146, 205, 255, 0.28), rgba(255, 180, 163, 0.22));
+}
+
+.landing .problem-flow .band-3 {
+  top: 40%;
+  height: clamp(18px, 1.9vw, 28px);
+  transform: translateY(-50%) rotate(-18deg);
+  background: linear-gradient(90deg, rgba(88, 139, 228, 0.06), rgba(128, 188, 255, 0.23), rgba(165, 136, 243, 0.2));
+}
+
+.landing .problem-flow .band-4 {
+  top: 61%;
+  height: clamp(10px, 1.1vw, 16px);
+  transform: translateY(-50%) rotate(-18deg);
+  background: linear-gradient(90deg, rgba(107, 167, 255, 0), rgba(140, 198, 255, 0.21), rgba(255, 176, 151, 0.12));
+}
+
+.landing .problem-flow .flow-glow {
+  position: absolute;
+  border-radius: 999px;
+  mix-blend-mode: screen;
+  filter: blur(34px);
+}
+
+.landing .problem-flow .glow-1 {
+  left: 36%;
+  bottom: 16%;
+  width: clamp(300px, 38vw, 530px);
+  height: clamp(118px, 13vw, 190px);
+  background: radial-gradient(ellipse at center, rgba(141, 207, 255, 0.38), rgba(120, 162, 255, 0.08) 62%, transparent 100%);
+}
+
+.landing .problem-flow .glow-2 {
+  left: 56%;
+  bottom: 28%;
+  width: clamp(250px, 30vw, 460px);
+  height: clamp(110px, 12vw, 180px);
+  background: radial-gradient(ellipse at center, rgba(176, 142, 255, 0.32), rgba(126, 108, 241, 0.06) 64%, transparent 100%);
+}
+
+.landing .problem-flow .glow-3 {
+  right: 0;
+  top: 6%;
+  width: clamp(220px, 24vw, 360px);
+  height: clamp(90px, 9vw, 130px);
+  background: radial-gradient(ellipse at center, rgba(255, 187, 164, 0.3), rgba(255, 173, 144, 0.08) 68%, transparent 100%);
+}
+
+.landing .truth-problem-body {
+  width: min(1040px, 100%);
+  margin: clamp(6px, 1.1vw, 16px) auto 0;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: clamp(16px, 2vw, 30px);
+  align-items: stretch;
+  position: relative;
+  z-index: 4;
+}
+
+.landing .truth-problem-block {
+  margin: 0;
+  color: color-mix(in srgb, var(--ink) 90%, #e6dcff 10%);
   font-size: clamp(1rem, 0.24vw + 0.94rem, 1.14rem);
-  line-height: 1.64;
-  text-align: center;
+  line-height: 1.58;
+  text-align: left;
   text-wrap: pretty;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+}
+
+.landing .truth-problem-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+.landing .truth-problem-icon--x {
+  color: rgba(255, 201, 187, 0.96);
+  background: rgba(237, 109, 93, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(255, 172, 160, 0.36);
+}
+
+.landing .truth-problem-icon--check {
+  color: rgba(193, 251, 251, 0.98);
+  background: rgba(66, 177, 200, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(132, 238, 243, 0.38);
+}
+
+.landing .truth-problem-divider {
+  width: 1px;
+  background: linear-gradient(180deg, transparent 0%, rgba(160, 190, 242, 0.6) 26%, rgba(151, 197, 255, 0.36) 74%, transparent 100%);
 }
 
 @media (max-width: 840px) {
-  .landing .problem-flow-visual {
-    width: min(1120px, 150%);
-    margin-left: -25%;
-    margin-right: -25%;
+  .landing .truth-problem-title--outside {
+    max-width: 10ch;
+    font-size: clamp(2rem, 7.6vw, 3.05rem);
   }
 
-  .landing .problem-flow-visual img {
-    opacity: 0.78;
-    -webkit-mask-image: linear-gradient(
-      180deg,
-      transparent 0%,
-      rgba(0, 0, 0, 0.9) 20%,
-      #000 50%,
-      rgba(0, 0, 0, 0.86) 78%,
-      transparent 100%
-    );
-    mask-image: linear-gradient(
-      180deg,
-      transparent 0%,
-      rgba(0, 0, 0, 0.9) 20%,
-      #000 50%,
-      rgba(0, 0, 0, 0.86) 78%,
-      transparent 100%
-    );
+  .landing .problem-visual-stage {
+    width: min(1380px, 196vw);
+    height: clamp(300px, 76vw, 430px);
+    margin-left: -52vw;
+    margin-right: -52vw;
+    transform: rotate(-7deg);
+  }
+
+  .landing .problem-grid {
+    left: 6%;
+    bottom: 5%;
+    width: clamp(220px, 46vw, 300px);
+  }
+
+  .landing .truth-problem-body {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    max-width: min(680px, 100%);
+  }
+
+  .landing .truth-problem-divider {
+    height: 1px;
+    width: 100%;
+    background: linear-gradient(90deg, transparent 0%, rgba(160, 190, 242, 0.56) 22%, rgba(151, 197, 255, 0.34) 72%, transparent 100%);
   }
 }
 

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -846,17 +846,84 @@ export default function LandingPage() {
               {copy.problem.title}
             </AdaptiveText>
 
-            <div className="problem-flow-visual" aria-hidden>
-              <img
-                src="/problem-adaptive-flow.png"
-                alt=""
-                loading="lazy"
-              />
+            <div className="problem-visual-stage" aria-hidden>
+              <div className="problem-grid">
+                {Array.from({ length: 36 }).map((_, index) => (
+                  <span
+                    key={`problem-grid-cell-${index}`}
+                    className="problem-grid-cell"
+                  >
+                    {index % 5 === 0 || index % 7 === 0 ? "✓" : ""}
+                  </span>
+                ))}
+              </div>
+
+              <svg
+                className="problem-flow problem-flow-svg"
+                viewBox="0 0 1440 560"
+                role="presentation"
+                focusable="false"
+              >
+                <defs>
+                  <linearGradient id="problem-flow-band-1" x1="0%" y1="90%" x2="100%" y2="14%">
+                    <stop offset="0%" stopColor="rgba(114, 170, 255, 0.06)" />
+                    <stop offset="45%" stopColor="rgba(139, 198, 255, 0.32)" />
+                    <stop offset="100%" stopColor="rgba(189, 150, 255, 0.26)" />
+                  </linearGradient>
+                  <linearGradient id="problem-flow-band-2" x1="2%" y1="85%" x2="100%" y2="10%">
+                    <stop offset="0%" stopColor="rgba(118, 164, 255, 0.04)" />
+                    <stop offset="52%" stopColor="rgba(153, 206, 255, 0.28)" />
+                    <stop offset="100%" stopColor="rgba(255, 179, 160, 0.24)" />
+                  </linearGradient>
+                  <linearGradient id="problem-flow-band-3" x1="0%" y1="88%" x2="98%" y2="4%">
+                    <stop offset="0%" stopColor="rgba(102, 145, 240, 0.03)" />
+                    <stop offset="54%" stopColor="rgba(134, 178, 255, 0.22)" />
+                    <stop offset="100%" stopColor="rgba(178, 132, 255, 0.2)" />
+                  </linearGradient>
+                </defs>
+                <path
+                  className="flow-band band-1"
+                  d="M 120 486 C 312 450, 456 328, 632 300 C 796 274, 882 192, 1012 170 C 1128 148, 1242 70, 1368 42"
+                  stroke="url(#problem-flow-band-1)"
+                />
+                <path
+                  className="flow-band band-2"
+                  d="M 138 520 C 320 474, 462 352, 664 334 C 842 318, 938 236, 1064 210 C 1176 188, 1274 124, 1402 92"
+                  stroke="url(#problem-flow-band-2)"
+                />
+                <path
+                  className="flow-band band-3"
+                  d="M 92 454 C 262 420, 412 298, 598 260 C 758 228, 858 164, 996 132 C 1118 104, 1236 48, 1366 22"
+                  stroke="url(#problem-flow-band-3)"
+                />
+              </svg>
+
+              <div className="problem-flow">
+                <span className="flow-band band-1" />
+                <span className="flow-band band-2" />
+                <span className="flow-band band-3" />
+                <span className="flow-band band-4" />
+                <span className="flow-glow glow-1" />
+                <span className="flow-glow glow-2" />
+                <span className="flow-glow glow-3" />
+              </div>
             </div>
 
-            <AdaptiveText as="p" className="section-sub truth-problem-body">
-              {renderMultilineText(copy.problem.body)}
-            </AdaptiveText>
+            <div className="truth-problem-body">
+              <AdaptiveText as="p" className="truth-problem-block truth-problem-block--left">
+                <span className="truth-problem-icon truth-problem-icon--x" aria-hidden>
+                  ×
+                </span>
+                <span>{renderMultilineText(copy.problem.left)}</span>
+              </AdaptiveText>
+              <div className="truth-problem-divider" aria-hidden />
+              <AdaptiveText as="p" className="truth-problem-block truth-problem-block--right">
+                <span className="truth-problem-icon truth-problem-icon--check" aria-hidden>
+                  ✓
+                </span>
+                <span>{renderMultilineText(copy.problem.right)}</span>
+              </AdaptiveText>
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
### Motivation
- Replace the current rectangular image-based visual with a native, code-built composition that matches the ChatGPT reference composition while avoiding JPG/PNG as the primary visual. 
- Restore the full long-form problem copy and provide a strong centered heading with a large diagonal visual behind it that reads as a premium native composition.

### Description
- Updated the landing copy shape and restored the long texts by changing `problem` from `body` to `left`/`right` and populating both languages with the exact required copy (`apps/web/src/content/officialLandingContent.ts`).
- Replaced the `<img>` visual with a `problem-visual-stage` that includes a left-side rigid habit-tracker grid, inline SVG path bands for the adaptive flow, and layered gradient/glow bands built from HTML/CSS and SVG (no raster image used) (`apps/web/src/pages/Landing.tsx`).
- Added CSS for a full-width deep-navy/violet background, diagonal rotated visual stage, grid perspective, translucent flow bands, controlled glows, masks, blend-modes and responsive breakpoints to ensure the heading remains above the visual and the composition scales on mobile/desktop (`apps/web/src/pages/Landing.css`).
- Restored two side-by-side text blocks under the visual with circular coral X and cyan check icons plus a subtle vertical divider on desktop (becomes horizontal on mobile); no glass/card or rectangular image is used and no new dependencies were added.

### Testing
- Ran `npm --workspace apps/web run build` and the production build completed successfully (CSS minify warnings only). ✅
- Ran `npm --workspace apps/web run typecheck` which failed due to pre-existing unrelated TypeScript errors elsewhere in the repo, not introduced by this change (typecheck reported multiple unrelated errors). ⚠️
- Confirmed modified files committed: `apps/web/src/pages/Landing.tsx`, `apps/web/src/pages/Landing.css`, `apps/web/src/content/officialLandingContent.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbd8d67888332912b86154e5d8c9a)