### PR TITLE
Fix landing hero phone light-mode dashboard text contrast

### DIFF
--- a/apps/web/src/pages/LandingThemeContrastPatch.css
+++ b/apps/web/src/pages/LandingThemeContrastPatch.css
@@ -1015,3 +1015,118 @@
   color: rgba(248, 250, 255, 0.88) !important;
   -webkit-text-fill-color: currentColor !important;
 }
+
+/* =========================================================
+   HERO PHONE LIGHT MODE — force dashboard text readable
+   Scope: ONLY official landing hero phone mock.
+   Do not affect the real dashboard.
+   ========================================================= */
+
+.landing[data-theme-mode="light"]
+  .hero-media
+  [data-light-scope="dashboard-v3"] {
+  --color-text: #171126;
+  --color-text-muted: rgba(45, 39, 70, 0.82);
+  --color-text-subtle: rgba(76, 68, 105, 0.72);
+
+  color: var(--color-text) !important;
+}
+
+.landing[data-theme-mode="light"]
+  .hero-media
+  [data-light-scope="dashboard-v3"]
+  :is(
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    span,
+    small,
+    strong,
+    li,
+    button,
+    label
+  ) {
+  color: var(--color-text) !important;
+  -webkit-text-fill-color: currentColor !important;
+  text-shadow: none !important;
+}
+
+.landing[data-theme-mode="light"]
+  .hero-media
+  [data-light-scope="dashboard-v3"]
+  :is(
+    .text-slate-300,
+    .text-slate-400,
+    .text-slate-500,
+    .text-white\/60,
+    .text-white\/70,
+    .text-white\/80,
+    [class*="text-muted"],
+    [class*="text-subtle"]
+  ) {
+  color: var(--color-text-muted) !important;
+  -webkit-text-fill-color: currentColor !important;
+  text-shadow: none !important;
+}
+
+.landing[data-theme-mode="light"]
+  .hero-media
+  [data-light-scope="dashboard-v3"]
+  :is(
+    .text-white,
+    .text-slate-50,
+    .text-slate-100,
+    .text-slate-200,
+    [class*="text-white"],
+    [class*="text-slate-50"],
+    [class*="text-slate-100"],
+    [class*="text-slate-200"]
+  ) {
+  color: var(--color-text) !important;
+  -webkit-text-fill-color: currentColor !important;
+  text-shadow: none !important;
+}
+
+.landing[data-theme-mode="light"]
+  .hero-media
+  [data-light-scope="dashboard-v3"]
+  :is(
+    small,
+    [class*="muted"],
+    [class*="subtle"],
+    [class*="caption"],
+    [class*="secondary"]
+  ) {
+  color: var(--color-text-subtle) !important;
+  -webkit-text-fill-color: currentColor !important;
+  text-shadow: none !important;
+}
+
+.landing[data-theme-mode="light"]
+  .hero-media
+  [data-light-scope="dashboard-v3"]
+  :is(
+    svg,
+    path,
+    circle,
+    rect,
+    line,
+    polygon,
+    [data-emotion-card="legend-swatch"],
+    .emotion-highlight-indicator,
+    [role="progressbar"],
+    [role="progressbar"] *,
+    [class*="swatch"],
+    [class*="dot"],
+    [class*="heatmap"],
+    [class*="progress"],
+    [class*="bar"]
+  ) {
+  color: initial !important;
+  -webkit-text-fill-color: initial !important;
+  text-shadow: none !important;
+}


### PR DESCRIPTION
### Motivation
- El texto dentro del celular/mock del hero en la landing en `light` se volvía blanco o demasiado pálido y resultaba ilegible sobre fondos claros. 
- El objetivo es forzar tinta oscura solo dentro del phone mock del hero sin tocar el dashboard real ni el modo oscuro ni recolorear elementos visuales.

### Description
- Añadido un bloque CSS al final de `apps/web/src/pages/LandingThemeContrastPatch.css` estrictamente scopeado a ` .landing[data-theme-mode="light"] .hero-media [data-light-scope="dashboard-v3"]` que no afecta estilos globales ni componentes de runtime. 
- Se definieron tokens oscuros `--color-text`, `--color-text-muted` y `--color-text-subtle` y se aplicaron a elementos textuales (`h1`–`h6`, `p`, `span`, `small`, `strong`, `li`, `button`, `label`) con `!important` y limpieza de `-webkit-text-fill-color` y `text-shadow` para evitar herencias pálidas. 
- Se añadieron overrides para utilidades comunes que filtran blanco/pálido (por ejemplo ` .text-white`, ` .text-slate-*`, y selectores por `[class*="text-white"]`) y un bloque que mantiene sin cambios los elementos visuales (`svg`, `path`, `circle`, `rect`, `[data-emotion-card="legend-swatch"]`, swatches/dots/heatmap/progress/bar, etc.).

### Testing
- Verificación automática del repositorio confirmó que solo se modificó `apps/web/src/pages/LandingThemeContrastPatch.css` y que el nuevo bloque fue añadido al final del archivo con las reglas y selectores esperados. 
- Inspección del diff validó que las reglas incluyen la definición de tokens y las reglas `:is(...)` para texto, utilidades blancas/muted y exclusiones de elementos visuales. 
- No se ejecutaron tests unitarios/integración específicos para este cambio y la verificación visual en navegador del hero phone en `light` y de la página `/dashboard` queda pendiente en entorno gráfico.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e615ea688332acb60bc348177095)