### PR TITLE
Unificar decisión de theme mode: usar `ib-theme-preference` como fuente única

### DIFF
--- a/apps/web/src/lib/landingTheme.ts
+++ b/apps/web/src/lib/landingTheme.ts
@@ -1,8 +1,7 @@
 import type { CSSProperties } from 'react';
+import { readStoredThemePreference, resolveThemeFromPreference, type ResolvedTheme } from '../theme/themePreference';
 
 export type LandingThemeMode = 'dark' | 'light';
-
-export const LANDING_THEME_STORAGE_KEY = 'ib:landing-theme-mode';
 
 const LANDING_BACKGROUNDS: Record<LandingThemeMode, { base: string; gradient: string }> = {
   dark: {
@@ -21,19 +20,10 @@ export function isLandingThemeMode(value: string | null): value is LandingThemeM
   return value === 'dark' || value === 'light';
 }
 
-export function readLandingThemeMode(defaultMode: LandingThemeMode = 'dark'): LandingThemeMode {
-  if (typeof window === 'undefined') {
-    return defaultMode;
-  }
-  const stored = window.localStorage.getItem(LANDING_THEME_STORAGE_KEY);
-  return isLandingThemeMode(stored) ? stored : defaultMode;
-}
-
-export function writeLandingThemeMode(mode: LandingThemeMode) {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  window.localStorage.setItem(LANDING_THEME_STORAGE_KEY, mode);
+export function readLandingThemeMode(): LandingThemeMode {
+  const preference = readStoredThemePreference();
+  const resolvedTheme: ResolvedTheme = resolveThemeFromPreference(preference);
+  return resolvedTheme;
 }
 
 export function getLandingThemeBackground(mode: LandingThemeMode) {

--- a/apps/web/src/pages/DemoDashboard.tsx
+++ b/apps/web/src/pages/DemoDashboard.tsx
@@ -34,7 +34,7 @@ export default function DemoDashboardPage() {
   const demoHubPath = getPublicDemoHubPath(location.search);
   const { theme, setPreference } = useThemePreference();
   const [showGuidedTour, setShowGuidedTour] = useState(true);
-  const landingThemeMode = readLandingThemeMode('dark');
+  const landingThemeMode = readLandingThemeMode();
   const landingThemeBackground = getLandingThemeBackground(landingThemeMode);
   const hasLoggedGuidedStart = useRef(false);
   const dailyQuestModalRef = useRef<DailyQuestModalHandle | null>(null);

--- a/apps/web/src/pages/LabsDemoModeSelect.tsx
+++ b/apps/web/src/pages/LabsDemoModeSelect.tsx
@@ -24,7 +24,7 @@ export default function LabsDemoModeSelectPage({ legacyLabsPath = false }: DemoM
   const navigate = useNavigate();
   const sourceParam = new URLSearchParams(location.search).get('source');
   const source: DemoEntrySource = sourceParam === 'selector' || sourceParam === 'labs' ? sourceParam : 'landing';
-  const themeMode = readLandingThemeMode('dark');
+  const themeMode = readLandingThemeMode();
   const landingThemeBackground = getLandingThemeBackground(themeMode);
 
   useEffect(() => {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -40,8 +40,8 @@ import {
   type LandingThemeMode,
   getLandingThemeStyle,
   readLandingThemeMode,
-  writeLandingThemeMode,
 } from "../lib/landingTheme";
+import { useThemePreference } from "../theme/ThemePreferenceProvider";
 import "./Landing.css";
 import "./LandingThemeContrastPatch.css";
 
@@ -394,9 +394,8 @@ export default function LandingPage() {
       ? resolveAuthLanguage(window.location.search)
       : "es",
   );
-  const [themeMode, setThemeMode] = useState<LandingThemeMode>(() =>
-    readLandingThemeMode("dark"),
-  );
+  const { theme, setPreference } = useThemePreference();
+  const themeMode: LandingThemeMode = theme;
   const copy = OFFICIAL_LANDING_CONTENT[language];
   const visibleNavLinks = copy.navLinks.filter(
     (link) => !/^\/demo$/i.test(link.href) && !/^#?demo$/i.test(link.href),
@@ -432,10 +431,6 @@ export default function LandingPage() {
   }, []);
 
   useEffect(() => {
-    writeLandingThemeMode(themeMode);
-  }, [themeMode]);
-
-  useEffect(() => {
     const resolvedLanguage = resolveAuthLanguage(location.search);
     setLanguage(resolvedLanguage);
     syncLocaleLanguage(resolvedLanguage);
@@ -451,7 +446,7 @@ export default function LandingPage() {
     setManualLanguage(nextLanguage);
   };
   const toggleThemeMode = () => {
-    setThemeMode((current) => (current === "dark" ? "light" : "dark"));
+    setPreference(themeMode === "dark" ? "light" : "dark");
   };
 
   useEffect(() => {

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -19,7 +19,7 @@ import {
 export default function LoginPage() {
   const location = useLocation();
   const language = resolveAuthLanguage(location.search);
-  const themeMode = readLandingThemeMode('dark');
+  const themeMode = readLandingThemeMode();
   const isLightTheme = themeMode === 'light';
   const isNativeApp = isNativeCapacitorPlatform();
 

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -21,7 +21,7 @@ export default function SignUpPage() {
   const signUpContainerRef = useRef<HTMLDivElement | null>(null);
   const location = useLocation();
   const language = resolveAuthLanguage(location.search);
-  const themeMode = readLandingThemeMode('dark');
+  const themeMode = readLandingThemeMode();
   const isLightTheme = themeMode === 'light';
   const isNativeApp = isNativeCapacitorPlatform();
 

--- a/apps/web/src/theme/themePreference.ts
+++ b/apps/web/src/theme/themePreference.ts
@@ -2,6 +2,7 @@ export type ThemePreference = 'light' | 'dark' | 'auto';
 export type ResolvedTheme = 'light' | 'dark';
 
 export const THEME_PREFERENCE_STORAGE_KEY = 'ib-theme-preference';
+export const LEGACY_LANDING_THEME_STORAGE_KEY = 'ib:landing-theme-mode';
 const DARK_SCHEME_MEDIA_QUERY = '(prefers-color-scheme: dark)';
 
 export function readStoredThemePreference(): ThemePreference {
@@ -13,6 +14,22 @@ export function readStoredThemePreference(): ThemePreference {
   return storedPreference === 'light' || storedPreference === 'dark' || storedPreference === 'auto'
     ? storedPreference
     : 'dark';
+}
+
+export function migrateLegacyLandingThemePreference() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const current = window.localStorage.getItem(THEME_PREFERENCE_STORAGE_KEY);
+  if (current === 'light' || current === 'dark' || current === 'auto') {
+    return;
+  }
+
+  const legacy = window.localStorage.getItem(LEGACY_LANDING_THEME_STORAGE_KEY);
+  if (legacy === 'light' || legacy === 'dark') {
+    window.localStorage.setItem(THEME_PREFERENCE_STORAGE_KEY, legacy);
+  }
 }
 
 export function resolveThemeFromPreference(preference: ThemePreference): ResolvedTheme {
@@ -53,6 +70,7 @@ export function applyThemePreference(preference: ThemePreference): ResolvedTheme
 }
 
 export function applyStoredThemePreference(): ThemePreference {
+  migrateLegacyLandingThemePreference();
   const preference = readStoredThemePreference();
   applyThemePreference(preference);
   return preference;


### PR DESCRIPTION
### Motivation
- Actualmente hay dos fuentes de verdad de tema (`ib-theme-preference` y `ib:landing-theme-mode`) que causan desalineación entre landing → auth → app; la intención es unificarlas sin cambiar estilos visuales.
- Mantener `auto` y la lógica de resolución existente y evitar flicker al aplicar la preferencia lo antes posible en el bootstrap.

### Description
- Añadida migración legacy en `apps/web/src/theme/themePreference.ts` con la constante `LEGACY_LANDING_THEME_STORAGE_KEY` y la función `migrateLegacyLandingThemePreference()` que copia `ib:landing-theme-mode` a `ib-theme-preference` si no existe la preferencia canónica, y se ejecuta desde `applyStoredThemePreference()`.
- `apps/web/src/lib/landingTheme.ts` ahora resuelve el modo visual (`light` | `dark`) desde la preferencia canónica usando `readStoredThemePreference()` + `resolveThemeFromPreference()` y se eliminó la persistencia propia de landing.
- `apps/web/src/pages/Landing.tsx` pasó a usar `useThemePreference()` para leer `theme` y a llamar a `setPreference()` en el toggle para escribir la preferencia canónica, manteniendo `getLandingThemeBackground`/`getLandingThemeStyle` intactos para los tratamientos visuales de landing.
- Alineadas las lecturas de theme en `Login.tsx`, `SignUp.tsx`, `LabsDemoModeSelect.tsx`, `DemoDashboard.tsx` para usar `readLandingThemeMode()` (que ahora devuelve el tema resuelto desde la preferencia canónica). 

### Testing
- Ejecuté el typecheck con `npm run typecheck:web` y la tarea falló por errores TypeScript preexistentes en varias áreas no relacionadas con este cambio (por ejemplo `runtimeAuth`, tipos de `PreviewAchievementCard`, y tests), por lo que no se detectaron errores introducidos por esta migración automática del tema.
- No se ejecutó `build` o suites de integración en este PR; la migración de almacenamiento se hace en el bootstrap temprano vía `applyStoredThemePreference()` para minimizar flicker.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b82cd0208332a891eac4339d351a)