### PR TITLE
refactor(web): simplify “The Real Problem” section by removing visual block

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -565,10 +565,7 @@
   position: relative;
   overflow: hidden;
   padding: clamp(68px, 7.6vw, 98px) 0 clamp(56px, 6.4vw, 84px);
-  background:
-    radial-gradient(circle at 16% 72%, rgba(26, 52, 118, 0.36), transparent 54%),
-    radial-gradient(circle at 88% 14%, rgba(70, 40, 140, 0.28), transparent 56%),
-    linear-gradient(166deg, rgba(8, 12, 34, 0.96), rgba(10, 16, 45, 0.98) 42%, rgba(12, 17, 42, 0.98));
+  background: linear-gradient(166deg, rgba(8, 12, 34, 0.96), rgba(10, 16, 45, 0.98) 42%, rgba(12, 17, 42, 0.98));
 }
 
 .landing .truth-problem-section {
@@ -602,35 +599,15 @@
   margin-bottom: 0;
   font-size: clamp(2.1rem, 1.95vw + 1.3rem, 3.05rem);
   line-height: 1.06;
-  position: relative;
-  z-index: 3;
-}
-
-.landing .problem-flow-visual {
-  width: min(100%, 920px);
-  margin: clamp(2px, 0.45vw, 10px) auto 0;
-  border-radius: 20px;
-  overflow: hidden;
-  border: 1px solid rgba(138, 177, 243, 0.26);
-  background: rgba(10, 17, 42, 0.72);
-  box-shadow: 0 22px 40px rgba(4, 8, 20, 0.34);
-}
-
-.landing .problem-flow-visual img {
-  display: block;
-  width: 100%;
-  height: auto;
 }
 
 .landing .truth-problem-body {
   width: min(900px, 100%);
-  margin: clamp(8px, 1vw, 14px) auto 0;
+  margin: clamp(12px, 1.5vw, 22px) auto 0;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   gap: clamp(14px, 1.7vw, 24px);
   align-items: stretch;
-  position: relative;
-  z-index: 4;
 }
 
 .landing .truth-problem-block {
@@ -678,10 +655,6 @@
   .landing .truth-problem-title--outside {
     max-width: 10ch;
     font-size: clamp(1.95rem, 7.2vw, 2.8rem);
-  }
-
-  .landing .problem-flow-visual {
-    border-radius: 16px;
   }
 
   .landing .truth-problem-body {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -846,10 +846,6 @@ export default function LandingPage() {
               {copy.problem.title}
             </AdaptiveText>
 
-            <div className="problem-flow-visual" aria-hidden>
-              <img src="/problem-adaptive-flow.png" alt="" loading="lazy" />
-            </div>
-
             <div className="truth-problem-body">
               <AdaptiveText as="p" className="truth-problem-block truth-problem-block--left">
                 <span className="truth-problem-icon truth-problem-icon--x" aria-hidden>


### PR DESCRIPTION
### Motivation
- The large decorative visual in the landing "THE REAL PROBLEM / You’re not the problem." section made the layout feel visually heavy and the section should be a cleaner, text-first comparison.
- Preserve the eyebrow, title and comparison bullets while removing the image/container and decorative background that created the unwanted visual weight.

### Description
- Removed the JSX block rendering the decorative image container (`div.problem-flow-visual` with `/problem-adaptive-flow.png`) from `apps/web/src/pages/Landing.tsx` so the section now contains only the eyebrow, title, and comparison body.
- Removed CSS rules for the visual block and image and simplified the section background by deleting the radial decorative gradients in `apps/web/src/pages/Landing.css` and adjusted `.truth-problem-body` margins to maintain spacing.
- Kept all copy, bullets, hero, phone showcase, CTAs and backend untouched as requested.
- Files modified: `apps/web/src/pages/Landing.tsx` and `apps/web/src/pages/Landing.css`.

### Testing
- Ran `npm run typecheck:web` which failed due to pre-existing TypeScript errors elsewhere in the codebase and not related to this UI change (typecheck failed).
- No other automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eccf6fcd908332ae4a27a0864f0a5b)