### PR TITLE
Onboarding: make light/dark theming theme-aware for Clerk, path selection and GP overlay

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1098,6 +1098,31 @@
     box-shadow: var(--onboarding-glass-shadow);
   }
 
+
+
+  .ib-onboarding-divider {
+    color: var(--color-text-subtle);
+  }
+
+  .onboarding-surface-base .text-white,
+  .onboarding-surface-base .text-white\/90,
+  .onboarding-surface-base .text-white\/85,
+  .onboarding-surface-base .text-white\/80,
+  .onboarding-surface-base .text-white\/75,
+  .onboarding-surface-base .text-white\/70 {
+    color: var(--color-text);
+  }
+
+  .onboarding-surface-base .text-white\/65,
+  .onboarding-surface-base .text-white\/60,
+  .onboarding-surface-base .text-white\/55 {
+    color: var(--color-text-muted);
+  }
+
+  .onboarding-surface-base .text-white\/50 {
+    color: var(--color-text-subtle);
+  }
+
   .onboarding-mode-chip {
     border-radius: 9999px;
     background:

--- a/apps/web/src/lib/clerkAppearance.ts
+++ b/apps/web/src/lib/clerkAppearance.ts
@@ -4,7 +4,7 @@ import type { Theme } from '@clerk/types';
 export const AUTH_LOGIN_MAX_WIDTH = 'max-w-full';
 export const AUTH_STACK_CLASS = 'mx-auto w-full max-w-xl space-y-3';
 export const AUTH_DIVIDER_CLASS =
-  'flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-white/45';
+  'flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-[color:var(--color-text-subtle)]';
 export const AUTH_CLERK_FORM_SHELL_CLASS = 'mx-auto w-full min-w-0 max-w-full px-1 sm:px-0';
 
 const baseLayout = {

--- a/apps/web/src/onboarding/steps/ClerkGate.tsx
+++ b/apps/web/src/onboarding/steps/ClerkGate.tsx
@@ -2,6 +2,7 @@ import { SignIn, SignUp } from '@clerk/clerk-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useThemePreference } from '../../theme/ThemePreferenceProvider';
 import { GoogleOAuthButton } from '../../components/auth/GoogleOAuthButton';
 import { useAuth, useUser } from '../../auth/runtimeAuth';
 import { buildLocalizedAuthPath } from '../../lib/authLanguage';
@@ -40,19 +41,10 @@ const TAB_OPTIONS = {
 
 type TabId = (typeof TAB_OPTIONS)['es'][number]['id'];
 
-const clerkAppearance = createAuthAppearance({
-  layout: {
-    showOptionalFields: true
-  },
-  elements: {
-    footerActionText: 'text-white/50',
-    footerActionLink: 'font-semibold text-white/70 hover:text-white underline-offset-4',
-    formFieldSuccessText: 'text-sm text-emerald-200'
-  }
-});
 
 export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: ClerkGateProps) {
   const location = useLocation();
+  const { theme } = useThemePreference();
   const { isLoaded, isSignedIn, getToken } = useAuth();
   const { user } = useUser();
   const mobileAuthSession = useMobileAuthSession();
@@ -64,6 +56,21 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
   const effectiveLoaded = isLoaded || hasNativeSession;
   const effectiveSignedIn = isSignedIn || hasNativeSession;
   const tabOptions = TAB_OPTIONS[language];
+  const isLight = theme === 'light';
+  const clerkAppearance = useMemo(() =>
+    createAuthAppearance({
+      mode: theme,
+      layout: {
+        showOptionalFields: true
+      },
+      elements: {
+        footerActionText: isLight ? 'text-[#51456f]/72' : 'text-white/50',
+        footerActionLink: isLight
+          ? 'font-semibold text-[#3a2b68] hover:text-[#171126] underline-offset-4'
+          : 'font-semibold text-white/70 hover:text-white underline-offset-4',
+        formFieldSuccessText: isLight ? 'text-sm text-emerald-700' : 'text-sm text-emerald-200'
+      }
+    }), [isLight, theme]);
   const copy = language === 'en'
     ? {
         loading: 'Loading secure access…',
@@ -167,7 +174,7 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.24, ease: 'easeOut' }}
-        className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl px-3 py-5 sm:p-6"
+        className="onboarding-premium-root onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl px-3 py-5 sm:p-6"
       >
         <div className="flex items-center justify-between border-b border-white/5 pb-4">
           <div>
@@ -175,21 +182,21 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
             <h2 className="text-2xl font-semibold text-white">{copy.create}</h2>
           </div>
         </div>
-        <div className="mt-4 flex gap-2 rounded-full bg-white/10 p-1 backdrop-blur">
+        <div className="onboarding-surface-inner mt-4 flex gap-2 rounded-full p-1 backdrop-blur">
           {tabOptions.map((option) => (
             <button
               key={option.id}
               type="button"
               onClick={() => setTab(option.id)}
               className={`flex-1 rounded-full px-4 py-2 text-sm font-medium transition ${
-                tab === option.id ? 'bg-white text-slate-900 shadow' : 'text-white/70 hover:text-white'
+                tab === option.id ? 'bg-[color:var(--color-surface-elevated)] text-[color:var(--color-text)] shadow' : 'text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]'
               }`}
             >
               {option.label}
             </button>
           ))}
         </div>
-        <div className="mt-6 space-y-3 rounded-2xl bg-white/6 p-5 text-white/80">
+        <div className="onboarding-surface-inner mt-6 space-y-3 rounded-2xl p-5 text-[color:var(--color-text-muted)]">
           <p className="text-sm leading-6">
             {tab === 'sign-up'
               ? language === 'en'
@@ -202,7 +209,7 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
           <button
             type="button"
             onClick={() => void openNativeAuth(tab)}
-            className="inline-flex w-full items-center justify-center rounded-full bg-white px-6 py-2 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-slate-100"
+            className="ib-primary-button inline-flex w-full items-center justify-center rounded-full px-6 py-2 text-sm font-semibold text-white shadow-lg transition"
           >
             {tab === 'sign-up'
               ? language === 'en' ? 'Create account' : 'Crear cuenta'
@@ -218,7 +225,7 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.24, ease: 'easeOut' }}
-      className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl px-3 py-5 sm:p-6"
+      className="onboarding-premium-root onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl px-3 py-5 sm:p-6"
     >
       <div className="flex items-center justify-between border-b border-white/5 pb-4">
         <div>
@@ -226,14 +233,14 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
           <h2 className="text-2xl font-semibold text-white">{copy.create}</h2>
         </div>
       </div>
-      <div className="mt-4 flex gap-2 rounded-full bg-white/10 p-1 backdrop-blur">
+      <div className="onboarding-surface-inner mt-4 flex gap-2 rounded-full p-1 backdrop-blur">
         {tabOptions.map((option) => (
           <button
             key={option.id}
             type="button"
             onClick={() => setTab(option.id)}
             className={`flex-1 rounded-full px-4 py-2 text-sm font-medium transition ${
-              tab === option.id ? 'bg-white text-slate-900 shadow' : 'text-white/70 hover:text-white'
+              tab === option.id ? 'bg-[color:var(--color-surface-elevated)] text-[color:var(--color-text)] shadow' : 'text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]'
             }`}
           >
             {option.label}
@@ -246,10 +253,10 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
           mode={tab}
           redirectUrlComplete={currentUrl}
         />
-        <div className={AUTH_DIVIDER_CLASS}>
-          <span className="h-px flex-1 bg-white/12" aria-hidden />
+        <div className={`${AUTH_DIVIDER_CLASS} ib-onboarding-divider`}>
+          <span className="h-px flex-1 bg-[color:var(--color-border-soft)]" aria-hidden />
           <span>{language === 'en' ? 'or continue with email' : 'o continúa con email'}</span>
-          <span className="h-px flex-1 bg-white/12" aria-hidden />
+          <span className="h-px flex-1 bg-[color:var(--color-border-soft)]" aria-hidden />
         </div>
         <AnimatePresence mode="wait" initial={false} presenceAffectsLayout={false}>
           {tab === 'sign-up' ? (

--- a/apps/web/src/onboarding/steps/PathSelectStep.tsx
+++ b/apps/web/src/onboarding/steps/PathSelectStep.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import { useState } from 'react';
+import { useThemePreference } from '../../theme/ThemePreferenceProvider';
 import type { OnboardingLanguage } from '../constants';
 
 type PathOption = 'traditional' | 'quick_start';
@@ -57,6 +58,7 @@ const getPathCardStyle = (isActive: boolean, variant: PathVariant) => {
 };
 
 export function PathSelectStep({ language = 'es', onSelectTraditional, onSelectQuickStart, onBack }: PathSelectStepProps) {
+  const { theme } = useThemePreference();
   const [selectedPath, setSelectedPath] = useState<PathOption | null>(null);
   const [isAdvancing, setIsAdvancing] = useState(false);
 
@@ -113,7 +115,7 @@ export function PathSelectStep({ language = 'es', onSelectTraditional, onSelectQ
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.2 }}
-      className="onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7"
+      className="onboarding-premium-root onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7"
     >
       <p className="text-xs uppercase tracking-[0.2em] text-white/50">{copy.step}</p>
       <h2 className="mt-2 text-3xl font-semibold text-white">{copy.title}</h2>
@@ -129,7 +131,7 @@ export function PathSelectStep({ language = 'es', onSelectTraditional, onSelectQ
             chips: [
               {
                 key: 'duration',
-                className: 'border-[#d8b4fe]/35 bg-[#d8b4fe]/20 text-[#f6e8ff]',
+                className: 'border-[color:var(--color-border-soft)] bg-[color:var(--onboarding-premium-overlay-soft)] text-[color:var(--color-text-muted)]',
                 text: copy.personalDuration,
               },
             ],
@@ -142,12 +144,12 @@ export function PathSelectStep({ language = 'es', onSelectTraditional, onSelectQ
             chips: [
               {
                 key: 'duration',
-                className: 'border-white/20 bg-white/10 text-white/75',
+                className: 'border-[color:var(--color-border-soft)] bg-[color:var(--onboarding-premium-overlay-soft)] text-[color:var(--color-text-muted)]',
                 text: copy.quickDuration,
               },
               {
                 key: 'label',
-                className: 'border-sky-200/30 bg-sky-200/12 text-sky-100/90',
+                className: 'border-[color:var(--color-border-soft)] bg-[color:var(--onboarding-premium-overlay-base)] text-[color:var(--color-text)]',
                 text: copy.quickLabel,
               },
             ],
@@ -167,10 +169,10 @@ export function PathSelectStep({ language = 'es', onSelectTraditional, onSelectQ
               aria-label={`${option.title}${isActive ? copy.selectedSuffix : ''}`}
               data-selected={isActive ? 'true' : 'false'}
               className={[
-                'glass-card onboarding-surface-inner onboarding-glass-border-soft relative flex h-full overflow-hidden rounded-3xl border p-4 text-left transition-all duration-250 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950/80 sm:p-5',
+                'glass-card onboarding-surface-inner onboarding-glass-border-soft relative flex h-full overflow-hidden rounded-3xl border p-4 text-left transition-all duration-250 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)] sm:p-5',
                 isActive
-                  ? 'ring-2 -translate-y-0.5 scale-[1.01] border-white/70 bg-white/[0.1] focus-visible:ring-4'
-                  : 'border-white/12 hover:border-white/35 hover:-translate-y-0.5 hover:bg-white/[0.04] focus-visible:border-white/45 focus-visible:ring-[#cf8bf3]/70',
+                  ? 'ring-2 -translate-y-0.5 scale-[1.01] border-[color:var(--color-border-strong)] bg-[color:var(--onboarding-premium-overlay-base)] focus-visible:ring-4'
+                  : 'border-[color:var(--color-border-soft)] hover:border-[color:var(--color-border-strong)] hover:-translate-y-0.5 hover:bg-[color:var(--onboarding-premium-overlay-soft)] focus-visible:border-[color:var(--color-border-strong)]',
                 isAdvancing && !isActive ? 'opacity-75' : '',
               ]
                 .filter(Boolean)
@@ -188,7 +190,7 @@ export function PathSelectStep({ language = 'es', onSelectTraditional, onSelectQ
 
               <span className="relative z-10 flex w-full flex-col gap-2.5">
                 <span className="flex items-start justify-between gap-3">
-                  <span className="flex items-center gap-2 text-lg font-semibold leading-tight text-white">
+                  <span className="flex items-center gap-2 text-lg font-semibold leading-tight text-[color:var(--color-text)]">
                     <span aria-hidden className="text-sm opacity-80">{option.emoji}</span>
                     {option.title}
                   </span>
@@ -208,7 +210,7 @@ export function PathSelectStep({ language = 'es', onSelectTraditional, onSelectQ
                   ) : null}
                 </span>
 
-                <p className="text-[0.95rem] leading-snug text-white/88">{option.description}</p>
+                <p className="text-[0.95rem] leading-snug text-[color:var(--color-text-muted)]">{option.description}</p>
 
                 <div className="mt-2 flex flex-wrap gap-2">
                   {option.chips.map((chip) => (
@@ -231,7 +233,7 @@ export function PathSelectStep({ language = 'es', onSelectTraditional, onSelectQ
           type="button"
           onClick={onBack}
           disabled={isAdvancing}
-          className="inline-flex items-center gap-2 rounded-full border border-white/10 px-5 py-2 text-sm font-medium text-white/80 transition hover:border-white/30 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cf8bf3]/60 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex items-center gap-2 rounded-full border border-[color:var(--color-border-soft)] px-5 py-2 text-sm font-medium text-[color:var(--color-text-muted)] transition hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)] disabled:cursor-not-allowed disabled:opacity-60"
         >
           ← {copy.back}
         </button>

--- a/apps/web/src/onboarding/ui/GpExplainerOverlay.tsx
+++ b/apps/web/src/onboarding/ui/GpExplainerOverlay.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import { ArrowRight, ArrowUp, CircleDot } from '../../components/icons';
 import { GpProgressBar } from './GpProgressBar';
 import type { OnboardingLanguage } from '../constants';
+import { useThemePreference } from '../../theme/ThemePreferenceProvider';
 
 interface GpExplainerOverlayProps {
   language?: OnboardingLanguage;
@@ -20,6 +21,7 @@ type ExplainerItem = {
 
 export function GpExplainerOverlay({ language = 'es', onClose }: GpExplainerOverlayProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
+  const { theme } = useThemePreference();
 
   const copy = useMemo(
     () =>
@@ -153,7 +155,7 @@ export function GpExplainerOverlay({ language = 'es', onClose }: GpExplainerOver
 
   return (
     <div className="pointer-events-none fixed inset-0 z-[70]" aria-hidden={false}>
-      <div className="pointer-events-auto absolute inset-0 bg-black/55 backdrop-blur-sm" onClick={onClose} />
+      <div className="pointer-events-auto absolute inset-0 bg-[color:var(--color-overlay-2)] backdrop-blur-sm" onClick={onClose} />
 
       <div className="pointer-events-auto absolute inset-x-0 top-[7.15rem] px-3 sm:top-[7.8rem] sm:px-4">
         <div
@@ -162,21 +164,21 @@ export function GpExplainerOverlay({ language = 'es', onClose }: GpExplainerOver
           aria-modal="true"
           aria-label={copy.title}
           tabIndex={-1}
-          className="relative mx-auto w-full max-w-sm rounded-3xl border border-white/20 bg-surface p-4 text-white shadow-[0_18px_40px_rgba(3,8,22,0.55)]"
+          className="relative mx-auto w-full max-w-sm rounded-3xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-surface-elevated)] p-4 text-[color:var(--color-text)] shadow-[var(--shadow-elev-2)]"
         >
           <button
             type="button"
             onClick={onClose}
             aria-label={copy.closeLabel}
-            className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/20 bg-white/5 text-sm text-white/75 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+            className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] text-sm text-[color:var(--color-text-muted)] transition hover:text-[color:var(--color-text)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]"
           >
             ✕
           </button>
 
           <div className="pr-8">
             <div className="flex items-center justify-between gap-3">
-              <h2 className="text-sm font-semibold tracking-wide text-white">{copy.title}</h2>
-              <span className="shrink-0 rounded-full border border-white/15 bg-white/10 px-2.5 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.2em] text-white/75">
+              <h2 className="text-sm font-semibold tracking-wide text-[color:var(--color-text)]">{copy.title}</h2>
+              <span className="shrink-0 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--color-text-muted)]">
                 {copy.chip}
               </span>
             </div>
@@ -186,9 +188,9 @@ export function GpExplainerOverlay({ language = 'es', onClose }: GpExplainerOver
             </div>
           </div>
 
-          <ul className="mt-3 space-y-2 text-xs leading-relaxed text-white/80">
+          <ul className="mt-3 space-y-2 text-xs leading-relaxed text-[color:var(--color-text-muted)]">
             {copy.items.map((item) => {
-              const iconClassName = 'h-3.5 w-3.5 shrink-0 text-violet-200';
+              const iconClassName = 'h-3.5 w-3.5 shrink-0 text-[color:var(--color-accent-primary)]';
 
               return (
                 <li key={item.id} className="flex items-start gap-2">
@@ -204,7 +206,7 @@ export function GpExplainerOverlay({ language = 'es', onClose }: GpExplainerOver
                       <span
                         key={`${item.id}-${segment.text}`}
                         className={[
-                          segment.emphasis === 'semibold' ? 'font-semibold text-white' : '',
+                          segment.emphasis === 'semibold' ? 'font-semibold text-[color:var(--color-text)]' : '',
                           segment.noWrap ? 'whitespace-nowrap' : '',
                         ]
                           .filter(Boolean)
@@ -222,7 +224,7 @@ export function GpExplainerOverlay({ language = 'es', onClose }: GpExplainerOver
           <button
             type="button"
             onClick={onClose}
-            className="mt-4 inline-flex w-full items-center justify-center rounded-xl border border-violet-300/45 bg-violet-500 px-3 py-2 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(76,29,149,0.3)] transition duration-200 hover:-translate-y-0.5 hover:bg-violet-400 hover:shadow-[0_14px_28px_rgba(76,29,149,0.4)] focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-300"
+            className="ib-primary-button mt-4 inline-flex w-full items-center justify-center rounded-xl px-3 py-2 text-sm font-semibold text-white transition duration-200 hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]"
           >
             {copy.cta}
           </button>


### PR DESCRIPTION
### Motivation
- El onboarding tenía múltiples superficies y componentes hardcodeados para modo oscuro que rompían contraste y legibilidad en `light` mode; `createAuthAppearance` también defaulteaba a `dark` y se construía fuera del componente. 
- Objetivo: conservar la estética premium de onboarding pero garantizar que todas las piezas respeten la decisión global de theme (`ib-theme-preference`) y usen tokens theme-aware del sistema post-login.

### Description
- Hice que `ClerkGate` use `useThemePreference()` y construya `appearance` con `createAuthAppearance({ mode: theme, ... })` dentro del componente usando `useMemo`, de modo que Clerk reciba el `mode` resuelto en runtime (light/dark) y pueda actualizarse correctamente.
- Reemplacé clases hardcodeadas de texto/superficie/borde en `PathSelectStep` y `GpExplainerOverlay` por utilidades tokenizadas (`var(--color-text)`, `var(--color-text-muted)`, `var(--color-border-soft)`, `var(--color-surface-elevated)`, `--shadow-elev-2`, etc.) para que cards, chips, overlays y botones funcionen en ambos modos manteniendo la jerarquía visual.
- Actualicé `AUTH_DIVIDER_CLASS` en `apps/web/src/lib/clerkAppearance.ts` para usar color tokenizado en vez de `text-white/45` y añadí overrides light/dark para `footerActionLink`, `footerActionText` y `formFieldSuccessText` desde `ClerkGate`.
- Añadí utilidades CSS en `apps/web/src/index.css` (`.ib-onboarding-divider` y mapeos `.onboarding-surface-base .text-white/*`) para normalizar conversiones rápidas de clases `text-white/*` a tokens en superficies de onboarding.
- Archivos modificados: `apps/web/src/onboarding/steps/ClerkGate.tsx`, `apps/web/src/lib/clerkAppearance.ts`, `apps/web/src/onboarding/steps/PathSelectStep.tsx`, `apps/web/src/onboarding/ui/GpExplainerOverlay.tsx`, `apps/web/src/index.css`.

### Testing
- Ejecuté una búsqueda de patrones en onboarding para localizar hardcodes problemáticos con `rg` (buscando `text-white`, `bg-white/`, `border-white/`, `bg-black/`, `rgba(...`, `onboarding-surface-*`, etc.) y corregí los puntos más relevantes; la búsqueda se ejecutó contra `apps/web/src/onboarding` y `apps/web/src/pages/QuickStartPreview.tsx` y permitió auditar los cambios.
- Intenté `npm run typecheck:web` para validar tipado estático, pero el comando falla por errores TypeScript preexistentes en otras áreas del repo (tipados de `runtimeAuth`, tests y componentes del dashboard), por lo que el fallo no fue introducido por este cambio.
- Resultado de pruebas automáticas: la búsqueda/inspección de código OK; `typecheck` falló por errores no relacionados con los cambios aplicados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c02cde788332ad8146cee4e10ffa)