### PR TITLE
Unify FLOW mode chip visuals and sharpen dark-mode surfaces

### DIFF
--- a/apps/web/src/components/common/GameModeChip.test.ts
+++ b/apps/web/src/components/common/GameModeChip.test.ts
@@ -40,11 +40,11 @@ describe('buildGameModeChip', () => {
     const chip = buildGameModeChip('Flow', { avatarProfile });
 
     expect(chip.label).toBe('FLOW');
-    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#F87171' });
+    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#F56767' });
   });
 
   it('uses safe legacy fallback accent when avatar is missing', () => {
     const chip = buildGameModeChip('Flow');
-    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#38BDF8' });
+    expect(chip.style).toMatchObject({ '--ib-chip-accent': '#32AEE4' });
   });
 });

--- a/apps/web/src/components/common/GameModeChip.tsx
+++ b/apps/web/src/components/common/GameModeChip.tsx
@@ -9,6 +9,11 @@ interface GameModeChipStyle {
   style: CSSProperties;
 }
 
+interface GameModeChipProps extends GameModeChipStyle {
+  size?: 'default' | 'compact';
+  className?: string;
+}
+
 const GAME_MODE_LABELS: Record<GameMode, string> = {
   Flow: 'FLOW',
   Chill: 'CHILL',
@@ -47,18 +52,27 @@ export function buildGameModeChip(
   };
 }
 
-export function GameModeChip({ label, animate, style }: GameModeChipStyle) {
+function cx(...values: Array<string | false | null | undefined>): string {
+  return values.filter(Boolean).join(' ');
+}
+
+export function GameModeChip({ label, animate, style, size = 'default', className }: GameModeChipProps) {
   return (
     <span
-      className={`ib-game-mode-chip relative inline-flex items-center ${animate ? 'ib-game-mode-chip--animated' : ''}`}
+      className={cx(
+        'ib-game-mode-chip relative inline-flex items-center',
+        animate && 'ib-game-mode-chip--animated',
+        size === 'compact' && 'ib-game-mode-chip--compact',
+        className,
+      )}
       style={style}
     >
       <span
         className="ib-game-mode-chip__glow absolute rounded-full"
         aria-hidden
       />
-      <span className="ib-game-mode-chip__inner relative inline-flex items-center gap-2 rounded-full border px-3 py-[0.26rem] text-[10px] font-semibold uppercase tracking-[0.2em] backdrop-blur">
-        <span className="h-[0.32rem] w-[0.32rem] rounded-full bg-white/80" />
+      <span className="ib-game-mode-chip__inner relative inline-flex items-center gap-2 rounded-full border px-3 py-[0.24rem] text-[10px] font-semibold uppercase tracking-[0.18em] backdrop-blur-md">
+        <span className="ib-game-mode-chip__dot h-[0.28rem] w-[0.28rem] rounded-full" />
         {label}
       </span>
     </span>

--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -957,9 +957,11 @@ export function DashboardMenu({
                         <span>{hasActiveUpgradeCta ? t('dashboard.menu.upgradeAvailable') : t('dashboard.menu.changeGameMode')}</span>
                         {hasActiveUpgradeCta ? <span className="rounded-full border border-black/20 bg-white/35 px-2 py-0.5 text-[10px] font-bold uppercase text-black shadow-[0_8px_20px_rgba(167,112,239,0.35)] backdrop-blur-sm">7d</span> : null}
                       </div>
-                      <span className="dashboard-menu-mode-chip [&_.ib-game-mode-chip__glow]:opacity-[0.08] [&_.ib-game-mode-chip__glow]:blur-[2px] [&_.ib-game-mode-chip__inner]:gap-0.5 [&_.ib-game-mode-chip__inner]:px-[0.4rem] [&_.ib-game-mode-chip__inner]:py-[0.12rem] [&_.ib-game-mode-chip__inner]:text-[7px] [&_.ib-game-mode-chip__inner]:tracking-[0.12em] [&_.ib-game-mode-chip__inner_span:first-child]:h-0.5 [&_.ib-game-mode-chip__inner_span:first-child]:w-0.5">
-                        <GameModeChip {...buildGameModeChip(normalizedCurrentMode ?? 'Flow', { avatarProfile: currentAvatarProfile })} />
-                      </span>
+                      <GameModeChip
+                        {...buildGameModeChip(normalizedCurrentMode ?? 'Flow', { avatarProfile: currentAvatarProfile })}
+                        size="compact"
+                        className="dashboard-menu-mode-chip"
+                      />
                     </button>
                     <div className="dashboard-menu-divider mx-3 h-px" aria-hidden />
                     <button

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts
@@ -39,13 +39,13 @@ describe('buildStreakModeChipVisual', () => {
 
     const visual = buildStreakModeChipVisual(avatarProfile);
 
-    expect(visual.accent).toBe('#F87171');
-    expect(visual.glowPrimary).toContain('248, 113, 113');
-    expect(visual.glowSecondary).toContain('248, 113, 113');
+    expect(visual.accent).toBe('#F56767');
+    expect(visual.glowPrimary).toContain('245, 103, 103');
+    expect(visual.glowSecondary).toContain('245, 103, 103');
   });
 
   it('falls back safely when avatar profile is unavailable', () => {
     const visual = buildStreakModeChipVisual(null);
-    expect(visual.accent).toBe('#38BDF8');
+    expect(visual.accent).toBe('#32AEE4');
   });
 });

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
@@ -21,6 +21,7 @@ import { usePostLoginLanguage } from '../../i18n/postLoginLanguage';
 import { HABIT_ACHIEVEMENT_UPDATED_EVENT } from '../../lib/habitAchievementEvents';
 import { type AvatarProfile } from '../../lib/avatarProfile';
 import { resolveAvatarChipColor } from '../../lib/avatarChipPalette';
+import { GameModeChip, buildGameModeChip } from '../common/GameModeChip';
 import {
   DASHBOARD_SEGMENTED_BUTTON_ACTIVE,
   DASHBOARD_SEGMENTED_BUTTON_BASE,
@@ -32,6 +33,29 @@ export const FEATURE_STREAKS_PANEL_V1 = false;
 
 function cx(...values: Array<string | false | null | undefined>): string {
   return values.filter(Boolean).join(' ');
+}
+
+type GlowChipProps = {
+  glowPrimary: string;
+  glowSecondary: string;
+  children: ReactNode;
+  className?: string;
+  innerClassName?: string;
+  style?: CSSProperties;
+};
+
+function GlowChip({ glowPrimary, glowSecondary, children, className, innerClassName, style }: GlowChipProps) {
+  const chipStyle = {
+    '--glow-primary': glowPrimary,
+    '--glow-secondary': glowSecondary,
+    ...style,
+  } as CSSProperties;
+
+  return (
+    <span className={cx('glow-chip inline-flex', className)} style={chipStyle}>
+      <span className={cx('relative z-[1] inline-flex items-center', innerClassName)}>{children}</span>
+    </span>
+  );
 }
 
 interface LegacyStreaksPanelProps {
@@ -288,29 +312,6 @@ type DisplayTask = {
 
 const numberFormatter = new Intl.NumberFormat('es-AR');
 
-type GlowChipProps = {
-  glowPrimary: string;
-  glowSecondary: string;
-  children: ReactNode;
-  className?: string;
-  innerClassName?: string;
-  style?: CSSProperties;
-};
-
-function GlowChip({ glowPrimary, glowSecondary, children, className, innerClassName, style }: GlowChipProps) {
-  const chipStyle = {
-    '--glow-primary': glowPrimary,
-    '--glow-secondary': glowSecondary,
-    ...style,
-  } as CSSProperties;
-
-  return (
-    <span className={cx('glow-chip inline-flex', className)} style={chipStyle}>
-      <span className={cx('relative z-[1] inline-flex items-center', innerClassName)}>{children}</span>
-    </span>
-  );
-}
-
 function hexToRgba(hex: string, alpha: number): string {
   const normalized = hex.replace('#', '').trim();
   const expanded = normalized.length === 3
@@ -330,8 +331,8 @@ export function buildStreakModeChipVisual(avatarProfile?: AvatarProfile | null) 
   const chipColor = resolveAvatarChipColor(avatarProfile ?? null);
   return {
     accent: chipColor,
-    glowPrimary: hexToRgba(chipColor, 0.28),
-    glowSecondary: hexToRgba(chipColor, 0.14),
+    glowPrimary: hexToRgba(chipColor, 0.26),
+    glowSecondary: hexToRgba(chipColor, 0.12),
   };
 }
 
@@ -879,16 +880,8 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, avatarProfile, fo
   }));
   const daysConsecutiveText = (days: string) => t('dashboard.streaks.daysConsecutiveSr', { days });
   const modeChipVisual = buildStreakModeChipVisual(avatarProfile);
-  const modeChip = {
-    className: 'ib-streak-mode-chip',
-    glowPrimary: modeChipVisual.glowPrimary,
-    glowSecondary: modeChipVisual.glowSecondary,
-    innerClassName:
-      'ib-streak-mode-chip__inner gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]',
-  };
-  const modeChipStyle = {
-    '--ib-chip-accent': modeChipVisual.accent,
-  } as CSSProperties;
+  const modeChipBase = buildGameModeChip(normalizedMode, { avatarProfile });
+  const modeChipStyle = { ...modeChipBase.style, '--ib-chip-accent': modeChipVisual.accent } as CSSProperties;
 
   return (
     <>
@@ -898,15 +891,12 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, avatarProfile, fo
         className="text-sm leading-relaxed"
         rightSlot={
           <InfoDotTarget id="streaksGuide" placement="left" className="flex items-center gap-2">
-            <GlowChip
-              className={modeChip.className}
-              glowPrimary={modeChip.glowPrimary}
-              glowSecondary={modeChip.glowSecondary}
-              innerClassName={modeChip.innerClassName}
+            <GameModeChip
+              label={modeLabel}
+              animate={modeChipBase.animate}
               style={modeChipStyle}
-            >
-              {modeLabel}
-            </GlowChip>
+              className="ib-streak-mode-chip"
+            />
           </InfoDotTarget>
         }
       >

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -22,10 +22,10 @@
     --onboarding-glass-border-soft: rgba(255, 255, 255, 0.12);
     --onboarding-glass-shadow: 0 26px 80px rgba(12, 18, 38, 0.24);
 
-    --color-surface: #030406;
-    --color-surface-muted: #06080c;
-    --color-surface-elevated: #090d13;
-    --color-surface-highlight: #10151e;
+    --color-surface: #010409;
+    --color-surface-muted: #05070b;
+    --color-surface-elevated: #0b0f14;
+    --color-surface-highlight: #11161d;
     --color-text: #f8fafc;
     --color-text-muted: #cbd5f5;
     --color-text-subtle: #94a3b8;
@@ -36,9 +36,9 @@
     --color-overlay-3: rgba(255, 255, 255, 0.12);
     --color-overlay-4: rgba(255, 255, 255, 0.16);
     --color-overlay-5: rgba(255, 255, 255, 0.22);
-    --color-border-subtle: rgba(255, 255, 255, 0.065);
-    --color-border-soft: rgba(255, 255, 255, 0.1);
-    --color-border-strong: rgba(231, 236, 255, 0.28);
+    --color-border-subtle: rgba(255, 255, 255, 0.075);
+    --color-border-soft: rgba(255, 255, 255, 0.115);
+    --color-border-strong: rgba(255, 255, 255, 0.18);
     --color-text-strong: #ffffff;
     --color-text-dim: rgba(255, 255, 255, 0.7);
     --color-text-faint: rgba(255, 255, 255, 0.6);
@@ -103,30 +103,31 @@
     --color-quickaccess-cta-disabled-text: rgba(224, 231, 255, 0.62);
     --color-card-gradient: linear-gradient(
       180deg,
-      rgba(12, 15, 20, 0.94),
-      rgba(5, 7, 10, 0.96)
+      rgba(11, 15, 20, 0.96),
+      rgba(5, 7, 11, 0.98)
     );
     --color-card-highlight-gradient: radial-gradient(
       ellipse at top,
-      rgba(99, 102, 241, 0.2),
-      rgba(15, 23, 42, 0.82)
+      rgba(255, 255, 255, 0.045),
+      rgba(6, 8, 12, 0.82)
     );
-    --color-card-shadow: 0 8px 20px rgba(1, 4, 12, 0.34);
+    --color-card-shadow:
+      0 8px 16px rgba(0, 0, 0, 0.32), 0 16px 28px rgba(0, 0, 0, 0.24);
     --color-card-border: var(--color-border-subtle);
     --color-glass-surface: linear-gradient(
       180deg,
-      rgba(20, 28, 43, 0.82),
-      rgba(8, 11, 20, 0.7)
+      rgba(11, 15, 20, 0.88),
+      rgba(5, 7, 11, 0.82)
     );
-    --color-glow-soft: rgba(139, 154, 180, 0.16);
+    --color-glow-soft: rgba(139, 154, 180, 0.09);
     --shadow-elev-1: 0 8px 20px rgba(0, 0, 0, 0.28);
     --shadow-elev-2: 0 14px 36px rgba(2, 6, 23, 0.34);
     --glass-bg: linear-gradient(
       180deg,
-      rgba(12, 15, 20, 0.84),
-      rgba(5, 7, 10, 0.78)
+      rgba(11, 15, 20, 0.88),
+      rgba(5, 7, 11, 0.82)
     );
-    --glass-border: rgba(255, 255, 255, 0.075);
+    --glass-border: rgba(255, 255, 255, 0.085);
     --ib-premium-divider: color-mix(
       in srgb,
       var(--color-border-soft) 72%,
@@ -148,10 +149,10 @@
 
   :root[data-theme="dark"] {
     color-scheme: dark;
-    --color-surface: #030406;
-    --color-surface-muted: #06080c;
-    --color-surface-elevated: #090d13;
-    --color-surface-highlight: #10151e;
+    --color-surface: #010409;
+    --color-surface-muted: #05070b;
+    --color-surface-elevated: #0b0f14;
+    --color-surface-highlight: #11161d;
     --color-text: #f8fafc;
     --color-text-muted: #cbd5f5;
     --color-text-subtle: #94a3b8;
@@ -162,9 +163,9 @@
     --color-overlay-3: rgba(255, 255, 255, 0.12);
     --color-overlay-4: rgba(255, 255, 255, 0.16);
     --color-overlay-5: rgba(255, 255, 255, 0.22);
-    --color-border-subtle: rgba(255, 255, 255, 0.065);
-    --color-border-soft: rgba(255, 255, 255, 0.1);
-    --color-border-strong: rgba(231, 236, 255, 0.28);
+    --color-border-subtle: rgba(255, 255, 255, 0.075);
+    --color-border-soft: rgba(255, 255, 255, 0.115);
+    --color-border-strong: rgba(255, 255, 255, 0.18);
     --color-text-strong: #ffffff;
     --color-text-dim: rgba(255, 255, 255, 0.7);
     --color-text-faint: rgba(255, 255, 255, 0.6);
@@ -206,30 +207,31 @@
     --color-quickaccess-cta-disabled-text: rgba(224, 231, 255, 0.62);
     --color-card-gradient: linear-gradient(
       180deg,
-      rgba(12, 15, 20, 0.94),
-      rgba(5, 7, 10, 0.96)
+      rgba(11, 15, 20, 0.96),
+      rgba(5, 7, 11, 0.98)
     );
     --color-card-highlight-gradient: radial-gradient(
       ellipse at top,
-      rgba(99, 102, 241, 0.2),
-      rgba(15, 23, 42, 0.82)
+      rgba(255, 255, 255, 0.045),
+      rgba(6, 8, 12, 0.82)
     );
-    --color-card-shadow: 0 8px 20px rgba(1, 4, 12, 0.34);
+    --color-card-shadow:
+      0 8px 16px rgba(0, 0, 0, 0.32), 0 16px 28px rgba(0, 0, 0, 0.24);
     --color-card-border: var(--color-border-subtle);
     --color-glass-surface: linear-gradient(
       180deg,
-      rgba(20, 28, 43, 0.82),
-      rgba(8, 11, 20, 0.7)
+      rgba(11, 15, 20, 0.88),
+      rgba(5, 7, 11, 0.82)
     );
-    --color-glow-soft: rgba(139, 154, 180, 0.16);
+    --color-glow-soft: rgba(139, 154, 180, 0.09);
     --shadow-elev-1: 0 8px 20px rgba(0, 0, 0, 0.28);
     --shadow-elev-2: 0 14px 36px rgba(2, 6, 23, 0.34);
     --glass-bg: linear-gradient(
       180deg,
-      rgba(12, 15, 20, 0.84),
-      rgba(5, 7, 10, 0.78)
+      rgba(11, 15, 20, 0.88),
+      rgba(5, 7, 11, 0.82)
     );
-    --glass-border: rgba(255, 255, 255, 0.075);
+    --glass-border: rgba(255, 255, 255, 0.085);
   }
 
   :root[data-theme="light"] {
@@ -357,11 +359,11 @@
   :root[data-theme="dark"] body {
     background-image:
       radial-gradient(
-        118% 86% at 12% -10%,
-        rgba(120, 110, 180, 0.06),
+        112% 84% at 16% -8%,
+        rgba(255, 255, 255, 0.04),
         transparent 62%
       ),
-      linear-gradient(180deg, #030406 0%, #05070b 58%, #020304 100%);
+      linear-gradient(180deg, #010409 0%, #030507 58%, #010203 100%);
   }
 
   :root[data-theme="light"] body {
@@ -916,13 +918,13 @@
     background: var(--color-glass-surface);
     border: 1px solid var(--color-border-subtle);
     box-shadow: var(--color-card-shadow);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
   }
 
   :root[data-theme="dark"] .glass-card {
-    backdrop-filter: blur(22px);
-    -webkit-backdrop-filter: blur(22px);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
   }
 
   .ib-premium-page {
@@ -937,12 +939,12 @@
   }
 
   .ib-premium-card-soft {
-    backdrop-filter: blur(14px);
-    -webkit-backdrop-filter: blur(14px);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
     box-shadow:
       var(--color-card-shadow),
-      inset 0 1px 0 color-mix(in srgb, #fff 8%, transparent),
-      inset 0 -1px 0 color-mix(in srgb, #000 10%, transparent);
+      inset 0 1px 0 color-mix(in srgb, #fff 6%, transparent),
+      inset 0 -1px 0 color-mix(in srgb, #000 8%, transparent);
   }
 
   :root[data-theme="light"] .ib-premium-card-soft {
@@ -6660,52 +6662,82 @@
   }
 
   .ib-game-mode-chip__glow {
-    inset: -2px;
-    background: color-mix(in srgb, var(--ib-chip-accent) 24%, transparent);
-    filter: blur(8px);
-    opacity: 0.36;
+    inset: -1px;
+    background: color-mix(in srgb, var(--ib-chip-accent) 16%, transparent);
+    filter: blur(6px);
+    opacity: 0.28;
   }
 
   .ib-game-mode-chip__inner {
     border-color: color-mix(
       in srgb,
-      var(--ib-chip-accent) 44%,
-      rgba(255, 255, 255, 0.24)
+      var(--ib-chip-accent) 38%,
+      rgba(255, 255, 255, 0.12)
     );
     background: linear-gradient(
-      120deg,
-      color-mix(in srgb, var(--ib-chip-accent) 14%, rgba(255, 255, 255, 0.92))
+      180deg,
+      color-mix(in srgb, var(--ib-chip-accent) 16%, rgba(255, 255, 255, 0.035))
         0%,
-      color-mix(in srgb, var(--ib-chip-accent) 22%, rgba(255, 255, 255, 0.18))
-        100%
+      rgba(255, 255, 255, 0.025) 100%
     );
-    color: color-mix(in srgb, var(--ib-chip-accent) 44%, #ffffff);
+    color: color-mix(in srgb, var(--ib-chip-accent) 34%, #f8fafc);
     box-shadow:
-      0 0 8px color-mix(in srgb, var(--ib-chip-accent) 14%, transparent),
-      inset 0 0 0 1px
-        color-mix(in srgb, var(--ib-chip-accent) 18%, rgba(255, 255, 255, 0.32));
+      0 0 0 1px rgba(255, 255, 255, 0.025) inset,
+      0 0 14px color-mix(in srgb, var(--ib-chip-accent) 14%, transparent);
   }
 
-  .ib-game-mode-chip--animated .ib-game-mode-chip__glow {
-    animation: ib-game-mode-chip-pulse 2.8s ease-in-out infinite;
+  .ib-game-mode-chip__dot {
+    background: color-mix(in srgb, var(--ib-chip-accent) 72%, #f8fafc 28%);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--ib-chip-accent) 38%, transparent);
+  }
+
+  .ib-game-mode-chip--compact .ib-game-mode-chip__inner {
+    gap: 0.34rem;
+    padding: 0.12rem 0.48rem;
+    font-size: 7px;
+    letter-spacing: 0.12em;
+  }
+
+  .ib-game-mode-chip--compact .ib-game-mode-chip__dot {
+    width: 0.22rem;
+    height: 0.22rem;
   }
 
   :root[data-theme="light"] .ib-game-mode-chip__inner {
-    color: color-mix(in srgb, var(--ib-chip-accent) 58%, #0f172a);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--ib-chip-accent) 12%, rgba(255, 255, 255, 0.95))
+        0%,
+      color-mix(in srgb, var(--ib-chip-accent) 8%, rgba(255, 255, 255, 0.88))
+        100%
+    );
+    color: color-mix(in srgb, var(--ib-chip-accent) 56%, #0f172a);
+    box-shadow:
+      0 0 0 1px rgba(255, 255, 255, 0.36) inset,
+      0 8px 18px color-mix(in srgb, var(--ib-chip-accent) 12%, transparent);
+  }
+
+  :root[data-theme="light"] .ib-game-mode-chip__glow {
+    opacity: 0.18;
   }
 
   :root[data-theme="dark"] .ib-game-mode-chip__glow {
     inset: -1px;
-    background: color-mix(in srgb, var(--ib-chip-accent) 16%, transparent);
+    background: color-mix(in srgb, var(--ib-chip-accent) 13%, transparent);
     filter: blur(4px);
-    opacity: 0.22;
+    opacity: 0.16;
   }
 
   :root[data-theme="dark"] .ib-game-mode-chip__inner {
     box-shadow:
-      0 0 5px color-mix(in srgb, var(--ib-chip-accent) 8%, transparent),
+      0 0 0 1px rgba(255, 255, 255, 0.025) inset,
+      0 0 14px color-mix(in srgb, var(--ib-chip-accent) 14%, transparent),
       inset 0 0 0 1px
-        color-mix(in srgb, var(--ib-chip-accent) 16%, rgba(255, 255, 255, 0.24));
+        color-mix(in srgb, var(--ib-chip-accent) 12%, rgba(255, 255, 255, 0.22));
+  }
+
+  .ib-game-mode-chip--animated .ib-game-mode-chip__glow {
+    animation: ib-game-mode-chip-pulse 4.6s ease-out infinite;
   }
 
   :root[data-theme="dark"]
@@ -6727,48 +6759,15 @@
   }
 
   :root[data-theme="dark"] .ib-game-mode-chip {
-    --ib-chip-glow-opacity-start: 0.18;
-    --ib-chip-glow-opacity-end: 0.24;
-    --ib-chip-glow-scale: 1.005;
+    --ib-chip-glow-opacity-start: 0.14;
+    --ib-chip-glow-opacity-end: 0.18;
+    --ib-chip-glow-scale: 1.003;
   }
 
   .ib-streak-mode-chip {
-    --ib-chip-accent: #8b5cf6;
-    --conic-border: 2px;
-    --conic-duration: 3.2s;
-  }
-
-  .ib-streak-mode-chip__inner {
-    border: 1px solid;
-    border-color: color-mix(
-      in srgb,
-      var(--ib-chip-accent) 42%,
-      rgba(255, 255, 255, 0.22)
-    );
-  }
-
-  :root[data-theme="light"] .ib-streak-mode-chip__inner {
-    background: linear-gradient(
-      120deg,
-      color-mix(in srgb, var(--ib-chip-accent) 14%, #ffffff) 0%,
-      color-mix(in srgb, var(--ib-chip-accent) 8%, rgba(255, 255, 255, 0.94))
-        100%
-    );
-    color: color-mix(in srgb, var(--ib-chip-accent) 58%, #0f172a);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
-  }
-
-  :root[data-theme="dark"] .ib-streak-mode-chip__inner {
-    background: linear-gradient(
-      120deg,
-      color-mix(in srgb, var(--ib-chip-accent) 28%, rgba(15, 23, 42, 0.86)) 0%,
-      color-mix(in srgb, var(--ib-chip-accent) 18%, rgba(15, 23, 42, 0.4)) 100%
-    );
-    color: color-mix(in srgb, var(--ib-chip-accent) 18%, #ffffff);
-    box-shadow:
-      0 0 8px color-mix(in srgb, var(--ib-chip-accent) 16%, transparent),
-      inset 0 0 0 1px
-        color-mix(in srgb, var(--ib-chip-accent) 16%, rgba(255, 255, 255, 0.2));
+    --ib-chip-glow-opacity-start: 0.14;
+    --ib-chip-glow-opacity-end: 0.19;
+    --ib-chip-glow-scale: 1.004;
   }
 
   :root[data-theme="light"] .ib-streak-fire-chip {


### PR DESCRIPTION
### Motivation
- Create a single, shared visual system for the current rhythm/mode chip used in Overall Progress (MetricHeader), DashboardMenu and StreaksPanel so the UI looks consistent across the dashboard. 
- Make dark-mode surfaces crisper and more premium (closer to a near-black hierarchy) while keeping Innerbloom identity and preserving all behavior and accent logic.

### Description
- Introduced a shared `GameModeChip` sizing variant and structural tweaks so all mode chips reuse the same markup and classes instead of per-screen one-offs (`apps/web/src/components/common/GameModeChip.tsx`).
- Replaced DashboardMenu and StreaksPanel local chip rendering with the shared `GameModeChip` (compact size for the menu) so Overall Progress / Progreso General, DashboardMenu and StreaksPanel use the same visual language (`apps/web/src/components/dashboard-v3/DashboardMenu.tsx`, `apps/web/src/components/dashboard-v3/StreaksPanel.tsx`).
- Tuned `buildStreakModeChipVisual` to reduce glow alpha values for a calmer glow and switched StreaksPanel to derive its chip style from `buildGameModeChip` while preserving avatar-driven accent mapping (`apps/web/src/components/dashboard-v3/StreaksPanel.tsx`).
- Updated chip CSS to: unify dot treatment, tighter typography/tracking, subtler translucent dark backgrounds, subtle borders and much lower glow; added a compact variant and preserved avatar-driven accent usage (no hardcoded FLOW color) (`apps/web/src/index.css`).
- Aggressively shifted dark-mode tokens toward a near-black hierarchy and reduced backdrop blur/soft glow so dashboard cards read as crisper, raised surfaces while keeping semantic colors intact (`apps/web/src/index.css`).
- Updated targeted unit expectations to reflect the runtime avatar palette used by the code (tests adjusted only to match palette values; no production behavior changes) (`apps/web/src/components/common/GameModeChip.test.ts`, `apps/web/src/components/dashboard-v3/StreaksPanel.theme.test.ts`).

### Testing
- Ran the focused unit tests with Vitest: `npm --workspace apps/web run test -- --run src/components/common/GameModeChip.test.ts src/components/dashboard-v3/StreaksPanel.theme.test.ts` and both tests passed. ✅
- Ran typecheck: `npm run typecheck:web` which surfaced pre-existing unrelated TypeScript issues in other parts of the repo (e.g. `runtimeAuth.tsx`, `PreviewAchievementCard` test typings); these are unrelated to the visual-only changes in this PR. ⚠️
- No functional behavior was changed and no UI elements removed; this PR only touches visuals, shared chip usage, and CSS tokens as described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1d0724908332a2d1b05fac3343f5)