### PR TITLE
Do not auto-fix INSIGHT taxonomy mismatches during normalization

### DIFF
--- a/apps/api/src/lib/taskgen/runner.ts
+++ b/apps/api/src/lib/taskgen/runner.ts
@@ -289,12 +289,15 @@ function normalizeAndValidatePayload(
 
     let normalizedTask = task;
     if (task.pillar_code !== canonicalPillarCode) {
-      normalizedTask = {
-        ...task,
-        pillar_code: canonicalPillarCode,
-        stat_code: task.trait_code,
-      };
-      autoFixedTaxonomyMismatches += 1;
+      const shouldAutoFixTaxonomyMismatch = !(task.trait_code === 'INSIGHT' && task.stat_code === task.trait_code);
+      if (shouldAutoFixTaxonomyMismatch) {
+        normalizedTask = {
+          ...task,
+          pillar_code: canonicalPillarCode,
+          stat_code: task.trait_code,
+        };
+        autoFixedTaxonomyMismatches += 1;
+      }
     }
 
     if (!catalogs.statCodes.has(normalizedTask.stat_code)) {


### PR DESCRIPTION
### Motivation
- Prevent silently correcting INSIGHT tasks that are malformed so downstream validation can reject invalid INSIGHT+pillar pairings. 
- Preserve existing auto-fix behavior for legacy/malformed outputs except for the special-case INSIGHT stat/pillar combination.

### Description
- Update `normalizeAndValidatePayload` in `apps/api/src/lib/taskgen/runner.ts` to skip the auto-fix when `task.trait_code === 'INSIGHT'` and `task.stat_code === task.trait_code`, leaving the mismatch intact for validation. 
- All other taxonomy mismatch auto-fix logic is unchanged and still canonicalizes pillar and stat codes when appropriate.

### Testing
- Ran the targeted unit test with `cd apps/api && npx vitest run src/lib/taskgen/runner.test.ts -t "rejects INSIGHT when paired with a non-catalog pillar"`, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f208417c98833290cd0fecf5d3f605)