### PR TITLE
Refine landing nav glass style for Lab Showcase Dark background

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -186,9 +186,18 @@
 
 .landing .nav {
   width: 100%;
-  background: rgba(17, 28, 51, 0.78);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--line);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(10, 9, 18, 0.68),
+      rgba(10, 9, 18, 0.46)
+    );
+  backdrop-filter: blur(18px) saturate(1.08);
+  -webkit-backdrop-filter: blur(18px) saturate(1.08);
+  border-bottom: 1px solid rgba(216, 194, 246, 0.14);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.035) inset,
+    0 10px 34px rgba(3, 3, 10, 0.24);
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
@@ -300,6 +309,35 @@
 .landing .gradient-select:focus-visible {
   outline: 2px solid rgba(125, 211, 252, 0.7);
   outline-offset: 2px;
+}
+
+.landing[data-background-id="lab_showcase_dark"] .nav {
+  background:
+    radial-gradient(
+      circle at 78% 0%,
+      rgba(153, 111, 244, 0.12),
+      transparent 42%
+    ),
+    linear-gradient(
+      180deg,
+      rgba(8, 7, 15, 0.72),
+      rgba(8, 7, 15, 0.48)
+    );
+  border-bottom-color: rgba(200, 166, 255, 0.16);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.035) inset,
+    0 12px 34px rgba(5, 4, 12, 0.28);
+}
+
+.landing[data-background-id="lab_showcase_dark"] .gradient-select-wrapper {
+  background: rgba(8, 7, 15, 0.42);
+  border-color: rgba(216, 194, 246, 0.18);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.025) inset;
+}
+
+.landing[data-background-id="lab_showcase_dark"] .gradient-select {
+  background: rgba(5, 5, 11, 0.68);
+  border-color: rgba(216, 194, 246, 0.18);
 }
 
 .landing[data-background-tone="light"] {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -791,6 +791,7 @@ export default function LandingPage() {
       className="landing"
       style={landingStyle}
       data-background-tone={selectedBackground?.tone ?? "dark"}
+      data-background-id={selectedBackground?.id}
       data-background-kind={selectedBackground?.type ?? "linear"}
     >
       <div className="landing-background-layer" aria-hidden="true" />


### PR DESCRIPTION
### Motivation
- The landing nav looked too blue/navy against the `lab_showcase_dark` preset and produced a visible blue bottom border that clashed with the background palette.
- The goal is to make the nav visually neutral and premium (dark translucent glass with stronger blur and subtle violet-gray accents) while allowing per-background overrides.

### Description
- Replaced the base nav styles in `apps/web/src/pages/Landing.css` with a neutral glass treatment using a dark translucent linear gradient, increased blur/saturation, a subtle violet-gray border, and softer shadow.
- Added `data-background-id={selectedBackground?.id}` to the landing root in `apps/web/src/pages/Landing.tsx` so CSS can target specific background presets.
- Added a `lab_showcase_dark`-specific override in `apps/web/src/pages/Landing.css` that applies a soft radial violet highlight, adjusts `border-bottom-color` to a violet-gray, and refines the nav shadow to remove blue casts.
- Added `lab_showcase_dark`-specific styling for the background selector wrapper and select (`.gradient-select-wrapper` and `.gradient-select`) to integrate visually with the adjusted nav.

### Testing
- Ran `npm run typecheck:web`, which failed due to pre-existing TypeScript errors in unrelated modules and not caused by these styling/data-attribute changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede7a0eeac8332b2cb55b888f76c33)