### PR TITLE
Improve official landing problem-section icons

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -749,27 +749,35 @@
 }
 
 .landing .truth-problem-icon {
-  width: 30px;
-  height: 30px;
+  width: 42px;
+  height: 42px;
   border-radius: 999px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.9rem;
-  font-weight: 700;
-  margin-top: 3px;
+  font-size: 1.18rem;
+  font-weight: 800;
+  line-height: 1;
+  margin-top: 2px;
+  flex: 0 0 auto;
+  position: relative;
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.24);
 }
 
 .landing .truth-problem-icon--x {
-  color: rgba(255, 215, 235, 0.96);
-  background: rgba(221, 140, 190, 0.2);
-  box-shadow: inset 0 0 0 1px rgba(237, 185, 221, 0.34);
+  color: rgba(255, 242, 250, 0.98);
+  background: radial-gradient(circle at 30% 24%, rgba(255, 218, 238, 0.56), rgba(232, 142, 196, 0.4) 60%, rgba(208, 98, 165, 0.34) 100%);
+  border: 1px solid rgba(255, 215, 236, 0.68);
+  box-shadow: 0 8px 20px rgba(206, 103, 164, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.38);
 }
 
 .landing .truth-problem-icon--check {
-  color: rgba(198, 250, 248, 0.98);
-  background: rgba(88, 188, 193, 0.2);
-  box-shadow: inset 0 0 0 1px rgba(144, 236, 233, 0.36);
+  color: rgba(236, 255, 255, 0.99);
+  background: radial-gradient(circle at 30% 24%, rgba(195, 255, 252, 0.6), rgba(117, 210, 206, 0.44) 58%, rgba(72, 174, 184, 0.36) 100%);
+  border: 1px solid rgba(176, 248, 242, 0.72);
+  box-shadow: 0 8px 20px rgba(60, 158, 170, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
 .landing .truth-problem-divider {


### PR DESCRIPTION
### Motivation
- Make the small X/✓ icons in the landing "El problema real" section more legible and visually polished so they read clearly at a glance and stand out over the background.

### Description
- Updated `apps/web/src/pages/Landing.css` to increase `.landing .truth-problem-icon` size to `42px` and raise `font-size`/`font-weight` for improved legibility.
- Added `backdrop-filter`, `text-shadow`, `position: relative` and `flex: 0 0 auto` to stabilize alignment and add subtle polish to the icon container. 
- Replaced flat fills for `.truth-problem-icon--x` and `.truth-problem-icon--check` with radial gradients, matching `border` rules and soft `box-shadow` for depth and contrast. 
- No changes to JSX or copy were made; this is a focused visual/CSS refinement to `apps/web/src/pages/Landing.css`.

### Testing
- Reviewed the CSS diff with `git diff -- apps/web/src/pages/Landing.css` and confirmed the intended changes were applied. 
- Checked repository state with `git status --short` and committed the change with `git commit`, both commands completed successfully. 
- No automated unit or visual regression tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20536edac8332badf21c6f6c2fb50)