### PR TITLE
fix(web): force Google account picker on sign-up

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -26,6 +26,7 @@ export function GoogleOAuthButton({
 
   const isLoaded = mode === 'sign-up' ? isSignUpLoaded : isSignInLoaded;
   const isDisabled = !isLoaded || isRedirecting;
+  const shouldForceAccountSelection = forceAccountSelection || mode === 'sign-up';
 
   const copy = useMemo(
     () => {
@@ -65,7 +66,7 @@ export function GoogleOAuthButton({
           redirectUrlComplete,
           continueSignIn: false,
           continueSignUp: false,
-          oidcPrompt: forceAccountSelection ? 'select_account' : undefined,
+          oidcPrompt: shouldForceAccountSelection ? 'select_account' : undefined,
         });
       } else {
         if (!signIn) {
@@ -77,14 +78,14 @@ export function GoogleOAuthButton({
           redirectUrlComplete,
           continueSignIn: false,
           continueSignUp: false,
-          oidcPrompt: forceAccountSelection ? 'select_account' : undefined,
+          oidcPrompt: shouldForceAccountSelection ? 'select_account' : undefined,
         });
       }
     } catch (error) {
       console.error('[auth] Google OAuth redirect failed', error);
       setIsRedirecting(false);
     }
-  }, [forceAccountSelection, isLoaded, isRedirecting, mode, redirectUrlComplete, signIn, signUp]);
+  }, [isLoaded, isRedirecting, mode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
 
   return (
     <button

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -105,7 +105,12 @@ export default function SignUpPage() {
       themeMode={themeMode}
     >
       <div className={AUTH_STACK_CLASS}>
-        <GoogleOAuthButton language={language} mode="sign-up" redirectUrlComplete={`${location.pathname}${location.search}${location.hash}`} />
+        <GoogleOAuthButton
+          language={language}
+          mode="sign-up"
+          redirectUrlComplete={`${location.pathname}${location.search}${location.hash}`}
+          forceAccountSelection
+        />
         <div className={`${AUTH_DIVIDER_CLASS} ${isLightTheme ? '!text-[#3b305f]/76' : ''}`}>
           <span className={`h-px flex-1 ${isLightTheme ? 'bg-[#5a478f]/28' : 'bg-white/12'}`} aria-hidden />
           <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>


### PR DESCRIPTION
### Motivation

- En la página WEB `/sign-up` el botón “Crear cuenta con Google” podía reutilizar una sesión de Google cacheada y comportarse como login en lugar de forzar la selección de cuenta.
- El flujo nativo/mobile ya fuerza selección explícita con `oidcPrompt: 'select_account'`, y la intención es alinear el comportamiento web con el móvil.

### Description

- En `apps/web/src/pages/SignUp.tsx` se pasa `forceAccountSelection` al componente `GoogleOAuthButton` en el flujo WEB sign-up.
- En `apps/web/src/components/auth/GoogleOAuthButton.tsx` se añadió `shouldForceAccountSelection = forceAccountSelection || mode === 'sign-up'` y se usa para establecer `oidcPrompt: 'select_account'` en ambas llamadas a `authenticateWithRedirect`.
- Se mantuvo el comportamiento de login sin cambios funcionales salvo que ahora acepta el prop `forceAccountSelection` si se quiere forzar en sign-in.
- No se modificaron estilos ni textos de UI, y el cambio alinea la web con `MobileBrowserAuth.tsx` que ya usa `oidcPrompt: 'select_account'`.

### Testing

- Ejecuté el chequeo de TypeScript con `pnpm -C apps/web exec tsc --noEmit`, y falló por errores TypeScript preexistentes en módulos no relacionados con este cambio; la falla es preexistente y no fue causada por las modificaciones realizadas.
- Verifiqué el diff con `git diff` para los archivos `GoogleOAuthButton.tsx` y `SignUp.tsx` y confirmé los cambios esperados.
- Se creó el commit con el mensaje `fix(web): force Google account picker on sign-up` y se registró en el repositorio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b0a8ac9483328cac1fc1cd1182e9)