### PR TITLE
Fix INSIGHT trait/pillar consistency in taskgen validation

### DIFF
--- a/apps/api/src/lib/taskgen/runner.test.ts
+++ b/apps/api/src/lib/taskgen/runner.test.ts
@@ -363,6 +363,64 @@ describe('runTaskGeneration', () => {
     expect(result.errors?.[0]).toContain('OpenAI request timed out or was aborted');
     expect(mockResponsesCreate).toHaveBeenCalledTimes(3);
   });
+
+  it('rejects INSIGHT when paired with a non-catalog pillar', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    process.env.OPENAI_MODEL = 'gpt-vitest';
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'taskgen-insight-snapshot-'));
+    const snapshotPath = path.join(tempDir, 'snapshot.json');
+    await fs.writeFile(
+      snapshotPath,
+      JSON.stringify({
+        samples: {
+          users: [{ user_id: TEST_USER_ID, tasks_group_id: 'debug-group', game_mode_id: 1 }],
+          cat_game_mode: [{ game_mode_id: 1, code: 'FLOW', name: 'Flow' }],
+          cat_pillar: [
+            { pillar_id: 1, code: 'BODY', name: 'Body' },
+            { pillar_id: 2, code: 'MIND', name: 'Mind' },
+            { pillar_id: 3, code: 'SOUL', name: 'Soul' },
+          ],
+          cat_trait: [{ trait_id: 26, pillar_id: 3, code: 'INSIGHT', name: 'Insight' }],
+          cat_difficulty: [{ difficulty_id: 1, code: 'Easy', name: 'Easy' }],
+          onboarding_session: [],
+        },
+      }),
+      'utf8',
+    );
+    process.env.DB_SNAPSHOT_PATH = snapshotPath;
+
+    mockResponsesCreate.mockReset();
+    mockResponsesCreate.mockResolvedValue({
+      output_text: JSON.stringify({
+        user_id: TEST_USER_ID,
+        tasks_group_id: 'debug-group',
+        tasks: [
+          {
+            task: 'Invalid insight pairing task',
+            pillar_code: 'MIND',
+            trait_code: 'INSIGHT',
+            stat_code: 'INSIGHT',
+            difficulty_code: 'Easy',
+            friction_score: 10,
+            friction_tier: 'LOW',
+          },
+        ],
+      }),
+    });
+
+    const { runTaskGeneration } = await loadRunnerModule();
+    const result = await runTaskGeneration({
+      userId: TEST_USER_ID,
+      mode: 'flow',
+      source: 'snapshot',
+      dryRun: false,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.errors?.[0]).toContain('Trait INSIGHT does not belong to pillar MIND');
+    await fs.rm(tempDir, { recursive: true, force: true });
+    delete process.env.DB_SNAPSHOT_PATH;
+  });
 });
 
 afterAll(() => {

--- a/apps/api/src/lib/taskgen/runner.ts
+++ b/apps/api/src/lib/taskgen/runner.ts
@@ -330,11 +330,13 @@ function buildCatalogStrings(snapshot: SnapshotData) {
   }
 
   const traitsByCode = new Map<string, TraitRow>();
+  const traitToPillarCode = new Map<string, string>();
   const traitsByPillarCode = new Map<string, TraitRow[]>();
   for (const trait of traits) {
     traitsByCode.set(trait.code, trait);
     const pillar = pillarById.get(trait.pillar_id);
     const pillarCode = pillar?.code ?? `pillar_${trait.pillar_id}`;
+    traitToPillarCode.set(trait.code, pillarCode);
     if (!traitsByPillarCode.has(pillarCode)) {
       traitsByPillarCode.set(pillarCode, []);
     }
@@ -376,6 +378,7 @@ function buildCatalogStrings(snapshot: SnapshotData) {
     catalogDifficulty,
     pillarCodes,
     traitsByCode,
+    traitToPillarCode,
     pillarById,
     statCodes,
     difficultyCodes,
@@ -598,7 +601,7 @@ function validatePayload(
     if (!trait) {
       return { valid: false, errors: [`Invalid trait_code: ${task.trait_code}`] };
     }
-    const pillarForTrait = catalogs.pillarById.get(trait.pillar_id)?.code;
+    const pillarForTrait = catalogs.traitToPillarCode.get(task.trait_code);
     if (pillarForTrait && pillarForTrait !== task.pillar_code) {
       return {
         valid: false,

--- a/apps/api/src/services/debugTaskgenService.ts
+++ b/apps/api/src/services/debugTaskgenService.ts
@@ -114,6 +114,7 @@ type Catalogs = {
   catalogDifficulty: string;
   pillarCodes: Set<string>;
   traitsByCode: Map<string, TraitRow>;
+  traitToPillarCode: Map<string, string>;
   pillarById: Map<number, PillarRow>;
   statCodes: Set<string>;
   difficultyCodes: Set<string>;
@@ -373,11 +374,13 @@ function buildCatalogStrings(args: {
   }
 
   const traitsByCode = new Map<string, TraitRow>();
+  const traitToPillarCode = new Map<string, string>();
   const traitsByPillarCode = new Map<string, TraitRow[]>();
   for (const trait of traits) {
     traitsByCode.set(trait.code, trait);
     const pillar = pillarById.get(trait.pillar_id);
     const pillarCode = pillar?.code ?? `pillar_${trait.pillar_id}`;
+    traitToPillarCode.set(trait.code, pillarCode);
     if (!traitsByPillarCode.has(pillarCode)) {
       traitsByPillarCode.set(pillarCode, []);
     }
@@ -419,6 +422,7 @@ function buildCatalogStrings(args: {
     catalogDifficulty,
     pillarCodes,
     traitsByCode,
+    traitToPillarCode,
     pillarById,
     statCodes,
     difficultyCodes,
@@ -606,7 +610,7 @@ function validatePayload(
     if (!trait) {
       return { valid: false, errors: [`Invalid trait_code: ${task.trait_code}`] };
     }
-    const pillarForTrait = catalogs.pillarById.get(trait.pillar_id)?.code;
+    const pillarForTrait = catalogs.traitToPillarCode.get(task.trait_code);
     if (pillarForTrait && pillarForTrait !== task.pillar_code) {
       return {
         valid: false,

--- a/apps/api/src/services/taskgenTriggerService.ts
+++ b/apps/api/src/services/taskgenTriggerService.ts
@@ -320,6 +320,22 @@ function createInstrumentedRunner(options: {
     },
     validateTasks: (payload, catalogs, placeholders, schema) => {
       const result = baseDeps.validateTasks(payload, catalogs, placeholders, schema);
+      const invalidTraitPillarPair =
+        result.valid || !Array.isArray(payload.tasks)
+          ? null
+          : payload.tasks
+              .map((task) => {
+                const expectedPillarCode = catalogs.traitToPillarCode.get(task.trait_code);
+                if (!expectedPillarCode || expectedPillarCode === task.pillar_code) {
+                  return null;
+                }
+                return {
+                  trait_code: task.trait_code,
+                  pillar_code: task.pillar_code,
+                  expected_pillar_code: expectedPillarCode,
+                };
+              })
+              .find((pair) => pair !== null) ?? null;
       emitEvent({
         level: result.valid ? 'info' : 'warn',
         event: result.valid ? 'VALIDATION_OK' : 'VALIDATION_FAILED',
@@ -330,6 +346,7 @@ function createInstrumentedRunner(options: {
         data: {
           taskCount: payload.tasks?.length ?? 0,
           errors: result.valid ? [] : result.errors,
+          invalidTraitPillarPair,
         },
       });
       return result;


### PR DESCRIPTION
### Motivation
- Ensure the trait->pillar coherence used in the prompt/catalog strings is the single source of truth for validation so the model output cannot pass inconsistent `trait_code -> pillar_code` pairs (notably `INSIGHT`).
- Confirm canonical catalog: `apps/api/db-snapshot.sample.json` shows `INSIGHT` has `pillar_id = 3` and `pillar_id = 3` maps to `SOUL`, so validation must reflect that.

### Description
- Add an explicit `traitToPillarCode` map when building catalogs in `runner.ts` and `debugTaskgenService.ts` so the trait->pillar mapping is derived from the same catalog used to construct `CATALOG_TRAITS`/`CATALOG_STATS` (added `traitToPillarCode`).
- Update validators in `runner.ts` and `debugTaskgenService.ts` to check trait/pillar coherence via `catalogs.traitToPillarCode` instead of recomputing from `pillarById` at validation time.
- Emit structured diagnostic data on validation failure by adding `invalidTraitPillarPair` (`trait_code`, `pillar_code`, `expected_pillar_code`) to the `VALIDATION_FAILED` event payload in the task generation runner (`taskgenTriggerService.ts`).
- Add a regression test in `apps/api/src/lib/taskgen/runner.test.ts` that loads a snapshot where `INSIGHT -> SOUL` and asserts generation fails when the model returns `trait_code: 'INSIGHT'` paired with `pillar_code: 'MIND'`.

### Testing
- Ran the taskgen unit tests with `pnpm --filter api test -- src/lib/taskgen/runner.test.ts`, which exercised the new regression test; the suite completed and the regression test asserted that `Trait INSIGHT does not belong to pillar MIND` (passed).
- Verified the canonical catalog entry in `apps/api/db-snapshot.sample.json` to confirm `INSIGHT` maps to `pillar_id = 3` and `SOUL` as the expected pillar.
- The change is covered by the existing runner tests and the new regression test to prevent future regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f204875eb0833298754bffb721f9b0)