### PR TITLE
Fix hero phone light-mode dashboard contrast scope

### DIFF
--- a/apps/web/src/pages/LandingThemeContrastPatch.css
+++ b/apps/web/src/pages/LandingThemeContrastPatch.css
@@ -39,21 +39,21 @@
   color-scheme: dark;
 }
 
-/* The phone/dashboard mock must remain visually dark even in landing light mode. */
-.landing[data-theme-mode="light"] .hero-media,
+/* In light landing mode, force the hero phone dashboard mock to use legible light tokens. */
 .landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"],
 .landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] * {
-  --color-text: #edf2ff;
-  --color-text-muted: rgba(216, 224, 245, 0.82);
-  --color-text-subtle: rgba(170, 181, 210, 0.72);
-  --color-surface: #080d1b;
-  --color-surface-elevated: #0b1224;
-  --color-border-subtle: rgba(171, 188, 230, 0.22);
+  --color-text: #171126;
+  --color-text-muted: rgba(45, 39, 70, 0.78);
+  --color-text-subtle: rgba(76, 68, 105, 0.66);
+  --color-surface: #f8fafc;
+  --color-surface-elevated: rgba(255, 255, 255, 0.94);
+  --color-border-subtle: rgba(80, 70, 120, 0.14);
+  --color-border-soft: rgba(80, 70, 120, 0.18);
 }
 
-/* Undo the landing h/p overrides inside the phone. */
-.landing[data-theme-mode="light"] .hero-media :is(h1, h2, h3, h4, h5, h6) {
-  color: var(--color-text, #edf2ff) !important;
+/* Undo landing heading overrides inside the phone by inheriting dashboard tokens. */
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] :is(h1, h2, h3, h4, h5, h6) {
+  color: inherit !important;
 }
 
 .landing[data-theme-mode="light"] .hero-media :is(p, span, small, li, div) {
@@ -70,6 +70,26 @@
 .landing[data-theme-mode="light"] .hero-media [data-demo-anchor="emotion-chart"] :is(h1, h2, h3, p, span),
 .landing[data-theme-mode="light"] .hero-media [data-demo-anchor="streaks"] :is(h1, h2, h3, p, span) {
   color: inherit;
+}
+
+
+/* Targeted readability anchors for the light-mode hero phone demo only. */
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="overall-progress"] :is(h1, h2, h3, h4, p, span, small, li),
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="emotion-chart"] :is(h1, h2, h3, h4, p, span, small, li),
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="streaks"] :is(h1, h2, h3, h4, p, span, small, li) {
+  color: inherit;
+}
+
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="overall-progress"] [class*="text-white"],
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="emotion-chart"] [class*="text-white"],
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="streaks"] [class*="text-white"],
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="overall-progress"] [class*="text-slate-100"],
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="emotion-chart"] [class*="text-slate-100"],
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="streaks"] [class*="text-slate-100"],
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="overall-progress"] [class*="text-slate-200"],
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="emotion-chart"] [class*="text-slate-200"],
+.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"] [data-demo-anchor="streaks"] [class*="text-slate-200"] {
+  color: var(--color-text) !important;
 }
 
 /* =========================================================


### PR DESCRIPTION
### Motivation
- Fix low-contrast text inside the hero phone mock when the landing is in light mode, where text tokens were being set to light values on light surfaces making many labels unreadable.
- Keep the fix strictly scoped to the hero phone/demo in landing light mode and avoid any changes to dark mode, post-login dashboard, layout, animations or content.
- Target the specific anchors where readability matters (`overall-progress`, `emotion-chart`, `streaks`) without introducing global overrides.

### Description
- Replaced the previous light-mode phone override that forced dark-themed tokens with light surface / light-text tokens scoped to `.landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"]` in `apps/web/src/pages/LandingThemeContrastPatch.css`.
- Removed the block that set `--color-text: #edf2ff` (and other dark-theme tokens) and introduced legible light-mode tokens such as `--color-text: #171126`, `--color-text-muted: rgba(45, 39, 70, 0.78)`, `--color-surface: #f8fafc`, and border tokens scoped to the phone demo.
- Added anchor-specific readability rules for `[data-demo-anchor="overall-progress"]`, `[data-demo-anchor="emotion-chart"]`, and `[data-demo-anchor="streaks"]` to inherit the corrected tokens and force readable color for hardcoded utility classes (`text-white`, `text-slate-100`, `text-slate-200`) only inside that scope.
- Files modified: `apps/web/src/pages/LandingThemeContrastPatch.css` (changes are narrowly scoped and do not alter other CSS or TSX files).

### Testing
- Ran targeted inspections and file reads (`sed -n` on the CSS and component files) to verify the patch content was updated successfully and the new selectors were inserted, all commands completed successfully.
- Executed `rg` searches for the demo anchors and low-contrast utility classes to ensure overrides only touch the hero phone scope, which returned expected matches and completed successfully.
- Verified the change was staged and committed (`git add` / `git commit`), and the diff shows only the intended modifications, with the commit success confirmed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c8f34a2c8332bf0ed36a0f98a0b8)