### PR TITLE
feat(web): reactivate and upgrade landing background selector

### DIFF
--- a/apps/web/src/config/releaseFlags.ts
+++ b/apps/web/src/config/releaseFlags.ts
@@ -2,5 +2,8 @@ export const SHOW_BILLING_UI = import.meta.env.VITE_SHOW_BILLING_UI === 'true';
 
 export const SHOW_LANDING_PRICING = import.meta.env.VITE_SHOW_LANDING_PRICING === 'true';
 
+export const SHOW_LANDING_BACKGROUND_SELECTOR =
+  import.meta.env.VITE_SHOW_LANDING_BACKGROUND_SELECTOR !== 'false';
+
 export const SHOW_NATIVE_TEST_NOTIFICATION =
   Boolean(import.meta.env.DEV) && import.meta.env.VITE_SHOW_NATIVE_TEST_NOTIFICATION !== 'false';

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -89,10 +89,13 @@
   overflow-x: hidden;
   font-family: var(--font-body);
   color: var(--ink);
-  background: linear-gradient(
-    var(--bg-angle, 135deg),
-    var(--bg-a, #525252),
-    var(--bg-b, #3d72b4)
+  background: var(
+    --landing-background,
+    linear-gradient(
+      var(--bg-angle, 135deg),
+      var(--bg-a, #525252),
+      var(--bg-b, #3d72b4)
+    )
   );
 }
 
@@ -253,25 +256,70 @@
 .landing .gradient-select-wrapper {
   display: inline-flex;
   align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid rgba(186, 212, 255, 0.28);
+  border-radius: 14px;
+  background: rgba(12, 16, 28, 0.62);
+  backdrop-filter: blur(8px);
+}
+
+.landing .gradient-select-label {
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(224, 237, 255, 0.9);
 }
 
 .landing .gradient-select {
-  border: 1px solid rgba(186, 212, 255, 0.36);
-  border-radius: 12px;
-  background: rgba(11, 18, 32, 0.82);
+  border: 1px solid rgba(186, 212, 255, 0.28);
+  border-radius: 10px;
+  background: rgba(11, 18, 32, 0.88);
   color: #eaf1ff;
   font-family: var(--font-body);
-  font-size: 0.74rem;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.02em;
-  padding: 7px 10px;
-  min-width: 130px;
+  padding: 6px 8px;
+  min-width: 122px;
   cursor: pointer;
 }
 
 .landing .gradient-select:focus-visible {
   outline: 2px solid rgba(125, 211, 252, 0.7);
   outline-offset: 2px;
+}
+
+.landing[data-background-tone="light"] {
+  --ink: #151326;
+  --muted: rgba(39, 35, 62, 0.72);
+  --line: rgba(78, 61, 130, 0.18);
+}
+
+.landing[data-background-tone="light"] .nav {
+  background: rgba(255, 255, 255, 0.72);
+  border-bottom-color: rgba(78, 61, 130, 0.16);
+}
+
+.landing[data-background-tone="light"] .brand,
+.landing[data-background-tone="light"] .nav-links a {
+  color: #151326;
+}
+
+.landing[data-background-tone="light"] .gradient-select-wrapper {
+  background: rgba(255, 255, 255, 0.76);
+  border-color: rgba(78, 61, 130, 0.2);
+}
+
+.landing[data-background-tone="light"] .gradient-select-label {
+  color: rgba(39, 35, 62, 0.78);
+}
+
+.landing[data-background-tone="light"] .gradient-select {
+  color: #151326;
+  background: rgba(255, 255, 255, 0.82);
+  border-color: rgba(78, 61, 130, 0.26);
 }
 
 .landing .lang-toggle {
@@ -2757,6 +2805,11 @@
     min-width: 102px;
     font-size: 0.6rem;
     padding: 5px 8px;
+  }
+
+  .landing .gradient-select-label {
+    font-size: 0.56rem;
+    letter-spacing: 0.08em;
   }
 
   .landing .lang-button {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -34,15 +34,22 @@ import {
   persistCookieConsentState,
   readCookieConsentState,
 } from "../lib/cookieConsent";
-import { SHOW_LANDING_PRICING } from "../config/releaseFlags";
+import {
+  SHOW_LANDING_BACKGROUND_SELECTOR,
+  SHOW_LANDING_PRICING,
+} from "../config/releaseFlags";
 import "./Landing.css";
 
-type LandingGradientOption = {
+type LandingBackgroundOption = {
   id: string;
   label: { es: string; en: string };
-  angle: string;
-  a: string;
-  b: string;
+  tone: "light" | "dark";
+  type: "linear" | "solid" | "css";
+  cssBackground?: string;
+  color?: string;
+  angle?: string;
+  a?: string;
+  b?: string;
 };
 
 const GRADIENT_LABELS: Record<string, { es: string; en: string }> = {
@@ -58,29 +65,103 @@ const GRADIENT_LABELS: Record<string, { es: string; en: string }> = {
   purple_afternoon: { es: "Purple Afternoon", en: "Purple Afternoon" },
 };
 
-const LANDING_GRADIENTS: LandingGradientOption[] =
-  OFFICIAL_DESIGN_TOKENS.gradients
-    .filter(
-      (gradient) => gradient.type === "linear" && gradient.stops.length >= 2,
-    )
-    .map((gradient) => {
-      const label = GRADIENT_LABELS[gradient.name] ?? {
-        es: gradient.name.replace(/_/g, " "),
-        en: gradient.name.replace(/_/g, " "),
-      };
+const LANDING_BASE_GRADIENTS: LandingBackgroundOption[] = OFFICIAL_DESIGN_TOKENS
+  .gradients
+  .filter((gradient) => gradient.type === "linear" && gradient.stops.length >= 2)
+  .map((gradient) => {
+    const label = GRADIENT_LABELS[gradient.name] ?? {
+      es: gradient.name.replace(/_/g, " "),
+      en: gradient.name.replace(/_/g, " "),
+    };
 
-      return {
-        id: gradient.name,
-        label,
-        angle: gradient.angle,
-        a: gradient.stops[0],
-        b: gradient.stops[1],
-      };
-    });
+    return {
+      id: gradient.name,
+      label,
+      tone: "dark",
+      type: "linear",
+      angle: gradient.angle,
+      a: gradient.stops[0],
+      b: gradient.stops[1],
+    };
+  });
+
+const LANDING_PREMIUM_BACKGROUNDS: LandingBackgroundOption[] = [
+  {
+    id: "lab_showcase_dark",
+    label: { es: "Lab Showcase Dark", en: "Lab Showcase Dark" },
+    tone: "dark",
+    type: "css",
+    cssBackground:
+      "radial-gradient(circle at 80% 10%, rgba(153, 111, 244, 0.2), transparent 37%), radial-gradient(circle at 17% 13%, rgba(117, 142, 252, 0.16), transparent 33%), radial-gradient(circle at 52% 82%, rgba(253, 173, 124, 0.08), transparent 52%), linear-gradient(180deg, #0f0f19 0%, #0a0a12 100%)",
+  },
+  {
+    id: "true_black",
+    label: { es: "True Black", en: "True Black" },
+    tone: "dark",
+    type: "solid",
+    color: "#030306",
+  },
+  {
+    id: "innerbloom_black_violet",
+    label: { es: "Innerbloom Black Violet", en: "Innerbloom Black Violet" },
+    tone: "dark",
+    type: "solid",
+    color: "#080610",
+  },
+  {
+    id: "deep_navy_premium",
+    label: { es: "Deep Navy Premium", en: "Deep Navy Premium" },
+    tone: "dark",
+    type: "solid",
+    color: "#0B1220",
+  },
+  {
+    id: "soft_white_premium",
+    label: { es: "Soft White Premium", en: "Soft White Premium" },
+    tone: "light",
+    type: "solid",
+    color: "#F7F4FF",
+  },
+  {
+    id: "warm_ivory_premium",
+    label: { es: "Warm Ivory Premium", en: "Warm Ivory Premium" },
+    tone: "light",
+    type: "solid",
+    color: "#FBF6EF",
+  },
+  {
+    id: "violet_mist",
+    label: { es: "Violet Mist", en: "Violet Mist" },
+    tone: "dark",
+    type: "solid",
+    color: "#171126",
+  },
+  {
+    id: "nebulum_violet_dark",
+    label: { es: "Nebulum Violet Dark", en: "Nebulum Violet Dark" },
+    tone: "dark",
+    type: "css",
+    cssBackground:
+      "radial-gradient(circle at 72% 18%, rgba(143, 91, 255, 0.24), transparent 38%), radial-gradient(circle at 24% 78%, rgba(72, 190, 255, 0.14), transparent 42%), linear-gradient(180deg, #0A0714 0%, #05050B 100%)",
+  },
+  {
+    id: "premium_white_violet",
+    label: { es: "Premium White Violet", en: "Premium White Violet" },
+    tone: "light",
+    type: "css",
+    cssBackground:
+      "radial-gradient(circle at 75% 12%, rgba(139, 92, 246, 0.16), transparent 36%), radial-gradient(circle at 18% 82%, rgba(56, 189, 248, 0.10), transparent 42%), linear-gradient(180deg, #FBFAFF 0%, #F3EEFF 100%)",
+  },
+];
+
+const LANDING_BACKGROUNDS: LandingBackgroundOption[] = [
+  ...LANDING_BASE_GRADIENTS,
+  ...LANDING_PREMIUM_BACKGROUNDS,
+];
 
 const LANDING_GRADIENT_STORAGE_KEY = "ib:official-landing-gradient";
 const OFFICIAL_DEFAULT_GRADIENT_ID = "purple_afternoon";
-const SHOW_GRADIENT_SELECTOR = false;
+const SHOW_BACKGROUND_SELECTOR = SHOW_LANDING_BACKGROUND_SELECTOR;
 
 type ModeVisual = {
   avatarVideo: string;
@@ -431,23 +512,23 @@ export default function LandingPage() {
       ? resolveAuthLanguage(window.location.search)
       : "es",
   );
-  const [gradientId, setGradientId] = useState<string>(() => {
-    const fallbackGradientId = LANDING_GRADIENTS[0]?.id ?? "";
-    const officialGradient = LANDING_GRADIENTS.find(
+  const [backgroundId, setBackgroundId] = useState<string>(() => {
+    const fallbackGradientId = LANDING_BACKGROUNDS[0]?.id ?? "";
+    const officialGradient = LANDING_BACKGROUNDS.find(
       (option) => option.id === OFFICIAL_DEFAULT_GRADIENT_ID,
     );
     const officialGradientId = officialGradient?.id ?? fallbackGradientId;
 
     if (typeof window === "undefined") return officialGradientId;
 
-    if (!SHOW_GRADIENT_SELECTOR) {
+    if (!SHOW_BACKGROUND_SELECTOR) {
       return officialGradientId;
     }
 
     const storedGradientId = window.localStorage.getItem(
       LANDING_GRADIENT_STORAGE_KEY,
     );
-    const storedGradient = LANDING_GRADIENTS.find(
+    const storedGradient = LANDING_BACKGROUNDS.find(
       (option) => option.id === storedGradientId,
     );
     return storedGradient?.id ?? officialGradientId;
@@ -456,14 +537,21 @@ export default function LandingPage() {
   const visibleNavLinks = copy.navLinks.filter(
     (link) => !/^\/demo$/i.test(link.href) && !/^#?demo$/i.test(link.href),
   );
-  const selectedGradient =
-    LANDING_GRADIENTS.find((option) => option.id === gradientId) ??
-    LANDING_GRADIENTS[0];
+  const selectedBackground =
+    LANDING_BACKGROUNDS.find((option) => option.id === backgroundId) ??
+    LANDING_BACKGROUNDS[0];
+  const resolvedLandingBackground =
+    selectedBackground?.type === "css" && selectedBackground.cssBackground
+      ? selectedBackground.cssBackground
+      : selectedBackground?.type === "solid" && selectedBackground.color
+        ? selectedBackground.color
+        : `linear-gradient(${selectedBackground?.angle ?? "135deg"}, ${selectedBackground?.a ?? "#525252"}, ${selectedBackground?.b ?? "#3d72b4"})`;
   const landingStyle = {
     ...(OFFICIAL_LANDING_CSS_VARIABLES as CSSProperties),
-    "--bg-angle": selectedGradient.angle,
-    "--bg-a": selectedGradient.a,
-    "--bg-b": selectedGradient.b,
+    "--bg-angle": selectedBackground?.angle ?? "135deg",
+    "--bg-a": selectedBackground?.a ?? "#525252",
+    "--bg-b": selectedBackground?.b ?? "#3d72b4",
+    "--landing-background": resolvedLandingBackground,
   } as CSSProperties;
   const [activeSlide, setActiveSlide] = useState(0);
   const [paused, setPaused] = useState(false);
@@ -492,8 +580,8 @@ export default function LandingPage() {
   }, []);
 
   useEffect(() => {
-    window.localStorage.setItem(LANDING_GRADIENT_STORAGE_KEY, gradientId);
-  }, [gradientId]);
+    window.localStorage.setItem(LANDING_GRADIENT_STORAGE_KEY, backgroundId);
+  }, [backgroundId]);
 
   useEffect(() => {
     const resolvedLanguage = resolveAuthLanguage(location.search);
@@ -697,7 +785,11 @@ export default function LandingPage() {
   };
 
   return (
-    <div className="landing" style={landingStyle}>
+    <div
+      className="landing"
+      style={landingStyle}
+      data-background-tone={selectedBackground?.tone ?? "dark"}
+    >
       <header className="nav">
         <Link
           className="brand"
@@ -725,22 +817,22 @@ export default function LandingPage() {
           </nav>
         ) : null}
         <div className="nav-actions">
-          {SHOW_GRADIENT_SELECTOR ? (
+          {SHOW_BACKGROUND_SELECTOR ? (
             <label className="gradient-select-wrapper">
-              <span className="visually-hidden">
-                {language === "es" ? "Seleccionar fondo" : "Select background"}
+              <span className="gradient-select-label">
+                {language === "es" ? "BG" : "BG"}
               </span>
               <select
                 className="gradient-select"
-                value={gradientId}
-                onChange={(event) => setGradientId(event.target.value)}
+                value={backgroundId}
+                onChange={(event) => setBackgroundId(event.target.value)}
                 aria-label={
                   language === "es"
                     ? "Selector de fondo"
                     : "Background selector"
                 }
               >
-                {LANDING_GRADIENTS.map((option) => (
+                {LANDING_BACKGROUNDS.map((option) => (
                   <option key={option.id} value={option.id}>
                     {option.label[language]}
                   </option>


### PR DESCRIPTION
### Motivation
- Reactivar el selector existente de la landing para poder probar variantes visuales premium sin crear un sistema nuevo desde cero.
- Soportar presets más ricos (solids, gradientes multi-capa y CSS completo) y poder probar fondos premium manteniendo compatibilidad con la UX actual y la persistencia.
- Hacer visible el control para pruebas y aportar un mínimo de ajuste para fondos claros (contraste) sin reescribir light mode.

### Description
- Añadido flag de entorno `VITE_SHOW_LANDING_BACKGROUND_SELECTOR` expuesto como `SHOW_LANDING_BACKGROUND_SELECTOR` en `apps/web/src/config/releaseFlags.ts` y usado para mostrar el selector (activo por defecto salvo `false`).
- Reemplazado el modelo de `gradient` por `background` en `apps/web/src/pages/Landing.tsx` con el tipo `LandingBackgroundOption` que soporta `type: "linear" | "solid" | "css"`, `tone`, `cssBackground`, `color`, `angle`, `a`, `b` y conserva los gradientes oficiales desde `OFFICIAL_DESIGN_TOKENS`.
- Agregados presets premium manuales (mínimo solicitados), incluyendo `lab_showcase_dark` que replica el CSS del hero (`HeroPhoneShowcaseLabPage.module.css`), `true_black`, `innerbloom_black_violet`, `deep_navy_premium`, `soft_white_premium`, `warm_ivory_premium`, `violet_mist`, `nebulum_violet_dark`, `premium_white_violet`.
- Manteniendo compatibilidad: la key de persistencia sigue siendo `ib:official-landing-gradient` y el `OFFICIAL_DEFAULT_GRADIENT_ID` sigue siendo `purple_afternoon`.
- Construcción del estilo: se introduce la variable `--landing-background` en `landingStyle` (resuelta según `type`), y se mantienen las variables legacy `--bg-angle/--bg-a/--bg-b` como fallback.
- CSS actualizado en `apps/web/src/pages/Landing.css` para usar `background: var(--landing-background, linear-gradient(...))`, se añadieron estilos para hacer más visible el selector en la nav (`.gradient-select-wrapper`, label `BG`), ajustes responsive y estilos mínimos para `data-background-tone="light"` (variables `--ink`, `--muted`, `--line` y ajustes en `.nav`/brand/nav-links).

### Testing
- Ejecutado `npm run typecheck` (proyecto raíz): falló por errores TypeScript preexistentes en otras partes del repo no relacionados con este cambio; los errores son externos a los archivos modificados y provienen de `src/*` en el workspace (por ejemplo `runtimeAuth.tsx`, tests y tipos en `dashboard-v3` y `lib`).
- Ejecutado `npm run lint`: la ejecución local del linter en el workspace web mostró problemas de configuración de ESLint en este entorno (ESLint indicó falta de `eslint.config.*`), por lo que no se pudo obtener un pase limpio automático aquí.
- Comprobaciones manuales locales realizadas en archivos modificados: la landing ahora expone el selector detrás del flag `VITE_SHOW_LANDING_BACKGROUND_SELECTOR`, las opciones listadas aparecen en el `<select>`, la selección guarda en `localStorage` con la key `ib:official-landing-gradient`, y la variable CSS `--landing-background` se inyecta en el estilo de `.landing` (se aplicaron las clases `data-background-tone` para presets claros).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece4b1e5c8833291fd1524d46c928c)