### PR TITLE
style(web): apply premium surface polish for Dashboard, Rewards, Editor and Missions

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -569,6 +569,133 @@
   }
 }
 
+@layer utilities {
+  :is([data-light-scope="dashboard-v3"], [data-light-scope="editor"]) .ib-premium-card-soft,
+  :is([data-light-scope="dashboard-v3"], [data-light-scope="editor"]) .ib-premium-panel {
+    border-color: color-mix(in srgb, var(--color-border-subtle) 86%, transparent);
+    box-shadow:
+      0 10px 28px color-mix(in srgb, var(--color-text) 8%, transparent),
+      0 2px 8px color-mix(in srgb, var(--color-text) 5%, transparent);
+  }
+
+  :root[data-theme="dark"] [data-light-scope="dashboard-v3"] .missions-card,
+  :root[data-theme="dark"] [data-light-scope="dashboard-v3"] .missions-active-card {
+    border-color: rgba(148, 163, 184, 0.2);
+    box-shadow:
+      0 12px 30px rgba(2, 6, 23, 0.42),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.025);
+  }
+
+  :root[data-theme="dark"] [data-light-scope="dashboard-v3"] .missions-card::after {
+    opacity: 0.42;
+    filter: saturate(0.8);
+  }
+
+  :root[data-theme="light"] [data-light-scope="dashboard-v3"] .missions-card,
+  :root[data-theme="light"] [data-light-scope="dashboard-v3"] .missions-active-card {
+    border-color: color-mix(in srgb, var(--color-border-subtle) 92%, #f3e8ff 8%);
+    background: linear-gradient(
+      150deg,
+      rgba(255, 255, 255, 0.98),
+      color-mix(in srgb, var(--color-surface-elevated) 86%, #f6f2ff 14%)
+    );
+    box-shadow:
+      0 14px 34px rgba(15, 23, 42, 0.08),
+      0 2px 8px rgba(139, 92, 246, 0.08);
+  }
+
+  :root[data-theme="light"] [data-light-scope="dashboard-v3"] .missions-card::after {
+    opacity: 0.24;
+    filter: saturate(0.75);
+  }
+
+  :is([data-light-scope="dashboard-v3"], [data-light-scope="editor"]) .emotion-grid--weekcols {
+    background: linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--color-overlay-2) 78%, transparent),
+      color-mix(in srgb, var(--color-overlay-1) 72%, transparent)
+    );
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  }
+
+  :root[data-theme="light"] [data-light-scope="dashboard-v3"] .emotion-grid--weekcols {
+    background: linear-gradient(
+      145deg,
+      rgba(248, 250, 255, 0.92),
+      rgba(241, 245, 255, 0.88)
+    );
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.88),
+      0 6px 18px rgba(99, 102, 241, 0.08);
+  }
+
+  :root[data-theme="light"]
+    [data-light-scope="dashboard-v3"]
+    [aria-label="Radar de GP por rasgo"]
+    polygon,
+  :root[data-theme="light"]
+    [data-light-scope="dashboard-v3"]
+    [aria-label="Radar de GP por rasgo"]
+    line {
+    stroke: color-mix(in srgb, var(--color-text-subtle) 50%, transparent);
+  }
+
+  :root[data-theme="dark"]
+    [data-light-scope="dashboard-v3"]
+    [aria-label="Radar de GP por rasgo"]
+    polygon,
+  :root[data-theme="dark"]
+    [data-light-scope="dashboard-v3"]
+    [aria-label="Radar de GP por rasgo"]
+    line {
+    stroke: color-mix(in srgb, var(--color-border-subtle) 55%, transparent);
+  }
+
+  :is([data-light-scope="dashboard-v3"], [data-light-scope="editor"]) .ib-streak-fire-chip__inner {
+    box-shadow: 0 0 8px rgba(245, 158, 11, 0.16);
+    filter: saturate(0.92);
+  }
+
+  :is([data-light-scope="dashboard-v3"], [data-light-scope="editor"]) .ib-streak-mode-chip__inner {
+    box-shadow:
+      0 6px 14px rgba(15, 23, 42, 0.1),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.07);
+  }
+
+  :root[data-theme="light"] [data-light-scope="dashboard-v3"] [data-demo-anchor="logros-shelves-pillars"] {
+    box-shadow:
+      0 14px 28px rgba(30, 41, 59, 0.08),
+      0 1px 0 rgba(255, 255, 255, 0.8) inset;
+    border-color: color-mix(in srgb, var(--color-border-subtle) 84%, #ede9fe 16%);
+  }
+
+  :root[data-theme="dark"] [data-light-scope="dashboard-v3"] [data-demo-anchor="logros-shelves-pillars"] {
+    box-shadow: 0 14px 28px rgba(2, 6, 23, 0.44);
+    border-color: rgba(148, 163, 184, 0.26);
+  }
+
+  :root[data-theme="light"] [data-light-scope="dashboard-v3"] [data-achievement-overlay] {
+    background: rgba(17, 24, 39, 0.58);
+    backdrop-filter: blur(8px);
+  }
+
+  :root[data-theme="light"] [data-light-scope="editor"] .editor-filters-mobile-panel {
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.95),
+      rgba(247, 244, 255, 0.92)
+    );
+    border-bottom: 1px solid color-mix(in srgb, var(--color-border-subtle) 86%, white);
+    box-shadow: 0 14px 24px rgba(15, 23, 42, 0.06);
+    backdrop-filter: blur(10px);
+  }
+
+  :root[data-theme="dark"] [data-light-scope="editor"] .editor-filters-mobile-panel {
+    border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+    box-shadow: 0 14px 30px rgba(2, 6, 23, 0.42);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   :root {
     --motion-duration-fast: 0ms;


### PR DESCRIPTION
### Motivation
- Introduce the new premium visual foundation across post-login surfaces (Dashboard, Logros/Rewards, Editor, Missions/DQuest) to make the product look calmer and more premium while preserving all UI elements and behavior.
- Keep functionality, APIs, hooks, routing, onboarding, analytics, rewards decisions, modals, and editor CRUD unchanged while adjusting surface/card/chart visuals and hierarchy.

### Description
- Add a scoped premium utilities layer in `apps/web/src/index.css` that targets `data-light-scope="dashboard-v3"` and `data-light-scope="editor"` to unify card and panel treatment across post-login screens via new `.ib-premium-card-soft` / `.ib-premium-panel` rules.
- Soften Missions/DQuest card halos, reduce background/art opacity and refine light/dark borders and shadows to lower visual noise without changing structure or interactions.
- Lower secondary grid / background contrast for charts by toning down Radar grid strokes and the Emotion heatmap container, and reduce streak chip/glow intensity while preserving progress bars, badges, and numbers.
- Calm surrounding surfaces used by Rewards/achievements (shelves, overlays) and restyle the Editor mobile filters panel to match the premium system, with all content, controls and modals left intact.

### Testing
- Ran type checking with `npm --workspace apps/web run typecheck` and observed failures that are pre-existing unrelated TypeScript issues in the branch, not introduced by this CSS-only change.
- No JavaScript/behavioral tests were changed; this is a styling-only PR limited to `apps/web/src/index.css` and should not affect runtime logic or tests beyond visual appearance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfa0aea90833280e3a4f39b4cfad8)