### PR TITLE
Fix taskgen taxonomy normalization for INSIGHT trait

### DIFF
--- a/apps/api/src/lib/taskgen/runner.test.ts
+++ b/apps/api/src/lib/taskgen/runner.test.ts
@@ -406,7 +406,7 @@ describe('runTaskGeneration', () => {
     expect(mockResponsesCreate).toHaveBeenCalledTimes(3);
   });
 
-  it('rejects INSIGHT when paired with a non-catalog pillar', async () => {
+  it('auto-fixes INSIGHT when paired with a non-catalog pillar', async () => {
     process.env.OPENAI_API_KEY = 'test-key';
     process.env.OPENAI_MODEL = 'gpt-vitest';
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'taskgen-insight-snapshot-'));
@@ -458,8 +458,10 @@ describe('runTaskGeneration', () => {
       dryRun: false,
     });
 
-    expect(result.status).toBe('error');
-    expect(result.errors?.[0]).toContain('Trait INSIGHT does not belong to pillar MIND');
+    expect(result.status).toBe('ok');
+    expect(result.meta.validation.valid).toBe(true);
+    expect(result.tasks?.[0]?.pillar_code).toBe('SOUL');
+    expect(result.tasks?.[0]?.stat_code).toBe('INSIGHT');
     await fs.rm(tempDir, { recursive: true, force: true });
     delete process.env.DB_SNAPSHOT_PATH;
   });

--- a/apps/api/src/lib/taskgen/runner.ts
+++ b/apps/api/src/lib/taskgen/runner.ts
@@ -289,15 +289,12 @@ function normalizeAndValidatePayload(
 
     let normalizedTask = task;
     if (task.pillar_code !== canonicalPillarCode) {
-      const shouldAutoFixTaxonomyMismatch = !(task.trait_code === 'INSIGHT' && task.stat_code === task.trait_code);
-      if (shouldAutoFixTaxonomyMismatch) {
-        normalizedTask = {
-          ...task,
-          pillar_code: canonicalPillarCode,
-          stat_code: task.trait_code,
-        };
-        autoFixedTaxonomyMismatches += 1;
-      }
+      normalizedTask = {
+        ...task,
+        pillar_code: canonicalPillarCode,
+        stat_code: task.trait_code,
+      };
+      autoFixedTaxonomyMismatches += 1;
     }
 
     if (!catalogs.statCodes.has(normalizedTask.stat_code)) {


### PR DESCRIPTION
### Motivation
- The task generation flow produced validation failures when OpenAI returned tasks with `trait_code: INSIGHT` paired to the wrong pillar (`MIND`) even though `INSIGHT` belongs to `SOUL`. 
- The intent is to ensure trait/pillar mismatches are normalized automatically so downstream validation and onboarding don't fail.

### Description
- Removed the special-case bypass that prevented auto-fixing INSIGHT mismatches inside `normalizeAndValidatePayload` in `apps/api/src/lib/taskgen/runner.ts`. 
- Always normalize mismatched `pillar_code` to the trait's canonical pillar and set `stat_code` to the `trait_code` when a mismatch is detected. 
- Updated tests in `apps/api/src/lib/taskgen/runner.test.ts` to assert auto-fix behavior (renamed/changed assertions for the INSIGHT case) so the runner expects `INSIGHT` to be corrected to `SOUL` and `stat_code` to be `INSIGHT`.

### Testing
- Ran the spec with `cd apps/api && pnpm vitest src/lib/taskgen/runner.test.ts`, and the suite for that file passed: 14 tests passed (the INSIGHT auto-fix cases now succeed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21a37317083329155ff198ee1c9cd)