### PR TITLE
style(web): Quick Start visual/theming pass to match premium dark/light surfaces

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1232,6 +1232,207 @@
     background: color-mix(in srgb, var(--onboarding-premium-root-text) 16%, var(--onboarding-glass-surface-base) 84%);
   }
 
+  .quickstart-premium-root {
+    background: var(--onboarding-premium-root-bg);
+    color: var(--onboarding-premium-root-text);
+  }
+
+  .quickstart-premium-card {
+    background: var(--color-card-gradient);
+    border: 1px solid var(--color-border-soft);
+    box-shadow: var(--shadow-elev-2);
+    backdrop-filter: blur(20px);
+  }
+
+  .quickstart-premium-surface {
+    background: color-mix(in srgb, var(--color-overlay-1) 74%, transparent);
+    border-color: var(--color-border-subtle);
+  }
+
+  .quickstart-pill {
+    border-color: color-mix(in srgb, var(--color-accent-secondary) 24%, var(--color-border-soft));
+    background: color-mix(in srgb, var(--color-accent-secondary) 12%, var(--color-overlay-1));
+    color: var(--onboarding-premium-root-text);
+  }
+
+  .quickstart-min-rule {
+    color: color-mix(in srgb, var(--onboarding-premium-root-text) 92%, transparent);
+  }
+
+  .quickstart-min-rule__dot {
+    color: var(--onboarding-premium-text-subtle);
+  }
+
+  .quickstart-bonus-pill {
+    border-color: var(--color-border-soft);
+  }
+
+  .quickstart-bonus-pill--ready {
+    background: color-mix(in srgb, #34d399 20%, transparent);
+    border-color: color-mix(in srgb, #34d399 35%, var(--color-border-soft));
+    color: color-mix(in srgb, #dcfce7 82%, var(--onboarding-premium-root-text));
+  }
+
+  .quickstart-bonus-pill--pending {
+    background: color-mix(in srgb, #38bdf8 16%, transparent);
+    border-color: color-mix(in srgb, #38bdf8 32%, var(--color-border-soft));
+    color: color-mix(in srgb, #dbeafe 82%, var(--onboarding-premium-root-text));
+  }
+
+  .quickstart-task-row {
+    background: var(--color-card-gradient);
+    border-color: var(--color-border-subtle);
+    box-shadow: 0 10px 24px rgba(2, 6, 23, 0.22);
+  }
+
+  .quickstart-task-row:hover {
+    border-color: var(--color-border-soft);
+    background: color-mix(in srgb, var(--color-overlay-1) 86%, var(--color-card-gradient));
+  }
+
+  .quickstart-task-row--selected {
+    border-color: color-mix(in srgb, var(--color-accent-secondary) 34%, var(--color-border-soft));
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-surface-elevated) 88%, var(--color-accent-secondary) 12%),
+      color-mix(in srgb, var(--color-surface-muted) 90%, var(--color-accent-secondary) 10%)
+    );
+    box-shadow: 0 16px 32px rgba(2, 6, 23, 0.32);
+  }
+
+  .quickstart-task-row__back {
+    border-color: color-mix(in srgb, var(--color-accent-secondary) 46%, var(--color-border-soft));
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-accent-secondary) 28%, var(--color-overlay-1)),
+      color-mix(in srgb, var(--color-accent-secondary) 22%, var(--color-surface-muted))
+    );
+    box-shadow: 0 10px 22px rgba(2, 6, 23, 0.24);
+  }
+
+  .quickstart-task-trait-band {
+    color: color-mix(in srgb, var(--onboarding-premium-root-text) 88%, #c4b5fd 12%);
+  }
+
+  .quickstart-task-input {
+    border-color: color-mix(in srgb, var(--color-accent-secondary) 22%, var(--color-border-soft));
+    background: color-mix(in srgb, var(--color-overlay-1) 70%, transparent);
+    color: var(--onboarding-premium-root-text);
+  }
+
+  .quickstart-task-input:focus-visible {
+    --tw-ring-color: color-mix(in srgb, var(--color-accent-secondary) 42%, #93c5fd);
+  }
+
+  .quickstart-task-help {
+    border-color: color-mix(in srgb, var(--color-accent-secondary) 30%, var(--color-border-soft));
+    background: color-mix(in srgb, var(--color-accent-secondary) 16%, var(--color-overlay-1));
+    color: color-mix(in srgb, var(--onboarding-premium-root-text) 92%, transparent);
+  }
+
+  .quickstart-suggestions-panel {
+    border-color: color-mix(in srgb, var(--color-accent-secondary) 28%, var(--color-border-soft));
+    background: color-mix(in srgb, var(--color-surface-elevated) 94%, var(--color-accent-secondary) 6%);
+    color: color-mix(in srgb, var(--onboarding-premium-root-text) 92%, transparent);
+    box-shadow: 0 10px 24px rgba(2, 6, 23, 0.34);
+  }
+
+  .quickstart-moderation-option {
+    border-color: var(--color-border-soft);
+    background: color-mix(in srgb, var(--color-overlay-1) 68%, transparent);
+  }
+
+  .quickstart-moderation-option--enabled {
+    border-color: color-mix(in srgb, var(--color-accent-secondary) 35%, var(--color-border-soft));
+    background: color-mix(in srgb, var(--color-accent-secondary) 20%, var(--color-overlay-1));
+  }
+
+  .quickstart-moderation-toggle {
+    background: color-mix(in srgb, var(--color-border-soft) 75%, transparent);
+  }
+
+  .quickstart-moderation-toggle--enabled {
+    background: color-mix(in srgb, var(--color-accent-secondary) 48%, #a5b4fc);
+  }
+
+  .quickstart-setup-dot {
+    background: color-mix(in srgb, var(--color-accent-secondary) 62%, #cbd5e1);
+  }
+
+  .quickstart-free-pill {
+    border-color: color-mix(in srgb, #34d399 44%, var(--color-border-soft));
+    background: color-mix(in srgb, #34d399 20%, transparent);
+    color: color-mix(in srgb, #dcfce7 82%, var(--onboarding-premium-root-text));
+  }
+
+  .quickstart-progress-track {
+    background: color-mix(in srgb, var(--color-border-soft) 80%, transparent);
+  }
+
+  .quickstart-progress-fill {
+    background: linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--color-accent-secondary) 68%, #a5b4fc),
+      color-mix(in srgb, var(--color-accent-primary) 52%, #cbd5e1),
+      color-mix(in srgb, var(--color-accent-secondary) 60%, #818cf8)
+    );
+  }
+
+  .quickstart-primary-cta {
+    border-color: color-mix(in srgb, var(--color-accent-secondary) 42%, var(--color-border-soft));
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--color-accent-secondary) 62%, var(--color-surface-elevated)),
+      color-mix(in srgb, var(--color-accent-primary) 36%, var(--color-surface-highlight))
+    );
+    color: #ffffff;
+    box-shadow: 0 10px 24px rgba(2, 6, 23, 0.32);
+  }
+
+  .quickstart-primary-cta:hover {
+    box-shadow: 0 14px 28px rgba(2, 6, 23, 0.38);
+  }
+
+  .quickstart-primary-cta:focus-visible {
+    --tw-ring-color: color-mix(in srgb, var(--color-accent-secondary) 48%, #93c5fd);
+  }
+
+  :root[data-theme="light"] .quickstart-task-row {
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+  }
+
+  :root[data-theme="light"] .quickstart-task-row--selected {
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, #ffffff 92%, #e0e7ff),
+      color-mix(in srgb, #f8fafc 88%, #e9d5ff)
+    );
+    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
+  }
+
+  :root[data-theme="light"] .quickstart-task-row__back {
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, #e9d5ff 26%, #ffffff),
+      color-mix(in srgb, #dbeafe 22%, #f8fafc)
+    );
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.1);
+  }
+
+  :root[data-theme="light"] .quickstart-suggestions-panel {
+    background: color-mix(in srgb, #ffffff 94%, #eef2ff);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.14);
+  }
+
+  :root[data-theme="light"] .quickstart-primary-cta {
+    color: #0f172a;
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, #ffffff 70%, #e0e7ff),
+      color-mix(in srgb, #f8fafc 70%, #dbeafe)
+    );
+  }
+
   @property --conic-angle {
     syntax: "<angle>";
     inherits: false;

--- a/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
+++ b/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
@@ -575,16 +575,6 @@ function InlineTaskRow({
   const hasInput = Boolean(task.inputAfter || task.inputBefore);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const rowRef = useRef<HTMLDivElement | null>(null);
-  const selectedFrontStyle = {
-    borderColor: 'color-mix(in srgb, var(--color-accent-secondary) 42%, var(--onboarding-glass-border))',
-    background: 'color-mix(in srgb, var(--color-surface-elevated) 82%, var(--color-accent-secondary) 18%)',
-    boxShadow: '0 18px 40px color-mix(in srgb, var(--color-surface-elevated) 56%, rgba(8,12,28,0.66))',
-  };
-  const selectedBackStyle = {
-    borderColor: 'color-mix(in srgb, var(--color-accent-secondary) 54%, var(--onboarding-glass-border-soft))',
-    background: 'color-mix(in srgb, var(--color-accent-secondary) 62%, var(--color-surface-elevated) 38%)',
-    boxShadow: '0 12px 24px color-mix(in srgb, var(--color-accent-secondary) 40%, rgba(8,12,28,0.64))',
-  };
 
   useEffect(() => {
     if (!selected) {
@@ -611,12 +601,8 @@ function InlineTaskRow({
   return (
     <div ref={rowRef} className={`relative ${selected ? 'pt-5 pb-1' : ''}`}>
       {selected ? (
-        <div
-          className="pointer-events-none absolute inset-x-0 top-0 bottom-1 rounded-2xl border px-4 pt-1.5 pb-3"
-          style={selectedBackStyle}
-          aria-hidden
-        >
-          <span className="block text-[10px] font-semibold uppercase leading-none tracking-[0.16em] text-violet-100/90">
+        <div className="quickstart-task-row__back pointer-events-none absolute inset-x-0 top-0 bottom-1 rounded-2xl border px-4 pt-1.5 pb-3" aria-hidden>
+          <span className="quickstart-task-trait-band block text-[10px] font-semibold uppercase leading-none tracking-[0.16em]">
             {copy.traitLabel}: {task.trait}
           </span>
         </div>
@@ -634,8 +620,7 @@ function InlineTaskRow({
         role="button"
         tabIndex={0}
         data-selected={selected ? 'true' : undefined}
-        className="onboarding-surface-inner relative z-10 w-full rounded-2xl border px-4 py-3.5 text-left text-white/85 shadow-[0_12px_24px_rgba(8,12,28,0.18)] transition hover:border-white/30 hover:bg-white/[0.12]"
-        style={selected ? selectedFrontStyle : undefined}
+        className={`quickstart-task-row onboarding-surface-inner relative z-10 w-full rounded-2xl border px-4 py-3.5 text-left text-white/85 transition ${selected ? 'quickstart-task-row--selected' : ''}`}
       >
         <div className="flex items-center gap-2.5">
           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 gap-y-2 text-sm leading-relaxed sm:text-base">
@@ -648,7 +633,7 @@ function InlineTaskRow({
                 inputMode="numeric"
                 onClick={(event) => event.stopPropagation()}
                 onChange={(event) => onInputChange(event.target.value)}
-                className="h-6 w-12 rounded-md border border-violet-200/30 bg-violet-100/5 px-1.5 text-center text-xs text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-300/70 disabled:opacity-40 sm:h-7 sm:w-14"
+                className="quickstart-task-input h-6 w-12 rounded-md border px-1.5 text-center text-xs focus:outline-none focus-visible:ring-2 disabled:opacity-40 sm:h-7 sm:w-14"
                 placeholder={copy.countPlaceholder}
               />
             ) : null}
@@ -663,7 +648,7 @@ function InlineTaskRow({
                 event.stopPropagation();
                 setShowSuggestions((prev) => !prev);
               }}
-              className="relative z-20 ml-auto inline-flex h-5 w-5 shrink-0 items-center justify-center self-start rounded-md border border-violet-200/45 bg-violet-300/18 text-white/90 transition"
+              className="quickstart-task-help relative z-20 ml-auto inline-flex h-5 w-5 shrink-0 items-center justify-center self-start rounded-md border transition"
               aria-label={copy.taskHelpLabel}
               aria-expanded={showSuggestions}
             >
@@ -679,8 +664,7 @@ function InlineTaskRow({
 
       {selected && task.suggestions?.length && showSuggestions ? (
         <div
-          className="absolute right-3 bottom-[calc(100%+0.35rem)] z-30 w-[min(18.5rem,calc(100%-1.5rem))] rounded-xl border p-3 text-xs text-white/92 shadow-[0_10px_30px_rgba(43,25,96,0.45)] backdrop-blur"
-          style={{ borderColor: 'rgba(196, 181, 253, 0.42)', backgroundColor: 'rgba(17, 24, 39, 0.93)' }}
+          className="quickstart-suggestions-panel absolute right-3 bottom-[calc(100%+0.35rem)] z-30 w-[min(18.5rem,calc(100%-1.5rem))] rounded-xl border p-3 text-xs backdrop-blur"
         >
           <ul className="space-y-1.5">
             {task.suggestions.map((suggestion) => (
@@ -1024,12 +1008,12 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
     const modeStyle = { tint: rhythmTheme.softTint, border: rhythmTheme.border, glow: rhythmTheme.glow };
 
     return (
-      <section className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">
+      <section className="quickstart-premium-card onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">
         <header className="mb-5 border-b border-white/10 pb-4">
           <h1 className="text-2xl font-semibold text-white sm:text-3xl">{copy.pillarTitles[currentPillar]}</h1>
           <p className="mt-2 text-sm text-white/70">{copy.pillarSubtitles[currentPillar]}</p>
           <div
-            className="mt-3 inline-flex max-w-full items-center gap-2 rounded-full border px-4 py-1.5 text-xs font-semibold text-violet-50/95"
+            className="quickstart-min-rule mt-3 inline-flex max-w-full items-center gap-2 rounded-full border px-4 py-1.5 text-xs font-semibold"
             style={{
               borderColor: `color-mix(in srgb, ${modeStyle.border} 92%, rgba(255,255,255,0.14))`,
               background: `linear-gradient(135deg, color-mix(in srgb, ${modeStyle.tint} 90%, rgba(10,14,30,0.72)), color-mix(in srgb, ${modeStyle.tint} 66%, rgba(10,14,30,0.58)))`,
@@ -1037,13 +1021,13 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
             }}
           >
             <span className="whitespace-nowrap">{copy.minRule(minimum)}</span>
-            <span className="text-violet-100/60" aria-hidden>·</span>
+            <span className="quickstart-min-rule__dot" aria-hidden>·</span>
             <span className="whitespace-nowrap">{copy.suggestedRule}</span>
           </div>
           <div className="mt-2.5 flex flex-wrap items-center gap-2 text-xs">
             <span
-              className={`inline-flex rounded-lg border px-3.5 py-1.5 text-[0.68rem] font-medium sm:text-[0.72rem] ${
-                balancedBonusActive ? 'border-cyan-200/30 bg-cyan-300/8 text-cyan-100/90' : 'border-sky-200/28 bg-sky-300/8 text-sky-100/85'
+              className={`quickstart-bonus-pill inline-flex rounded-lg border px-3.5 py-1.5 text-[0.68rem] font-medium sm:text-[0.72rem] ${
+                balancedBonusActive ? 'quickstart-bonus-pill--ready' : 'quickstart-bonus-pill--pending'
               }`}
             >
               {balancedBonusActive ? copy.bonusReady : copy.bonusPending}
@@ -1086,7 +1070,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
   };
 
   return (
-    <div className={`min-h-screen min-h-dvh bg-[#000c40] text-white ${step === 'setup' ? '' : 'pb-12 pt-28 sm:pt-32'}`}>
+    <div className={`quickstart-premium-root onboarding-premium-root min-h-screen min-h-dvh text-white ${step === 'setup' ? '' : 'pb-12 pt-28 sm:pt-32'}`}>
       {step !== 'setup' ? (
         <HUD
           language={language}
@@ -1105,7 +1089,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
         {step === 'body' || step === 'mind' || step === 'soul' ? quickStartBody() : null}
 
         {step === 'moderation' ? (
-          <section className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">
+          <section className="quickstart-premium-card onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">
             <h1 className="text-2xl font-semibold text-white sm:text-3xl">{copy.moderationTitle}</h1>
             <p className="mt-2 text-sm text-white/70">{copy.moderationSubtitle}</p>
             <p className="mt-2 text-xs text-white/55">{copy.moderationHint}</p>
@@ -1118,13 +1102,13 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
                     key={option}
                     type="button"
                     onClick={() => setModerationPrefs((prev) => ({ ...prev, [option]: !prev[option] }))}
-                    className={`flex w-full items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left transition ${enabled ? 'border-violet-200/45 bg-violet-400/18' : 'border-white/20 bg-white/6'}`}
+                    className={`quickstart-moderation-option flex w-full items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left transition ${enabled ? 'quickstart-moderation-option--enabled' : ''}`}
                   >
                     <div>
                       <p className="text-sm font-semibold text-white">{card.icon} {card.title}</p>
                       <p className="mt-1 text-xs text-white/65">{card.description}</p>
                     </div>
-                    <span className={`inline-flex h-5 w-10 shrink-0 items-center overflow-hidden rounded-full p-0.5 ${enabled ? 'bg-violet-300/70' : 'bg-white/20'}`}>
+                    <span className={`quickstart-moderation-toggle inline-flex h-5 w-10 shrink-0 items-center overflow-hidden rounded-full p-0.5 ${enabled ? 'quickstart-moderation-toggle--enabled' : ''}`}>
                       <span className={`block h-4 w-4 shrink-0 rounded-full bg-white transition-transform ${enabled ? 'translate-x-[1.125rem]' : ''}`} />
                     </span>
                   </button>
@@ -1137,7 +1121,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
         ) : null}
 
         {step === 'summary' ? (
-          <section className="glass-card onboarding-surface-base mx-auto w-full max-w-5xl rounded-3xl p-6 sm:p-8">
+          <section className="quickstart-premium-card glass-card onboarding-surface-base mx-auto w-full max-w-5xl rounded-3xl p-6 sm:p-8">
             <header className="flex flex-col gap-2 border-b border-white/5 pb-4">
               <p className="text-xs uppercase tracking-[0.35em] text-white/50">{copy.quickSummary.eyebrow}</p>
               <h2 className="text-3xl font-semibold text-white">{copy.quickSummary.title}</h2>
@@ -1145,7 +1129,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
             </header>
             <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1.45fr)_minmax(0,1fr)]">
               <div className="space-y-5">
-                <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                <section className="quickstart-premium-surface rounded-2xl border p-5">
                   <header className="border-b border-white/5 pb-3">
                     <p className="text-xs uppercase tracking-[0.35em] text-white/50">{copy.quickSummary.baseData}</p>
                   </header>
@@ -1169,20 +1153,20 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
                     </div>
                   </div>
                 </section>
-                <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                <section className="quickstart-premium-surface rounded-2xl border p-5">
                   <header className="border-b border-white/5 pb-3">
                     <p className="text-xs uppercase tracking-[0.35em] text-white/50">{copy.quickSummary.pillars}</p>
                   </header>
                   <div className="mt-4 space-y-3">
                     <p className="text-sm text-white/70">{copy.quickSummary.selectedTraits}</p>
                     {(['Body', 'Mind', 'Soul'] as Pillar[]).map((pillar) => (
-                      <div key={pillar} className="rounded-xl border border-white/10 bg-white/5 p-3">
+                      <div key={pillar} className="quickstart-premium-surface rounded-xl border p-3">
                         <p className="text-sm font-semibold text-white">{copy.pillarTitles[pillar]}</p>
                         <p className="mt-1 text-xs text-white/70">{copy.quickSummary.selectedTasks}: {selectedByPillar[pillar].length}</p>
                         <div className="mt-2 flex flex-wrap gap-1.5">
                           {quickStartDraft.selectedTraitsByPillar[pillar].length > 0
                             ? quickStartDraft.selectedTraitsByPillar[pillar].map((trait) => (
-                              <span key={`${pillar}-${trait}`} className="rounded-full border border-white/15 bg-white/10 px-2.5 py-1 text-[11px] font-medium text-white/90">
+                              <span key={`${pillar}-${trait}`} className="quickstart-pill rounded-full border px-2.5 py-1 text-[11px] font-medium">
                                 {trait}
                               </span>
                             ))
@@ -1194,7 +1178,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
                 </section>
               </div>
               <aside className="space-y-5">
-                <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                <section className="quickstart-premium-surface rounded-2xl border p-5">
                   <header className="border-b border-white/5 pb-3">
                     <p className="text-xs uppercase tracking-[0.35em] text-white/50">{copy.quickSummary.xp}</p>
                   </header>
@@ -1221,7 +1205,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
         ) : null}
 
         {step === 'setup' ? (
-          <section className="relative mx-auto mt-5 w-full max-w-3xl rounded-3xl border border-white/10 bg-[#0a133d]/85 p-5 shadow-[0_0_45px_rgba(79,70,229,0.22)] backdrop-blur-xl sm:p-8">
+          <section className="quickstart-premium-card relative mx-auto mt-5 w-full max-w-3xl rounded-3xl p-5 sm:p-8">
             <div className="mb-5 flex items-center justify-center gap-2 text-center text-[0.68rem] font-semibold uppercase tracking-[0.36em] text-white/65 sm:text-xs">
               <span>Innerbloom</span>
               <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logo" className="h-[1.8em] w-auto" />
@@ -1237,11 +1221,11 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
                     key={setupStep}
                     className="flex items-center gap-3 text-sm text-slate-100/90 transition-all duration-500"
                   >
-                    <span className={`h-2.5 w-2.5 rounded-full bg-violet-300 ${!complete && index === setupProgress - 1 ? 'animate-pulse' : ''}`} />
+                    <span className={`quickstart-setup-dot h-2.5 w-2.5 rounded-full ${!complete && index === setupProgress - 1 ? 'animate-pulse' : ''}`} />
                     <span>
                       {setupStep}
                       {isPlanStep ? (
-                        <span className="ml-2 inline-flex rounded-full border border-emerald-300/35 bg-emerald-400/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-emerald-100 align-middle">
+                        <span className="quickstart-free-pill ml-2 inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] align-middle">
                           FREE
                         </span>
                       ) : null}
@@ -1250,9 +1234,9 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
                 );
               })}
             </ul>
-            <div className="mt-6 h-1.5 w-full overflow-hidden rounded-full bg-white/15">
+            <div className="quickstart-progress-track mt-6 h-1.5 w-full overflow-hidden rounded-full">
               <div
-                className={`h-full bg-gradient-to-r from-violet-300/80 via-indigo-300/85 to-violet-300/80 transition-all duration-700 ${
+                className={`quickstart-progress-fill h-full transition-all duration-700 ${
                   setupProgress >= setupSteps.length ? 'w-full quick-start-setup__progress-complete' : 'w-1/3 quick-start-setup__progress-animated'
                 }`}
               />
@@ -1280,7 +1264,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
                 type="button"
                 onClick={openGuidedDemo}
                 whileTap={{ scale: 0.97 }}
-                className="order-1 inline-flex items-center justify-center rounded-full border border-violet-300/45 bg-violet-500 px-6 py-2.5 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(76,29,149,0.3)] transition duration-200 hover:-translate-y-0.5 hover:bg-violet-400 hover:shadow-[0_14px_28px_rgba(76,29,149,0.4)] focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 sm:order-2"
+                className="quickstart-primary-cta order-1 inline-flex items-center justify-center rounded-full border px-6 py-2.5 text-sm font-semibold transition duration-200 hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 sm:order-2"
                 disabled={isSubmitting || !submitCompleted}
               >
                 {isSubmitting

--- a/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
+++ b/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
@@ -54,8 +54,8 @@ export function QuickStartGeneratingScreen({
   }, [steps.length]);
 
   return (
-    <div className="onboarding-premium-root min-h-screen min-h-dvh overflow-y-auto px-4 py-10">
-      <section className="onboarding-premium-card relative mx-auto mt-5 w-full max-w-3xl rounded-3xl p-5 sm:p-8">
+    <div className="quickstart-premium-root onboarding-premium-root min-h-screen min-h-dvh overflow-y-auto px-4 py-10">
+      <section className="quickstart-premium-card onboarding-premium-card relative mx-auto mt-5 w-full max-w-3xl rounded-3xl p-5 sm:p-8">
         <div className="mb-5 flex items-center justify-center gap-2 text-center text-[0.68rem] font-semibold uppercase tracking-[0.36em] text-white/65 sm:text-xs">
           <span>Innerbloom</span>
           <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logo" className="h-[1.8em] w-auto" />
@@ -68,21 +68,21 @@ export function QuickStartGeneratingScreen({
             const isPlanStep = index === steps.length - 1;
             return (
               <li key={setupStep} className="flex items-center gap-3 text-sm text-slate-100/90 transition-all duration-500">
-                <span className={`h-2.5 w-2.5 rounded-full bg-violet-300 ${!complete && index === setupProgress - 1 ? 'animate-pulse' : ''}`} />
+                <span className={`quickstart-setup-dot h-2.5 w-2.5 rounded-full ${!complete && index === setupProgress - 1 ? 'animate-pulse' : ''}`} />
                 <span>
                   {setupStep}
-                  {isPlanStep ? <span className="ml-2 inline-flex rounded-full border border-emerald-300/35 bg-emerald-400/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-emerald-100 align-middle">FREE</span> : null}
+                  {isPlanStep ? <span className="quickstart-free-pill ml-2 inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] align-middle">FREE</span> : null}
                 </span>
               </li>
             );
           })}
         </ul>
-        <div className="mt-6 h-1.5 w-full overflow-hidden rounded-full bg-white/15">
-          <div className={`h-full bg-gradient-to-r from-violet-300/80 via-indigo-300/85 to-violet-300/80 transition-all duration-700 ${setupProgress >= steps.length ? 'w-full quick-start-setup__progress-complete' : 'w-1/3 quick-start-setup__progress-animated'}`} />
+        <div className="quickstart-progress-track mt-6 h-1.5 w-full overflow-hidden rounded-full">
+          <div className={`quickstart-progress-fill h-full transition-all duration-700 ${setupProgress >= steps.length ? 'w-full quick-start-setup__progress-complete' : 'w-1/3 quick-start-setup__progress-animated'}`} />
         </div>
         <p className="mt-6 text-sm text-slate-300">{copy.bridgeHint}</p>
         <div className="mt-8 flex flex-col items-center gap-3">
-          <button type="button" onClick={onOpenGuidedDemo} disabled={isSubmitting || !submitCompleted} className="inline-flex items-center justify-center rounded-full border border-violet-300/45 bg-violet-500 px-7 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(76,29,149,0.3)] transition duration-200 hover:-translate-y-0.5 hover:bg-violet-400 hover:shadow-[0_14px_28px_rgba(76,29,149,0.4)] disabled:cursor-not-allowed disabled:opacity-55">{isSubmitting ? copy.saving : submitCompleted ? copy.cta : copy.saving}</button>
+          <button type="button" onClick={onOpenGuidedDemo} disabled={isSubmitting || !submitCompleted} className="quickstart-primary-cta inline-flex items-center justify-center rounded-full border px-7 py-3 text-sm font-semibold transition duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-55">{isSubmitting ? copy.saving : submitCompleted ? copy.cta : copy.saving}</button>
           {submitCompleted ? <p className="text-sm text-emerald-200">{copy.done}</p> : null}
           {submitError ? <p className="text-sm text-rose-200">{submitError}</p> : null}
         </div>

--- a/apps/web/src/onboarding/steps/QuickStartModerationStep.tsx
+++ b/apps/web/src/onboarding/steps/QuickStartModerationStep.tsx
@@ -66,7 +66,7 @@ export function QuickStartModerationStep({ language = 'es', selectedModerations,
       };
 
   return (
-    <section className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">
+    <section className="onboarding-premium-root quickstart-premium-card onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">
       <h1 className="text-2xl font-semibold text-white sm:text-3xl">{copy.title}</h1>
       <p className="mt-2 text-sm text-white/70">{copy.subtitle}</p>
       <p className="mt-2 text-xs text-white/55">{copy.hint}</p>
@@ -79,13 +79,13 @@ export function QuickStartModerationStep({ language = 'es', selectedModerations,
               key={option}
               type="button"
               onClick={() => onToggle(option)}
-              className={`flex w-full items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left transition ${enabled ? 'border-violet-200/45 bg-violet-400/18' : 'border-white/20 bg-white/6'}`}
+              className={`quickstart-moderation-option flex w-full items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left transition ${enabled ? 'quickstart-moderation-option--enabled' : ''}`}
             >
               <div>
                 <p className="text-sm font-semibold text-white">{OPTIONS[option].icon} {card.title}</p>
                 <p className="mt-1 text-xs text-white/65">{card.description}</p>
               </div>
-              <span className={`inline-flex h-5 w-10 shrink-0 items-center overflow-hidden rounded-full p-0.5 ${enabled ? 'bg-violet-300/70' : 'bg-white/20'}`}>
+              <span className={`quickstart-moderation-toggle inline-flex h-5 w-10 shrink-0 items-center overflow-hidden rounded-full p-0.5 ${enabled ? 'quickstart-moderation-toggle--enabled' : ''}`}>
                 <span className={`block h-4 w-4 shrink-0 rounded-full bg-white transition-transform ${enabled ? 'translate-x-[1.125rem]' : ''}`} />
               </span>
             </button>

--- a/apps/web/src/onboarding/steps/QuickStartSummaryStep.tsx
+++ b/apps/web/src/onboarding/steps/QuickStartSummaryStep.tsx
@@ -82,7 +82,7 @@ export function QuickStartSummaryStep({
   const avatarPreviewImage = avatarOption ? resolveAvatarPickerPreviewImage(avatarOption) : null;
 
   return (
-    <section className="glass-card onboarding-surface-base mx-auto w-full max-w-5xl rounded-3xl p-6 sm:p-8">
+    <section className="onboarding-premium-root quickstart-premium-card glass-card onboarding-surface-base mx-auto w-full max-w-5xl rounded-3xl p-6 sm:p-8">
       <header className="flex flex-col gap-2 border-b border-white/5 pb-4">
         <p className="text-xs uppercase tracking-[0.35em] text-white/50">{copy.eyebrow}</p>
         <h2 className="text-3xl font-semibold text-white">{copy.title}</h2>
@@ -90,7 +90,7 @@ export function QuickStartSummaryStep({
       </header>
       <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1.45fr)_minmax(0,1fr)]">
         <div className="space-y-5">
-          <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+          <section className="quickstart-premium-surface rounded-2xl border p-5">
             <header className="border-b border-white/5 pb-3">
               <p className="text-xs uppercase tracking-[0.35em] text-white/50">{copy.baseData}</p>
             </header>
@@ -114,20 +114,20 @@ export function QuickStartSummaryStep({
               </div>
             </div>
           </section>
-          <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+          <section className="quickstart-premium-surface rounded-2xl border p-5">
             <header className="border-b border-white/5 pb-3">
               <p className="text-xs uppercase tracking-[0.35em] text-white/50">{copy.pillars}</p>
             </header>
             <div className="mt-4 space-y-3">
               <p className="text-sm text-white/70">{copy.selectedTraits}</p>
               {(['Body', 'Mind', 'Soul'] as Pillar[]).map((pillar) => (
-                <div key={pillar} className="rounded-xl border border-white/10 bg-white/5 p-3">
+                <div key={pillar} className="quickstart-premium-surface rounded-xl border p-3">
                   <p className="text-sm font-semibold text-white">{pillar === 'Body' ? 'Body 🫀' : pillar === 'Mind' ? 'Mind 🧠' : 'Soul 🏵️'}</p>
                   <p className="mt-1 text-xs text-white/70">{copy.selectedTasks}: {selectedByPillar[pillar].length}</p>
                   <div className="mt-2 flex flex-wrap gap-1.5">
                     {selectedTraits[pillar].length > 0
                       ? selectedTraits[pillar].map((trait) => (
-                        <span key={`${pillar}-${trait}`} className="rounded-full border border-white/15 bg-white/10 px-2.5 py-1 text-[11px] font-medium text-white/90">
+                        <span key={`${pillar}-${trait}`} className="quickstart-pill rounded-full border px-2.5 py-1 text-[11px] font-medium">
                           {trait}
                         </span>
                       ))
@@ -139,7 +139,7 @@ export function QuickStartSummaryStep({
           </section>
         </div>
         <aside className="space-y-5">
-          <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+          <section className="quickstart-premium-surface rounded-2xl border p-5">
             <header className="border-b border-white/5 pb-3">
               <p className="text-xs uppercase tracking-[0.35em] text-white/50">{copy.gp}</p>
             </header>

--- a/apps/web/src/onboarding/steps/QuickStartTasksStep.tsx
+++ b/apps/web/src/onboarding/steps/QuickStartTasksStep.tsx
@@ -42,16 +42,6 @@ function InlineTaskRow({
   const hasInput = Boolean(task.inputAfter || task.inputBefore);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const rowRef = useRef<HTMLDivElement | null>(null);
-  const selectedFrontStyle = {
-    borderColor: 'color-mix(in srgb, var(--color-accent-secondary) 42%, var(--onboarding-glass-border))',
-    background: 'color-mix(in srgb, var(--color-surface-elevated) 82%, var(--color-accent-secondary) 18%)',
-    boxShadow: '0 18px 40px color-mix(in srgb, var(--color-surface-elevated) 56%, rgba(8,12,28,0.66))',
-  };
-  const selectedBackStyle = {
-    borderColor: 'color-mix(in srgb, var(--color-accent-secondary) 54%, var(--onboarding-glass-border-soft))',
-    background: 'color-mix(in srgb, var(--color-accent-secondary) 62%, var(--color-surface-elevated) 38%)',
-    boxShadow: '0 12px 24px color-mix(in srgb, var(--color-accent-secondary) 40%, rgba(8,12,28,0.64))',
-  };
 
   useEffect(() => {
     if (!selected) {
@@ -77,12 +67,8 @@ function InlineTaskRow({
   return (
     <div ref={rowRef} className={`relative ${selected ? 'pt-5 pb-1' : ''}`}>
       {selected ? (
-        <div
-          className="pointer-events-none absolute inset-x-0 top-0 bottom-1 rounded-2xl border px-4 pt-1.5 pb-3"
-          style={selectedBackStyle}
-          aria-hidden
-        >
-          <span className="block text-[10px] font-semibold uppercase leading-none tracking-[0.16em] text-violet-100/90">
+        <div className="quickstart-task-row__back pointer-events-none absolute inset-x-0 top-0 bottom-1 rounded-2xl border px-4 pt-1.5 pb-3" aria-hidden>
+          <span className="quickstart-task-trait-band block text-[10px] font-semibold uppercase leading-none tracking-[0.16em]">
             {copy.traitLabel}: {task.trait}
           </span>
         </div>
@@ -100,8 +86,7 @@ function InlineTaskRow({
         role="button"
         tabIndex={0}
         data-selected={selected ? 'true' : undefined}
-        className="onboarding-surface-inner relative z-10 w-full rounded-2xl border px-4 py-3.5 text-left text-white/85 shadow-[0_12px_24px_rgba(8,12,28,0.18)] transition hover:border-white/30 hover:bg-white/[0.12]"
-        style={selected ? selectedFrontStyle : undefined}
+        className={`quickstart-task-row onboarding-surface-inner relative z-10 w-full rounded-2xl border px-4 py-3.5 text-left text-white/85 transition ${selected ? 'quickstart-task-row--selected' : ''}`}
       >
         <div className="flex items-center gap-2.5">
           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 gap-y-2 text-sm leading-relaxed sm:text-base">
@@ -114,7 +99,7 @@ function InlineTaskRow({
                 inputMode="numeric"
                 onClick={(event) => event.stopPropagation()}
                 onChange={(event) => onInputChange(event.target.value)}
-                className="h-6 w-12 rounded-md border border-violet-200/30 bg-violet-100/5 px-1.5 text-center text-xs text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-300/70 disabled:opacity-40 sm:h-7 sm:w-14"
+                className="quickstart-task-input h-6 w-12 rounded-md border px-1.5 text-center text-xs focus:outline-none focus-visible:ring-2 disabled:opacity-40 sm:h-7 sm:w-14"
                 placeholder={copy.countPlaceholder}
               />
             ) : null}
@@ -129,7 +114,7 @@ function InlineTaskRow({
                 event.stopPropagation();
                 setShowSuggestions((prev) => !prev);
               }}
-              className="relative z-20 ml-auto inline-flex h-5 w-5 shrink-0 items-center justify-center self-start rounded-md border border-violet-200/45 bg-violet-300/18 text-white/90 transition"
+              className="quickstart-task-help relative z-20 ml-auto inline-flex h-5 w-5 shrink-0 items-center justify-center self-start rounded-md border transition"
               aria-label={copy.taskHelpLabel}
               aria-expanded={showSuggestions}
             >
@@ -145,8 +130,7 @@ function InlineTaskRow({
 
       {selected && task.suggestions?.length && showSuggestions ? (
         <div
-          className="absolute right-3 bottom-[calc(100%+0.35rem)] z-30 w-[min(18.5rem,calc(100%-1.5rem))] rounded-xl border p-3 text-xs text-white/92 shadow-[0_10px_30px_rgba(43,25,96,0.45)] backdrop-blur"
-          style={{ borderColor: 'rgba(196, 181, 253, 0.42)', backgroundColor: 'rgba(17, 24, 39, 0.93)' }}
+          className="quickstart-suggestions-panel absolute right-3 bottom-[calc(100%+0.35rem)] z-30 w-[min(18.5rem,calc(100%-1.5rem))] rounded-xl border p-3 text-xs backdrop-blur"
         >
           <ul className="space-y-1.5">
             {task.suggestions.map((suggestion) => (
@@ -215,13 +199,13 @@ export function QuickStartTasksStep({
   const modeStyle = QUICK_START_MODE_SOFT_STYLES[gameMode];
 
   return (
-    <section className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">
+    <section className="onboarding-premium-root quickstart-premium-card onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7">
       <header className="mb-5 border-b border-white/10 pb-4">
         <p className="text-xs uppercase tracking-[0.25em] text-white/55">{gameMode} · Quick Start</p>
         <h1 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">{copy.title}</h1>
         <p className="mt-2 text-sm text-white/70">{copy.subtitle}</p>
         <div
-          className="mt-3 inline-flex max-w-full items-center gap-2 rounded-full border px-4 py-1.5 text-xs font-semibold text-violet-50/95"
+          className="quickstart-min-rule mt-3 inline-flex max-w-full items-center gap-2 rounded-full border px-4 py-1.5 text-xs font-semibold"
           style={{
             borderColor: `color-mix(in srgb, ${modeStyle.border} 92%, rgba(255,255,255,0.14))`,
             background: `linear-gradient(135deg, color-mix(in srgb, ${modeStyle.tint} 90%, rgba(10,14,30,0.72)), color-mix(in srgb, ${modeStyle.tint} 66%, rgba(10,14,30,0.58)))`,
@@ -229,13 +213,13 @@ export function QuickStartTasksStep({
           }}
         >
           <span className="whitespace-nowrap">{copy.minRule}</span>
-          <span className="text-violet-100/60" aria-hidden>·</span>
+          <span className="quickstart-min-rule__dot" aria-hidden>·</span>
           <span className="whitespace-nowrap">{copy.suggestedRule}</span>
         </div>
         <div className="mt-2.5 flex flex-wrap items-center gap-2 text-xs">
           <span
-            className={`inline-flex rounded-lg border px-3.5 py-1.5 text-[0.68rem] font-medium sm:text-[0.72rem] ${
-              balancedBonusActive ? 'border-cyan-200/30 bg-cyan-300/8 text-cyan-100/90' : 'border-sky-200/28 bg-sky-300/8 text-sky-100/85'
+            className={`quickstart-bonus-pill inline-flex rounded-lg border px-3.5 py-1.5 text-[0.68rem] font-medium sm:text-[0.72rem] ${
+              balancedBonusActive ? 'quickstart-bonus-pill--ready' : 'quickstart-bonus-pill--pending'
             }`}
           >
             {balancedBonusActive ? copy.bonusReady : copy.bonusPending}


### PR DESCRIPTION
### Motivation
- Align the Quick Start onboarding screens with the current premium product dark/light visual system while keeping all Quick Start UX and logic unchanged.
- Deliver a visual-only theming pass that reduces blue/violet wash, increases surface clarity in dark mode, and uses neutral off-white surfaces in light mode consistent with other premium screens.

### Description
- Added Quick Start–specific theme-aware classes and tokens in `apps/web/src/index.css` (e.g. `quickstart-premium-root`, `quickstart-premium-card`, `quickstart-task-row`, `quickstart-task-row--selected`, `quickstart-task-trait-band`, `quickstart-task-input`, `quickstart-suggestions-panel`, etc.) and provided `:root[data-theme="light"]` overrides to support both themes.
- Replaced inline selected-layer styles and hardcoded violet/blue surfaces in Quick Start components with the new CSS classes and variables while preserving DOM structure and behavior in `apps/web/src/onboarding/IntegratedQuickStartFlow.tsx` and `apps/web/src/onboarding/steps/QuickStartTasksStep.tsx`.
- Applied the same visual classes to the Moderation, Summary and Generating/Setup screens by updating `apps/web/src/onboarding/steps/QuickStartModerationStep.tsx`, `apps/web/src/onboarding/steps/QuickStartSummaryStep.tsx`, and `apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx` so Quick Start visuals remain consistent whether used standalone or via the integrated flow.
- This is strictly a styling pass and preserves task IDs, selection logic, inputs, suggestions, GP/balance computation, payloads, routing, auth, progress tracking and submission behavior.

### Testing
- Ran type checking with `npm run typecheck:web`, which failed due to pre-existing, unrelated TypeScript issues in other modules (for example `runtimeAuth`, `PreviewAchievementCard`, and some demo/test typing mismatches) and not because of Quick Start changes.
- Verified there are no code-path/logic edits to Quick Start interactions and no unit/test files were modified as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5c81f9c08332996bee63e4694ccc)