### PR TITLE
Add Labs Innerbloom System Map experimental route

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -30,6 +30,7 @@ import LandingRhythmSectionMvpPage from './pages/labs/LandingRhythmSectionMvpPag
 import EditorLabPage from './pages/labs/EditorLabPage';
 import PublicTasksDemoPage from './pages/labs/PublicTasksDemoPage';
 import HeroPhoneShowcaseLabPage from './pages/labs/HeroPhoneShowcaseLabPage';
+import InnerbloomSystemMapPage from './pages/labs/InnerbloomSystemMapPage';
 import { useGa4FunnelTracking } from './hooks/useGa4FunnelTracking';
 import { isNativeCapacitorPlatform } from './mobile/capacitor';
 import { writeMobileDebug } from './mobile/mobileDebug';
@@ -279,6 +280,7 @@ export default function App() {
         <Route path="/labs/logros" element={<LabsLogrosDemoPage />} />
         <Route path="/labs/tasks-demo" element={<PublicTasksDemoPage />} />
         <Route path="/labs/hero-phone-showcase" element={<HeroPhoneShowcaseLabPage />} />
+        <Route path="/labs/innerbloom-system-map" element={<InnerbloomSystemMapPage />} />
         <Route path="/demo/logros" element={<LabsLogrosDemoPage />} />
         <Route path="/demo/tasks" element={<PublicTasksDemoPage />} />
         <Route path="/labs/landing-rhythm-section" element={<LandingRhythmSectionMvpPage />} />

--- a/apps/web/src/pages/labs/InnerbloomSystemMapPage.tsx
+++ b/apps/web/src/pages/labs/InnerbloomSystemMapPage.tsx
@@ -1,0 +1,144 @@
+import { OFFICIAL_DESIGN_TOKENS } from '../../content/officialDesignTokens';
+
+const INPUTS = [
+  {
+    title: 'User decisions',
+    description: 'Onboarding answers · selected rhythm · goals · pillars',
+  },
+  {
+    title: 'Real progress',
+    description: 'Completed tasks · GP · streaks · weekly consistency',
+  },
+  {
+    title: 'State signals',
+    description: 'Energy · emotion check-ins · friction · task history',
+  },
+];
+
+const OUTPUTS = [
+  {
+    title: 'Next best step',
+    description: 'What to do next',
+  },
+  {
+    title: 'Right intensity',
+    description: 'When to increase or lower rhythm',
+  },
+  {
+    title: 'Sustainable tasks',
+    description: 'Tasks that match current capacity',
+  },
+  {
+    title: 'Achieved habits',
+    description: 'Habits that become part of the user’s life',
+  },
+];
+
+const ENGINES = [
+  {
+    title: 'Journey Setup Engine',
+    description: 'Creates your first sustainable habit base from your onboarding decisions.',
+  },
+  {
+    title: 'Weekly Progress Loop',
+    description: 'Turns completed tasks, GP, streaks, and check-ins into progress signals.',
+  },
+  {
+    title: 'Growth Calibration Engine',
+    description: 'Adjusts difficulty and rhythm when your consistency changes.',
+    subNode: 'Rhythm Upgrade Engine: Suggests a higher rhythm when your progress is solid.',
+  },
+  {
+    title: 'Habit Achievement Engine',
+    description: 'Detects when a task becomes a consolidated habit.',
+  },
+];
+
+export default function InnerbloomSystemMapPage() {
+  const purpleAfternoon = OFFICIAL_DESIGN_TOKENS.gradients.find((gradient) => gradient.name === 'purple_afternoon');
+  const pageBackground = purpleAfternoon
+    ? {
+        backgroundImage: `linear-gradient(${purpleAfternoon.angle}, ${purpleAfternoon.stops[0]}, ${purpleAfternoon.stops[1]})`,
+      }
+    : undefined;
+
+  return (
+    <main className="min-h-screen px-4 py-8 text-[color:var(--color-text)] md:px-6 md:py-12" style={pageBackground}>
+      <section className="mx-auto w-full max-w-7xl rounded-[2rem] border border-white/14 bg-white/10 p-6 shadow-[0_24px_50px_rgba(25,14,51,0.28)] backdrop-blur-xl md:p-10">
+        <header className="text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/70">Innerbloom System Map</p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white md:text-[2.4rem]">How Innerbloom adapts to your progress</h1>
+          <p className="mx-auto mt-4 max-w-3xl text-sm leading-relaxed text-white/82 md:text-base">
+            Innerbloom uses your decisions and real progress to decide when to increase intensity, when to lower it,
+            and what your next step should be.
+          </p>
+        </header>
+
+        <div className="mt-8 grid gap-4 lg:grid-cols-[1fr_1.7fr_1fr]">
+          <aside aria-labelledby="inputs-heading" className="rounded-3xl bg-white/8 p-4 backdrop-blur-md md:p-5">
+            <h2 id="inputs-heading" className="text-lg font-semibold text-white">Inputs</h2>
+            <ul className="mt-4 space-y-3">
+              {INPUTS.map((item) => (
+                <li key={item.title} className="rounded-2xl bg-white/12 p-3">
+                  <h3 className="text-sm font-semibold text-white">{item.title}</h3>
+                  <p className="mt-1 text-xs leading-relaxed text-white/78 md:text-sm">{item.description}</p>
+                </li>
+              ))}
+            </ul>
+          </aside>
+
+          <section aria-labelledby="diagram-heading" className="relative overflow-hidden rounded-3xl bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.24),rgba(255,255,255,0.06)_58%,rgba(14,10,35,0.2)_100%)] p-4 md:p-8">
+            <h2 id="diagram-heading" className="sr-only">Innerbloom adaptive system diagram</h2>
+            <div className="pointer-events-none absolute inset-[10%] rounded-full border border-white/20" aria-hidden="true" />
+            <div className="pointer-events-none absolute inset-[18%] rounded-full border border-white/14" aria-hidden="true" />
+
+            <div className="relative mx-auto grid max-w-3xl gap-4 md:grid-cols-2">
+              {ENGINES.map((engine) => (
+                <article key={engine.title} className="rounded-2xl border border-white/16 bg-white/14 p-4 shadow-[0_12px_22px_rgba(21,11,45,0.2)]">
+                  <h3 className="text-sm font-semibold text-white md:text-base">{engine.title}</h3>
+                  <p className="mt-2 text-xs leading-relaxed text-white/82 md:text-sm">{engine.description}</p>
+                  {engine.subNode ? (
+                    <p className="mt-2 rounded-xl bg-white/14 px-2.5 py-2 text-[0.69rem] leading-relaxed text-white/80 md:text-xs">{engine.subNode}</p>
+                  ) : null}
+                </article>
+              ))}
+            </div>
+
+            <div className="relative z-10 mx-auto mt-5 flex h-44 w-44 items-center justify-center rounded-full border border-white/30 bg-[linear-gradient(150deg,rgba(255,255,255,0.34),rgba(255,255,255,0.14))] text-center shadow-[0_16px_30px_rgba(25,13,52,0.3)] md:-mt-44 md:h-56 md:w-56 animate-pulse">
+              <div>
+                <p className="text-sm font-semibold tracking-[0.18em] text-white">INNERBLOOM</p>
+                <p className="mt-2 text-xs leading-relaxed text-white/84 md:text-sm">Adaptive Habit System</p>
+              </div>
+            </div>
+
+            <p className="mt-6 text-center text-xs font-medium tracking-[0.08em] text-white/85 md:text-sm">
+              Decisions → Progress → Analysis → Adjustment → Next step
+            </p>
+          </section>
+
+          <aside aria-labelledby="outputs-heading" className="rounded-3xl bg-white/8 p-4 backdrop-blur-md md:p-5">
+            <h2 id="outputs-heading" className="text-lg font-semibold text-white">Outputs</h2>
+            <ul className="mt-4 space-y-3">
+              {OUTPUTS.map((item) => (
+                <li key={item.title} className="rounded-2xl bg-white/12 p-3">
+                  <h3 className="text-sm font-semibold text-white">{item.title}</h3>
+                  <p className="mt-1 text-xs leading-relaxed text-white/78 md:text-sm">{item.description}</p>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+
+        <section className="mt-8 rounded-3xl border border-white/16 bg-white/12 p-5 text-center md:p-7">
+          <h2 className="text-2xl font-semibold tracking-[-0.02em] text-white">Not a tracker. A system that adapts to your progress.</h2>
+          <p className="mx-auto mt-3 max-w-3xl text-sm leading-relaxed text-white/82 md:text-base">
+            A tracker shows what you did. Innerbloom uses your progress to decide what should happen next.
+          </p>
+          <p className="mx-auto mt-3 max-w-3xl text-sm leading-relaxed text-white/72 md:text-base">
+            Un tracker registra comportamiento. Innerbloom usa tu progreso para adaptar el sistema.
+          </p>
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/pages/labs/LabsIndexPage.tsx
+++ b/apps/web/src/pages/labs/LabsIndexPage.tsx
@@ -23,6 +23,11 @@ const LAB_EXPERIMENTS = [
     description: 'Experimental hero fold replacing static AI art with a looping Innerbloom product phone showcase.',
     href: '/labs/hero-phone-showcase',
   },
+  {
+    title: 'Innerbloom System Map',
+    description: 'Visual concept map explaining how Innerbloom adapts decisions, progress, engines, and outputs.',
+    href: '/labs/innerbloom-system-map',
+  },
 ];
 
 export default function LabsIndexPage() {


### PR DESCRIPTION
### Motivation
- Provide an isolated Labs experiment page to visually iterate a premium infographic that explains Innerbloom as an "adaptive habit system" rather than a simple tracker. 
- Let product and design stakeholders explore the radial center+engines+inputs/outputs composition and messaging without touching the official landing or production routes.

### Description
- Added a new React page component `InnerbloomSystemMapPage` that renders a radial-infographic-style layout with center positioning, four core engines, inputs, outputs, a feedback loop line, and final positioning copy (including the requested Spanish line). 
- Registered the new route at `/labs/innerbloom-system-map` in `App.tsx` and added an entry to the Labs index so the experiment is discoverable from `LabsIndexPage`. 
- Visual styling uses existing design tokens (`OFFICIAL_DESIGN_TOKENS`) and scoped Tailwind/CSS utility classes so styles remain contained to the new page and match the soft violet / glassy panel direction; no external chart libraries or canvas were introduced. 
- Files changed: `apps/web/src/pages/labs/InnerbloomSystemMapPage.tsx` (new), `apps/web/src/App.tsx` (route import + route entry), and `apps/web/src/pages/labs/LabsIndexPage.tsx` (added experiment link). 

### Testing
- Ran `npm --prefix apps/web run build`, and the Vite production build completed successfully with non-blocking warnings. 
- Ran `npm --prefix apps/web run typecheck`, and TypeScript typecheck failed due to pre-existing repository type issues unrelated to this change (errors in `runtimeAuth.tsx`, dashboard tests, and other files). 
- The change was committed and the new page is reachable at the registered Labs route for manual review and design iteration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20644f2b88332b16169e56f41eea8)