### PR TITLE
Refine landing “You’re not the problem” comparison block

### DIFF
--- a/apps/web/src/content/officialLandingContent.ts
+++ b/apps/web/src/content/officialLandingContent.ts
@@ -24,7 +24,13 @@ export type LandingCopy = {
     note: string;
     alt: string;
   };
-  problem: { title: string; left: string; right: string };
+  problem: {
+    title: string;
+    leftPrimary: string;
+    leftSecondary: string;
+    rightPrimary: string;
+    rightSecondary: string;
+  };
   pillars: { kicker: string; title: string; intro: string; highlightLeadIn: string; highlight: string; items: Pillar[] };
   modes: { kicker: string; title: string; intro: string; items: Mode[] };
   how: { kicker: string; title: string; intro: string; closingLine: string; steps: HowTimelineStep[] };
@@ -58,10 +64,14 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
     },
     problem: {
       title: 'El problema no sos vos.',
-      left:
-        '✕ La mayoría de las apps de hábitos asumen que todos tus días tienen la misma energía.\n\n✕ Te piden la misma intensidad incluso cuando estás cansado o saturado.\n\n✕ Si no cumplís el plan rígido, te hacen sentir que vos fallaste.',
-      right:
-        '✓ Innerbloom parte de tu capacidad real de hoy, no de una versión idealizada tuya.\n\n✓ Ajusta tu carga semanal cuando cambia tu energía, tu foco o tu contexto.\n\n✓ Así sostenés el proceso en el tiempo y convertís constancia en hábitos reales.'
+      leftPrimary:
+        'La mayoría de las apps de hábitos están diseñadas\npara una versión de vos que no existe:',
+      leftSecondary:
+        'siempre con la misma energía,\nel mismo foco y la misma disciplina.',
+      rightPrimary:
+        'Pero la vida cambia. Y cuando\nel sistema no cambia con vos,',
+      rightSecondary:
+        'no se siente como si el sistema hubiera fallado:\nse siente como si hubieras fallado vos.'
     },
     pillars: {
       kicker: 'PROGRESO EN EQUILIBRIO',
@@ -297,10 +307,14 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
     },
     problem: {
       title: 'You’re not the problem.',
-      left:
-        '✕ Most habit apps assume you show up with the same energy every single day.\n\n✕ They demand the same intensity even when your week is heavy or unpredictable.\n\n✕ If you miss a rigid plan, the app makes it feel like you failed.',
-      right:
-        '✓ Innerbloom starts from your real capacity today, not an idealized version of you.\n\n✓ It adapts your weekly load as your energy, focus, and context change.\n\n✓ That helps you stay consistent long enough to build habits that actually last.'
+      leftPrimary:
+        'Most habit apps are designed\nfor a version of you that doesn’t exist:',
+      leftSecondary:
+        'always with the same energy,\nthe same focus, and the same discipline.',
+      rightPrimary:
+        'But life changes. And when\nthe system doesn’t change with you,',
+      rightSecondary:
+        'it doesn’t feel like the system failed—\nit feels like you did.'
     },
     pillars: {
       kicker: 'PROGRESS IN BALANCE',

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -649,53 +649,72 @@
 }
 
 .landing .truth-problem-body {
-  width: min(900px, 100%);
+  width: min(940px, 100%);
   margin: clamp(12px, 1.5vw, 22px) auto 0;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
-  gap: clamp(14px, 1.7vw, 24px);
+  gap: clamp(18px, 2.4vw, 36px);
   align-items: stretch;
 }
 
 .landing .truth-problem-block {
-  margin: 0;
-  color: color-mix(in srgb, var(--ink) 90%, #e6dcff 10%);
-  font-size: clamp(0.98rem, 0.22vw + 0.92rem, 1.08rem);
-  line-height: 1.52;
-  text-align: left;
-  text-wrap: pretty;
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 10px;
+  gap: 14px;
+  align-content: start;
+}
+
+.landing .truth-problem-copy {
+  display: grid;
+  gap: 14px;
+  text-wrap: pretty;
+}
+
+.landing .truth-problem-primary,
+.landing .truth-problem-secondary {
+  margin: 0;
+  text-align: left;
+}
+
+.landing .truth-problem-primary {
+  color: rgba(242, 248, 255, 0.97);
+  font-size: clamp(1.03rem, 0.28vw + 0.96rem, 1.16rem);
+  line-height: 1.48;
+}
+
+.landing .truth-problem-secondary {
+  color: rgba(194, 184, 226, 0.9);
+  font-size: clamp(0.95rem, 0.22vw + 0.9rem, 1.04rem);
+  line-height: 1.52;
 }
 
 .landing .truth-problem-icon {
-  width: 26px;
-  height: 26px;
+  width: 30px;
+  height: 30px;
   border-radius: 999px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.86rem;
+  font-size: 0.9rem;
   font-weight: 700;
-  margin-top: 1px;
+  margin-top: 3px;
 }
 
 .landing .truth-problem-icon--x {
-  color: rgba(255, 201, 187, 0.96);
-  background: rgba(237, 109, 93, 0.22);
-  box-shadow: inset 0 0 0 1px rgba(255, 172, 160, 0.36);
+  color: rgba(255, 215, 235, 0.96);
+  background: rgba(221, 140, 190, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(237, 185, 221, 0.34);
 }
 
 .landing .truth-problem-icon--check {
-  color: rgba(193, 251, 251, 0.98);
-  background: rgba(66, 177, 200, 0.2);
-  box-shadow: inset 0 0 0 1px rgba(132, 238, 243, 0.38);
+  color: rgba(198, 250, 248, 0.98);
+  background: rgba(88, 188, 193, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(144, 236, 233, 0.36);
 }
 
 .landing .truth-problem-divider {
   width: 1px;
-  background: linear-gradient(180deg, transparent 0%, rgba(160, 190, 242, 0.56) 24%, rgba(151, 197, 255, 0.34) 74%, transparent 100%);
+  background: linear-gradient(180deg, transparent 0%, rgba(181, 193, 234, 0.42) 18%, rgba(168, 181, 225, 0.28) 80%, transparent 100%);
 }
 
 @media (max-width: 840px) {
@@ -711,9 +730,7 @@
   }
 
   .landing .truth-problem-divider {
-    height: 1px;
-    width: 100%;
-    background: linear-gradient(90deg, transparent 0%, rgba(160, 190, 242, 0.56) 22%, rgba(151, 197, 255, 0.34) 72%, transparent 100%);
+    display: none;
   }
 }
 

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -939,19 +939,33 @@ export default function LandingPage() {
             </AdaptiveText>
 
             <div className="truth-problem-body">
-              <AdaptiveText as="p" className="truth-problem-block truth-problem-block--left">
+              <div className="truth-problem-block truth-problem-block--left">
                 <span className="truth-problem-icon truth-problem-icon--x" aria-hidden>
                   ×
                 </span>
-                <span>{renderMultilineText(copy.problem.left)}</span>
-              </AdaptiveText>
+                <div className="truth-problem-copy">
+                  <AdaptiveText as="p" className="truth-problem-primary">
+                    {renderMultilineText(copy.problem.leftPrimary)}
+                  </AdaptiveText>
+                  <AdaptiveText as="p" className="truth-problem-secondary">
+                    {renderMultilineText(copy.problem.leftSecondary)}
+                  </AdaptiveText>
+                </div>
+              </div>
               <div className="truth-problem-divider" aria-hidden />
-              <AdaptiveText as="p" className="truth-problem-block truth-problem-block--right">
+              <div className="truth-problem-block truth-problem-block--right">
                 <span className="truth-problem-icon truth-problem-icon--check" aria-hidden>
                   ✓
                 </span>
-                <span>{renderMultilineText(copy.problem.right)}</span>
-              </AdaptiveText>
+                <div className="truth-problem-copy">
+                  <AdaptiveText as="p" className="truth-problem-primary">
+                    {renderMultilineText(copy.problem.rightPrimary)}
+                  </AdaptiveText>
+                  <AdaptiveText as="p" className="truth-problem-secondary">
+                    {renderMultilineText(copy.problem.rightSecondary)}
+                  </AdaptiveText>
+                </div>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
### Motivation
- Replace the current lower comparative content in the “You’re not the problem” section with an editorial two-column block that integrates with the section background and matches the provided visual reference.
- Provide clearer typographic hierarchy so each side can present a short lead statement plus supporting secondary text for improved visual rhythm.
- Keep the existing i18n flow and avoid changes to the hero or other landing sections.

### Description
- Updated the `problem` shape in `apps/web/src/content/officialLandingContent.ts` to expose `leftPrimary`, `leftSecondary`, `rightPrimary`, and `rightSecondary` for both `es` and `en` locales and populated them with the requested copy.
- Reworked the markup in `apps/web/src/pages/Landing.tsx` to render a two-column editorial block with icon chips (X / ✓), a subtle central divider, and separate primary/secondary text elements while preserving the section title and translation usage.
- Restyled the block in `apps/web/src/pages/Landing.css` to remove heavy card/container treatment, add visual hierarchy (white-ish primary, lavendar secondary), soften icon backgrounds (pink-lilac and cyan-teal tones), increase spacing, and ensure responsive stacking on mobile with the divider hidden when stacked.
- Kept design tokens and palette choices consistent with the existing site styling and avoided introducing new color palettes or outlines.

### Testing
- Ran the production build with `pnpm -C apps/web build`, which completed successfully (vite build OK). 
- Ran TypeScript typecheck with `pnpm -C apps/web typecheck`, which failed due to pre-existing unrelated TypeScript errors in other modules (these errors are outside the landing changes and did not affect the CSS/markup output for this section).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5981113083329477f87c29dac3ba)