### PR TITLE
Improve Quick Start card text contrast in light theme

### DIFF
--- a/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
+++ b/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useThemePreference } from '../../theme/ThemePreferenceProvider';
 import type { OnboardingLanguage } from '../constants';
 
 interface QuickStartGeneratingScreenProps {
@@ -16,6 +17,9 @@ export function QuickStartGeneratingScreen({
   submitError = null,
   onOpenGuidedDemo,
 }: QuickStartGeneratingScreenProps) {
+  const { theme } = useThemePreference();
+  const isLight = theme === 'light';
+
   const copy = language === 'en'
     ? {
         title: 'Configuring your Quick Start',
@@ -60,14 +64,14 @@ export function QuickStartGeneratingScreen({
           <span>Innerbloom</span>
           <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logo" className="h-[1.8em] w-auto" />
         </div>
-        <h1 className="text-balance text-2xl font-semibold text-[color:var(--color-text)] sm:text-3xl">{copy.title}</h1>
-        <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">{copy.subtitle}</p>
+        <h1 className={`text-balance text-2xl font-semibold sm:text-3xl ${isLight ? 'text-slate-900' : 'text-[color:var(--color-text)]'}`}>{copy.title}</h1>
+        <p className={`mt-2 text-sm ${isLight ? 'text-slate-700' : 'text-[color:var(--color-text-muted)]'}`}>{copy.subtitle}</p>
         <ul className="mt-6 space-y-3">
           {steps.slice(0, setupProgress).map((setupStep, index) => {
             const complete = setupProgress >= steps.length;
             const isPlanStep = index === steps.length - 1;
             return (
-              <li key={setupStep} className="flex items-center gap-3 text-sm text-[color:var(--color-text-muted)] transition-all duration-500">
+              <li key={setupStep} className={`flex items-center gap-3 text-sm transition-all duration-500 ${isLight ? 'text-slate-700' : 'text-[color:var(--color-text-muted)]'}`}>
                 <span className={`quickstart-setup-dot h-2.5 w-2.5 rounded-full ${!complete && index === setupProgress - 1 ? 'animate-pulse' : ''}`} />
                 <span>
                   {setupStep}
@@ -80,7 +84,7 @@ export function QuickStartGeneratingScreen({
         <div className="quickstart-progress-track mt-6 h-1.5 w-full overflow-hidden rounded-full">
           <div className={`quickstart-progress-fill h-full transition-all duration-700 ${setupProgress >= steps.length ? 'w-full quick-start-setup__progress-complete' : 'w-1/3 quick-start-setup__progress-animated'}`} />
         </div>
-        <p className="mt-6 text-sm text-[color:var(--color-text-muted)]">{copy.bridgeHint}</p>
+        <p className={`mt-6 text-sm ${isLight ? 'text-slate-700' : 'text-[color:var(--color-text-muted)]'}`}>{copy.bridgeHint}</p>
         <div className="mt-8 flex flex-col items-center gap-3">
           <button type="button" onClick={onOpenGuidedDemo} disabled={isSubmitting || !submitCompleted} className="quickstart-primary-cta inline-flex items-center justify-center rounded-full border px-7 py-3 text-sm font-semibold !text-white transition duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-55" style={{ color: "#fff" }}>{isSubmitting ? copy.saving : submitCompleted ? copy.cta : copy.saving}</button>
           {submitCompleted ? <p className="text-sm text-emerald-500">{copy.done}</p> : null}


### PR DESCRIPTION
### Motivation
- Ensure the Quick Start card content is readable in `theme === 'light'` by replacing low-contrast text tokens with darker, high-contrast variants while keeping dark mode styling unchanged.

### Description
- Read the current theme with `useThemePreference` and derive `isLight` to conditionally apply styles in `QuickStartGeneratingScreen`.
- In light mode the title uses `text-slate-900` and subtitle/list/bridge hint use `text-slate-700` for stronger contrast. 
- Dark mode behavior is preserved by falling back to the original token-based classes (`text-[color:var(--color-text)]` / `text-[color:var(--color-text-muted)]`).
- No functional logic was changed; timers, submit state, navigation, persistence and task generation remain untouched.

### Testing
- No automated tests were run for this visual-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ef5421208332963f53b331df9ac2)