### PR TITLE
Auto-correct task pillar_code from trait mapping and report correction metrics

### DIFF
--- a/apps/api/src/services/debugTaskgenService.ts
+++ b/apps/api/src/services/debugTaskgenService.ts
@@ -612,10 +612,7 @@ function validatePayload(
     }
     const pillarForTrait = catalogs.traitToPillarCode.get(task.trait_code);
     if (pillarForTrait && pillarForTrait !== task.pillar_code) {
-      return {
-        valid: false,
-        errors: [`Trait ${task.trait_code} does not belong to pillar ${task.pillar_code}`],
-      };
+      task.pillar_code = pillarForTrait;
     }
     if (!catalogs.statCodes.has(task.stat_code)) {
       return { valid: false, errors: [`Invalid stat_code: ${task.stat_code}`] };

--- a/apps/api/src/services/taskgenTriggerService.ts
+++ b/apps/api/src/services/taskgenTriggerService.ts
@@ -319,13 +319,33 @@ function createInstrumentedRunner(options: {
       }
     },
     validateTasks: (payload, catalogs, placeholders, schema) => {
-      const result = baseDeps.validateTasks(payload, catalogs, placeholders, schema);
+      const repairedPayload = { ...payload };
+      let pillarCorrections = 0;
+      if (Array.isArray(payload.tasks)) {
+        repairedPayload.tasks = payload.tasks.map((task) => {
+          const expectedPillarCode = catalogs.traitToPillarCode?.get(task.trait_code);
+          if (!expectedPillarCode || expectedPillarCode === task.pillar_code) {
+            return task;
+          }
+          pillarCorrections += 1;
+          return {
+            ...task,
+            pillar_code: expectedPillarCode,
+          };
+        });
+      }
+
+      if (pillarCorrections > 0) {
+        payload.tasks = repairedPayload.tasks;
+      }
+
+      const result = baseDeps.validateTasks(repairedPayload, catalogs, placeholders, schema);
       const invalidTraitPillarPair =
-        result.valid || !Array.isArray(payload.tasks)
+        result.valid || !Array.isArray(repairedPayload.tasks)
           ? null
-          : payload.tasks
+          : repairedPayload.tasks
               .map((task) => {
-                const expectedPillarCode = catalogs.traitToPillarCode.get(task.trait_code);
+                const expectedPillarCode = catalogs.traitToPillarCode?.get(task.trait_code);
                 if (!expectedPillarCode || expectedPillarCode === task.pillar_code) {
                   return null;
                 }
@@ -344,9 +364,10 @@ function createInstrumentedRunner(options: {
         mode: options.mode,
         origin: options.origin,
         data: {
-          taskCount: payload.tasks?.length ?? 0,
+          taskCount: repairedPayload.tasks?.length ?? 0,
           errors: result.valid ? [] : result.errors,
           invalidTraitPillarPair,
+          pillarCorrections,
         },
       });
       return result;
@@ -619,6 +640,19 @@ async function runQuickStartManualTaskGeneration(args: {
     })
     .filter((task): task is NonNullable<typeof task> => task !== null);
 
+  const catalogTraitToPillar = context.catalogs.traitToPillarCode;
+  const adjustedTasks = normalizedTasks.map((task) => {
+    const expectedPillarCode = catalogTraitToPillar?.get(task.trait_code);
+    if (!expectedPillarCode || expectedPillarCode === task.pillar_code) {
+      return task;
+    }
+
+    return {
+      ...task,
+      pillar_code: expectedPillarCode,
+    };
+  });
+
   emitEvent({
     level: 'info',
     event: 'VALIDATION_OK',
@@ -626,11 +660,21 @@ async function runQuickStartManualTaskGeneration(args: {
     userId: args.userId,
     mode: args.mode,
     origin: args.origin,
-    data: { stage: 'quick_start normalized tasks', count: normalizedTasks.length },
+    data: {
+      stage: 'quick_start normalized tasks',
+      count: adjustedTasks.length,
+      pillarCorrections: adjustedTasks.reduce((acc, task, index) => {
+        const original = normalizedTasks[index];
+        if (original && original.pillar_code !== task.pillar_code) {
+          acc += 1;
+        }
+        return acc;
+      }, 0),
+    },
   });
 
   const tasks = assignBalancedDifficultiesByPillar({
-    tasks: normalizedTasks,
+    tasks: adjustedTasks,
     gameMode: normalizeGameModeForDifficultyEngine(gameModeCode),
     seed: `${args.userId}:${args.correlationId}`,
   });


### PR DESCRIPTION
### Motivation
- Validation should automatically reconcile tasks whose `trait_code` maps to a different pillar to avoid failing payloads for simple mismatches. 
- The system should record how often such automatic pillar corrections occur for observability. 
- The quick-start task generation path must use corrected pillar assignments before difficulty balancing to keep downstream logic consistent.

### Description
- In `debugTaskgenService.ts` validation no longer returns an error when `trait_code` maps to a different pillar and instead mutates `task.pillar_code` to the catalog's `traitToPillarCode` value. 
- In `taskgenTriggerService.ts` introduced `repairedPayload` which maps and fixes `pillar_code` for tasks, counts `pillarCorrections`, uses the repaired payload for `validateTasks`, and surfaces `pillarCorrections` and adjusted `taskCount` in emitted events. 
- In the quick-start flow the normalized tasks are adjusted using `catalogs.traitToPillarCode` before calling `assignBalancedDifficultiesByPillar`, and the validation event now reports the number of pillar corrections. 
- Added a few defensive optional-chaining checks when reading `traitToPillarCode` to avoid runtime errors.

### Testing
- Ran unit tests with `pnpm test` and all tests passed. 
- Performed a TypeScript build with `pnpm build` and there were no type errors. 
- Ran the linter with `pnpm lint` and reported no lint issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f224a81d088332a0320e84a1889708)