### PR TITLE
Replace landing background selector with persisted Light/Dark theme

### DIFF
--- a/apps/web/src/components/layout/AuthLayout.tsx
+++ b/apps/web/src/components/layout/AuthLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { getGradientButtonClass } from '../../lib/clerkAppearance';
+import { getLandingThemeBackground, type LandingThemeMode } from '../../lib/landingTheme';
 import { BrandWordmark } from './BrandWordmark';
 
 interface AuthLayoutProps {
@@ -10,6 +11,7 @@ interface AuthLayoutProps {
   onPrimaryActionClick?: () => void;
   secondaryActionLabel?: string;
   secondaryActionHref?: string;
+  themeMode?: LandingThemeMode;
 }
 
 export function AuthLayout({
@@ -19,22 +21,34 @@ export function AuthLayout({
   primaryActionLabel,
   onPrimaryActionClick,
   secondaryActionLabel,
-  secondaryActionHref
+  secondaryActionHref,
+  themeMode = 'dark',
 }: AuthLayoutProps) {
+  const landingThemeBackground = getLandingThemeBackground(themeMode);
+  const isLight = themeMode === 'light';
+
   return (
-    <div className="relative flex min-h-screen min-h-dvh flex-col items-center justify-center overflow-x-hidden overflow-y-auto bg-[#0b1335] px-4 pb-[calc(env(safe-area-inset-bottom)+2.5rem)] pt-[calc(env(safe-area-inset-top,0px)+1.15rem)] text-white sm:px-6 sm:pb-[calc(env(safe-area-inset-bottom)+3rem)] sm:pt-[calc(env(safe-area-inset-top,0px)+1.35rem)] lg:overflow-hidden lg:px-12 lg:pb-[calc(env(safe-area-inset-bottom)+3.5rem)] lg:pt-[calc(env(safe-area-inset-top,0px)+1.5rem)]">
+    <div
+      className={`relative flex min-h-screen min-h-dvh flex-col items-center justify-center overflow-x-hidden overflow-y-auto px-4 pb-[calc(env(safe-area-inset-bottom)+2.5rem)] pt-[calc(env(safe-area-inset-top,0px)+1.15rem)] sm:px-6 sm:pb-[calc(env(safe-area-inset-bottom)+3rem)] sm:pt-[calc(env(safe-area-inset-top,0px)+1.35rem)] lg:overflow-hidden lg:px-12 lg:pb-[calc(env(safe-area-inset-bottom)+3.5rem)] lg:pt-[calc(env(safe-area-inset-top,0px)+1.5rem)] ${isLight ? 'text-[#171126]' : 'text-white'}`}
+      style={{ background: landingThemeBackground.base }}
+      data-theme-mode={themeMode}
+    >
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 opacity-100"
       >
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(104,69,255,0.28),transparent_34%),radial-gradient(circle_at_78%_18%,rgba(167,139,250,0.18),transparent_22%),linear-gradient(180deg,#10193f_0%,#0b1335_50%,#090f2d_100%)]" />
+        <div className="absolute inset-0" style={{ background: landingThemeBackground.gradient }} />
         <div className="absolute inset-x-0 top-0 h-44 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent)]" />
       </div>
 
       {secondaryActionLabel && secondaryActionHref ? (
         <a
           href={secondaryActionHref}
-          className="absolute left-4 top-[calc(env(safe-area-inset-top,0px)+0.45rem)] z-20 inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/[0.055] px-3 py-2 text-sm font-semibold text-white/68 shadow-[0_12px_28px_rgba(0,0,0,0.16)] backdrop-blur transition-colors duration-200 hover:border-white/18 hover:bg-white/[0.08] hover:text-white sm:left-6 lg:left-8"
+          className={`absolute left-4 top-[calc(env(safe-area-inset-top,0px)+0.45rem)] z-20 inline-flex items-center justify-center gap-2 rounded-full px-3 py-2 text-sm font-semibold shadow-[0_12px_28px_rgba(0,0,0,0.16)] backdrop-blur transition-colors duration-200 sm:left-6 lg:left-8 ${
+            isLight
+              ? 'border border-[rgba(78,61,130,0.2)] bg-white/70 text-[#2a2142] hover:border-[rgba(78,61,130,0.28)] hover:bg-white/82 hover:text-[#171126]'
+              : 'border border-white/10 bg-white/[0.055] text-white/68 hover:border-white/18 hover:bg-white/[0.08] hover:text-white'
+          }`}
         >
           <span aria-hidden="true" className="text-base leading-none">←</span>
           {secondaryActionLabel}
@@ -42,18 +56,18 @@ export function AuthLayout({
       ) : null}
 
       <div className="relative z-10 mx-auto flex w-full min-w-0 max-w-md flex-col items-center gap-6 pt-5 text-center sm:gap-7">
-        <div className="flex items-center justify-center text-[17px] font-semibold uppercase tracking-[0.42em] text-white/66">
+        <div className={`flex items-center justify-center text-[17px] font-semibold uppercase tracking-[0.42em] ${isLight ? 'text-[#2f2552]/70' : 'text-white/66'}`}>
           <BrandWordmark className="gap-3.5" textClassName="tracking-[0.42em]" iconClassName="h-[3.2em]" />
         </div>
 
         <div className="w-full space-y-3 text-balance text-center">
           {typeof title === 'string' ? (
-            <h1 className="text-[2.4rem] font-semibold leading-tight tracking-tight text-white sm:text-[2.8rem]">{title}</h1>
+            <h1 className={`text-[2.4rem] font-semibold leading-tight tracking-tight sm:text-[2.8rem] ${isLight ? 'text-[#120f1f]' : 'text-white'}`}>{title}</h1>
           ) : (
             title
           )}
           {description ? (
-            <p className="text-sm text-white/70 sm:text-base md:text-lg">{description}</p>
+            <p className={`text-sm sm:text-base md:text-lg ${isLight ? 'text-[#3b305f]/78' : 'text-white/70'}`}>{description}</p>
           ) : null}
         </div>
 

--- a/apps/web/src/config/releaseFlags.ts
+++ b/apps/web/src/config/releaseFlags.ts
@@ -2,8 +2,5 @@ export const SHOW_BILLING_UI = import.meta.env.VITE_SHOW_BILLING_UI === 'true';
 
 export const SHOW_LANDING_PRICING = import.meta.env.VITE_SHOW_LANDING_PRICING === 'true';
 
-export const SHOW_LANDING_BACKGROUND_SELECTOR =
-  import.meta.env.VITE_SHOW_LANDING_BACKGROUND_SELECTOR !== 'false';
-
 export const SHOW_NATIVE_TEST_NOTIFICATION =
   Boolean(import.meta.env.DEV) && import.meta.env.VITE_SHOW_NATIVE_TEST_NOTIFICATION !== 'false';

--- a/apps/web/src/lib/landingTheme.ts
+++ b/apps/web/src/lib/landingTheme.ts
@@ -1,0 +1,49 @@
+import type { CSSProperties } from 'react';
+
+export type LandingThemeMode = 'dark' | 'light';
+
+export const LANDING_THEME_STORAGE_KEY = 'ib:landing-theme-mode';
+
+const LANDING_BACKGROUNDS: Record<LandingThemeMode, { base: string; gradient: string }> = {
+  dark: {
+    base: '#05050B',
+    gradient:
+      'radial-gradient(circle at 72% 18%, rgba(143, 91, 255, 0.24), transparent 38%), radial-gradient(circle at 24% 78%, rgba(72, 190, 255, 0.14), transparent 42%), linear-gradient(180deg, #0A0714 0%, #05050B 100%)',
+  },
+  light: {
+    base: '#FBFAFF',
+    gradient:
+      'radial-gradient(circle at 75% 12%, rgba(139, 92, 246, 0.16), transparent 36%), radial-gradient(circle at 18% 82%, rgba(56, 189, 248, 0.10), transparent 42%), linear-gradient(180deg, #FBFAFF 0%, #F3EEFF 100%)',
+  },
+};
+
+export function isLandingThemeMode(value: string | null): value is LandingThemeMode {
+  return value === 'dark' || value === 'light';
+}
+
+export function readLandingThemeMode(defaultMode: LandingThemeMode = 'dark'): LandingThemeMode {
+  if (typeof window === 'undefined') {
+    return defaultMode;
+  }
+  const stored = window.localStorage.getItem(LANDING_THEME_STORAGE_KEY);
+  return isLandingThemeMode(stored) ? stored : defaultMode;
+}
+
+export function writeLandingThemeMode(mode: LandingThemeMode) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(LANDING_THEME_STORAGE_KEY, mode);
+}
+
+export function getLandingThemeBackground(mode: LandingThemeMode) {
+  return LANDING_BACKGROUNDS[mode];
+}
+
+export function getLandingThemeStyle(mode: LandingThemeMode): CSSProperties {
+  const background = getLandingThemeBackground(mode);
+  return {
+    '--landing-background-base': background.base,
+    '--landing-background': background.gradient,
+  } as CSSProperties;
+}

--- a/apps/web/src/pages/DemoDashboard.tsx
+++ b/apps/web/src/pages/DemoDashboard.tsx
@@ -14,6 +14,7 @@ import { getLabsGameModeConfig } from '../config/labsGameModes';
 import { DASHBOARD_PATH } from '../config/auth';
 import { usePageMeta } from '../lib/seo';
 import { DemoDashboardOverviewScene } from '../components/demo/DemoDashboardOverviewScene';
+import { getLandingThemeBackground, readLandingThemeMode } from '../lib/landingTheme';
 
 const DEMO_SHARE_IMAGE = 'https://innerbloomjourney.org/og/neneOGP.png';
 
@@ -33,6 +34,8 @@ export default function DemoDashboardPage() {
   const demoHubPath = getPublicDemoHubPath(location.search);
   const { theme, setPreference } = useThemePreference();
   const [showGuidedTour, setShowGuidedTour] = useState(true);
+  const landingThemeMode = readLandingThemeMode('dark');
+  const landingThemeBackground = getLandingThemeBackground(landingThemeMode);
   const hasLoggedGuidedStart = useRef(false);
   const dailyQuestModalRef = useRef<DailyQuestModalHandle | null>(null);
 
@@ -115,7 +118,17 @@ export default function DemoDashboardPage() {
   }, [dashboardPath, demoContext.fromOnboarding, demoContext.mode, demoContext.source, guidedSteps.length, navigate, userId]);
 
   return (
-    <div className="min-h-screen bg-transparent" data-light-scope="dashboard-v3">
+    <div
+      className="relative min-h-screen bg-transparent"
+      data-light-scope="dashboard-v3"
+      data-theme-mode={landingThemeMode}
+      style={{ background: landingThemeBackground.base }}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 z-0 bg-cover bg-center bg-no-repeat"
+        style={{ background: landingThemeBackground.gradient }}
+      />
       <Navbar
         title="Dashboard"
         menuSlot={
@@ -209,7 +222,7 @@ export default function DemoDashboardPage() {
       />
 
       <main
-        className="mx-auto w-full max-w-7xl px-3 py-4 md:px-5 md:py-6 lg:px-6 lg:py-8"
+        className="relative z-[1] mx-auto w-full max-w-7xl px-3 py-4 md:px-5 md:py-6 lg:px-6 lg:py-8"
         data-demo-source={demoContext.source}
         data-demo-mode={demoContext.mode}
         style={{ '--demo-mode-accent': selectedModeConfig.accentColor } as CSSProperties}

--- a/apps/web/src/pages/LabsDemoModeSelect.tsx
+++ b/apps/web/src/pages/LabsDemoModeSelect.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Sparkles, Target, WandSparkles } from 'lucide-react';
-import { OFFICIAL_DESIGN_TOKENS } from '../content/officialDesignTokens';
 import { usePostLoginLanguage } from '../i18n/postLoginLanguage';
 import { buildDemoUrl, getDemoModeSelectPath, type DemoEntrySource } from '../lib/demoEntry';
 import { buildLocalizedAuthPath, resolveAuthLanguage } from '../lib/authLanguage';
+import { getLandingThemeBackground, readLandingThemeMode } from '../lib/landingTheme';
 import {
   DEMO_MODE_SELECT_OG_IMAGE_HEIGHT,
   DEMO_MODE_SELECT_OG_IMAGE_PATH,
@@ -24,12 +24,8 @@ export default function LabsDemoModeSelectPage({ legacyLabsPath = false }: DemoM
   const navigate = useNavigate();
   const sourceParam = new URLSearchParams(location.search).get('source');
   const source: DemoEntrySource = sourceParam === 'selector' || sourceParam === 'labs' ? sourceParam : 'landing';
-  const purpleAfternoon = OFFICIAL_DESIGN_TOKENS.gradients.find((gradient) => gradient.name === 'purple_afternoon');
-  const landingBackground = purpleAfternoon
-    ? {
-        backgroundImage: `linear-gradient(${purpleAfternoon.angle}, ${purpleAfternoon.stops[0]}, ${purpleAfternoon.stops[1]})`,
-      }
-    : undefined;
+  const themeMode = readLandingThemeMode('dark');
+  const landingThemeBackground = getLandingThemeBackground(themeMode);
 
   useEffect(() => {
     syncLocaleLanguage(resolveAuthLanguage(location.search));
@@ -88,26 +84,47 @@ export default function LabsDemoModeSelectPage({ legacyLabsPath = false }: DemoM
   ];
 
   return (
-    <main className="min-h-screen text-[color:var(--color-text)] md:h-svh md:min-h-svh" style={landingBackground}>
+    <main
+      className={`relative min-h-screen text-[color:var(--color-text)] md:h-svh md:min-h-svh ${themeMode === 'light' ? 'text-[#171126]' : 'text-white'}`}
+      style={{ background: landingThemeBackground.base }}
+      data-theme-mode={themeMode}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 z-0 bg-cover bg-center bg-no-repeat"
+        style={{ background: landingThemeBackground.gradient }}
+      />
       <div className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-4 py-4 sm:px-6 sm:py-5 md:h-svh md:min-h-svh md:max-w-5xl md:px-8 md:py-6 lg:max-w-6xl lg:px-10 lg:py-7 xl:max-w-[84rem] xl:px-12">
-        <section className="relative isolate flex flex-1 flex-col overflow-hidden rounded-[2rem] border border-white/12 bg-[linear-gradient(140deg,rgba(255,255,255,0.085),rgba(167,123,245,0.075)_48%,rgba(72,43,126,0.05))] px-5 py-4 shadow-[0_22px_56px_rgba(26,12,52,0.22),inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-[20px] sm:px-6 sm:py-5 md:rounded-[2.35rem] md:px-7 md:py-5 md:shadow-[0_28px_80px_rgba(26,12,52,0.28),inset_0_1px_0_rgba(255,255,255,0.2)] lg:px-8 lg:py-6 xl:px-10 xl:py-6">
+        <section className={`relative isolate z-[1] flex flex-1 flex-col overflow-hidden rounded-[2rem] px-5 py-4 backdrop-blur-[20px] sm:px-6 sm:py-5 md:rounded-[2.35rem] md:px-7 md:py-5 lg:px-8 lg:py-6 xl:px-10 xl:py-6 ${
+          themeMode === 'light'
+            ? 'border border-[rgba(109,86,170,0.2)] bg-[linear-gradient(140deg,rgba(255,255,255,0.74),rgba(246,240,255,0.62)_48%,rgba(236,247,255,0.52))] shadow-[0_22px_56px_rgba(61,39,110,0.16),inset_0_1px_0_rgba(255,255,255,0.82)] md:shadow-[0_28px_80px_rgba(61,39,110,0.2),inset_0_1px_0_rgba(255,255,255,0.88)]'
+            : 'border border-white/12 bg-[linear-gradient(140deg,rgba(255,255,255,0.085),rgba(167,123,245,0.075)_48%,rgba(72,43,126,0.05))] shadow-[0_22px_56px_rgba(26,12,52,0.22),inset_0_1px_0_rgba(255,255,255,0.18)] md:shadow-[0_28px_80px_rgba(26,12,52,0.28),inset_0_1px_0_rgba(255,255,255,0.2)]'
+        }`}>
           <div className="pointer-events-none absolute inset-x-2 -top-3 h-24 rounded-full bg-[radial-gradient(circle_at_50%_52%,rgba(176,122,255,0.3),rgba(176,122,255,0.08)_54%,transparent_74%)] blur-[18px] md:h-28 md:blur-[22px]" />
           <button
             type="button"
             onClick={() => navigate(buildLocalizedAuthPath('/', language))}
             aria-label={language === 'es' ? 'Cerrar demo hub y volver al inicio' : 'Close demo hub and return home'}
-            className="absolute right-4 top-4 z-10 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/12 bg-white/[0.06] text-xl leading-none text-white/82 shadow-[0_12px_28px_rgba(26,12,52,0.2),inset_0_1px_0_rgba(255,255,255,0.12)] backdrop-blur-md transition duration-200 ease-out hover:border-white/18 hover:bg-white/[0.1] hover:text-white active:scale-[0.97] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+            className={`absolute right-4 top-4 z-10 inline-flex h-11 w-11 items-center justify-center rounded-full border text-xl leading-none shadow-[0_12px_28px_rgba(26,12,52,0.2),inset_0_1px_0_rgba(255,255,255,0.12)] backdrop-blur-md transition duration-200 ease-out active:scale-[0.97] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+              themeMode === 'light'
+                ? 'border-[rgba(78,61,130,0.22)] bg-white/68 text-[#221a38] hover:border-[rgba(78,61,130,0.3)] hover:bg-white/82 hover:text-[#171126] focus-visible:outline-[#4e3d82]'
+                : 'border-white/12 bg-white/[0.06] text-white/82 hover:border-white/18 hover:bg-white/[0.1] hover:text-white focus-visible:outline-white/70'
+            }`}
           >
             <span aria-hidden="true">×</span>
           </button>
 
           <div className="relative flex flex-col gap-4 text-center sm:gap-[1.125rem] md:gap-5">
-            <BrandWordmark className="text-white/84" textClassName="text-[0.72rem] font-semibold tracking-[0.34em] text-white/72 sm:text-xs" iconClassName="h-[1.65em] sm:h-[1.75em]" />
+            <BrandWordmark
+              className={themeMode === 'light' ? 'text-[#241a3d]/80' : 'text-white/84'}
+              textClassName={`text-[0.72rem] font-semibold tracking-[0.34em] sm:text-xs ${themeMode === 'light' ? 'text-[#3b305f]/70' : 'text-white/72'}`}
+              iconClassName="h-[1.65em] sm:h-[1.75em]"
+            />
             <div className="mx-auto flex w-full max-w-[56rem] flex-col gap-2 md:gap-2.5">
-              <h1 className="mx-auto max-w-[24ch] text-balance text-[1.8rem] font-semibold leading-[0.98] tracking-[-0.03em] text-white sm:text-[2rem] md:text-[2.4rem] lg:text-[2.75rem]">
+              <h1 className={`mx-auto max-w-[24ch] text-balance text-[1.8rem] font-semibold leading-[0.98] tracking-[-0.03em] sm:text-[2rem] md:text-[2.4rem] lg:text-[2.75rem] ${themeMode === 'light' ? 'text-[#120f1f]' : 'text-white'}`}>
                 {language === 'es' ? 'Explora Innerbloom por sección de producto' : 'Explore Innerbloom by product section'}
               </h1>
-              <p className="mx-auto max-w-[58ch] text-sm leading-[1.5] text-white/78 sm:text-[0.96rem] md:text-[1.02rem]">
+              <p className={`mx-auto max-w-[58ch] text-sm leading-[1.5] sm:text-[0.96rem] md:text-[1.02rem] ${themeMode === 'light' ? 'text-[#3b305f]/80' : 'text-white/78'}`}>
                 {language === 'es'
                   ? 'Abre una sección y entra directo a la experiencia.'
                   : 'Pick a section and jump straight into the experience.'}
@@ -115,7 +132,11 @@ export default function LabsDemoModeSelectPage({ legacyLabsPath = false }: DemoM
             </div>
           </div>
 
-          <div className="relative mt-5 flex flex-col overflow-hidden rounded-[1.4rem] border border-white/12 bg-[linear-gradient(145deg,rgba(255,255,255,0.055),rgba(132,98,204,0.04)_60%,rgba(48,28,86,0.03))] shadow-[0_18px_36px_rgba(26,12,52,0.16),inset_0_1px_0_rgba(255,255,255,0.1)] md:mt-8 md:grid md:min-h-[24rem] md:grid-cols-[1.14fr_0.86fr] md:grid-rows-2 md:rounded-[1.9rem]">
+          <div className={`relative mt-5 flex flex-col overflow-hidden rounded-[1.4rem] border md:mt-8 md:grid md:min-h-[24rem] md:grid-cols-[1.14fr_0.86fr] md:grid-rows-2 md:rounded-[1.9rem] ${
+            themeMode === 'light'
+              ? 'border-[rgba(109,86,170,0.2)] bg-[linear-gradient(145deg,rgba(255,255,255,0.75),rgba(243,238,255,0.62)_60%,rgba(234,246,255,0.54))] shadow-[0_18px_36px_rgba(61,39,110,0.12),inset_0_1px_0_rgba(255,255,255,0.84)]'
+              : 'border-white/12 bg-[linear-gradient(145deg,rgba(255,255,255,0.055),rgba(132,98,204,0.04)_60%,rgba(48,28,86,0.03))] shadow-[0_18px_36px_rgba(26,12,52,0.16),inset_0_1px_0_rgba(255,255,255,0.1)]'
+          }`}>
             <div className="pointer-events-none absolute inset-x-8 top-0 h-20 bg-[radial-gradient(circle_at_50%_0%,rgba(198,153,255,0.24),transparent_68%)] blur-xl md:inset-x-10 md:h-24" />
             {cards.map(({ id, title, description, href, Icon }, index) => (
               <Link
@@ -133,10 +154,14 @@ export default function LabsDemoModeSelectPage({ legacyLabsPath = false }: DemoM
                     : index === 2
                       ? 'md:border-l md:border-white/10'
                       : ''
-                } hover:bg-white/[0.06] active:bg-white/[0.08]`}
+                } ${themeMode === 'light' ? 'hover:bg-[#ffffff]/58 active:bg-[#ffffff]/72' : 'hover:bg-white/[0.06] active:bg-white/[0.08]'}`}
               >
                 <div
-                  className={`inline-flex shrink-0 items-center justify-center rounded-[1.2rem] border border-white/20 bg-white/[0.09] text-white shadow-[0_14px_28px_rgba(28,14,56,0.2),inset_0_1px_0_rgba(255,255,255,0.2)] transition duration-300 group-hover:scale-[1.02] group-hover:bg-white/[0.14] ${
+                  className={`inline-flex shrink-0 items-center justify-center rounded-[1.2rem] border shadow-[0_14px_28px_rgba(28,14,56,0.2),inset_0_1px_0_rgba(255,255,255,0.2)] transition duration-300 group-hover:scale-[1.02] ${
+                    themeMode === 'light'
+                      ? 'border-[rgba(109,86,170,0.24)] bg-white/72 text-[#251b40] group-hover:bg-white/90'
+                      : 'border-white/20 bg-white/[0.09] text-white group-hover:bg-white/[0.14]'
+                  } ${
                     index === 0 ? 'h-[4.15rem] w-[4.15rem] md:h-[6.4rem] md:w-[6.4rem] md:rounded-[1.7rem]' : 'h-[3.5rem] w-[3.5rem] md:h-[4.25rem] md:w-[4.25rem]'
                   }`}
                 >
@@ -144,18 +169,20 @@ export default function LabsDemoModeSelectPage({ legacyLabsPath = false }: DemoM
                 </div>
                 <div className={`min-w-0 flex-1 ${index === 0 ? 'md:mt-7 md:space-y-3' : 'space-y-1.5'}`}>
                   <h2
-                    className={`text-balance font-semibold tracking-[-0.02em] text-white ${
+                    className={`text-balance font-semibold tracking-[-0.02em] ${themeMode === 'light' ? 'text-[#120f1f]' : 'text-white'} ${
                       index === 0 ? 'text-[1.2rem] md:text-[1.82rem] md:leading-[1.05]' : 'text-[1.03rem] md:text-[1.22rem]'
                     }`}
                   >
                     {title}
                   </h2>
-                  <p className={`text-white/76 ${index === 0 ? 'text-[0.92rem] leading-[1.55] md:max-w-[28ch] md:text-[1rem]' : 'text-[0.8rem] leading-[1.45] md:text-[0.9rem]'}`}>
+                  <p className={`${themeMode === 'light' ? 'text-[#3b305f]/80' : 'text-white/76'} ${index === 0 ? 'text-[0.92rem] leading-[1.55] md:max-w-[28ch] md:text-[1rem]' : 'text-[0.8rem] leading-[1.45] md:text-[0.9rem]'}`}>
                     {description}
                   </p>
                 </div>
                 <span
-                  className={`inline-flex shrink-0 items-center gap-1.5 text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-white/80 transition group-hover:text-white md:text-[0.66rem] ${
+                  className={`inline-flex shrink-0 items-center gap-1.5 text-[0.62rem] font-semibold uppercase tracking-[0.18em] transition md:text-[0.66rem] ${
+                    themeMode === 'light' ? 'text-[#2f2552]/78 group-hover:text-[#171126]' : 'text-white/80 group-hover:text-white'
+                  } ${
                     index === 0 ? 'md:mt-7' : ''
                   }`}
                 >

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -69,8 +69,12 @@
       transparent 64%
     );
   --landing-glass-blur: 12px;
-  --ink: #eaf1ff;
-  --muted: color-mix(in srgb, #d6e5ff 72%, #9fb6e3 28%);
+  --ink: #f4f1ff;
+  --heading-ink: #f7f4ff;
+  --muted: rgba(218, 224, 245, 0.78);
+  --subtle: rgba(206, 198, 231, 0.7);
+  --nav-text: rgba(244, 241, 255, 0.92);
+  --nav-muted: rgba(218, 224, 245, 0.72);
   --accent: var(--color-accent-secondary);
   --accent-2: var(--color-accent-primary);
   --line: color-mix(in srgb, var(--color-accent-primary) 24%, transparent);
@@ -159,6 +163,7 @@
 .landing h6 {
   font-family: var(--font-heading);
   letter-spacing: -0.015em;
+  color: var(--heading-ink);
 }
 
 .landing strong,
@@ -208,11 +213,20 @@
   z-index: 40;
 }
 
+.landing[data-theme-mode="dark"] .nav {
+  background:
+    radial-gradient(circle at 78% 0%, rgba(153, 111, 244, 0.1), transparent 42%),
+    linear-gradient(180deg, rgba(8, 7, 15, 0.72), rgba(8, 7, 15, 0.48));
+  backdrop-filter: blur(18px) saturate(1.08);
+  -webkit-backdrop-filter: blur(18px) saturate(1.08);
+  border-bottom: 1px solid rgba(216, 194, 246, 0.14);
+}
+
 .landing .brand {
   display: flex;
   align-items: center;
   gap: 0.3rem;
-  color: #fff;
+  color: var(--nav-text);
   text-decoration: none;
   font-family: var(--font-body);
   font-weight: 700;
@@ -246,7 +260,7 @@
 }
 
 .landing .nav-links a {
-  color: #cbd5f5;
+  color: var(--nav-muted);
   text-decoration: none;
   font-size: 14px;
   opacity: 0.9;
@@ -273,102 +287,85 @@
   flex-wrap: nowrap;
 }
 
-.landing .gradient-select-wrapper {
+.landing .landing-theme-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  border: 1px solid rgba(186, 212, 255, 0.28);
-  border-radius: 14px;
-  background: rgba(12, 16, 28, 0.62);
-  backdrop-filter: blur(8px);
-}
-
-.landing .gradient-select-label {
-  font-size: 0.65rem;
-  font-weight: 800;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: rgba(224, 237, 255, 0.9);
-}
-
-.landing .gradient-select {
-  border: 1px solid rgba(186, 212, 255, 0.28);
-  border-radius: 10px;
-  background: rgba(11, 18, 32, 0.88);
-  color: #eaf1ff;
-  font-family: var(--font-body);
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  padding: 6px 8px;
-  min-width: 122px;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--nav-text) 24%, transparent);
+  background: color-mix(in srgb, var(--nav-text) 8%, transparent);
+  color: var(--nav-text);
   cursor: pointer;
+  transition: all 150ms ease;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
-.landing .gradient-select:focus-visible {
-  outline: 2px solid rgba(125, 211, 252, 0.7);
+.landing .landing-theme-toggle:hover {
+  background: color-mix(in srgb, var(--nav-text) 14%, transparent);
+}
+
+.landing .landing-theme-toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent-2) 56%, white 44%);
   outline-offset: 2px;
 }
 
-.landing[data-background-id="lab_showcase_dark"] .nav {
-  background:
-    radial-gradient(
-      circle at 78% 0%,
-      rgba(153, 111, 244, 0.12),
-      transparent 42%
-    ),
-    linear-gradient(
-      180deg,
-      rgba(8, 7, 15, 0.72),
-      rgba(8, 7, 15, 0.48)
-    );
-  border-bottom-color: rgba(200, 166, 255, 0.16);
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.035) inset,
-    0 12px 34px rgba(5, 4, 12, 0.28);
+.landing[data-theme-mode="dark"] {
+  --ink: #f4f1ff;
+  --heading-ink: #f7f4ff;
+  --muted: rgba(218, 224, 245, 0.78);
+  --subtle: rgba(206, 198, 231, 0.7);
+  --nav-text: rgba(244, 241, 255, 0.92);
+  --nav-muted: rgba(218, 224, 245, 0.72);
 }
 
-.landing[data-background-id="lab_showcase_dark"] .gradient-select-wrapper {
-  background: rgba(8, 7, 15, 0.42);
-  border-color: rgba(216, 194, 246, 0.18);
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.025) inset;
-}
-
-.landing[data-background-id="lab_showcase_dark"] .gradient-select {
-  background: rgba(5, 5, 11, 0.68);
-  border-color: rgba(216, 194, 246, 0.18);
-}
-
-.landing[data-background-tone="light"] {
-  --ink: #151326;
-  --muted: rgba(39, 35, 62, 0.72);
+.landing[data-theme-mode="light"] {
+  --ink: #171126;
+  --heading-ink: #120f1f;
+  --muted: rgba(39, 35, 62, 0.74);
+  --subtle: rgba(71, 61, 105, 0.62);
+  --nav-text: #171126;
+  --nav-muted: rgba(39, 35, 62, 0.68);
   --line: rgba(78, 61, 130, 0.18);
 }
 
-.landing[data-background-tone="light"] .nav {
-  background: rgba(255, 255, 255, 0.72);
-  border-bottom-color: rgba(78, 61, 130, 0.16);
+.landing[data-theme-mode="light"] .nav {
+  background:
+    radial-gradient(circle at 78% 0%, rgba(139, 92, 246, 0.1), transparent 42%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.76), rgba(255, 255, 255, 0.52));
+  backdrop-filter: blur(18px) saturate(1.05);
+  -webkit-backdrop-filter: blur(18px) saturate(1.05);
+  border-bottom: 1px solid rgba(78, 61, 130, 0.14);
 }
 
-.landing[data-background-tone="light"] .brand,
-.landing[data-background-tone="light"] .nav-links a {
-  color: #151326;
-}
-
-.landing[data-background-tone="light"] .gradient-select-wrapper {
-  background: rgba(255, 255, 255, 0.76);
-  border-color: rgba(78, 61, 130, 0.2);
-}
-
-.landing[data-background-tone="light"] .gradient-select-label {
-  color: rgba(39, 35, 62, 0.78);
-}
-
-.landing[data-background-tone="light"] .gradient-select {
-  color: #151326;
-  background: rgba(255, 255, 255, 0.82);
-  border-color: rgba(78, 61, 130, 0.26);
+.landing[data-theme-mode="light"] {
+  --landing-surface-border: rgba(109, 86, 170, 0.22);
+  --landing-surface-bg:
+    radial-gradient(
+      118% 100% at 12% 8%,
+      rgba(255, 255, 255, 0.86),
+      rgba(255, 255, 255, 0.42) 54%
+    ),
+    linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.72),
+      rgba(243, 238, 255, 0.62)
+    );
+  --landing-glass-border: rgba(109, 86, 170, 0.24);
+  --landing-glass-bg:
+    radial-gradient(
+      120% 118% at 14% 12%,
+      rgba(255, 255, 255, 0.88),
+      rgba(255, 255, 255, 0.54) 58%
+    ),
+    linear-gradient(
+      136deg,
+      rgba(255, 255, 255, 0.74),
+      rgba(243, 238, 255, 0.64)
+    );
+  --landing-glass-shadow:
+    0 20px 40px rgba(54, 32, 109, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.82);
 }
 
 .landing .lang-toggle {
@@ -461,6 +458,20 @@
   color: var(--ink);
 }
 
+.landing[data-theme-mode="light"] .lang-menu {
+  background: linear-gradient(
+    150deg,
+    rgba(255, 255, 255, 0.94),
+    rgba(242, 237, 255, 0.92)
+  );
+  border-color: rgba(78, 61, 130, 0.22);
+  box-shadow: 0 10px 30px rgba(34, 22, 70, 0.16);
+}
+
+.landing[data-theme-mode="light"] .lang-menu button {
+  color: #171126;
+}
+
 .landing .hero {
   position: relative;
 }
@@ -492,7 +503,7 @@
 }
 
 .landing .hero .sub {
-  color: #cbd5f5;
+  color: var(--muted);
   margin: 0 0 18px;
 }
 
@@ -904,7 +915,7 @@
 
 .landing .card p {
   margin: 0;
-  color: #dbe7ff;
+  color: var(--muted);
 }
 
 .landing .pillar-card {
@@ -2357,13 +2368,13 @@
   cursor: pointer;
   font-weight: 650;
   font-family: var(--font-heading);
-  color: rgba(244, 248, 255, 0.96);
+  color: var(--heading-ink);
   letter-spacing: -0.01em;
   overflow-wrap: anywhere;
 }
 
 .landing .faq p {
-  color: rgba(216, 227, 245, 0.88);
+  color: var(--muted);
   margin-bottom: 0;
   margin-top: 9px;
   line-height: 1.58;
@@ -2393,7 +2404,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  color: #21142f;
+  color: var(--muted);
 }
 
 .landing .footer-links {
@@ -2416,11 +2427,11 @@
 }
 
 .landing .footer-links a:hover {
-  color: #120a1c;
+  color: var(--heading-ink);
 }
 
 .landing .footer-cookies-link:hover {
-  color: #120a1c;
+  color: var(--heading-ink);
 }
 
 .landing .cookie-consent {
@@ -2865,17 +2876,6 @@
   .landing .nav-actions .nav-auth-button {
     font-size: 0.625rem;
     padding: 0.525rem 1.05rem;
-  }
-
-  .landing .gradient-select {
-    min-width: 102px;
-    font-size: 0.6rem;
-    padding: 5px 8px;
-  }
-
-  .landing .gradient-select-label {
-    font-size: 0.56rem;
-    letter-spacing: 0.08em;
   }
 
   .landing .lang-button {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -10,7 +10,6 @@ import {
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "@clerk/clerk-react";
 import {
-  OFFICIAL_DESIGN_TOKENS,
   OFFICIAL_LANDING_CSS_VARIABLES,
 } from "../content/officialDesignTokens";
 import {
@@ -35,133 +34,15 @@ import {
   readCookieConsentState,
 } from "../lib/cookieConsent";
 import {
-  SHOW_LANDING_BACKGROUND_SELECTOR,
   SHOW_LANDING_PRICING,
 } from "../config/releaseFlags";
+import {
+  type LandingThemeMode,
+  getLandingThemeStyle,
+  readLandingThemeMode,
+  writeLandingThemeMode,
+} from "../lib/landingTheme";
 import "./Landing.css";
-
-type LandingBackgroundOption = {
-  id: string;
-  label: { es: string; en: string };
-  tone: "light" | "dark";
-  type: "linear" | "solid" | "css";
-  cssBackground?: string;
-  color?: string;
-  angle?: string;
-  a?: string;
-  b?: string;
-};
-
-const GRADIENT_LABELS: Record<string, { es: string; en: string }> = {
-  curiosity_blue: { es: "Curiosity Blue", en: "Curiosity Blue" },
-  endless_river: { es: "Endless River", en: "Endless River" },
-  amethyst: { es: "Amethyst", en: "Amethyst" },
-  dirty_fog: { es: "Dirty Fog", en: "Dirty Fog" },
-  purple_paradise: { es: "Purple Paradise", en: "Purple Paradise" },
-  color_1: { es: "Color 1", en: "Color 1" },
-  color_2: { es: "Color 2", en: "Color 2" },
-  purple_love: { es: "Purple Love", en: "Purple Love" },
-  afternoon: { es: "Afternoon", en: "Afternoon" },
-  purple_afternoon: { es: "Purple Afternoon", en: "Purple Afternoon" },
-};
-
-const LANDING_BASE_GRADIENTS: LandingBackgroundOption[] = OFFICIAL_DESIGN_TOKENS
-  .gradients
-  .filter((gradient) => gradient.type === "linear" && gradient.stops.length >= 2)
-  .map((gradient) => {
-    const label = GRADIENT_LABELS[gradient.name] ?? {
-      es: gradient.name.replace(/_/g, " "),
-      en: gradient.name.replace(/_/g, " "),
-    };
-
-    return {
-      id: gradient.name,
-      label,
-      tone: "dark",
-      type: "linear",
-      angle: gradient.angle,
-      a: gradient.stops[0],
-      b: gradient.stops[1],
-    };
-  });
-
-const LANDING_PREMIUM_BACKGROUNDS: LandingBackgroundOption[] = [
-  {
-    id: "lab_showcase_dark",
-    label: { es: "Lab Showcase Dark", en: "Lab Showcase Dark" },
-    tone: "dark",
-    type: "css",
-    cssBackground:
-      "radial-gradient(circle at 80% 10%, rgba(153, 111, 244, 0.2), transparent 37%), radial-gradient(circle at 17% 13%, rgba(117, 142, 252, 0.16), transparent 33%), radial-gradient(circle at 52% 82%, rgba(253, 173, 124, 0.08), transparent 52%), linear-gradient(180deg, #0f0f19 0%, #0a0a12 100%)",
-  },
-  {
-    id: "true_black",
-    label: { es: "True Black", en: "True Black" },
-    tone: "dark",
-    type: "solid",
-    color: "#030306",
-  },
-  {
-    id: "innerbloom_black_violet",
-    label: { es: "Innerbloom Black Violet", en: "Innerbloom Black Violet" },
-    tone: "dark",
-    type: "solid",
-    color: "#080610",
-  },
-  {
-    id: "deep_navy_premium",
-    label: { es: "Deep Navy Premium", en: "Deep Navy Premium" },
-    tone: "dark",
-    type: "solid",
-    color: "#0B1220",
-  },
-  {
-    id: "soft_white_premium",
-    label: { es: "Soft White Premium", en: "Soft White Premium" },
-    tone: "light",
-    type: "solid",
-    color: "#F7F4FF",
-  },
-  {
-    id: "warm_ivory_premium",
-    label: { es: "Warm Ivory Premium", en: "Warm Ivory Premium" },
-    tone: "light",
-    type: "solid",
-    color: "#FBF6EF",
-  },
-  {
-    id: "violet_mist",
-    label: { es: "Violet Mist", en: "Violet Mist" },
-    tone: "dark",
-    type: "solid",
-    color: "#171126",
-  },
-  {
-    id: "nebulum_violet_dark",
-    label: { es: "Nebulum Violet Dark", en: "Nebulum Violet Dark" },
-    tone: "dark",
-    type: "css",
-    cssBackground:
-      "radial-gradient(circle at 72% 18%, rgba(143, 91, 255, 0.24), transparent 38%), radial-gradient(circle at 24% 78%, rgba(72, 190, 255, 0.14), transparent 42%), linear-gradient(180deg, #0A0714 0%, #05050B 100%)",
-  },
-  {
-    id: "premium_white_violet",
-    label: { es: "Premium White Violet", en: "Premium White Violet" },
-    tone: "light",
-    type: "css",
-    cssBackground:
-      "radial-gradient(circle at 75% 12%, rgba(139, 92, 246, 0.16), transparent 36%), radial-gradient(circle at 18% 82%, rgba(56, 189, 248, 0.10), transparent 42%), linear-gradient(180deg, #FBFAFF 0%, #F3EEFF 100%)",
-  },
-];
-
-const LANDING_BACKGROUNDS: LandingBackgroundOption[] = [
-  ...LANDING_BASE_GRADIENTS,
-  ...LANDING_PREMIUM_BACKGROUNDS,
-];
-
-const LANDING_GRADIENT_STORAGE_KEY = "ib:official-landing-gradient";
-const OFFICIAL_DEFAULT_GRADIENT_ID = "purple_afternoon";
-const SHOW_BACKGROUND_SELECTOR = SHOW_LANDING_BACKGROUND_SELECTOR;
 
 type ModeVisual = {
   avatarVideo: string;
@@ -512,48 +393,16 @@ export default function LandingPage() {
       ? resolveAuthLanguage(window.location.search)
       : "es",
   );
-  const [backgroundId, setBackgroundId] = useState<string>(() => {
-    const fallbackGradientId = LANDING_BACKGROUNDS[0]?.id ?? "";
-    const officialGradient = LANDING_BACKGROUNDS.find(
-      (option) => option.id === OFFICIAL_DEFAULT_GRADIENT_ID,
-    );
-    const officialGradientId = officialGradient?.id ?? fallbackGradientId;
-
-    if (typeof window === "undefined") return officialGradientId;
-
-    if (!SHOW_BACKGROUND_SELECTOR) {
-      return officialGradientId;
-    }
-
-    const storedGradientId = window.localStorage.getItem(
-      LANDING_GRADIENT_STORAGE_KEY,
-    );
-    const storedGradient = LANDING_BACKGROUNDS.find(
-      (option) => option.id === storedGradientId,
-    );
-    return storedGradient?.id ?? officialGradientId;
-  });
+  const [themeMode, setThemeMode] = useState<LandingThemeMode>(() =>
+    readLandingThemeMode("dark"),
+  );
   const copy = OFFICIAL_LANDING_CONTENT[language];
   const visibleNavLinks = copy.navLinks.filter(
     (link) => !/^\/demo$/i.test(link.href) && !/^#?demo$/i.test(link.href),
   );
-  const selectedBackground =
-    LANDING_BACKGROUNDS.find((option) => option.id === backgroundId) ??
-    LANDING_BACKGROUNDS[0];
-  const resolvedLandingBackground =
-    selectedBackground?.type === "css" && selectedBackground.cssBackground
-      ? selectedBackground.cssBackground
-      : selectedBackground?.type === "solid" && selectedBackground.color
-        ? selectedBackground.color
-        : `linear-gradient(${selectedBackground?.angle ?? "135deg"}, ${selectedBackground?.a ?? "#525252"}, ${selectedBackground?.b ?? "#3d72b4"})`;
   const landingStyle = {
     ...(OFFICIAL_LANDING_CSS_VARIABLES as CSSProperties),
-    "--bg-angle": selectedBackground?.angle ?? "135deg",
-    "--bg-a": selectedBackground?.a ?? "#525252",
-    "--bg-b": selectedBackground?.b ?? "#3d72b4",
-    "--landing-background": resolvedLandingBackground,
-    "--landing-background-base":
-      selectedBackground?.tone === "light" ? "#f6f1ff" : "#0a0a12",
+    ...getLandingThemeStyle(themeMode),
   } as CSSProperties;
   const [activeSlide, setActiveSlide] = useState(0);
   const [paused, setPaused] = useState(false);
@@ -582,8 +431,8 @@ export default function LandingPage() {
   }, []);
 
   useEffect(() => {
-    window.localStorage.setItem(LANDING_GRADIENT_STORAGE_KEY, backgroundId);
-  }, [backgroundId]);
+    writeLandingThemeMode(themeMode);
+  }, [themeMode]);
 
   useEffect(() => {
     const resolvedLanguage = resolveAuthLanguage(location.search);
@@ -599,6 +448,9 @@ export default function LandingPage() {
   const handleLanguageChange = (nextLanguage: Language) => {
     setLanguage(nextLanguage);
     setManualLanguage(nextLanguage);
+  };
+  const toggleThemeMode = () => {
+    setThemeMode((current) => (current === "dark" ? "light" : "dark"));
   };
 
   useEffect(() => {
@@ -790,9 +642,7 @@ export default function LandingPage() {
     <div
       className="landing"
       style={landingStyle}
-      data-background-tone={selectedBackground?.tone ?? "dark"}
-      data-background-id={selectedBackground?.id}
-      data-background-kind={selectedBackground?.type ?? "linear"}
+      data-theme-mode={themeMode}
     >
       <div className="landing-background-layer" aria-hidden="true" />
       <header className="nav">
@@ -822,29 +672,45 @@ export default function LandingPage() {
           </nav>
         ) : null}
         <div className="nav-actions">
-          {SHOW_BACKGROUND_SELECTOR ? (
-            <label className="gradient-select-wrapper">
-              <span className="gradient-select-label">
-                {language === "es" ? "BG" : "BG"}
-              </span>
-              <select
-                className="gradient-select"
-                value={backgroundId}
-                onChange={(event) => setBackgroundId(event.target.value)}
-                aria-label={
-                  language === "es"
-                    ? "Selector de fondo"
-                    : "Background selector"
-                }
+          <button
+            type="button"
+            onClick={toggleThemeMode}
+            className="landing-theme-toggle"
+            aria-label={
+              themeMode === "dark"
+                ? language === "es"
+                  ? "Cambiar a modo claro"
+                  : "Switch to light mode"
+                : language === "es"
+                  ? "Cambiar a modo oscuro"
+                  : "Switch to dark mode"
+            }
+          >
+            {themeMode === "dark" ? (
+              <svg
+                aria-hidden="true"
+                className="h-[15px] w-[15px]"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
               >
-                {LANDING_BACKGROUNDS.map((option) => (
-                  <option key={option.id} value={option.id}>
-                    {option.label[language]}
-                  </option>
-                ))}
-              </select>
-            </label>
-          ) : null}
+                <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 1 0 9.8 9.8Z" />
+              </svg>
+            ) : (
+              <svg
+                aria-hidden="true"
+                className="h-[15px] w-[15px]"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+              >
+                <circle cx="12" cy="12" r="4" />
+                <path d="M12 2v2.2M12 19.8V22M4.93 4.93l1.56 1.56M17.51 17.51l1.56 1.56M2 12h2.2M19.8 12H22M4.93 19.07l1.56-1.56M17.51 6.49l1.56-1.56" />
+              </svg>
+            )}
+          </button>
           <LanguageDropdown value={language} onChange={handleLanguageChange} />
           {isSignedIn ? (
             <Link className={buttonClasses()} to="/dashboard">

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -10,6 +10,7 @@ import {
   AUTH_STACK_CLASS,
   createAuthAppearance,
 } from '../lib/clerkAppearance';
+import { readLandingThemeMode } from '../lib/landingTheme';
 import { usePageMeta } from '../lib/seo';
 import {
   isNativeCapacitorPlatform,
@@ -18,6 +19,8 @@ import {
 export default function LoginPage() {
   const location = useLocation();
   const language = resolveAuthLanguage(location.search);
+  const themeMode = readLandingThemeMode('dark');
+  const isLightTheme = themeMode === 'light';
   const isNativeApp = isNativeCapacitorPlatform();
 
   usePageMeta({
@@ -42,6 +45,7 @@ export default function LoginPage() {
         title={language === 'en' ? 'Sign in' : 'Iniciar sesión'}
         secondaryActionLabel={language === 'en' ? 'Back to app' : 'Volver a la app'}
         secondaryActionHref="/"
+        themeMode={themeMode}
       >
         <div className={AUTH_STACK_CLASS}>
           <div className={AUTH_CLERK_FORM_SHELL_CLASS}>
@@ -68,13 +72,14 @@ export default function LoginPage() {
       title={language === 'en' ? 'Sign in' : 'Iniciar sesión'}
       secondaryActionLabel={language === 'en' ? 'Back to home' : 'Volver al inicio'}
       secondaryActionHref={`/?lang=${language}`}
+      themeMode={themeMode}
     >
       <div className={AUTH_STACK_CLASS}>
         <GoogleOAuthButton language={language} mode="sign-in" redirectUrlComplete={`${location.pathname}${location.search}${location.hash}`} />
-        <div className={AUTH_DIVIDER_CLASS}>
-          <span className="h-px flex-1 bg-white/12" aria-hidden />
+        <div className={`${AUTH_DIVIDER_CLASS} ${isLightTheme ? '!text-[#3b305f]/52' : ''}`}>
+          <span className={`h-px flex-1 ${isLightTheme ? 'bg-[#5a478f]/20' : 'bg-white/12'}`} aria-hidden />
           <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
-          <span className="h-px flex-1 bg-white/12" aria-hidden />
+          <span className={`h-px flex-1 ${isLightTheme ? 'bg-[#5a478f]/20' : 'bg-white/12'}`} aria-hidden />
         </div>
         <div className={AUTH_CLERK_FORM_SHELL_CLASS}>
           <SignIn

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -10,6 +10,7 @@ import {
   AUTH_STACK_CLASS,
   createAuthAppearance,
 } from '../lib/clerkAppearance';
+import { readLandingThemeMode } from '../lib/landingTheme';
 import {
   isNativeCapacitorPlatform,
   openUrlInCapacitorBrowser,
@@ -20,6 +21,8 @@ export default function SignUpPage() {
   const signUpContainerRef = useRef<HTMLDivElement | null>(null);
   const location = useLocation();
   const language = resolveAuthLanguage(location.search);
+  const themeMode = readLandingThemeMode('dark');
+  const isLightTheme = themeMode === 'light';
   const isNativeApp = isNativeCapacitorPlatform();
 
   const appearance = createAuthAppearance({
@@ -41,6 +44,7 @@ export default function SignUpPage() {
         title={language === 'en' ? 'Create your account' : 'Crear tu cuenta'}
         secondaryActionLabel={language === 'en' ? 'Back to app' : 'Volver a la app'}
         secondaryActionHref="/"
+        themeMode={themeMode}
       >
         <div className={AUTH_STACK_CLASS}>
           <button
@@ -62,10 +66,10 @@ export default function SignUpPage() {
             </svg>
             {language === 'en' ? 'Sign up with Google' : 'Crear cuenta con Google'}
           </button>
-          <div className={AUTH_DIVIDER_CLASS}>
-            <span className="h-px flex-1 bg-white/12" aria-hidden />
+          <div className={`${AUTH_DIVIDER_CLASS} ${isLightTheme ? '!text-[#3b305f]/52' : ''}`}>
+            <span className={`h-px flex-1 ${isLightTheme ? 'bg-[#5a478f]/20' : 'bg-white/12'}`} aria-hidden />
             <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
-            <span className="h-px flex-1 bg-white/12" aria-hidden />
+            <span className={`h-px flex-1 ${isLightTheme ? 'bg-[#5a478f]/20' : 'bg-white/12'}`} aria-hidden />
           </div>
           <div
             ref={signUpContainerRef}
@@ -89,13 +93,14 @@ export default function SignUpPage() {
       title={language === 'en' ? 'Create your account' : 'Crear tu cuenta'}
       secondaryActionLabel={language === 'en' ? 'Back to home' : 'Volver al inicio'}
       secondaryActionHref={`/?lang=${language}`}
+      themeMode={themeMode}
     >
       <div className={AUTH_STACK_CLASS}>
         <GoogleOAuthButton language={language} mode="sign-up" redirectUrlComplete={`${location.pathname}${location.search}${location.hash}`} />
-        <div className={AUTH_DIVIDER_CLASS}>
-          <span className="h-px flex-1 bg-white/12" aria-hidden />
+        <div className={`${AUTH_DIVIDER_CLASS} ${isLightTheme ? '!text-[#3b305f]/52' : ''}`}>
+          <span className={`h-px flex-1 ${isLightTheme ? 'bg-[#5a478f]/20' : 'bg-white/12'}`} aria-hidden />
           <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
-          <span className="h-px flex-1 bg-white/12" aria-hidden />
+          <span className={`h-px flex-1 ${isLightTheme ? 'bg-[#5a478f]/20' : 'bg-white/12'}`} aria-hidden />
         </div>
         <div
           ref={signUpContainerRef}


### PR DESCRIPTION
### Motivation
- Cerrar el selector libre de fondos de la landing y reemplazarlo por un sistema final con solo dos modos visuales (dark / light) persistidos entre rutas y sesiones. 
- Asegurar que landing, páginas públicas de demo y las páginas de auth hereden el mismo fondo premium sin mantener el selector `BG` de pruebas. 

### Description
- Se introdujo un helper compartido `apps/web/src/lib/landingTheme.ts` con el tipo `LandingThemeMode`, la key de `localStorage` `ib:landing-theme-mode`, funciones `readLandingThemeMode` / `writeLandingThemeMode` y getters de background para los dos fondos finales (Nebulum Violet Dark / Premium White Violet). 
- Se removió el selector de fondos y su plumbing de `Landing.tsx` y se añadió un toggle compacto Light/Dark en la nav que persiste la elección y expone `data-theme-mode` en el wrapper principal; el fondo se aplica mediante la capa fija `.landing-background-layer`. 
- `Landing.css` se adaptó a `data-theme-mode` con variables por modo (`--landing-background`, `--landing-background-base`, `--ink`, `--heading-ink`, etc.), ajustes de nav glass, contrastes y superficies para ambos modos respetando el gradiente del `h1 .grad`. 
- Se eliminó la flag legacy `SHOW_LANDING_BACKGROUND_SELECTOR` en `apps/web/src/config/releaseFlags.ts` y se propagó la selección de modo a `AuthLayout`, `Login`, `SignUp`, `LabsDemoModeSelect` y `DemoDashboard` para que hereden el mismo fondo y comportamiento visual (sin tocar onboarding). 

### Testing
- `npm run typecheck:web` fue ejecutado y falló por errores TypeScript preexistentes en el repo no introducidos por este cambio; no se identificaron errores nuevos atribuibles a la lógica del theme. 
- `npm run build:web` fue ejecutado y la build de producción completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edee1f798c833284e47e4cbc040779)