### PR TITLE
Fix dry-run task payload reference in taskgen runner

### DIFF
--- a/apps/api/src/lib/taskgen/runner.ts
+++ b/apps/api/src/lib/taskgen/runner.ts
@@ -971,7 +971,7 @@ export async function runTaskGeneration(args: {
         seed: args.seed,
         placeholders,
         prompt_preview: promptPreview,
-        tasks: normalized.payload.tasks,
+        tasks: payload.tasks,
         meta: {
           schema_version: 'v1',
           validation,


### PR DESCRIPTION
### Motivation
- Fix a TypeScript build error in the task generation runner where an out-of-scope `normalized` variable was referenced in the dry-run return, which caused `tsc` to fail and blocked builds.

### Description
- Replace `tasks: normalized.payload.tasks` with `tasks: payload.tasks` in `apps/api/src/lib/taskgen/runner.ts` so the dry-run path uses the correctly-scoped `payload` variable.

### Testing
- Ran `npm run build` in `apps/api` which completed successfully (`tsc` and `node scripts/copy-taskgen-assets.mjs` passed), and note that a prior combined `npm install --no-audit --no-fund && npm run build` failed during `npm install` with `Cannot read properties of null (reading 'matches')`, which is unrelated to this code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20c19632c83329de65226ece1f0c4)