### PR TITLE
Refine post-login premium surfaces to near‑black/neutral and calm avatar chip glow

### DIFF
--- a/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
@@ -330,8 +330,8 @@ export function buildStreakModeChipVisual(avatarProfile?: AvatarProfile | null) 
   const chipColor = resolveAvatarChipColor(avatarProfile ?? null);
   return {
     accent: chipColor,
-    glowPrimary: hexToRgba(chipColor, 0.66),
-    glowSecondary: hexToRgba(chipColor, 0.36),
+    glowPrimary: hexToRgba(chipColor, 0.28),
+    glowSecondary: hexToRgba(chipColor, 0.14),
   };
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -22,10 +22,10 @@
     --onboarding-glass-border-soft: rgba(255, 255, 255, 0.12);
     --onboarding-glass-shadow: 0 26px 80px rgba(12, 18, 38, 0.24);
 
-    --color-surface: #080b14;
-    --color-surface-muted: #0d1220;
-    --color-surface-elevated: #131a2a;
-    --color-surface-highlight: #1a2336;
+    --color-surface: #030406;
+    --color-surface-muted: #06080c;
+    --color-surface-elevated: #090d13;
+    --color-surface-highlight: #10151e;
     --color-text: #f8fafc;
     --color-text-muted: #cbd5f5;
     --color-text-subtle: #94a3b8;
@@ -36,8 +36,8 @@
     --color-overlay-3: rgba(255, 255, 255, 0.12);
     --color-overlay-4: rgba(255, 255, 255, 0.16);
     --color-overlay-5: rgba(255, 255, 255, 0.22);
-    --color-border-subtle: rgba(231, 236, 255, 0.09);
-    --color-border-soft: rgba(231, 236, 255, 0.16);
+    --color-border-subtle: rgba(255, 255, 255, 0.065);
+    --color-border-soft: rgba(255, 255, 255, 0.1);
     --color-border-strong: rgba(231, 236, 255, 0.28);
     --color-text-strong: #ffffff;
     --color-text-dim: rgba(255, 255, 255, 0.7);
@@ -102,9 +102,9 @@
     --color-quickaccess-cta-disabled-border: rgba(165, 180, 252, 0.3);
     --color-quickaccess-cta-disabled-text: rgba(224, 231, 255, 0.62);
     --color-card-gradient: linear-gradient(
-      165deg,
-      rgba(22, 30, 46, 0.84),
-      rgba(11, 16, 27, 0.92)
+      180deg,
+      rgba(12, 15, 20, 0.94),
+      rgba(5, 7, 10, 0.96)
     );
     --color-card-highlight-gradient: radial-gradient(
       ellipse at top,
@@ -123,10 +123,10 @@
     --shadow-elev-2: 0 14px 36px rgba(2, 6, 23, 0.34);
     --glass-bg: linear-gradient(
       180deg,
-      rgba(20, 27, 41, 0.84),
-      rgba(9, 13, 24, 0.74)
+      rgba(12, 15, 20, 0.84),
+      rgba(5, 7, 10, 0.78)
     );
-    --glass-border: rgba(224, 231, 255, 0.14);
+    --glass-border: rgba(255, 255, 255, 0.075);
     --ib-premium-divider: color-mix(
       in srgb,
       var(--color-border-soft) 72%,
@@ -148,10 +148,10 @@
 
   :root[data-theme="dark"] {
     color-scheme: dark;
-    --color-surface: #080b14;
-    --color-surface-muted: #0d1220;
-    --color-surface-elevated: #131a2a;
-    --color-surface-highlight: #1a2336;
+    --color-surface: #030406;
+    --color-surface-muted: #06080c;
+    --color-surface-elevated: #090d13;
+    --color-surface-highlight: #10151e;
     --color-text: #f8fafc;
     --color-text-muted: #cbd5f5;
     --color-text-subtle: #94a3b8;
@@ -162,8 +162,8 @@
     --color-overlay-3: rgba(255, 255, 255, 0.12);
     --color-overlay-4: rgba(255, 255, 255, 0.16);
     --color-overlay-5: rgba(255, 255, 255, 0.22);
-    --color-border-subtle: rgba(231, 236, 255, 0.09);
-    --color-border-soft: rgba(231, 236, 255, 0.16);
+    --color-border-subtle: rgba(255, 255, 255, 0.065);
+    --color-border-soft: rgba(255, 255, 255, 0.1);
     --color-border-strong: rgba(231, 236, 255, 0.28);
     --color-text-strong: #ffffff;
     --color-text-dim: rgba(255, 255, 255, 0.7);
@@ -205,9 +205,9 @@
     --color-quickaccess-cta-disabled-border: rgba(165, 180, 252, 0.3);
     --color-quickaccess-cta-disabled-text: rgba(224, 231, 255, 0.62);
     --color-card-gradient: linear-gradient(
-      165deg,
-      rgba(22, 30, 46, 0.84),
-      rgba(11, 16, 27, 0.92)
+      180deg,
+      rgba(12, 15, 20, 0.94),
+      rgba(5, 7, 10, 0.96)
     );
     --color-card-highlight-gradient: radial-gradient(
       ellipse at top,
@@ -226,48 +226,38 @@
     --shadow-elev-2: 0 14px 36px rgba(2, 6, 23, 0.34);
     --glass-bg: linear-gradient(
       180deg,
-      rgba(20, 27, 41, 0.84),
-      rgba(9, 13, 24, 0.74)
+      rgba(12, 15, 20, 0.84),
+      rgba(5, 7, 10, 0.78)
     );
-    --glass-border: rgba(224, 231, 255, 0.14);
+    --glass-border: rgba(255, 255, 255, 0.075);
   }
 
   :root[data-theme="light"] {
     color-scheme: light;
     --color-dashboard-light-bg:
       radial-gradient(
-        118% 86% at 10% -12%,
-        rgba(248, 194, 218, 0.44) 0%,
-        rgba(248, 194, 218, 0) 61%
+        116% 84% at 84% -6%,
+        rgba(148, 163, 184, 0.06) 0%,
+        rgba(148, 163, 184, 0) 62%
       ),
-      radial-gradient(
-        94% 80% at 86% -4%,
-        rgba(233, 210, 255, 0.4) 0%,
-        rgba(233, 210, 255, 0) 64%
-      ),
-      radial-gradient(
-        114% 86% at 52% 114%,
-        rgba(248, 224, 183, 0.28) 0%,
-        rgba(248, 224, 183, 0) 67%
-      ),
-      linear-gradient(180deg, #fdf8f4 0%, #f8f4ff 48%, #f3f8ff 100%);
-    --color-surface: #f5f0e8;
-    --color-surface-muted: #efe8de;
-    --color-surface-elevated: #fffdfa;
-    --color-surface-highlight: #f8f2ea;
+      linear-gradient(180deg, #f8fafc 0%, #f4f6f8 52%, #eef2f6 100%);
+    --color-surface: #f7f8fa;
+    --color-surface-muted: #f1f3f6;
+    --color-surface-elevated: #ffffff;
+    --color-surface-highlight: #fafbfc;
     --color-text: #0f172a;
     --color-text-muted: #334155;
     --color-text-subtle: #64748b;
     --color-accent-primary: #6366f1;
     --color-accent-secondary: #d946ef;
-    --color-overlay-1: rgba(255, 252, 247, 0.9);
-    --color-overlay-2: rgba(250, 244, 236, 0.82);
-    --color-overlay-3: rgba(230, 220, 207, 0.52);
+    --color-overlay-1: rgba(255, 255, 255, 0.9);
+    --color-overlay-2: rgba(245, 248, 252, 0.84);
+    --color-overlay-3: rgba(226, 232, 240, 0.52);
     --color-overlay-4: rgba(148, 163, 184, 0.22);
     --color-overlay-5: rgba(148, 163, 184, 0.3);
-    --color-border-subtle: #e4dacd;
-    --color-border-soft: #efe4d7;
-    --color-border-strong: #ccbca9;
+    --color-border-subtle: rgba(15, 23, 42, 0.075);
+    --color-border-soft: rgba(15, 23, 42, 0.11);
+    --color-border-strong: rgba(15, 23, 42, 0.2);
     --color-text-strong: #020617;
     --color-text-dim: rgba(15, 23, 42, 0.78);
     --color-text-faint: rgba(51, 65, 85, 0.68);
@@ -307,8 +297,12 @@
     --color-quickaccess-cta-disabled-bg: rgba(237, 233, 254, 0.85);
     --color-quickaccess-cta-disabled-border: rgba(196, 181, 253, 0.55);
     --color-quickaccess-cta-disabled-text: rgba(67, 56, 202, 0.58);
-    --color-card-gradient: linear-gradient(170deg, #fffdfa, #f7efe4 94%);
-    --color-card-highlight-gradient: linear-gradient(180deg, #fffefb, #f8f2ea);
+    --color-card-gradient: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(246, 248, 251, 0.92)
+    );
+    --color-card-highlight-gradient: linear-gradient(180deg, #ffffff, #f7f9fc);
     --color-card-shadow:
       0 8px 18px rgba(52, 38, 27, 0.1), 0 20px 48px rgba(138, 116, 96, 0.14);
     --color-card-border: color-mix(
@@ -318,22 +312,22 @@
     );
     --color-glass-surface: linear-gradient(
       180deg,
-      rgba(255, 253, 248, 0.96),
-      rgba(249, 241, 232, 0.92)
+      rgba(255, 255, 255, 0.96),
+      rgba(246, 248, 251, 0.92)
     );
-    --color-glow-soft: rgba(255, 249, 238, 0.72);
+    --color-glow-soft: rgba(226, 232, 240, 0.5);
     --shadow-elev-1:
-      0 8px 20px rgba(68, 50, 34, 0.11), 0 18px 36px rgba(173, 143, 117, 0.12);
+      0 8px 20px rgba(15, 23, 42, 0.08), 0 18px 36px rgba(51, 65, 85, 0.08);
     --shadow-elev-2:
-      0 14px 34px rgba(68, 50, 34, 0.13), 0 30px 64px rgba(173, 143, 117, 0.18);
+      0 14px 34px rgba(15, 23, 42, 0.1), 0 30px 64px rgba(51, 65, 85, 0.12);
     --IB_SURFACE_CARD_LIGHT:
-      0 7px 16px rgba(68, 50, 34, 0.08), 0 16px 34px rgba(173, 143, 117, 0.12);
+      0 7px 16px rgba(15, 23, 42, 0.06), 0 16px 34px rgba(51, 65, 85, 0.1);
     --glass-bg: linear-gradient(
       180deg,
-      rgba(255, 253, 248, 0.96),
-      rgba(246, 237, 226, 0.92)
+      rgba(255, 255, 255, 0.96),
+      rgba(246, 248, 251, 0.92)
     );
-    --glass-border: rgba(172, 147, 122, 0.28);
+    --glass-border: rgba(15, 23, 42, 0.08);
     --onboarding-glass-surface-base: rgba(255, 255, 255, 0.92);
     --onboarding-glass-surface-inner: rgba(255, 255, 255, 0.85);
     --onboarding-glass-surface-ghost: rgba(248, 250, 255, 0.76);
@@ -363,16 +357,11 @@
   :root[data-theme="dark"] body {
     background-image:
       radial-gradient(
-        120% 90% at 8% -10%,
-        rgba(106, 92, 182, 0.18),
-        transparent 60%
+        118% 86% at 12% -10%,
+        rgba(120, 110, 180, 0.06),
+        transparent 62%
       ),
-      radial-gradient(
-        140% 110% at 80% 96%,
-        rgba(73, 106, 150, 0.12),
-        transparent 64%
-      ),
-      linear-gradient(180deg, rgba(8, 11, 20, 0.98), #080b14 58%, #060810);
+      linear-gradient(180deg, #030406 0%, #05070b 58%, #020304 100%);
   }
 
   :root[data-theme="light"] body {
@@ -593,15 +582,15 @@
 
   :root[data-theme="light"] [data-light-scope="dashboard-v3"] .missions-card,
   :root[data-theme="light"] [data-light-scope="dashboard-v3"] .missions-active-card {
-    border-color: color-mix(in srgb, var(--color-border-subtle) 92%, #f3e8ff 8%);
+    border-color: color-mix(in srgb, var(--color-border-subtle) 96%, #ffffff 4%);
     background: linear-gradient(
       150deg,
       rgba(255, 255, 255, 0.98),
-      color-mix(in srgb, var(--color-surface-elevated) 86%, #f6f2ff 14%)
+      color-mix(in srgb, var(--color-surface-elevated) 92%, #f3f6fb 8%)
     );
     box-shadow:
       0 14px 34px rgba(15, 23, 42, 0.08),
-      0 2px 8px rgba(139, 92, 246, 0.08);
+      0 2px 8px rgba(148, 163, 184, 0.08);
   }
 
   :root[data-theme="light"] [data-light-scope="dashboard-v3"] .missions-card::after {
@@ -652,13 +641,13 @@
   }
 
   :is([data-light-scope="dashboard-v3"], [data-light-scope="editor"]) .ib-streak-fire-chip__inner {
-    box-shadow: 0 0 8px rgba(245, 158, 11, 0.16);
-    filter: saturate(0.92);
+    box-shadow: 0 0 6px rgba(245, 158, 11, 0.1);
+    filter: saturate(0.84);
   }
 
   :is([data-light-scope="dashboard-v3"], [data-light-scope="editor"]) .ib-streak-mode-chip__inner {
     box-shadow:
-      0 6px 14px rgba(15, 23, 42, 0.1),
+      0 4px 10px rgba(15, 23, 42, 0.08),
       inset 0 0 0 1px rgba(255, 255, 255, 0.07);
   }
 
@@ -5367,9 +5356,9 @@
     --color-slate-900-95: rgba(255, 255, 255, 0.96);
     --color-slate-950-80: rgba(241, 245, 255, 0.82);
     --color-card-border: transparent;
-    --color-card-gradient: linear-gradient(180deg, #ffffff 0%, #fffdfd 100%);
+    --color-card-gradient: linear-gradient(180deg, #ffffff 0%, #f6f8fb 100%);
     --color-card-shadow:
-      0 6px 18px rgba(15, 23, 42, 0.06), 0 20px 46px rgba(196, 181, 253, 0.16);
+      0 6px 18px rgba(15, 23, 42, 0.06), 0 20px 46px rgba(148, 163, 184, 0.12);
     background-image: var(--color-dashboard-light-bg);
     background-attachment: fixed;
   }
@@ -5383,7 +5372,7 @@
     [data-light-scope="dashboard-v3"]
     .ib-metric-header-card {
     box-shadow:
-      0 8px 22px rgba(99, 102, 241, 0.08),
+      0 8px 22px rgba(148, 163, 184, 0.08),
       0 22px 48px rgba(15, 23, 42, 0.07);
   }
 
@@ -6544,29 +6533,29 @@
 
   .ib-game-mode-chip__glow {
     inset: -2px;
-    background: color-mix(in srgb, var(--ib-chip-accent) 45%, transparent);
-    filter: blur(10px);
-    opacity: 0.6;
+    background: color-mix(in srgb, var(--ib-chip-accent) 24%, transparent);
+    filter: blur(8px);
+    opacity: 0.36;
   }
 
   .ib-game-mode-chip__inner {
     border-color: color-mix(
       in srgb,
-      var(--ib-chip-accent) 58%,
+      var(--ib-chip-accent) 44%,
       rgba(255, 255, 255, 0.24)
     );
     background: linear-gradient(
       120deg,
-      color-mix(in srgb, var(--ib-chip-accent) 22%, rgba(255, 255, 255, 0.92))
+      color-mix(in srgb, var(--ib-chip-accent) 14%, rgba(255, 255, 255, 0.92))
         0%,
-      color-mix(in srgb, var(--ib-chip-accent) 34%, rgba(255, 255, 255, 0.18))
+      color-mix(in srgb, var(--ib-chip-accent) 22%, rgba(255, 255, 255, 0.18))
         100%
     );
-    color: color-mix(in srgb, var(--ib-chip-accent) 55%, #ffffff);
+    color: color-mix(in srgb, var(--ib-chip-accent) 44%, #ffffff);
     box-shadow:
-      0 0 14px color-mix(in srgb, var(--ib-chip-accent) 24%, transparent),
+      0 0 8px color-mix(in srgb, var(--ib-chip-accent) 14%, transparent),
       inset 0 0 0 1px
-        color-mix(in srgb, var(--ib-chip-accent) 28%, rgba(255, 255, 255, 0.32));
+        color-mix(in srgb, var(--ib-chip-accent) 18%, rgba(255, 255, 255, 0.32));
   }
 
   .ib-game-mode-chip--animated .ib-game-mode-chip__glow {
@@ -6574,21 +6563,21 @@
   }
 
   :root[data-theme="light"] .ib-game-mode-chip__inner {
-    color: color-mix(in srgb, var(--ib-chip-accent) 72%, #0f172a);
+    color: color-mix(in srgb, var(--ib-chip-accent) 58%, #0f172a);
   }
 
   :root[data-theme="dark"] .ib-game-mode-chip__glow {
     inset: -1px;
-    background: color-mix(in srgb, var(--ib-chip-accent) 28%, transparent);
-    filter: blur(5px);
-    opacity: 0.32;
+    background: color-mix(in srgb, var(--ib-chip-accent) 16%, transparent);
+    filter: blur(4px);
+    opacity: 0.22;
   }
 
   :root[data-theme="dark"] .ib-game-mode-chip__inner {
     box-shadow:
-      0 0 7px color-mix(in srgb, var(--ib-chip-accent) 12%, transparent),
+      0 0 5px color-mix(in srgb, var(--ib-chip-accent) 8%, transparent),
       inset 0 0 0 1px
-        color-mix(in srgb, var(--ib-chip-accent) 22%, rgba(255, 255, 255, 0.24));
+        color-mix(in srgb, var(--ib-chip-accent) 16%, rgba(255, 255, 255, 0.24));
   }
 
   :root[data-theme="dark"]
@@ -6610,9 +6599,9 @@
   }
 
   :root[data-theme="dark"] .ib-game-mode-chip {
-    --ib-chip-glow-opacity-start: 0.28;
-    --ib-chip-glow-opacity-end: 0.36;
-    --ib-chip-glow-scale: 1.01;
+    --ib-chip-glow-opacity-start: 0.18;
+    --ib-chip-glow-opacity-end: 0.24;
+    --ib-chip-glow-scale: 1.005;
   }
 
   .ib-streak-mode-chip {
@@ -6625,7 +6614,7 @@
     border: 1px solid;
     border-color: color-mix(
       in srgb,
-      var(--ib-chip-accent) 58%,
+      var(--ib-chip-accent) 42%,
       rgba(255, 255, 255, 0.22)
     );
   }
@@ -6633,30 +6622,30 @@
   :root[data-theme="light"] .ib-streak-mode-chip__inner {
     background: linear-gradient(
       120deg,
-      color-mix(in srgb, var(--ib-chip-accent) 20%, #ffffff) 0%,
-      color-mix(in srgb, var(--ib-chip-accent) 12%, rgba(255, 255, 255, 0.94))
+      color-mix(in srgb, var(--ib-chip-accent) 14%, #ffffff) 0%,
+      color-mix(in srgb, var(--ib-chip-accent) 8%, rgba(255, 255, 255, 0.94))
         100%
     );
-    color: color-mix(in srgb, var(--ib-chip-accent) 72%, #0f172a);
+    color: color-mix(in srgb, var(--ib-chip-accent) 58%, #0f172a);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
   }
 
   :root[data-theme="dark"] .ib-streak-mode-chip__inner {
     background: linear-gradient(
       120deg,
-      color-mix(in srgb, var(--ib-chip-accent) 42%, rgba(15, 23, 42, 0.86)) 0%,
-      color-mix(in srgb, var(--ib-chip-accent) 28%, rgba(15, 23, 42, 0.4)) 100%
+      color-mix(in srgb, var(--ib-chip-accent) 28%, rgba(15, 23, 42, 0.86)) 0%,
+      color-mix(in srgb, var(--ib-chip-accent) 18%, rgba(15, 23, 42, 0.4)) 100%
     );
-    color: color-mix(in srgb, var(--ib-chip-accent) 24%, #ffffff);
+    color: color-mix(in srgb, var(--ib-chip-accent) 18%, #ffffff);
     box-shadow:
-      0 0 12px color-mix(in srgb, var(--ib-chip-accent) 30%, transparent),
+      0 0 8px color-mix(in srgb, var(--ib-chip-accent) 16%, transparent),
       inset 0 0 0 1px
-        color-mix(in srgb, var(--ib-chip-accent) 24%, rgba(255, 255, 255, 0.2));
+        color-mix(in srgb, var(--ib-chip-accent) 16%, rgba(255, 255, 255, 0.2));
   }
 
   :root[data-theme="light"] .ib-streak-fire-chip {
-    --glow-primary: rgba(192, 132, 252, 0.78);
-    --glow-secondary: rgba(139, 92, 246, 0.46);
+    --glow-primary: rgba(192, 132, 252, 0.34);
+    --glow-secondary: rgba(139, 92, 246, 0.18);
   }
 
   :root[data-theme="light"] .ib-streak-fire-chip .ib-streak-fire-chip__inner {

--- a/apps/web/src/lib/avatarChipPalette.ts
+++ b/apps/web/src/lib/avatarChipPalette.ts
@@ -2,10 +2,10 @@ import { resolveAvatarOption, type AvatarOption } from './avatarCatalog';
 import type { AvatarProfile } from './avatarProfile';
 
 const AVATAR_CHIP_PALETTE: Record<AvatarOption['code'], string> = {
-  RED_CAT: '#F87171',
-  GREEN_BEAR: '#4ADE80',
-  BLUE_AMPHIBIAN: '#38BDF8',
-  VIOLET_OWL: '#A78BFA',
+  RED_CAT: '#F56767',
+  GREEN_BEAR: '#38CC76',
+  BLUE_AMPHIBIAN: '#32AEE4',
+  VIOLET_OWL: '#9B82EE',
 };
 
 export function resolveAvatarChipColor(avatarProfile: AvatarProfile | null | undefined): string {


### PR DESCRIPTION
### Motivation
- Address remaining visual imbalances after prior passes: dark mode was too blue, light mode too sepia/yellow, background wash too pink/violet, and Flow/avatar chips felt too bright/neon while preserving avatar-driven accents.
- Changes are strictly visual-only and aim to make dark mode near-black and light mode a neutral premium off-white without altering behavior or UI structure.

### Description
- Rebalanced core dark tokens in `apps/web/src/index.css` to near-black values (`--color-surface: #030406`, `--color-surface-muted: #06080c`, `--color-surface-elevated: #090d13`, `--color-surface-highlight: #10151e`) and replaced the dark body gradient with a neutral near-black gradient and a very subtle radial wash.
- Reworked light theme tokens to neutral off-whites (`--color-surface: #F7F8FA`, `--color-surface-muted: #F1F3F6`, `--color-surface-elevated: #FFFFFF`, `--color-surface-highlight: #FAFBFC`) and removed/reduced the heavy pink/violet/coral radials, replacing the body background with a cleaner cool-neutral gradient.
- Calmed card/glass surfaces, borders and global glow/shadow tokens (card gradients, `--glass-bg`, `--color-card-gradient`, `--glass-border`, border subtle/soft values) so cards read charcoal/neutral in dark mode and premium off-white in light mode.
- Reduced chip/mode glow/shadow/border intensity in CSS (multiple `.ib-game-mode-chip` / `.ib-streak-mode-chip` / `.ib-streak-fire-chip` rules) to remove neon effects while keeping contrast for accessibility (smaller blur, lower color-mix weights, lower box-shadow and glow opacities).
- Preserved avatar-driven accent logic and lowered the programmatic glow alpha in `buildStreakModeChipVisual` inside `StreaksPanel.tsx` from `0.66`/`0.36` to `0.28`/`0.14` respectively.
- Slightly desaturated avatar palette entries in `apps/web/src/lib/avatarChipPalette.ts` to maintain identity while reducing perceived brightness (kept RED_CAT / GREEN_BEAR / BLUE_AMPHIBIAN / VIOLET_OWL mappings and did not hardcode Flow green).

### Testing
- Ran a focused pattern search with `rg` for chip/flow/emerald/bright-green tokens and confirmed the codebase still uses avatar-driven accents and there are no changes that hardcode Flow to green (`rg` succeeded and results were inspected). 
- Ran `npm run typecheck:web` (`tsc --noEmit`) and observed pre-existing TypeScript errors unrelated to these visual-only changes, so typecheck exited non-zero; no new type errors were introduced by this PR.
- Attempted `npm --workspace apps/web run lint` and found the workspace has no `lint` script configured, so lint did not run.
- All edits were limited to styling and palette code; no functional tests were modified or required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed006994c88332a2bb4da048044843)