### PR TITLE
Remove custom background from truth-problem landing section

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -565,7 +565,6 @@
   position: relative;
   overflow: hidden;
   padding: clamp(68px, 7.6vw, 98px) 0 clamp(56px, 6.4vw, 84px);
-  background: linear-gradient(164deg, rgba(27, 33, 72, 0.9) 0%, rgba(42, 35, 88, 0.9) 46%, rgba(34, 28, 82, 0.9) 100%);
 }
 
 .landing .truth-problem-section {


### PR DESCRIPTION
### Motivation
- The “You’re not the problem” section used a custom dark gradient which made it read as a separate dark rectangle instead of inheriting the landing background continuity requested in issue #2052.

### Description
- Removed the `background` declaration from `.landing .truth-problem` in `apps/web/src/pages/Landing.css` while preserving `position`, `overflow`, `padding`, existing copy, JSX, and the X/check layout.

### Testing
- Verified the change by inspecting the CSS diff to confirm only the `background` property was removed and confirmed no other files, JSX, or layout rules were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecda350b988332a1a3a9f135a6a3dd)