### PR TITLE
style(onboarding): add premium theme-aware shells/cards for dark & light modes

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -21,6 +21,18 @@
     --onboarding-glass-border: rgba(255, 255, 255, 0.2);
     --onboarding-glass-border-soft: rgba(255, 255, 255, 0.12);
     --onboarding-glass-shadow: 0 26px 80px rgba(12, 18, 38, 0.24);
+    --onboarding-premium-root-bg:
+      radial-gradient(
+        112% 84% at 16% -8%,
+        rgba(255, 255, 255, 0.04),
+        transparent 62%
+      ),
+      linear-gradient(180deg, #010409 0%, #030507 58%, #010203 100%);
+    --onboarding-premium-root-text: #f8fafc;
+    --onboarding-premium-text-muted: rgba(255, 255, 255, 0.7);
+    --onboarding-premium-text-subtle: rgba(255, 255, 255, 0.5);
+    --onboarding-premium-overlay-soft: rgba(255, 255, 255, 0.06);
+    --onboarding-premium-overlay-base: rgba(255, 255, 255, 0.1);
 
     --color-surface: #010409;
     --color-surface-muted: #05070b;
@@ -330,6 +342,18 @@
       rgba(246, 248, 251, 0.92)
     );
     --glass-border: rgba(15, 23, 42, 0.08);
+    --onboarding-premium-root-bg:
+      radial-gradient(
+        116% 84% at 84% -6%,
+        rgba(148, 163, 184, 0.07) 0%,
+        rgba(148, 163, 184, 0) 62%
+      ),
+      linear-gradient(180deg, #f8fafc 0%, #f4f6f8 52%, #eef2f6 100%);
+    --onboarding-premium-root-text: #0f172a;
+    --onboarding-premium-text-muted: #334155;
+    --onboarding-premium-text-subtle: #64748b;
+    --onboarding-premium-overlay-soft: rgba(15, 23, 42, 0.035);
+    --onboarding-premium-overlay-base: rgba(15, 23, 42, 0.06);
     --onboarding-glass-surface-base: rgba(255, 255, 255, 0.92);
     --onboarding-glass-surface-inner: rgba(255, 255, 255, 0.85);
     --onboarding-glass-surface-ghost: rgba(248, 250, 255, 0.76);
@@ -1121,43 +1145,91 @@
     outline-offset: 2px;
   }
 
-  .onboarding-force-white,
-  .onboarding-force-white
-    :is(
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6,
-      p,
-      span,
-      label,
-      legend,
-      li,
-      dt,
-      dd,
-      small,
-      strong,
-      em,
-      a
-    ) {
-    color: #ffffff;
+  .onboarding-premium-root {
+    background: var(--onboarding-premium-root-bg);
+    color: var(--onboarding-premium-root-text);
   }
 
-  .onboarding-force-white {
-    /* Keep IntroJourney in dark mode even when app theme is light. */
-    --onboarding-glass-surface-base: rgba(255, 255, 255, 0.1);
-    --onboarding-glass-surface-inner: rgba(255, 255, 255, 0.06);
-    --onboarding-glass-surface-ghost: rgba(255, 255, 255, 0.03);
-    --onboarding-glass-border: rgba(255, 255, 255, 0.2);
-    --onboarding-glass-border-soft: rgba(255, 255, 255, 0.12);
-    --onboarding-glass-shadow: 0 26px 80px rgba(12, 18, 38, 0.24);
+  .onboarding-premium-shell {
+    background: color-mix(in srgb, var(--onboarding-premium-overlay-soft) 72%, transparent);
+    border-bottom: 1px solid var(--onboarding-glass-border-soft);
+    backdrop-filter: blur(22px);
+    -webkit-backdrop-filter: blur(22px);
   }
 
-  .onboarding-force-white :is(input, textarea)::placeholder {
-    color: #ffffff;
+  .onboarding-premium-card {
+    background: var(--onboarding-glass-surface-base);
+    border: 1px solid var(--onboarding-glass-border);
+    box-shadow: var(--onboarding-glass-shadow);
+    backdrop-filter: blur(22px);
+  }
+
+  .onboarding-premium-surface {
+    background: var(--onboarding-glass-surface-inner);
+    border: 1px solid var(--onboarding-glass-border-soft);
+    backdrop-filter: blur(16px);
+  }
+
+  .onboarding-premium-button {
+    border: 1px solid var(--onboarding-glass-border-soft);
+    background: var(--onboarding-premium-overlay-base);
+    color: var(--onboarding-premium-root-text);
+  }
+
+  .onboarding-premium-input {
+    border: 1px solid var(--onboarding-glass-border-soft);
+    background: var(--onboarding-premium-overlay-soft);
+    color: var(--onboarding-premium-root-text);
+  }
+
+  .onboarding-premium-input::placeholder {
+    color: color-mix(in srgb, var(--onboarding-premium-root-text) 62%, transparent);
     opacity: 1;
+  }
+
+  .onboarding-premium-divider {
+    border-color: color-mix(in srgb, var(--onboarding-glass-border-soft) 55%, transparent);
+  }
+
+  .onboarding-premium-root .text-white,
+  .onboarding-premium-root .text-white\/90,
+  .onboarding-premium-root .text-white\/85,
+  .onboarding-premium-root .text-white\/80,
+  .onboarding-premium-root .text-white\/75,
+  .onboarding-premium-root .text-white\/70 {
+    color: var(--onboarding-premium-root-text);
+  }
+
+  .onboarding-premium-root .text-white\/65,
+  .onboarding-premium-root .text-white\/60 {
+    color: var(--onboarding-premium-text-muted);
+  }
+
+  .onboarding-premium-root .text-white\/50 {
+    color: var(--onboarding-premium-text-subtle);
+  }
+
+  .onboarding-premium-root .border-white\/20,
+  .onboarding-premium-root .border-white\/15,
+  .onboarding-premium-root .border-white\/12,
+  .onboarding-premium-root .border-white\/10,
+  .onboarding-premium-root .border-white\/5 {
+    border-color: var(--onboarding-glass-border-soft);
+  }
+
+  .onboarding-premium-root .bg-white\/12,
+  .onboarding-premium-root .bg-white\/10,
+  .onboarding-premium-root .bg-white\/6,
+  .onboarding-premium-root .bg-white\/5,
+  .onboarding-premium-root .bg-white\/\[0\.11\],
+  .onboarding-premium-root .bg-white\/\[0\.1\],
+  .onboarding-premium-root .bg-white\/\[0\.07\],
+  .onboarding-premium-root .bg-white\/\[0\.04\] {
+    background: var(--onboarding-premium-overlay-soft);
+  }
+
+  .onboarding-premium-root .bg-white\/80 {
+    background: color-mix(in srgb, var(--onboarding-premium-root-text) 16%, var(--onboarding-glass-surface-base) 84%);
   }
 
   @property --conic-angle {

--- a/apps/web/src/onboarding/IntroJourney.tsx
+++ b/apps/web/src/onboarding/IntroJourney.tsx
@@ -597,7 +597,7 @@ export function IntroJourney({ language = 'es', onFinish, isSubmitting = false, 
   }
 
   return (
-    <div className="onboarding-force-white relative flex min-h-screen min-h-dvh flex-col overflow-x-hidden bg-[#000c40] pb-16">
+    <div className="onboarding-premium-root relative flex min-h-screen min-h-dvh flex-col overflow-x-hidden pb-16">
       <HUD
         language={language}
         mode={answers.mode}

--- a/apps/web/src/onboarding/screens/JourneyGeneratingScreen.tsx
+++ b/apps/web/src/onboarding/screens/JourneyGeneratingScreen.tsx
@@ -94,7 +94,7 @@ export function JourneyGeneratingScreen({ gameMode, language, onGoToDashboard, o
   }, [bullets.length]);
 
   return (
-    <div className="relative flex min-h-screen min-h-dvh items-center justify-center overflow-hidden bg-[#000c40] px-6 py-10 text-white">
+    <div className="onboarding-premium-root relative flex min-h-screen min-h-dvh items-center justify-center overflow-hidden px-6 py-10">
       <div className="pointer-events-none absolute inset-0 opacity-60">
         <svg viewBox="0 0 1200 720" className="h-full w-full" role="presentation" aria-hidden>
           <defs>
@@ -117,7 +117,7 @@ export function JourneyGeneratingScreen({ gameMode, language, onGoToDashboard, o
 
       <div className="pointer-events-none absolute inset-0 bg-black/55 backdrop-blur-sm" aria-hidden />
 
-      <section className="relative z-10 w-full max-w-3xl rounded-3xl border border-white/10 bg-[#0a133d]/85 p-6 shadow-[0_0_45px_rgba(79,70,229,0.22)] backdrop-blur-xl sm:p-10">
+      <section className="onboarding-premium-card relative z-10 w-full max-w-3xl rounded-3xl p-6 sm:p-10">
         <div className="mb-6 flex items-center justify-center gap-2 text-center text-xs font-semibold uppercase tracking-[0.42em] text-white/65 sm:text-sm">
           <span>Innerbloom</span>
           <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logo" className="h-[1.9em] w-auto" />

--- a/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
+++ b/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
@@ -54,8 +54,8 @@ export function QuickStartGeneratingScreen({
   }, [steps.length]);
 
   return (
-    <div className="min-h-screen min-h-dvh overflow-y-auto bg-[#000c40] px-4 py-10 text-white">
-      <section className="relative mx-auto mt-5 w-full max-w-3xl rounded-3xl border border-white/10 bg-[#0a133d]/85 p-5 shadow-[0_0_45px_rgba(79,70,229,0.22)] backdrop-blur-xl sm:p-8">
+    <div className="onboarding-premium-root min-h-screen min-h-dvh overflow-y-auto px-4 py-10">
+      <section className="onboarding-premium-card relative mx-auto mt-5 w-full max-w-3xl rounded-3xl p-5 sm:p-8">
         <div className="mb-5 flex items-center justify-center gap-2 text-center text-[0.68rem] font-semibold uppercase tracking-[0.36em] text-white/65 sm:text-xs">
           <span>Innerbloom</span>
           <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logo" className="h-[1.8em] w-auto" />

--- a/apps/web/src/onboarding/ui/HUD.tsx
+++ b/apps/web/src/onboarding/ui/HUD.tsx
@@ -78,7 +78,7 @@ export function HUD({ language = 'es', mode, stepIndex, totalSteps, xp, highligh
 
   return (
     <header
-      className={`fixed inset-x-0 top-0 z-40 border-b bg-white/10 backdrop-blur-2xl transition duration-200 ${
+      className={`onboarding-premium-shell fixed inset-x-0 top-0 z-40 border-b transition duration-200 ${
         highlighted
           ? 'border-sky-200/40 shadow-[0_14px_38px_rgba(8,57,104,0.35)] ring-1 ring-sky-200/30'
           : 'border-white/15'


### PR DESCRIPTION
### Motivation

- Replace legacy hardcoded navy/blue onboarding backgrounds (e.g. `#000c40`, `#0a133d`) with the current premium visual system while keeping onboarding behaviour unchanged.
- Ensure shared onboarding shells and the traditional onboarding screens align with Dashboard/Daily Quest premium surfaces in both dark and light themes.
- Provide reusable, theme-aware tokens and classes so individual onboarding components can keep their DOM and Tailwind usage without scattered one-off colors. 

### Description

- Added onboarding premium theme tokens and reusable classes in `apps/web/src/index.css`, including `onboarding-premium-root`, `onboarding-premium-shell`, `onboarding-premium-card`, `onboarding-premium-surface`, `onboarding-premium-button`, `onboarding-premium-input`, and `onboarding-premium-divider`, with support for `:root[data-theme="dark"]` and `:root[data-theme="light"]` token variants. 
- Scoped utility overrides so existing onboarding classnames (e.g. `text-white/*`, `bg-white/*`, `border-white/*`) inherit theme-aware colors inside the onboarding shell without changing component APIs. 
- Replaced dark hardcoded container classes with the new theme classes in the shared/traditional onboarding entry: `apps/web/src/onboarding/IntroJourney.tsx` now uses `onboarding-premium-root` instead of `bg-[#000c40]`/force-dark wrapper. 
- Updated HUD/intro/generation screens to use theme-aware shell/card classes (visual-only): `apps/web/src/onboarding/ui/HUD.tsx`, `apps/web/src/onboarding/screens/JourneyGeneratingScreen.tsx`, and `apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx`. 
- No changes to routing, step logic, payloads, task generation, API calls, auth/Clerk internals, onboarding progress tracking, GP calculation, Quick Start row DOM/layout, or copy (except where strictly needed for visual overflow). 

### Testing

- Ran a search to confirm navy backgrounds were replaced using `rg` and validated no onboarding screens left using `#000c40` / `#0a133d` as the main shell backgrounds (verification succeeded). 
- Ran typecheck with `pnpm -C apps/web typecheck`, which failed; failures are pre-existing and unrelated to these visual-only onboarding changes (examples include `runtimeAuth.tsx` Clerk typings and several dashboard/demo typing/test errors). 
- No onboarding unit/e2e tests were modified; visual changes are CSS/class scoped so behavior and component props remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5afc4b1483328f5b494bb1931266)