### PR TITLE
Restore landing problem section to asset-based visual and long X/check copy

### DIFF
--- a/apps/web/src/content/officialLandingContent.ts
+++ b/apps/web/src/content/officialLandingContent.ts
@@ -59,9 +59,9 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
     problem: {
       title: 'El problema no sos vos.',
       left:
-        'La mayoría de las apps de hábitos están diseñadas para una versión de vos que no existe:\n\nsiempre con la misma energía,\nel mismo foco y la misma disciplina.',
+        '✕ La mayoría de las apps de hábitos asumen que todos tus días tienen la misma energía.\n\n✕ Te piden la misma intensidad incluso cuando estás cansado o saturado.\n\n✕ Si no cumplís el plan rígido, te hacen sentir que vos fallaste.',
       right:
-        'Pero la vida cambia. Y cuando\nel sistema no cambia con vos,\n\nno se siente que el sistema falló:\nse siente que fallaste vos.'
+        '✓ Innerbloom parte de tu capacidad real de hoy, no de una versión idealizada tuya.\n\n✓ Ajusta tu carga semanal cuando cambia tu energía, tu foco o tu contexto.\n\n✓ Así sostenés el proceso en el tiempo y convertís constancia en hábitos reales.'
     },
     pillars: {
       kicker: 'PROGRESO EN EQUILIBRIO',
@@ -298,9 +298,9 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
     problem: {
       title: 'You’re not the problem.',
       left:
-        'Most habit apps are designed\nfor a version of you that doesn’t exist:\n\nalways with the same energy,\nthe same focus, and the same discipline.',
+        '✕ Most habit apps assume you show up with the same energy every single day.\n\n✕ They demand the same intensity even when your week is heavy or unpredictable.\n\n✕ If you miss a rigid plan, the app makes it feel like you failed.',
       right:
-        'But life changes. And when\nthe system doesn’t change with you,\n\nit doesn’t feel like the system failed—\nit feels like you did.'
+        '✓ Innerbloom starts from your real capacity today, not an idealized version of you.\n\n✓ It adapts your weekly load as your energy, focus, and context change.\n\n✓ That helps you stay consistent long enough to build habits that actually last.'
     },
     pillars: {
       kicker: 'PROGRESS IN BALANCE',

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -564,21 +564,21 @@
 .landing .truth-problem {
   position: relative;
   overflow: hidden;
-  padding: clamp(78px, 8.8vw, 116px) 0 clamp(58px, 6.9vw, 90px);
+  padding: clamp(68px, 7.6vw, 98px) 0 clamp(56px, 6.4vw, 84px);
   background:
-    radial-gradient(circle at 22% 82%, rgba(24, 52, 118, 0.42), transparent 56%),
-    radial-gradient(circle at 86% 18%, rgba(68, 38, 132, 0.36), transparent 60%),
-    linear-gradient(165deg, rgba(8, 12, 34, 0.96), rgba(9, 16, 45, 0.98) 42%, rgba(13, 17, 42, 0.98));
+    radial-gradient(circle at 16% 72%, rgba(26, 52, 118, 0.36), transparent 54%),
+    radial-gradient(circle at 88% 14%, rgba(70, 40, 140, 0.28), transparent 56%),
+    linear-gradient(166deg, rgba(8, 12, 34, 0.96), rgba(10, 16, 45, 0.98) 42%, rgba(12, 17, 42, 0.98));
 }
 
 .landing .truth-problem-section {
   display: grid;
   justify-items: center;
-  gap: clamp(16px, 2vw, 28px);
+  gap: clamp(14px, 1.6vw, 24px);
 }
 
 .landing .truth-problem-kicker {
-  margin: 0 auto 10px;
+  margin: 0 auto 8px;
   font-size: 0.72rem;
   font-weight: 700;
   line-height: 1;
@@ -598,174 +598,36 @@
 }
 
 .landing .truth-problem-title--outside {
-  max-width: 11ch;
+  max-width: 12ch;
   margin-bottom: 0;
-  font-size: clamp(2.25rem, 2.5vw + 1.2rem, 4.35rem);
-  line-height: 1.02;
+  font-size: clamp(2.1rem, 1.95vw + 1.3rem, 3.05rem);
+  line-height: 1.06;
   position: relative;
   z-index: 3;
 }
 
-.landing .problem-visual-stage {
-  position: relative;
-  width: clamp(1100px, 88vw, 1360px);
-  height: clamp(350px, 38vw, 510px);
-  margin: clamp(-40px, -4vw, -12px) auto clamp(0px, 0.4vw, 12px);
-  transform: rotate(-5deg);
-  pointer-events: none;
-  z-index: 1;
-  -webkit-mask-image: radial-gradient(ellipse 80% 74% at 52% 56%, #000 56%, rgba(0, 0, 0, 0.82) 72%, transparent 100%);
-  mask-image: radial-gradient(ellipse 80% 74% at 52% 56%, #000 56%, rgba(0, 0, 0, 0.82) 72%, transparent 100%);
-}
-
-.landing .problem-grid {
-  position: absolute;
-  left: 3.2%;
-  bottom: 8%;
-  width: clamp(260px, 27vw, 420px);
-  aspect-ratio: 1.18 / 1;
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: clamp(4px, 0.5vw, 7px);
-  padding: clamp(12px, 1.3vw, 16px);
-  border-radius: 14px;
-  border: 1px solid rgba(129, 171, 255, 0.22);
-  background:
-    linear-gradient(160deg, rgba(17, 28, 58, 0.7), rgba(9, 15, 40, 0.34)),
-    radial-gradient(circle at 18% 15%, rgba(102, 159, 255, 0.18), transparent 54%);
-  box-shadow: inset 0 1px 0 rgba(211, 232, 255, 0.12), 0 28px 36px rgba(3, 8, 22, 0.36);
-  transform: perspective(700px) rotateY(13deg) rotateX(4deg) skew(-2deg, -3deg);
-  transform-origin: left center;
+.landing .problem-flow-visual {
+  width: min(100%, 920px);
+  margin: clamp(2px, 0.45vw, 10px) auto 0;
+  border-radius: 20px;
   overflow: hidden;
+  border: 1px solid rgba(138, 177, 243, 0.26);
+  background: rgba(10, 17, 42, 0.72);
+  box-shadow: 0 22px 40px rgba(4, 8, 20, 0.34);
 }
 
-.landing .problem-grid::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, rgba(114, 166, 255, 0.18), transparent 42%, rgba(255, 168, 148, 0.14) 92%);
-  mix-blend-mode: screen;
-  opacity: 0.66;
-}
-
-.landing .problem-grid-cell {
-  display: grid;
-  place-items: center;
-  border: 1px solid rgba(142, 186, 255, 0.2);
-  border-radius: 4px;
-  color: rgba(177, 228, 243, 0.5);
-  font-size: clamp(0.55rem, 0.38vw, 0.7rem);
-  line-height: 1;
-  background: rgba(15, 26, 52, 0.36);
-}
-
-.landing .problem-flow-svg {
-  position: absolute;
-  inset: 0;
+.landing .problem-flow-visual img {
+  display: block;
   width: 100%;
-  height: 100%;
-}
-
-.landing .problem-flow-svg .flow-band {
-  fill: none;
-  stroke-linecap: round;
-  mix-blend-mode: screen;
-}
-
-.landing .problem-flow-svg .band-1 {
-  stroke-width: 56;
-  opacity: 0.72;
-}
-
-.landing .problem-flow-svg .band-2 {
-  stroke-width: 34;
-  opacity: 0.62;
-}
-
-.landing .problem-flow-svg .band-3 {
-  stroke-width: 22;
-  opacity: 0.54;
-}
-
-.landing .problem-flow {
-  position: absolute;
-  inset: 0;
-}
-
-.landing .problem-flow .flow-band {
-  position: absolute;
-  left: 10%;
-  right: 2%;
-  border-radius: 999px;
-  mix-blend-mode: screen;
-  filter: blur(0.2px);
-}
-
-.landing .problem-flow .band-1 {
-  top: 46%;
-  height: clamp(34px, 3.1vw, 46px);
-  transform: translateY(-50%) rotate(-18deg);
-  background: linear-gradient(90deg, rgba(125, 182, 255, 0.1), rgba(135, 216, 239, 0.36), rgba(176, 147, 255, 0.24));
-}
-
-.landing .problem-flow .band-2 {
-  top: 54%;
-  height: clamp(22px, 2.2vw, 32px);
-  transform: translateY(-50%) rotate(-18deg);
-  background: linear-gradient(90deg, rgba(116, 171, 255, 0.06), rgba(146, 205, 255, 0.28), rgba(255, 180, 163, 0.22));
-}
-
-.landing .problem-flow .band-3 {
-  top: 40%;
-  height: clamp(18px, 1.9vw, 28px);
-  transform: translateY(-50%) rotate(-18deg);
-  background: linear-gradient(90deg, rgba(88, 139, 228, 0.06), rgba(128, 188, 255, 0.23), rgba(165, 136, 243, 0.2));
-}
-
-.landing .problem-flow .band-4 {
-  top: 61%;
-  height: clamp(10px, 1.1vw, 16px);
-  transform: translateY(-50%) rotate(-18deg);
-  background: linear-gradient(90deg, rgba(107, 167, 255, 0), rgba(140, 198, 255, 0.21), rgba(255, 176, 151, 0.12));
-}
-
-.landing .problem-flow .flow-glow {
-  position: absolute;
-  border-radius: 999px;
-  mix-blend-mode: screen;
-  filter: blur(34px);
-}
-
-.landing .problem-flow .glow-1 {
-  left: 36%;
-  bottom: 16%;
-  width: clamp(300px, 38vw, 530px);
-  height: clamp(118px, 13vw, 190px);
-  background: radial-gradient(ellipse at center, rgba(141, 207, 255, 0.38), rgba(120, 162, 255, 0.08) 62%, transparent 100%);
-}
-
-.landing .problem-flow .glow-2 {
-  left: 56%;
-  bottom: 28%;
-  width: clamp(250px, 30vw, 460px);
-  height: clamp(110px, 12vw, 180px);
-  background: radial-gradient(ellipse at center, rgba(176, 142, 255, 0.32), rgba(126, 108, 241, 0.06) 64%, transparent 100%);
-}
-
-.landing .problem-flow .glow-3 {
-  right: 0;
-  top: 6%;
-  width: clamp(220px, 24vw, 360px);
-  height: clamp(90px, 9vw, 130px);
-  background: radial-gradient(ellipse at center, rgba(255, 187, 164, 0.3), rgba(255, 173, 144, 0.08) 68%, transparent 100%);
+  height: auto;
 }
 
 .landing .truth-problem-body {
-  width: min(1040px, 100%);
-  margin: clamp(6px, 1.1vw, 16px) auto 0;
+  width: min(900px, 100%);
+  margin: clamp(8px, 1vw, 14px) auto 0;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
-  gap: clamp(16px, 2vw, 30px);
+  gap: clamp(14px, 1.7vw, 24px);
   align-items: stretch;
   position: relative;
   z-index: 4;
@@ -774,25 +636,25 @@
 .landing .truth-problem-block {
   margin: 0;
   color: color-mix(in srgb, var(--ink) 90%, #e6dcff 10%);
-  font-size: clamp(1rem, 0.24vw + 0.94rem, 1.14rem);
-  line-height: 1.58;
+  font-size: clamp(0.98rem, 0.22vw + 0.92rem, 1.08rem);
+  line-height: 1.52;
   text-align: left;
   text-wrap: pretty;
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 12px;
+  gap: 10px;
 }
 
 .landing .truth-problem-icon {
-  width: 28px;
-  height: 28px;
+  width: 26px;
+  height: 26px;
   border-radius: 999px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.9rem;
+  font-size: 0.86rem;
   font-weight: 700;
-  margin-top: 2px;
+  margin-top: 1px;
 }
 
 .landing .truth-problem-icon--x {
@@ -809,27 +671,17 @@
 
 .landing .truth-problem-divider {
   width: 1px;
-  background: linear-gradient(180deg, transparent 0%, rgba(160, 190, 242, 0.6) 26%, rgba(151, 197, 255, 0.36) 74%, transparent 100%);
+  background: linear-gradient(180deg, transparent 0%, rgba(160, 190, 242, 0.56) 24%, rgba(151, 197, 255, 0.34) 74%, transparent 100%);
 }
 
 @media (max-width: 840px) {
   .landing .truth-problem-title--outside {
     max-width: 10ch;
-    font-size: clamp(2rem, 7.6vw, 3.05rem);
+    font-size: clamp(1.95rem, 7.2vw, 2.8rem);
   }
 
-  .landing .problem-visual-stage {
-    width: min(1380px, 196vw);
-    height: clamp(300px, 76vw, 430px);
-    margin-left: -52vw;
-    margin-right: -52vw;
-    transform: rotate(-7deg);
-  }
-
-  .landing .problem-grid {
-    left: 6%;
-    bottom: 5%;
-    width: clamp(220px, 46vw, 300px);
+  .landing .problem-flow-visual {
+    border-radius: 16px;
   }
 
   .landing .truth-problem-body {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -846,67 +846,8 @@ export default function LandingPage() {
               {copy.problem.title}
             </AdaptiveText>
 
-            <div className="problem-visual-stage" aria-hidden>
-              <div className="problem-grid">
-                {Array.from({ length: 36 }).map((_, index) => (
-                  <span
-                    key={`problem-grid-cell-${index}`}
-                    className="problem-grid-cell"
-                  >
-                    {index % 5 === 0 || index % 7 === 0 ? "✓" : ""}
-                  </span>
-                ))}
-              </div>
-
-              <svg
-                className="problem-flow problem-flow-svg"
-                viewBox="0 0 1440 560"
-                role="presentation"
-                focusable="false"
-              >
-                <defs>
-                  <linearGradient id="problem-flow-band-1" x1="0%" y1="90%" x2="100%" y2="14%">
-                    <stop offset="0%" stopColor="rgba(114, 170, 255, 0.06)" />
-                    <stop offset="45%" stopColor="rgba(139, 198, 255, 0.32)" />
-                    <stop offset="100%" stopColor="rgba(189, 150, 255, 0.26)" />
-                  </linearGradient>
-                  <linearGradient id="problem-flow-band-2" x1="2%" y1="85%" x2="100%" y2="10%">
-                    <stop offset="0%" stopColor="rgba(118, 164, 255, 0.04)" />
-                    <stop offset="52%" stopColor="rgba(153, 206, 255, 0.28)" />
-                    <stop offset="100%" stopColor="rgba(255, 179, 160, 0.24)" />
-                  </linearGradient>
-                  <linearGradient id="problem-flow-band-3" x1="0%" y1="88%" x2="98%" y2="4%">
-                    <stop offset="0%" stopColor="rgba(102, 145, 240, 0.03)" />
-                    <stop offset="54%" stopColor="rgba(134, 178, 255, 0.22)" />
-                    <stop offset="100%" stopColor="rgba(178, 132, 255, 0.2)" />
-                  </linearGradient>
-                </defs>
-                <path
-                  className="flow-band band-1"
-                  d="M 120 486 C 312 450, 456 328, 632 300 C 796 274, 882 192, 1012 170 C 1128 148, 1242 70, 1368 42"
-                  stroke="url(#problem-flow-band-1)"
-                />
-                <path
-                  className="flow-band band-2"
-                  d="M 138 520 C 320 474, 462 352, 664 334 C 842 318, 938 236, 1064 210 C 1176 188, 1274 124, 1402 92"
-                  stroke="url(#problem-flow-band-2)"
-                />
-                <path
-                  className="flow-band band-3"
-                  d="M 92 454 C 262 420, 412 298, 598 260 C 758 228, 858 164, 996 132 C 1118 104, 1236 48, 1366 22"
-                  stroke="url(#problem-flow-band-3)"
-                />
-              </svg>
-
-              <div className="problem-flow">
-                <span className="flow-band band-1" />
-                <span className="flow-band band-2" />
-                <span className="flow-band band-3" />
-                <span className="flow-band band-4" />
-                <span className="flow-glow glow-1" />
-                <span className="flow-glow glow-2" />
-                <span className="flow-glow glow-3" />
-              </div>
+            <div className="problem-flow-visual" aria-hidden>
+              <img src="/problem-adaptive-flow.png" alt="" loading="lazy" />
             </div>
 
             <div className="truth-problem-body">


### PR DESCRIPTION
### Motivation
- Revert the oversized CSS-driven visual in the landing "truth-problem" section to the previously saved public asset to match the issue direction to stop the current CSS-built visual. 
- Restore the longer X/✓ two-column copy blocks so the section reads closer to the original ChatGPT reference. 
- Tighten spacing and scale in the section so it’s closer to the original reference rather than the oversized composition.

### Description
- Replaced the CSS-composed visual markup in `apps/web/src/pages/Landing.tsx` with a simple asset wrapper that renders the existing public image `"/problem-adaptive-flow.png"`.
- Simplified and resized the landing problem CSS in `apps/web/src/pages/Landing.css` (spacing, max widths, font sizing and a new `.problem-flow-visual` wrapper) and removed the large CSS-only visual pieces. 
- Restored long-form left/right problem copy using explicit X (✕) and check (✓) lines in both Spanish and English in `apps/web/src/content/officialLandingContent.ts`.
- Minor typographic and layout tweaks to keep the section tighter and framed around the integrated asset instead of the previous large animated composition.

### Testing
- Ran the workspace typecheck with `npm --workspace apps/web run typecheck`, which failed due to existing repository-wide TypeScript issues unrelated to the landing section changes. 
- The `git diff` for the three edited files was inspected before committing and the changes were committed to the branch (commit message: "Restore problem section image visual and long x/check copy").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc2cd0ebc8332abcc6a8fa5c009a8)