### PR TITLE
fix(web): render landing preset backgrounds on fixed viewport layer

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -89,6 +89,14 @@
   overflow-x: hidden;
   font-family: var(--font-body);
   color: var(--ink);
+  background: var(--landing-background-base, #0a0a12);
+}
+
+.landing-background-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
   background: var(
     --landing-background,
     linear-gradient(
@@ -97,6 +105,9 @@
       var(--bg-b, #3d72b4)
     )
   );
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
 }
 
 .landing::before {
@@ -107,7 +118,7 @@
   content: none;
 }
 
-.landing > * {
+.landing > *:not(.landing-background-layer) {
   position: relative;
   z-index: 1;
 }

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -552,6 +552,8 @@ export default function LandingPage() {
     "--bg-a": selectedBackground?.a ?? "#525252",
     "--bg-b": selectedBackground?.b ?? "#3d72b4",
     "--landing-background": resolvedLandingBackground,
+    "--landing-background-base":
+      selectedBackground?.tone === "light" ? "#f6f1ff" : "#0a0a12",
   } as CSSProperties;
   const [activeSlide, setActiveSlide] = useState(0);
   const [paused, setPaused] = useState(false);
@@ -789,7 +791,9 @@ export default function LandingPage() {
       className="landing"
       style={landingStyle}
       data-background-tone={selectedBackground?.tone ?? "dark"}
+      data-background-kind={selectedBackground?.type ?? "linear"}
     >
+      <div className="landing-background-layer" aria-hidden="true" />
       <header className="nav">
         <Link
           className="brand"


### PR DESCRIPTION
### Motivation
- CSS presets with radial gradients (e.g. `lab_showcase_dark`) were painted on `.landing` which spans the full document height, causing gradients to stretch and visually shift while scrolling instead of behaving like a fixed viewport background. 
- The goal is to render `css`-type presets as a stable, viewport-fixed background that matches the lab appearance without changing page copy or lab components.

### Description
- Added a viewport-fixed background layer DOM node inside the landing wrapper: `<div className="landing-background-layer" aria-hidden="true" />` in `Landing.tsx`. 
- Introduced `--landing-background-base` CSS variable and set it from `Landing.tsx` to keep `.landing` as a simple base color while the complex preset is painted by the fixed layer. 
- Implemented `.landing-background-layer` in `Landing.css` with `position: fixed; inset: 0; pointer-events: none; background: var(--landing-background)` plus `background-repeat: no-repeat; background-size: cover; background-position: center`. 
- Adjusted stacking so foreground remains above the new layer using `.landing > *:not(.landing-background-layer)` and added `data-background-kind` on the landing root; files changed: `apps/web/src/pages/Landing.tsx` and `apps/web/src/pages/Landing.css`.

### Testing
- Ran the web workspace typecheck with `npm --workspace apps/web run typecheck`, which failed due to pre-existing unrelated TypeScript errors in other parts of the repo and not caused by these styling/structural changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede45312248332b55026a9164a518a)