### PR TITLE
Fix light-mode onboarding contrast and add looping "+ GP" micro-animation

### DIFF
--- a/apps/web/src/onboarding/steps/PathSelectStep.tsx
+++ b/apps/web/src/onboarding/steps/PathSelectStep.tsx
@@ -16,7 +16,7 @@ interface PathSelectStepProps {
 
 const ADVANCE_DELAY_MS = 140;
 
-const getPathCardStyle = (isActive: boolean, variant: PathVariant) => {
+const getPathCardStyle = (isActive: boolean, variant: PathVariant, theme: 'light' | 'dark') => {
   const palettes: Record<PathVariant, { glow: string; softTint: string; accent: string; border: string; badgeBg: string; badgeText: string; badgeBorder: string }> = {
     traditional: {
       glow: 'rgba(196, 132, 252, 0.34)',
@@ -40,19 +40,33 @@ const getPathCardStyle = (isActive: boolean, variant: PathVariant) => {
 
   const palette = palettes[variant];
 
+  const isLight = theme === 'light';
+
   return {
     palette,
     cardStyle: isActive
       ? {
-          boxShadow: `0 0 0 1px rgba(255,255,255,0.26), 0 0 30px ${palette.glow}, 0 0 56px ${palette.softTint}`,
-          borderColor: palette.border,
-          background: `color-mix(in srgb, ${palette.softTint} 52%, rgba(8,14,38,0.78))`,
+          boxShadow: isLight
+            ? `0 0 0 1px ${palette.border}, 0 16px 32px rgba(15,23,42,0.13), 0 10px 22px ${palette.softTint}`
+            : `0 0 0 1px rgba(255,255,255,0.26), 0 0 30px ${palette.glow}, 0 0 56px ${palette.softTint}`,
+          borderColor: isLight ? palette.badgeBorder : palette.border,
+          background: isLight
+            ? variant === 'traditional'
+              ? 'linear-gradient(180deg, rgba(254,245,255,0.98), rgba(252,244,255,0.94))'
+              : 'linear-gradient(180deg, rgba(241,252,255,0.98), rgba(238,248,255,0.95))'
+            : `color-mix(in srgb, ${palette.softTint} 52%, rgba(8,14,38,0.78))`,
         }
       : {
-          background: 'linear-gradient(165deg, rgba(14,20,44,0.84) 0%, rgba(11,17,38,0.7) 55%, rgba(8,14,33,0.84) 100%)',
+          background: isLight
+            ? 'linear-gradient(180deg, rgba(255,255,255,0.98), rgba(248,250,252,0.94))'
+            : 'linear-gradient(165deg, rgba(14,20,44,0.84) 0%, rgba(11,17,38,0.7) 55%, rgba(8,14,33,0.84) 100%)',
+          borderColor: isLight ? 'rgba(148,163,184,0.24)' : undefined,
+          boxShadow: isLight ? '0 14px 34px rgba(15,23,42,0.08)' : undefined,
         },
     overlayStyle: {
-      background: `radial-gradient(circle at 18% 8%, color-mix(in srgb, ${palette.accent} 34%, transparent) 0%, color-mix(in srgb, ${palette.accent} 20%, transparent) 30%, color-mix(in srgb, ${palette.accent} 12%, transparent) 58%, transparent 100%)`,
+      background: isLight
+        ? `radial-gradient(circle at 18% 8%, color-mix(in srgb, ${palette.accent} 16%, transparent) 0%, color-mix(in srgb, ${palette.accent} 10%, transparent) 32%, color-mix(in srgb, ${palette.accent} 5%, transparent) 62%, transparent 100%)`
+        : `radial-gradient(circle at 18% 8%, color-mix(in srgb, ${palette.accent} 34%, transparent) 0%, color-mix(in srgb, ${palette.accent} 20%, transparent) 30%, color-mix(in srgb, ${palette.accent} 12%, transparent) 58%, transparent 100%)`,
     },
   };
 };
@@ -117,9 +131,9 @@ export function PathSelectStep({ language = 'es', onSelectTraditional, onSelectQ
       transition={{ duration: 0.2 }}
       className="onboarding-premium-root onboarding-surface-base mx-auto w-full max-w-3xl rounded-3xl p-5 sm:p-7"
     >
-      <p className="text-xs uppercase tracking-[0.2em] text-white/50">{copy.step}</p>
-      <h2 className="mt-2 text-3xl font-semibold text-white">{copy.title}</h2>
-      <p className="mt-2 text-sm text-white/70">{copy.subtitle}</p>
+      <p className="text-xs uppercase tracking-[0.2em] text-[color:var(--color-text-subtle)]">{copy.step}</p>
+      <h2 className="mt-2 text-3xl font-semibold text-[color:var(--color-text)]">{copy.title}</h2>
+      <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">{copy.subtitle}</p>
 
       <div className="mt-6 grid gap-3.5 sm:grid-cols-2">
         {[
@@ -156,7 +170,7 @@ export function PathSelectStep({ language = 'es', onSelectTraditional, onSelectQ
           },
         ].map((option) => {
           const isActive = selectedPath === option.id;
-          const { palette, cardStyle, overlayStyle } = getPathCardStyle(isActive, option.id);
+          const { palette, cardStyle, overlayStyle } = getPathCardStyle(isActive, option.id, theme);
 
           return (
             <motion.button

--- a/apps/web/src/onboarding/ui/GpExplainerOverlay.tsx
+++ b/apps/web/src/onboarding/ui/GpExplainerOverlay.tsx
@@ -1,3 +1,4 @@
+import { motion, useReducedMotion } from 'framer-motion';
 import { useEffect, useMemo, useRef } from 'react';
 import { ArrowRight, ArrowUp, CircleDot } from '../../components/icons';
 import { GpProgressBar } from './GpProgressBar';
@@ -22,6 +23,7 @@ type ExplainerItem = {
 export function GpExplainerOverlay({ language = 'es', onClose }: GpExplainerOverlayProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const { theme } = useThemePreference();
+  const prefersReducedMotion = useReducedMotion();
 
   const copy = useMemo(
     () =>
@@ -184,7 +186,30 @@ export function GpExplainerOverlay({ language = 'es', onClose }: GpExplainerOver
             </div>
 
             <div className="mt-3">
-              <GpProgressBar progress={40} totalGp={0} />
+              <div className="relative">
+                <GpProgressBar progress={40} totalGp={0} />
+                <div className="pointer-events-none absolute -top-2 right-2">
+                  {prefersReducedMotion ? (
+                    <span className="inline-flex rounded-full border border-emerald-500/35 bg-emerald-500/15 px-2 py-0.5 text-[0.56rem] font-semibold uppercase tracking-[0.15em] text-emerald-700 dark:text-emerald-300">
+                      + GP
+                    </span>
+                  ) : (
+                    <div className="relative h-9 w-16">
+                      {[0, 1, 2].map((pill) => (
+                        <motion.span
+                          key={pill}
+                          className="absolute right-0 inline-flex rounded-full border border-emerald-500/35 bg-emerald-500/15 px-2 py-0.5 text-[0.56rem] font-semibold uppercase tracking-[0.15em] text-emerald-700 dark:text-emerald-300"
+                          initial={{ opacity: 0, y: 8, scale: 0.92 }}
+                          animate={{ opacity: [0, 1, 1, 0], y: [8, 2, -8, -18], scale: [0.92, 1.04, 1, 0.98] }}
+                          transition={{ duration: 1.7, repeat: Infinity, ease: 'easeOut', delay: pill * 0.38 }}
+                        >
+                          + GP
+                        </motion.span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
             </div>
           </div>
 
@@ -224,7 +249,8 @@ export function GpExplainerOverlay({ language = 'es', onClose }: GpExplainerOver
           <button
             type="button"
             onClick={onClose}
-            className="ib-primary-button mt-4 inline-flex w-full items-center justify-center rounded-xl px-3 py-2 text-sm font-semibold text-white transition duration-200 hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]"
+            className="ib-primary-button mt-4 inline-flex w-full items-center justify-center rounded-xl px-3 py-2 text-sm font-semibold !text-white transition duration-200 hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]"
+            style={{ color: '#fff' }}
           >
             {copy.cta}
           </button>

--- a/apps/web/src/onboarding/ui/HUD.tsx
+++ b/apps/web/src/onboarding/ui/HUD.tsx
@@ -38,11 +38,18 @@ function ModeBadge({ mode }: { mode: GameMode | null }) {
   }
 
   const theme = getOnboardingRhythmTheme(mode);
-  const style = { '--chip-accent': theme.badgeAccent } as CSSProperties;
+  const style = {
+    '--chip-accent': theme.badgeAccent,
+    background: 'linear-gradient(135deg, rgba(91, 79, 140, 0.96), rgba(48, 55, 86, 0.98))',
+    color: '#ffffff',
+    borderColor: 'rgba(255,255,255,0.28)',
+    textShadow: '0 1px 2px rgba(7,10,24,0.35)',
+    boxShadow: '0 10px 24px rgba(34, 28, 72, 0.32)',
+  } as CSSProperties;
 
   return (
     <span
-      className="onboarding-mode-chip inline-flex items-center px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white/85 shadow-[0_0_18px_rgba(8,12,24,0.5)] ring-1 ring-white/10"
+      className="onboarding-mode-chip inline-flex items-center rounded-full border px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white ring-1 ring-white/10"
       style={style}
     >
       {MODE_BADGE_LABELS[mode]}


### PR DESCRIPTION
### Motivation
- Fix critical legibility/contrast issues in onboarding light mode without changing business logic or flow, focusing on the HUD mode chip, GP explainer CTA, and path selection cards.
- Add a small, accessible visual cue that communicates GP gains in the GP explainer modal as a non-disruptive micro-animation that respects `prefers-reduced-motion`.
- Ensure the selected state and text tokens in the path selection step are readable and consistent across light and dark themes.

### Description
- Updated the HUD `ModeBadge` to use an inline premium indigo/violet gradient, forced white text, subtle border and shadow, and removed reliance on `text-white/85` for reliable light-mode contrast by changing `apps/web/src/onboarding/ui/HUD.tsx`.
- Enforced white text on the GP explainer modal primary CTA and preserved the existing button gradient by adding `!text-white` plus `style={{ color: '#fff' }}` and improved accessibility in `apps/web/src/onboarding/ui/GpExplainerOverlay.tsx`.
- Implemented a looping floating `+ GP` micro-animation using `framer-motion` positioned above the `GpProgressBar`, with a `useReducedMotion` fallback that renders a static chip, in `apps/web/src/onboarding/ui/GpExplainerOverlay.tsx`.
- Made `getPathCardStyle` theme-aware and added light-mode card backgrounds, borders, and softer shadows, switched text tokens for step/title/subtitle to theme variables, and improved selected-state visuals in `apps/web/src/onboarding/steps/PathSelectStep.tsx`.

### Testing
- Ran `npm run typecheck:web` which failed due to pre-existing unrelated TypeScript errors elsewhere in the web app and did not indicate regressions introduced by these UI-only changes.
- Ran `npm run build:web` which completed successfully (the build emitted existing non-blocking CSS/minify and chunk warnings but produced artifacts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d3e7ac988332b89bc4c7a7918f25)