### PR TITLE
Fix quickstart saving CTA text contrast in light theme

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1414,6 +1414,10 @@
     box-shadow: 0 10px 24px rgba(2, 6, 23, 0.32);
   }
 
+  :root[data-theme="light"] .quickstart-primary-cta {
+    color: #0f172a;
+  }
+
   .quickstart-primary-cta:hover {
     box-shadow: 0 14px 28px rgba(2, 6, 23, 0.38);
   }

--- a/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
+++ b/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
@@ -82,7 +82,7 @@ export function QuickStartGeneratingScreen({
         </div>
         <p className="mt-6 text-sm text-[color:var(--color-text-muted)]">{copy.bridgeHint}</p>
         <div className="mt-8 flex flex-col items-center gap-3">
-          <button type="button" onClick={onOpenGuidedDemo} disabled={isSubmitting || !submitCompleted} className="quickstart-primary-cta inline-flex items-center justify-center rounded-full border px-7 py-3 text-sm font-semibold !text-white transition duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-55" style={{ color: "#fff" }}>{isSubmitting ? copy.saving : submitCompleted ? copy.cta : copy.saving}</button>
+          <button type="button" onClick={onOpenGuidedDemo} disabled={isSubmitting || !submitCompleted} className="quickstart-primary-cta inline-flex items-center justify-center rounded-full border px-7 py-3 text-sm font-semibold transition duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-55">{isSubmitting ? copy.saving : submitCompleted ? copy.cta : copy.saving}</button>
           {submitCompleted ? <p className="text-sm text-emerald-500">{copy.done}</p> : null}
           {submitError ? <p className="text-sm text-rose-500">{submitError}</p> : null}
         </div>


### PR DESCRIPTION
### Motivation
- Ensure the Quick Start CTA label (loading state: `Guardando...` / `Saving...`) has sufficient contrast in light theme without altering the button's visual design or behavior.
- Prevent inline styles and utility classes from forcing white text that can be overridden by theme-aware CSS.

### Description
- Removed the `!text-white` utility and the inline `style={{ color: "#fff" }}` from the quickstart CTA in `apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx` so the label color is controlled by CSS.
- Added a theme-aware override `:root[data-theme="light"] .quickstart-primary-cta { color: #0f172a; }` to `apps/web/src/index.css` to ensure dark label text in light mode while preserving light text in dark mode.
- Kept the CTA's gradient, sizing, border radius, disabled state and behavior unchanged, and left localized labels intact for both Spanish and English.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ef562c28833290cf833c16e114a0)