### PR TITLE
Ajuste del wordmark INNERBLOOM en el splash del HeroPhoneShowcase

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -273,7 +273,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: clamp(5px, 1vw, 7px);
+  gap: clamp(4px, 0.85vw, 6px);
   padding-inline: clamp(4px, 1.8vw, 10px);
   box-sizing: border-box;
   transform-origin: center center;
@@ -310,9 +310,9 @@
   max-width: calc(100% - clamp(62px, 20vw, 76px));
   overflow: hidden;
   white-space: nowrap;
-  font-size: clamp(0.825rem, 1.275vw, 1.05rem);
+  font-size: clamp(0.95rem, 1.47vw, 1.21rem);
   font-weight: 700;
-  letter-spacing: 0.11em;
+  letter-spacing: 0.32em;
   text-transform: uppercase;
   color: rgba(244, 239, 255, 0.96);
   text-shadow:


### PR DESCRIPTION
### Motivation
- Alinear el wordmark `INNERBLOOM` del splash dentro del celular con el estilo real de la barra principal (tamaño y tracking) manteniendo el lockup compacto dentro del frame sin tocar el header ni la animación.

### Description
- Archivo modificado: `apps/web/src/components/landing/HeroPhoneShowcase.module.css`.
- En `.loopSplashWordmark` ajusté `font-size` de `clamp(0.825rem, 1.275vw, 1.05rem)` a `clamp(0.95rem, 1.47vw, 1.21rem)` (≈ +15%).
- En `.loopSplashWordmark` actualicé `letter-spacing` de `0.11em` a `0.32em` para replicar el tracking usado en el header oficial.
- En `.loopSplashLockup` reduje levemente el `gap` de `clamp(5px, 1vw, 7px)` a `clamp(4px, 0.85vw, 6px)` para mantener la composición compacta con la flor y que todo siga entrando en el celular.
- No se modificaron el header real, H1, CTAs, backend, ni las animaciones/timing del splash; la flor solo sufrió un ajuste de gap para conservar el lockup.

### Testing
- Ejecuté el linter del workspace con `pnpm -w run lint` y finalizó correctamente.
- Intenté `pnpm -C apps/web run lint` que falló porque `apps/web` no define un script `lint`, por eso usé el comando de workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc525c2508332a44c6625e39bc2ad)