### PR TITLE
Adjust landing-v2 Spanish copy to use Avatar section and shorter messaging

### DIFF
--- a/apps/web/src/content/landingV2Content.ts
+++ b/apps/web/src/content/landingV2Content.ts
@@ -39,14 +39,14 @@ export const LANDING_V2_CONTENT: Record<Language, LandingCopy> = {
     },
     modes: {
       ...OFFICIAL_LANDING_CONTENT.es.modes,
-      kicker: 'SISTEMA DE RITMO SEMANAL',
-      title: 'Elegí un ritmo sostenible.',
-      intro: 'Cuatro intensidades para avanzar sin romperte.',
+      kicker: 'AVATARES DE INNERBLOOM',
+      title: 'Elige cómo quieres verte dentro del sistema.',
+      intro: 'Tu avatar acompaña tu experiencia, pero el centro sigue siendo tu progreso.',
       items: [
-        { id: 'low', title: 'LOW', state: '1× semana', goal: 'Empieza liviano.' },
-        { id: 'chill', title: 'CHILL', state: '2× semana', goal: 'Crea constancia.' },
-        { id: 'flow', title: 'FLOW', state: '3× semana', goal: 'Sostén impulso.' },
-        { id: 'evolve', title: 'EVOLVE', state: '4× semana', goal: 'Sube estructura.' },
+        { id: 'low', title: '🐈 RED CAT', state: '', goal: 'Energía visible para empezar con presencia.' },
+        { id: 'chill', title: '🐻 GREEN BEAR', state: '', goal: 'Estabilidad y calma para sostener el proceso.' },
+        { id: 'flow', title: '🦎 BLUE AMPHIBIAN', state: '', goal: 'Adaptabilidad para avanzar con flexibilidad.' },
+        { id: 'evolve', title: '🦉 VIOLET OWL', state: '', goal: 'Visión y criterio para subir de nivel.' },
       ],
     },
     pillars: {


### PR DESCRIPTION
### Motivation
- Provide the `/landing-v2` variant with shorter, mobile-first copy while preserving the official landing UI and structure. 
- Ensure the Spanish variant presents an explicit avatar section instead of the previous rhythm-oriented copy to match the requested content structure.

### Description
- Updated the Spanish overrides in `apps/web/src/content/landingV2Content.ts` to replace the `modes` (rhythm) copy with an `AVATARES DE INNERBLOOM` kicker, concise title/intro, and avatar items with short labels and goals. 
- Kept the variant content inheriting from `OFFICIAL_LANDING_CONTENT` so all visual/layout/CTA behavior remains unchanged. 
- No changes to components, styles, assets, routes, CTA destinations, or the official landing (`/`) were made; this is a content-only change.

### Testing
- Ran the web TypeScript check with `pnpm --filter @innerbloom/web typecheck`, which failed due to existing repository TypeScript errors unrelated to this copy-only change. 
- Built the web app with `pnpm --filter @innerbloom/web build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23f141ca083328f54ee0c92e40eac)