### PR TITLE
style: soften landing .truth-problem background

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -565,7 +565,7 @@
   position: relative;
   overflow: hidden;
   padding: clamp(68px, 7.6vw, 98px) 0 clamp(56px, 6.4vw, 84px);
-  background: linear-gradient(166deg, rgba(8, 12, 34, 0.96), rgba(10, 16, 45, 0.98) 42%, rgba(12, 17, 42, 0.98));
+  background: linear-gradient(164deg, rgba(27, 33, 72, 0.9) 0%, rgba(42, 35, 88, 0.9) 46%, rgba(34, 28, 82, 0.9) 100%);
 }
 
 .landing .truth-problem-section {


### PR DESCRIPTION
### Motivation
- Replace the nearly-black, isolated background on the landing page's truth-problem section so it blends smoothly with the surrounding purple/navy areas while leaving copy and layout untouched.

### Description
- Updated the background gradient for `.landing .truth-problem` in `apps/web/src/pages/Landing.css` to a softer navy/violet linear gradient and did not modify copy, JSX, or any other sections.

### Testing
- Verified the change with `git diff -- apps/web/src/pages/Landing.css` and committed the update with `git commit -m "style: soften truth problem section background"`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd56e22a48332993187b104492b3b)