### PR TITLE
Fix ratio-based percentage display in monthly achievement preview

### DIFF
--- a/apps/web/src/components/dashboard-v3/PreviewAchievementCard.tsx
+++ b/apps/web/src/components/dashboard-v3/PreviewAchievementCard.tsx
@@ -127,10 +127,14 @@ function getMonthSymbol(monthState: string | null | undefined): string {
   return '○';
 }
 
+function formatCompletionRatePercent(rate: number | null | undefined): string {
+  if (typeof rate !== 'number' || Number.isNaN(rate)) return '--';
+  const safeRate = Math.max(0, rate);
+  return `${Math.round(safeRate * 100)}%`;
+}
+
 function getMonthMetric(value: number | null | undefined): string {
-  if (typeof value !== 'number' || Number.isNaN(value)) return '--';
-  const normalized = value <= 1 ? value * 100 : value;
-  return `${Math.max(0, Math.min(100, Math.round(normalized)))}%`;
+  return formatCompletionRatePercent(value);
 }
 
 function RecentMonthNode({ entry, language, compact = false }: MonthNodeProps) {

--- a/apps/web/src/components/dashboard-v3/__tests__/PreviewAchievementCard.test.tsx
+++ b/apps/web/src/components/dashboard-v3/__tests__/PreviewAchievementCard.test.tsx
@@ -92,6 +92,21 @@ describe('PreviewAchievementCard', () => {
     expect(screen.getAllByTestId('recent-month-label')).toHaveLength(4);
   });
 
+
+  test('formats monthly ratios as percentages above 100 when needed', () => {
+    renderCard({
+      recentMonths: [
+        { periodKey: '2026-01', closed: true, completionRate: 0.8, state: 'building' },
+        { periodKey: '2026-02', closed: true, completionRate: 1, state: 'strong' },
+        { periodKey: '2026-03', closed: true, completionRate: 1.25, state: 'strong' },
+        { periodKey: '2026-04', closed: true, completionRate: 2.256, state: 'strong' },
+        { periodKey: '2026-05', closed: false, projectedCompletionRate: 2, state: 'projected_valid' },
+      ],
+    });
+
+    expect(screen.getAllByTestId('recent-month-progress').map((node) => node.textContent)).toEqual(['80%', '100%', '125%', '226%', '200%']);
+  });
+
   test('highlights the last 3 months in a grouped window that spans the intended 3-month range', () => {
     renderCard({
       recentMonths: [


### PR DESCRIPTION
### Motivation
- The monthly "Resultado últimos meses" preview was displaying backend ratio values incorrectly (e.g. `2` shown as `2%` instead of `200%`).
- Backend provides `completion_rate` and related fields as ratios (e.g. `1.25` means `125%`), so the UI must always multiply by 100 for month preview labels.

### Description
- Added a dedicated formatter `formatCompletionRatePercent(rate: number | null | undefined): string` that returns `--` for invalid inputs, clamps negatives to `0`, always multiplies by `100`, and rounds consistently. 
- Replaced the old heuristic in `getMonthMetric` to call `formatCompletionRatePercent` so monthly preview values (`completionRate`, `projectedCompletionRate`, `projectedMonthEndRate`) are treated as ratios. 
- Kept visual state/threshold logic and the main score donut unchanged and added a regression test in `apps/web/src/components/dashboard-v3/__tests__/PreviewAchievementCard.test.tsx` to validate `0.8`, `1`, `1.25`, `2`, `2.256` and a projected `2.0` render as `80%`, `100%`, `125%`, `226%`, `200%` respectively (files changed: `apps/web/src/components/dashboard-v3/PreviewAchievementCard.tsx`, `apps/web/src/components/dashboard-v3/__tests__/PreviewAchievementCard.test.tsx`).

### Testing
- Ran the component tests with `npm --workspace apps/web run test -- src/components/dashboard-v3/__tests__/PreviewAchievementCard.test.tsx` and the suite passed. 
- The test run reported `1 test file` and `23 passed` tests for the updated spec.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ba1d89e88332b1788059f7eb0164)