### PR TITLE
Update “Cómo funciona Innerbloom” copy and add adaptability concept doc

### DIFF
--- a/apps/web/src/components/PremiumTimeline.tsx
+++ b/apps/web/src/components/PremiumTimeline.tsx
@@ -12,6 +12,7 @@ export type TimelineStep = {
 type PremiumTimelineProps = {
   steps: TimelineStep[];
   closingLine: string;
+  closingBody?: string;
   className?: string;
   axisX?: number;
   lineOffsetX?: number;
@@ -65,6 +66,7 @@ const catmullRomToBezierPath = (points: Point[]) => {
 export default function PremiumTimeline({
   steps,
   closingLine,
+  closingBody,
   className,
   axisX,
   lineOffsetX = 56,
@@ -525,7 +527,8 @@ export default function PremiumTimeline({
             backgroundImage: 'radial-gradient(circle at 18% 48%, rgba(152,214,255,0.14), transparent 55%)',
           }}
         >
-          {closingLine}
+          <p className="font-semibold leading-snug">{closingLine}</p>
+          {closingBody ? <p className="mt-2">{closingBody}</p> : null}
         </motion.div>
       </div>
     </section>

--- a/apps/web/src/content/officialLandingContent.ts
+++ b/apps/web/src/content/officialLandingContent.ts
@@ -33,7 +33,7 @@ export type LandingCopy = {
   };
   pillars: { kicker: string; title: string; intro: string; highlightLeadIn: string; highlight: string; items: Pillar[] };
   modes: { kicker: string; title: string; intro: string; items: Mode[] };
-  how: { kicker: string; title: string; intro: string; closingLine: string; steps: HowTimelineStep[] };
+  how: { kicker: string; title: string; intro: string; closingLine: string; closingBody: string; steps: HowTimelineStep[] };
   featureShowcase: { kicker: string; title: string; intro: string; items: FeatureShowcaseItem[] };
   demo: { title: string; text: string; banner: string; cta: string };
   testimonials: { title: string; intro: string; items: Testimonial[]; prev: string; next: string; groupLabel: string };
@@ -132,42 +132,43 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
     how: {
       kicker: 'EL SISTEMA DE INNERBLOOM',
       title: 'Cómo funciona Innerbloom',
-      intro: 'Empieza desde tu nivel real, avanza en ciclos semanales, recalibra con el tiempo y construye hábitos que sí perduran.',
-      closingLine: 'Un hábito logrado no es una racha bonita. Es algo que ya forma parte de vos.',
+      intro: 'Innerbloom no te da una rutina fija. Usa tus decisiones y tu progreso real para ajustar el sistema: cuándo subir la intensidad, cuándo bajarla y cómo ayudarte a sostener hábitos en el tiempo.',
+      closingLine: 'No es un tracker. Es un sistema que se adapta a tu progreso.',
+      closingBody: 'Innerbloom usa tu progreso para decidir cuándo subir la intensidad, cuándo bajarla y cuál debería ser tu próximo paso.',
       steps: [
         {
-          title: 'Empieza realista, no perfecto',
+          title: 'Setea un inicio posible',
           badge: 'ONBOARDING PERSONALIZADO',
           bullets: [
-            '🟢 Empieza desde tu nivel real',
-            '🌱 Construye una base que puedas sostener',
+            '🟢 Te hace las preguntas justas para entender tu punto de partida',
+            '🌱 Crea tus primeras tareas según lo que elegís y podés sostener',
           ],
-          chips: ['ONBOARDING · BASE REALISTA'],
+          chips: ['ONBOARDING · INICIO REALISTA'],
         },
         {
-          title: 'Avanza en ciclos semanales',
+          title: 'Convierte tus acciones en información',
           badge: 'CICLO SEMANAL',
           bullets: [
-            '📅 Avanza por semanas, no por días sueltos',
-            '🧭 Detecta patrones reales y ajusta tu plan',
+            '📅 Registra qué tareas completás cada semana',
+            '📊 Usa GP, rachas y progreso para entender tu constancia',
           ],
-          chips: ['CICLO SEMANAL · PROGRESO Y PATRONES'],
+          chips: ['CICLO SEMANAL · PROGRESO REAL'],
         },
         {
-          title: 'Ajusta el sistema a medida que creces',
+          title: 'Ajusta dificultad e intensidad',
           badge: 'RECALIBRACIÓN MENSUAL',
           bullets: [
-            '🔄 Recalibra la dificultad de tus tareas según tu evolución',
-            '📈 Te propone una intensidad mayor cuando tu constancia se fortalece',
+            '🔁 Si una tarea te está costando, el sistema lo detecta',
+            '📈 Si tu progreso es sólido, puede proponerte subir de ritmo',
           ],
-          chips: ['RECALIBRACIÓN · DIFICULTAD Y EVOLUCIÓN'],
+          chips: ['RECALIBRACIÓN · AJUSTE Y RITMO'],
         },
         {
-          title: 'Convierte constancia en hábitos reales',
+          title: 'Reconoce hábitos consolidados',
           badge: 'HÁBITOS LOGRADOS',
           bullets: [
-            '🏆 Convierte constancia en hábitos duraderos',
-            '🌿 Construye hábitos que sigan contigo más allá de una buena semana',
+            '🏆 Detecta cuándo una tarea ya se volvió parte de tu rutina',
+            '🌿 Podés seguir midiéndola o guardarla como un logro alcanzado',
           ],
           chips: ['HÁBITOS LOGRADOS · CONSOLIDACIÓN'],
         }
@@ -377,6 +378,7 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
       title: 'How Innerbloom works',
       intro: 'Start from your real level, move through weekly cycles, recalibrate over time, and build habits that actually last.',
       closingLine: 'An achieved habit isn’t just a pretty streak. It’s something that has become part of you.',
+      closingBody: 'Innerbloom uses your progress to decide when to increase intensity, when to reduce it, and what your next step should be.',
       steps: [
         {
           title: 'Start realistic, not perfect',

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -854,6 +854,7 @@ export default function LandingPage() {
             <PremiumTimeline
               steps={copy.how.steps}
               closingLine={copy.how.closingLine}
+              closingBody={copy.how.closingBody}
               className="mt-2"
             />
           </div>

--- a/docs/innerbloom-adaptability-concept.md
+++ b/docs/innerbloom-adaptability-concept.md
@@ -1,0 +1,45 @@
+# Innerbloom Adaptability Concept
+
+## Core definition
+
+Innerbloom is adaptive because it does not give users a fixed habit routine. It uses the user’s initial decisions and real progress data to adjust what the system recommends next.
+
+The product should be explained as:
+- not just a habit tracker
+- not a generic routine generator
+- a system that adapts intensity, difficulty, rhythm, and habit lifecycle based on user behavior
+
+## Adaptability layers
+
+1. Onboarding / Journey setup  
+The system asks the user key questions and uses their choices to create a realistic starting point.
+
+2. Weekly progress loop  
+The system turns completed tasks, GP, streaks, and activity into usable progress signals.
+
+3. Monthly recalibration  
+The system compares real completion behavior against expected rhythm and can adjust difficulty or suggest a rhythm change.
+
+4. Habit consolidation  
+When a task is sustained over time, the product can treat it as an achieved habit rather than just another active task.
+
+## Product positioning
+
+The key distinction:  
+“A tracker shows what you did. Innerbloom uses your progress to decide what your next step should be.”
+
+## Copy principles
+
+When explaining adaptability:
+- be clear, direct, and concrete
+- avoid vague claims like “AI understands you”
+- avoid overpromising emotional intelligence
+- explain the mechanism: decisions → progress data → adjustment → next step
+- use “intensity” instead of “pressure”
+- connect adaptation to helping users sustain habits over time
+
+## Approved final landing message
+
+No es un tracker. Es un sistema que se adapta a tu progreso.
+
+Innerbloom usa tu progreso para decidir cuándo subir la intensidad, cuándo bajarla y cuál debería ser tu próximo paso.


### PR DESCRIPTION
### Motivation
- Clarify on the official landing why Innerbloom is an adaptive, gamified habits system that uses the user’s initial choices and real progress to adjust intensity, difficulty and next steps. 
- Add short product documentation describing the adaptability concept so the messaging and team artifacts are aligned.

### Description
- Replaced the Spanish copy for the “Cómo funciona Innerbloom” section in the centralized content file, updating the eyebrow, title, subtitle, four steps (labels/titles/bullets/tags) and the final message (`apps/web/src/content/officialLandingContent.ts`).
- Added an optional `closingBody?: string` prop to `PremiumTimeline` and render the closing card as a title plus optional body without changing layout or styles (`apps/web/src/components/PremiumTimeline.tsx`).
- Passed the new `copy.how.closingBody` into the timeline in the landing page (`apps/web/src/pages/Landing.tsx`).
- Added the requested documentation file `docs/innerbloom-adaptability-concept.md` with definition, adaptability layers, positioning and copy principles.

### Testing
- Ran the web typecheck with `npm run typecheck:web`, which failed due to pre-existing TypeScript errors in unrelated areas of the app and not caused by these content/prop rendering changes. 
- No other automated tests were run for this content-only UI/markdown update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b55c4e208332875dd05a3c1013c9)