### PR TITLE
Fix HeroPhoneShowcase splash wordmark clipping on desktop

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -221,11 +221,13 @@
 }
 
 .loopSplashScene {
+  --loop-splash-wordmark-width: min(178px, calc(100% - 62px));
   position: absolute;
   inset: 10px;
   border-radius: 30px;
   display: grid;
   place-items: center;
+  container-type: inline-size;
   box-sizing: border-box;
   padding-inline: clamp(12px, 5.5%, 18px);
   overflow: hidden;
@@ -268,7 +270,7 @@
 
 .loopSplashLockup {
   position: relative;
-  width: min(100%, 240px);
+  width: min(100%, 252px);
   max-width: 100%;
   display: inline-flex;
   align-items: center;
@@ -288,7 +290,7 @@
 }
 
 .loopSplashFlower {
-  width: clamp(50px, 18vw, 62px);
+  width: clamp(46px, 18cqw, 58px);
   flex: 0 0 auto;
   height: auto;
   z-index: 2;
@@ -307,12 +309,12 @@
   margin: 0;
   flex: 0 1 auto;
   width: 0;
-  max-width: calc(100% - clamp(62px, 20vw, 76px));
+  max-width: var(--loop-splash-wordmark-width);
   overflow: hidden;
   white-space: nowrap;
-  font-size: clamp(0.95rem, 1.47vw, 1.21rem);
+  font-size: clamp(0.82rem, 5.1cqw, 1.02rem);
   font-weight: 700;
-  letter-spacing: 0.32em;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
   color: rgba(244, 239, 255, 0.96);
   text-shadow:
@@ -377,13 +379,13 @@
   }
 
   74% {
-    width: min(100%, 165px);
+    width: var(--loop-splash-wordmark-width);
     clip-path: inset(0 0 0 0);
     opacity: 1;
   }
 
   100% {
-    width: min(100%, 165px);
+    width: var(--loop-splash-wordmark-width);
     clip-path: inset(0 0 0 0);
     opacity: 1;
   }


### PR DESCRIPTION
### Motivation
- The splash wordmark inside the hero phone was being clipped on desktop because the wordmark sizing used `vw` (viewport) which scaled relative to the page, exceeding the hardcoded reveal width and truncating the last letters. 
- The component lives inside a phone mockup with its own width, so sizing must be container-safe to avoid visual breakage while preserving the reveal animation and lockup composition.

### Description
- Added a container-local CSS variable `--loop-splash-wordmark-width` on `.loopSplashScene` and switched the reveal keyframes to use that variable instead of the fragile `165px` hardcode. 
- Enabled a container context with `container-type: inline-size` on `.loopSplashScene` so container-aware units (`cqw`) can be used safely. 
- Rebalanced lockup sizing by changing `.loopSplashLockup` to `width: min(100%, 252px)` and set `.loopSplashWordmark` `max-width` to `var(--loop-splash-wordmark-width)`. 
- Replaced viewport-based sizes with container-aware values: `.loopSplashFlower` uses `clamp(46px, 18cqw, 58px)`, `.loopSplashWordmark` font-size uses `clamp(0.82rem, 5.1cqw, 1.02rem)`, and letter-spacing reduced from `0.32em` to `0.28em` to keep the premium look while ensuring the full `INNERBLOOM` wordmark fits.
- Files modified: `apps/web/src/components/landing/HeroPhoneShowcase.module.css`.

### Testing
- Ran workspace linter with `pnpm -w run lint` and it completed successfully. 
- Attempted targeted lint for `apps/web` with `pnpm -C apps/web run lint` which failed because `apps/web` does not define a `lint` script (lint is run from the workspace root).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b0c3feb48332ad165ca733296a43)