### PR TITLE
Tighten splash wordmark reveal width and flower spacing

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -221,7 +221,7 @@
 }
 
 .loopSplashScene {
-  --loop-splash-wordmark-width: min(178px, calc(100% - 62px));
+  --loop-splash-wordmark-width: min(138px, calc(100% - 54px));
   position: absolute;
   inset: 10px;
   border-radius: 30px;
@@ -291,6 +291,7 @@
 
 .loopSplashFlower {
   width: clamp(46px, 18cqw, 58px);
+  margin-inline-end: -2px;
   flex: 0 0 auto;
   height: auto;
   z-index: 2;


### PR DESCRIPTION
### Motivation
- Reducir la “caja invisible” del reveal del wordmark porque `--loop-splash-wordmark-width` era demasiado amplio y mantenía la flor visualmente separada de la última “M”, buscando que la flor quede junto a la M como en el logo real.

### Description
- En `apps/web/src/components/landing/HeroPhoneShowcase.module.css` se cambió `--loop-splash-wordmark-width` de `min(178px, calc(100% - 62px))` a `min(138px, calc(100% - 54px))` y se añadió `margin-inline-end: -2px` a `.loopSplashFlower` para un ajuste óptico que mantiene el `gap` bajo.

### Testing
- No se ejecutaron pruebas automáticas para este ajuste (cambio solo de CSS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1bf7865ec83328781ed1b14ed4286)