### PR TITLE
Make onboarding screens theme-aware using ThemePreference

### DIFF
--- a/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
+++ b/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
@@ -13,6 +13,7 @@ import { NavButtons } from './ui/NavButtons';
 import { GameModeChip as SharedGameModeChip, buildGameModeChip } from '../components/common/GameModeChip';
 import { buildAvatarPreviewProfile, getAvatarOptionById, resolveAvatarPickerPreviewImage } from '../lib/avatarCatalog';
 import { getOnboardingRhythmTheme } from './utils/onboardingRhythmTheme';
+import { useThemePreference } from '../theme/ThemePreferenceProvider';
 
 type Pillar = 'Body' | 'Mind' | 'Soul';
 type Step = 'body' | 'mind' | 'soul' | 'moderation' | 'summary' | 'setup';
@@ -687,6 +688,8 @@ interface IntegratedQuickStartFlowProps {
 }
 
 export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gameMode: initialGameMode, avatarId, onBackToPathSelect, onExit, onRestart }: IntegratedQuickStartFlowProps) {
+  const { theme } = useThemePreference();
+  const isLight = theme === 'light';
   const navigate = useNavigate();
   const language = initialLanguage;
   const [step, setStep] = useState<Step>('body');
@@ -1206,12 +1209,12 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
 
         {step === 'setup' ? (
           <section className="quickstart-premium-card relative mx-auto mt-5 w-full max-w-3xl rounded-3xl p-5 sm:p-8">
-            <div className="mb-5 flex items-center justify-center gap-2 text-center text-[0.68rem] font-semibold uppercase tracking-[0.36em] text-white/65 sm:text-xs">
+            <div className={`mb-5 flex items-center justify-center gap-2 text-center text-[0.68rem] font-semibold uppercase tracking-[0.36em] sm:text-xs ${isLight ? 'text-slate-500' : 'text-white/65'}`}>
               <span>Innerbloom</span>
               <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logo" className="h-[1.8em] w-auto" />
             </div>
-            <h1 className="text-balance text-2xl font-semibold text-white sm:text-3xl">{copy.setupTitle}</h1>
-            <p className="mt-2 text-sm text-slate-300">{copy.setupSubtitle}</p>
+            <h1 className={`text-balance text-2xl font-semibold sm:text-3xl ${isLight ? 'text-slate-900' : 'text-white'}`}>{copy.setupTitle}</h1>
+            <p className={`mt-2 text-sm ${isLight ? 'text-slate-700' : 'text-slate-300'}`}>{copy.setupSubtitle}</p>
             <ul className="mt-6 space-y-3">
               {setupSteps.slice(0, setupProgress).map((setupStep, index) => {
                 const complete = setupProgress >= setupSteps.length;
@@ -1219,7 +1222,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
                 return (
                   <li
                     key={setupStep}
-                    className="flex items-center gap-3 text-sm text-slate-100/90 transition-all duration-500"
+                    className={`flex items-center gap-3 text-sm transition-all duration-500 ${isLight ? 'text-slate-700' : 'text-slate-100/90'}`}
                   >
                     <span className={`quickstart-setup-dot h-2.5 w-2.5 rounded-full ${!complete && index === setupProgress - 1 ? 'animate-pulse' : ''}`} />
                     <span>
@@ -1257,7 +1260,7 @@ export function IntegratedQuickStartFlow({ language: initialLanguage = 'es', gam
                 }
               }
             `}</style>
-            <p className="mt-4 text-sm text-slate-300">{copy.setupBridgeHint}</p>
+            <p className={`mt-4 text-sm ${isLight ? 'text-slate-700' : 'text-slate-300'}`}>{copy.setupBridgeHint}</p>
             {setupProgress >= setupSteps.length ? <p className="mt-3 text-sm text-emerald-100">{copy.setupDone}</p> : null}
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-center">
               <motion.button

--- a/apps/web/src/onboarding/screens/JourneyGeneratingScreen.tsx
+++ b/apps/web/src/onboarding/screens/JourneyGeneratingScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { getJourneyGenerationStatus } from '../../lib/api';
+import { useThemePreference } from '../../theme/ThemePreferenceProvider';
 
 interface JourneyGeneratingScreenProps {
   gameMode: string;
@@ -11,6 +12,8 @@ interface JourneyGeneratingScreenProps {
 const BULLET_REVEAL_MS = 1300;
 
 export function JourneyGeneratingScreen({ gameMode, language, onGoToDashboard, onOpenGuidedDemo }: JourneyGeneratingScreenProps) {
+  const { theme } = useThemePreference();
+  const isLight = theme === 'light';
   const copy = language === 'en'
     ? {
         title: 'We are calibrating your personal formula',
@@ -115,16 +118,16 @@ export function JourneyGeneratingScreen({ gameMode, language, onGoToDashboard, o
         </svg>
       </div>
 
-      <div className="pointer-events-none absolute inset-0 bg-black/55 backdrop-blur-sm" aria-hidden />
+      <div className={`pointer-events-none absolute inset-0 backdrop-blur-sm ${isLight ? 'bg-white/60' : 'bg-black/55'}`} aria-hidden />
 
       <section className="onboarding-premium-card relative z-10 w-full max-w-3xl rounded-3xl p-6 sm:p-10">
-        <div className="mb-6 flex items-center justify-center gap-2 text-center text-xs font-semibold uppercase tracking-[0.42em] text-white/65 sm:text-sm">
+        <div className={`mb-6 flex items-center justify-center gap-2 text-center text-xs font-semibold uppercase tracking-[0.42em] sm:text-sm ${isLight ? 'text-slate-500' : 'text-white/65'}`}>
           <span>Innerbloom</span>
           <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logo" className="h-[1.9em] w-auto" />
         </div>
 
-        <h1 className="text-balance text-3xl font-semibold text-white sm:text-4xl">{copy.title}</h1>
-        <p className="mt-3 text-sm text-slate-300 sm:text-base">
+        <h1 className={`text-balance text-3xl font-semibold sm:text-4xl ${isLight ? 'text-slate-900' : 'text-white'}`}>{copy.title}</h1>
+        <p className={`mt-3 text-sm sm:text-base ${isLight ? 'text-slate-700' : 'text-slate-300'}`}>
           {copy.subtitle}
         </p>
 
@@ -135,7 +138,7 @@ export function JourneyGeneratingScreen({ gameMode, language, onGoToDashboard, o
             return (
               <li
                 key={bullet}
-                className={`flex items-start gap-3 text-sm text-slate-100/90 transition-all duration-500 sm:text-base ${
+                className={`flex items-start gap-3 text-sm transition-all duration-500 sm:text-base ${isLight ? 'text-slate-700' : 'text-slate-100/90'} ${
                   isVisible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
                 }`}
               >
@@ -146,14 +149,14 @@ export function JourneyGeneratingScreen({ gameMode, language, onGoToDashboard, o
           })}
 
           <li
-            className={`flex items-start gap-3 text-sm text-white transition-all duration-500 sm:text-base ${
+            className={`flex items-start gap-3 text-sm transition-all duration-500 sm:text-base ${isLight ? 'text-slate-800' : 'text-white'} ${
               isSequenceComplete ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
             } drop-shadow-[0_0_10px_rgba(165,180,252,0.5)]`}
           >
             <span className="mt-2 h-2.5 w-2.5 rounded-full bg-sky-300" aria-hidden />
             <span>
               {copy.planLabel}{' '}
-              <span className="inline-flex rounded-full border border-emerald-300/35 bg-emerald-400/20 px-2 py-0.5 text-xs font-semibold text-emerald-100 align-middle">
+              <span className={`inline-flex rounded-full border px-2 py-0.5 text-xs font-semibold align-middle ${isLight ? 'border-emerald-500/45 bg-emerald-100 text-emerald-700' : 'border-emerald-300/35 bg-emerald-400/20 text-emerald-100'}`}>
                 FREE
               </span>{' '}
               – {copy.includedMonths}
@@ -171,7 +174,7 @@ export function JourneyGeneratingScreen({ gameMode, language, onGoToDashboard, o
           />
         </div>
 
-        <p className="mt-8 text-sm text-slate-300 sm:text-base">
+        <p className={`mt-8 text-sm sm:text-base ${isLight ? 'text-slate-700' : 'text-slate-300'}`}>
           {copy.minutesHint}
           <br />
           {copy.bridgeHint}

--- a/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
+++ b/apps/web/src/onboarding/screens/QuickStartGeneratingScreen.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useThemePreference } from '../../theme/ThemePreferenceProvider';
 import type { OnboardingLanguage } from '../constants';
 
 interface QuickStartGeneratingScreenProps {
@@ -16,6 +17,9 @@ export function QuickStartGeneratingScreen({
   submitError = null,
   onOpenGuidedDemo,
 }: QuickStartGeneratingScreenProps) {
+  const { theme } = useThemePreference();
+  const isLight = theme === 'light';
+
   const copy = language === 'en'
     ? {
         title: 'Configuring your Quick Start',
@@ -60,14 +64,14 @@ export function QuickStartGeneratingScreen({
           <span>Innerbloom</span>
           <img src="/IB-COLOR-LOGO.png" alt="Innerbloom logo" className="h-[1.8em] w-auto" />
         </div>
-        <h1 className="text-balance text-2xl font-semibold text-[color:var(--color-text)] sm:text-3xl">{copy.title}</h1>
-        <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">{copy.subtitle}</p>
+        <h1 className={`text-balance text-2xl font-semibold sm:text-3xl ${isLight ? 'text-slate-900' : 'text-[color:var(--color-text)]'}`}>{copy.title}</h1>
+        <p className={`mt-2 text-sm ${isLight ? 'text-slate-700' : 'text-[color:var(--color-text-muted)]'}`}>{copy.subtitle}</p>
         <ul className="mt-6 space-y-3">
           {steps.slice(0, setupProgress).map((setupStep, index) => {
             const complete = setupProgress >= steps.length;
             const isPlanStep = index === steps.length - 1;
             return (
-              <li key={setupStep} className="flex items-center gap-3 text-sm text-[color:var(--color-text-muted)] transition-all duration-500">
+              <li key={setupStep} className={`flex items-center gap-3 text-sm transition-all duration-500 ${isLight ? 'text-slate-700' : 'text-[color:var(--color-text-muted)]'}`}>
                 <span className={`quickstart-setup-dot h-2.5 w-2.5 rounded-full ${!complete && index === setupProgress - 1 ? 'animate-pulse' : ''}`} />
                 <span>
                   {setupStep}
@@ -80,7 +84,7 @@ export function QuickStartGeneratingScreen({
         <div className="quickstart-progress-track mt-6 h-1.5 w-full overflow-hidden rounded-full">
           <div className={`quickstart-progress-fill h-full transition-all duration-700 ${setupProgress >= steps.length ? 'w-full quick-start-setup__progress-complete' : 'w-1/3 quick-start-setup__progress-animated'}`} />
         </div>
-        <p className="mt-6 text-sm text-[color:var(--color-text-muted)]">{copy.bridgeHint}</p>
+        <p className={`mt-6 text-sm ${isLight ? 'text-slate-700' : 'text-[color:var(--color-text-muted)]'}`}>{copy.bridgeHint}</p>
         <div className="mt-8 flex flex-col items-center gap-3">
           <button type="button" onClick={onOpenGuidedDemo} disabled={isSubmitting || !submitCompleted} className="quickstart-primary-cta inline-flex items-center justify-center rounded-full border px-7 py-3 text-sm font-semibold !text-white transition duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-55" style={{ color: "#fff" }}>{isSubmitting ? copy.saving : submitCompleted ? copy.cta : copy.saving}</button>
           {submitCompleted ? <p className="text-sm text-emerald-500">{copy.done}</p> : null}


### PR DESCRIPTION
### Motivation

- Provide consistent light/dark theme styling for onboarding screens and the quick-start flow to improve readability in light mode.
- Replace several hardcoded color classes with conditional classes driven by the app's theme preference.
- Ensure visual elements such as logos, progress bars, and labels render appropriately under both themes.

### Description

- Import and use `useThemePreference` in `IntegratedQuickStartFlow`, `JourneyGeneratingScreen`, and `QuickStartGeneratingScreen` and derive an `isLight` flag from `theme`.
- Replace hardcoded color utility classes with conditional class strings that select light- and dark-mode classes based on `isLight` for headings, body text, overlays, and status pills.
- Preserve existing layout, animations, and progress behavior while only altering visual styles for theme-awareness.

### Testing

- Ran TypeScript type checking with `yarn tsc --noEmit` which completed without errors.
- Ran the existing automated test suite with `yarn test --watchAll=false` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ef5421208332963f53b331df9ac2)