### PR TITLE
Theme-aware JourneyReadyModal & Quick Start; update "Edit tasks" copy

### DIFF
--- a/apps/web/src/components/dashboard-v3/JourneyReadyModal.tsx
+++ b/apps/web/src/components/dashboard-v3/JourneyReadyModal.tsx
@@ -21,55 +21,56 @@ export function JourneyReadyModal({
 
   return (
     <div
-      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/55 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-[color:var(--color-overlay-4)] p-4 backdrop-blur-sm"
       onClick={onClose}
     >
       <div
         role="dialog"
         aria-modal="true"
-        className="w-full max-w-[560px] max-h-[90dvh] overflow-y-auto rounded-3xl border border-white/20 bg-surface p-4 md:max-h-[80vh]"
+        className="w-full max-w-[560px] max-h-[90dvh] overflow-y-auto rounded-3xl border border-[color:var(--color-border-strong)] bg-[color:var(--color-surface-elevated)] p-4 shadow-[var(--shadow-elev-2)] md:max-h-[80vh]"
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="mb-5 flex items-center justify-center gap-2 text-center text-xs font-semibold uppercase tracking-[0.32em] text-white/65 sm:text-sm">
+        <div className="mb-5 flex items-center justify-center gap-2 text-center text-xs font-semibold uppercase tracking-[0.32em] text-[color:var(--color-text-subtle)] sm:text-sm">
           <span>Innerbloom</span>
           <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logo" className="h-[1.45em] w-auto" />
         </div>
 
-        <h2 className="font-display text-2xl font-semibold text-white">{t('dashboard.journeyReady.title')}</h2>
-        <p className="mt-2 text-sm text-white/80">{t('dashboard.journeyReady.subtitle')}</p>
+        <h2 className="font-display text-2xl font-semibold text-[color:var(--color-text)]">{t('dashboard.journeyReady.title')}</h2>
+        <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">{t('dashboard.journeyReady.subtitle')}</p>
 
-        <div className="mt-4 rounded-2xl border border-white/15 bg-white/5 p-3">
-          <button type="button" onClick={() => setExpanded((value) => !value)} className="text-sm font-semibold text-white">
+        <div className="mt-4 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] p-3">
+          <button type="button" onClick={() => setExpanded((value) => !value)} className="text-sm font-semibold text-[color:var(--color-text)]">
             {t('dashboard.journeyReady.viewTasks', { count: tasks.length })}
           </button>
           {expanded ? (
-            <div className="mt-2 space-y-1 text-sm text-white/80">
+            <div className="mt-2 space-y-1 text-sm text-[color:var(--color-text-muted)]">
               {preview.map((task) => (
                 <p key={task.id}>• {task.title} {task.pillarId ? `· ${task.pillarId}` : ''}</p>
               ))}
               {tasks.length > 5 ? <p>{t('dashboard.journeyReady.moreTasks', { count: tasks.length - 5 })}</p> : null}
-              <Link to="/dashboard-v3/missions" onClick={onClose} className="inline-block pt-1 text-cyan-300">{t('dashboard.journeyReady.viewAll')}</Link>
+              <Link to="/dashboard-v3/missions" onClick={onClose} className="inline-block pt-1 text-[color:var(--color-accent-primary)] hover:opacity-80">{t('dashboard.journeyReady.viewAll')}</Link>
             </div>
           ) : null}
         </div>
 
-        <div className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-3 text-sm">
-          <p className="font-semibold text-white">{t('dashboard.journeyReady.firstStep')}</p>
-          <p className="text-white/75">{t('dashboard.journeyReady.firstStepHelp')}</p>
+        <div className="mt-4 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] p-3 text-sm">
+          <p className="font-semibold text-[color:var(--color-text)]">{t('dashboard.journeyReady.firstStep')}</p>
+          <p className="text-[color:var(--color-text-muted)]">{t('dashboard.journeyReady.firstStepHelp')}</p>
         </div>
 
         <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end">
           <button
             type="button"
             onClick={onClose}
-            className="order-2 text-xs text-white/60 sm:order-1 sm:px-3 sm:py-2"
+            className="order-2 text-xs text-[color:var(--color-text-subtle)] transition-colors hover:text-[color:var(--color-text)] sm:order-1 sm:px-3 sm:py-2"
           >
             {t('dashboard.journeyReady.goDashboard')}
           </button>
           <button
             type="button"
             onClick={onEditor}
-            className="order-1 inline-flex items-center justify-center rounded-full border border-violet-300/45 bg-violet-500 px-4 py-2 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(76,29,149,0.3)] transition duration-200 hover:-translate-y-0.5 hover:bg-violet-400 hover:shadow-[0_14px_28px_rgba(76,29,149,0.4)] sm:order-2"
+            className="order-1 inline-flex items-center justify-center rounded-full border border-violet-300/45 bg-violet-500 px-4 py-2 text-sm font-semibold !text-white shadow-[0_10px_24px_rgba(76,29,149,0.3)] transition duration-200 hover:-translate-y-0.5 hover:bg-violet-400 hover:shadow-[0_14px_28px_rgba(76,29,149,0.4)] sm:order-2"
+            style={{ color: "#fff" }}
           >
             {t('dashboard.journeyReady.editBaseTasks')}
           </button>

--- a/apps/web/src/i18n/post-login/dashboard.ts
+++ b/apps/web/src/i18n/post-login/dashboard.ts
@@ -168,7 +168,7 @@ export const dashboardTranslations = {
     en: 'Edit your base to make sure tasks fit your real energy.',
   },
   'dashboard.journeyReady.goDashboard': { es: 'Ir al Dashboard', en: 'Go to Dashboard' },
-  'dashboard.journeyReady.editBaseTasks': { es: 'Editar base / Editar tareas', en: 'Edit base / Edit tasks' },
+  'dashboard.journeyReady.editBaseTasks': { es: 'Editar tareas', en: 'Edit tasks' },
   'dashboard.streakTaskInsights.weeklyProgressAria': { es: 'Progreso semanal: {{progress}}%', en: 'Weekly progress: {{progress}}%' },
   'dashboard.streakTaskInsights.dialogAria': { es: 'Detalle de tarea', en: 'Task details' },
   'dashboard.streakTaskInsights.title': { es: 'Detalle de tarea', en: 'Task details' },

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1449,15 +1449,6 @@
     box-shadow: 0 12px 24px rgba(15, 23, 42, 0.14);
   }
 
-  :root[data-theme="light"] .quickstart-primary-cta {
-    color: #0f172a;
-    background: linear-gradient(
-      135deg,
-      color-mix(in srgb, #ffffff 70%, #e0e7ff),
-      color-mix(in srgb, #f8fafc 70%, #dbeafe)
-    );
-  }
-
   @property --conic-angle {
     syntax: "<angle>";
     inherits: false;

--- a/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
+++ b/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
@@ -56,18 +56,18 @@ export function QuickStartGeneratingScreen({
   return (
     <div className="quickstart-premium-root onboarding-premium-root min-h-screen min-h-dvh overflow-y-auto px-4 py-10">
       <section className="quickstart-premium-card onboarding-premium-card relative mx-auto mt-5 w-full max-w-3xl rounded-3xl p-5 sm:p-8">
-        <div className="mb-5 flex items-center justify-center gap-2 text-center text-[0.68rem] font-semibold uppercase tracking-[0.36em] text-white/65 sm:text-xs">
+        <div className="mb-5 flex items-center justify-center gap-2 text-center text-[0.68rem] font-semibold uppercase tracking-[0.36em] text-[color:var(--color-text-subtle)] sm:text-xs">
           <span>Innerbloom</span>
           <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logo" className="h-[1.8em] w-auto" />
         </div>
-        <h1 className="text-balance text-2xl font-semibold text-white sm:text-3xl">{copy.title}</h1>
-        <p className="mt-2 text-sm text-slate-300">{copy.subtitle}</p>
+        <h1 className="text-balance text-2xl font-semibold text-[color:var(--color-text)] sm:text-3xl">{copy.title}</h1>
+        <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">{copy.subtitle}</p>
         <ul className="mt-6 space-y-3">
           {steps.slice(0, setupProgress).map((setupStep, index) => {
             const complete = setupProgress >= steps.length;
             const isPlanStep = index === steps.length - 1;
             return (
-              <li key={setupStep} className="flex items-center gap-3 text-sm text-slate-100/90 transition-all duration-500">
+              <li key={setupStep} className="flex items-center gap-3 text-sm text-[color:var(--color-text-muted)] transition-all duration-500">
                 <span className={`quickstart-setup-dot h-2.5 w-2.5 rounded-full ${!complete && index === setupProgress - 1 ? 'animate-pulse' : ''}`} />
                 <span>
                   {setupStep}
@@ -80,11 +80,11 @@ export function QuickStartGeneratingScreen({
         <div className="quickstart-progress-track mt-6 h-1.5 w-full overflow-hidden rounded-full">
           <div className={`quickstart-progress-fill h-full transition-all duration-700 ${setupProgress >= steps.length ? 'w-full quick-start-setup__progress-complete' : 'w-1/3 quick-start-setup__progress-animated'}`} />
         </div>
-        <p className="mt-6 text-sm text-slate-300">{copy.bridgeHint}</p>
+        <p className="mt-6 text-sm text-[color:var(--color-text-muted)]">{copy.bridgeHint}</p>
         <div className="mt-8 flex flex-col items-center gap-3">
-          <button type="button" onClick={onOpenGuidedDemo} disabled={isSubmitting || !submitCompleted} className="quickstart-primary-cta inline-flex items-center justify-center rounded-full border px-7 py-3 text-sm font-semibold transition duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-55">{isSubmitting ? copy.saving : submitCompleted ? copy.cta : copy.saving}</button>
-          {submitCompleted ? <p className="text-sm text-emerald-200">{copy.done}</p> : null}
-          {submitError ? <p className="text-sm text-rose-200">{submitError}</p> : null}
+          <button type="button" onClick={onOpenGuidedDemo} disabled={isSubmitting || !submitCompleted} className="quickstart-primary-cta inline-flex items-center justify-center rounded-full border px-7 py-3 text-sm font-semibold !text-white transition duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-55" style={{ color: "#fff" }}>{isSubmitting ? copy.saving : submitCompleted ? copy.cta : copy.saving}</button>
+          {submitCompleted ? <p className="text-sm text-emerald-500">{copy.done}</p> : null}
+          {submitError ? <p className="text-sm text-rose-500">{submitError}</p> : null}
         </div>
         <style>{`
           .quick-start-setup__progress-animated { animation: quick-start-progress 2.3s ease-in-out infinite; transform-origin: left; }


### PR DESCRIPTION
### Motivation
- Convertir el modal de post-onboarding y la pantalla Quick Start para que respeten light/dark themes y tokens globales en lugar de estilos hardcodeados en modo oscuro.
- Mantener la identidad visual del CTA principal (violeta con texto blanco) y corregir la copy del botón para evitar la redacción ambigua actual.

### Description
- Replaced hardcoded dark classes in `JourneyReadyModal.tsx` with theme-aware tokens such as `var(--color-surface-elevated)`, `var(--color-text)`, `var(--color-text-muted)`, `var(--color-text-subtle)`, `var(--color-border-soft)`, `var(--color-border-strong)`, `var(--color-overlay-*)` and `var(--shadow-elev-2)` and adjusted overlay, dialog, cards, headers, links and secondary button to use those tokens (file: `apps/web/src/components/dashboard-v3/JourneyReadyModal.tsx`).
- Updated Quick Start generating screen to use tokenized text colors and enforce the purple CTA with white text in both themes, and improved bullets/bridge hint contrast for light mode (file: `apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx`).
- Changed the i18n key `dashboard.journeyReady.editBaseTasks` to use the new copy `es: "Editar tareas"` and `en: "Edit tasks"` (file: `apps/web/src/i18n/post-login/dashboard.ts`).
- Removed the light-theme CSS override that turned `.quickstart-primary-cta` into a light button so the CTA remains violet in both themes (file: `apps/web/src/index.css`).

### Testing
- Ran the production build with `cd apps/web && npm run build` and the build completed successfully.
- Ran type checking with `cd apps/web && npm run typecheck` which failed due to pre-existing unrelated TypeScript errors in other modules/tests and not caused by these UI theming/copy changes.
- Verified by inspection that visual changes affect only theming/copy and do not modify onboarding logic, routing, persistence or submit behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d7bc1290833285a457c02b2e5dab)