### PR TITLE
Align post-onboarding Moderation modal with Quick Start UI

### DIFF
--- a/apps/web/src/components/dashboard-v3/ModerationOnboardingSuggestion.tsx
+++ b/apps/web/src/components/dashboard-v3/ModerationOnboardingSuggestion.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from 'react';
+import { useMemo } from 'react';
 import type { ModerationTrackerType } from '../../lib/api';
 
 interface ModerationOnboardingSuggestionProps {
@@ -11,35 +11,11 @@ interface ModerationOnboardingSuggestionProps {
   isSubmitting?: boolean;
 }
 
-type TrackerChip = {
+type TrackerOption = {
   type: ModerationTrackerType;
+  icon: string;
   title: string;
-  subtitle?: string;
-};
-
-const trackerIcons: Record<ModerationTrackerType, ReactNode> = {
-  alcohol: (
-    <svg viewBox="0 0 24 24" fill="none" className="h-8 w-8" aria-hidden>
-      <path d="M8 3h8" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-      <path d="M10 3v4l-2.5 4v7a3 3 0 003 3h3a3 3 0 003-3v-7L14 7V3" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M8 11h8" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-    </svg>
-  ),
-  tobacco: (
-    <svg viewBox="0 0 24 24" fill="none" className="h-8 w-8" aria-hidden>
-      <path d="M3 14h11a2 2 0 012 2v1H3v-3z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M16 14h3a2 2 0 012 2v1h-3" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M18 10c0-1.4 1.1-2.5 2.5-2.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-      <path d="M20 11c0-2 1.6-3.5 3.5-3.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-    </svg>
-  ),
-  sugar: (
-    <svg viewBox="0 0 24 24" fill="none" className="h-8 w-8" aria-hidden>
-      <path d="M6 8l6-4 6 4v8l-6 4-6-4V8z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M6 8l6 4 6-4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M12 12v8" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-    </svg>
-  ),
+  description: string;
 };
 
 export function ModerationOnboardingSuggestion({
@@ -51,18 +27,59 @@ export function ModerationOnboardingSuggestion({
   onSkip,
   isSubmitting = false,
 }: ModerationOnboardingSuggestionProps) {
-  const chips = useMemo<TrackerChip[]>(
+  const options = useMemo<TrackerOption[]>(
     () => [
-      { type: 'alcohol', title: language === 'en' ? 'Alcohol' : 'Alcohol' },
-      { type: 'tobacco', title: language === 'en' ? 'Tobacco' : 'Tabaco' },
       {
         type: 'sugar',
+        icon: '🍬',
         title: language === 'en' ? 'Sugar' : 'Azúcar',
-        subtitle: language === 'en' ? 'added sugar' : 'azúcar añadido',
+        description:
+          language === 'en'
+            ? 'Track cravings and excess moments to improve decisions.'
+            : 'Registrar cuándo aparece antojo o exceso para mejorar decisiones.',
+      },
+      {
+        type: 'tobacco',
+        icon: '🚭',
+        title: language === 'en' ? 'Tobacco' : 'Tabaco',
+        description:
+          language === 'en'
+            ? 'Track usage and context to reduce sustainably.'
+            : 'Seguir consumo y contexto para recortar de forma sostenible.',
+      },
+      {
+        type: 'alcohol',
+        icon: '🍷',
+        title: 'Alcohol',
+        description:
+          language === 'en'
+            ? 'Observe frequency and moments to keep balance.'
+            : 'Observar frecuencia y momentos para mantener equilibrio.',
       },
     ],
     [language],
   );
+
+  const copy =
+    language === 'en'
+      ? {
+          title: 'Moderation',
+          subtitle: 'Choose what you want to track with more awareness.',
+          hint: 'No judgment: only tracking to find your own balance.',
+          flex: 'You can also use flexible tolerance settings (for example, weekends).',
+          skip: 'Not now',
+          confirm: 'Continue',
+          submitting: 'Continuing...',
+        }
+      : {
+          title: 'Moderación',
+          subtitle: 'Elegí qué querés observar con más consciencia.',
+          hint: 'Sin juicios: solo seguimiento para encontrar balance.',
+          flex: 'También podés manejar tolerancias flexibles (por ejemplo, fines de semana).',
+          skip: 'Ahora no',
+          confirm: 'Continuar',
+          submitting: 'Continuando...',
+        };
 
   if (!open) {
     return null;
@@ -70,57 +87,37 @@ export function ModerationOnboardingSuggestion({
 
   return (
     <div className="fixed inset-0 z-[95] flex items-end justify-center bg-slate-950/70 p-3 backdrop-blur-sm sm:items-center sm:p-6">
-      <section className="onboarding-surface-base w-full max-w-4xl rounded-3xl border border-white/15 p-5 text-white shadow-[0_30px_90px_rgba(3,9,32,0.7)] sm:p-7">
-        <div className="mb-5 space-y-2">
-          <h2 className="text-2xl font-semibold tracking-tight">{language === 'en' ? 'Add daily trackers' : 'Sumá trackers diarios'}</h2>
-          <p className="text-sm text-white/75">
-            {language === 'en'
-              ? 'One tap per day. You mark it in your Daily Quest.'
-              : 'Un toque por día. Lo marcás en tu Daily Quest.'}
-          </p>
-          <p className="text-xs font-medium tracking-wide text-[color:color-mix(in_srgb,var(--color-accent-secondary)_72%,white)]">
-            {language === 'en'
-              ? 'All trackers are selected by default. Tap to unselect any of them.'
-              : 'Todos los trackers están seleccionados por defecto. Tocá para desmarcar cualquiera.'}
-          </p>
-        </div>
+      <section className="onboarding-premium-root quickstart-premium-card onboarding-surface-base w-full max-w-3xl rounded-3xl p-5 sm:p-7">
+        <h2 className="text-2xl font-semibold text-white sm:text-3xl">{copy.title}</h2>
+        <p className="mt-2 text-sm text-white/70">{copy.subtitle}</p>
+        <p className="mt-2 text-xs text-white/55">{copy.hint}</p>
 
-        <div className="grid gap-3 sm:grid-cols-3">
-          {chips.map((chip) => {
-            const isSelected = selected.includes(chip.type);
+        <div className="mt-5 space-y-3">
+          {options.map((option) => {
+            const enabled = selected.includes(option.type);
             return (
               <button
+                key={option.type}
                 type="button"
-                key={chip.type}
-                onClick={() => onToggle(chip.type)}
-                title={chip.subtitle}
-                className={[
-                  'group rounded-2xl border p-4 text-left transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--color-accent-secondary)_75%,white)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
-                  isSelected
-                    ? 'border-[color:color-mix(in_srgb,var(--color-accent-secondary)_70%,white)] bg-[color:color-mix(in_srgb,var(--color-accent-secondary)_26%,var(--color-surface)_74%)] text-white shadow-[0_0_0_1px_color-mix(in_srgb,var(--color-accent-secondary)_34%,transparent),0_16px_30px_color-mix(in_srgb,var(--color-accent-secondary)_35%,transparent)]'
-                    : 'border-white/20 bg-[color:rgba(15,23,42,0.22)] text-white/88 hover:border-[color:color-mix(in_srgb,var(--color-accent-secondary)_45%,white)] hover:bg-[color:color-mix(in_srgb,var(--color-accent-secondary)_14%,var(--color-surface)_86%)] active:scale-[0.995] active:border-[color:color-mix(in_srgb,var(--color-accent-secondary)_62%,white)]',
-                ].join(' ')}
-                aria-pressed={isSelected}
+                onClick={() => onToggle(option.type)}
+                className={`quickstart-moderation-option flex w-full items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left transition ${enabled ? 'quickstart-moderation-option--enabled' : ''}`}
+                aria-pressed={enabled}
               >
-                <div className="mb-4 flex items-start justify-between text-white/90">
-                  {trackerIcons[chip.type]}
-                  <span
-                    className={[
-                      'rounded-full border px-2 py-0.5 text-xs font-semibold tracking-wide transition-colors',
-                      isSelected
-                        ? 'border-[color:color-mix(in_srgb,var(--color-accent-secondary)_58%,white)] bg-[color:color-mix(in_srgb,var(--color-accent-secondary)_42%,transparent)] text-white'
-                        : 'border-white/20 bg-white/5 text-white/80',
-                    ].join(' ')}
-                  >
-                    {isSelected ? (language === 'en' ? 'active' : 'activo') : language === 'en' ? 'off' : 'pausado'}
-                  </span>
+                <div>
+                  <p className="text-sm font-semibold text-white">
+                    {option.icon} {option.title}
+                  </p>
+                  <p className="mt-1 text-xs text-white/65">{option.description}</p>
                 </div>
-                <p className="text-lg font-semibold">{chip.title}</p>
-                {chip.subtitle ? <p className="text-xs text-white/65">{chip.subtitle}</p> : <div className="h-4" />}
+                <span className={`quickstart-moderation-toggle inline-flex h-5 w-10 shrink-0 items-center overflow-hidden rounded-full p-0.5 ${enabled ? 'quickstart-moderation-toggle--enabled' : ''}`}>
+                  <span className={`block h-4 w-4 shrink-0 rounded-full bg-white transition-transform ${enabled ? 'translate-x-[1.125rem]' : ''}`} />
+                </span>
               </button>
             );
           })}
         </div>
+
+        <p className="mt-4 text-xs text-white/65">{copy.flex}</p>
 
         <div className="mt-6 flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end">
           <button
@@ -129,15 +126,15 @@ export function ModerationOnboardingSuggestion({
             className="rounded-full px-4 py-2 text-sm font-medium text-white/75 transition hover:bg-white/10 hover:text-white"
             disabled={isSubmitting}
           >
-            {language === 'en' ? 'Not now' : 'Ahora no'}
+            {copy.skip}
           </button>
           <button
             type="button"
             onClick={onActivate}
-            disabled={isSubmitting || selected.length === 0}
-            className="rounded-full bg-[color:var(--color-accent-secondary)] px-5 py-2.5 text-sm font-semibold text-white shadow-[0_12px_24px_color-mix(in_srgb,var(--color-accent-secondary)_40%,transparent)] transition hover:bg-[color:color-mix(in_srgb,var(--color-accent-secondary)_82%,white)] active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--color-accent-secondary)_70%,white)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+            disabled={isSubmitting}
+            className="quickstart-primary-cta rounded-full px-5 py-2.5 text-sm font-semibold transition active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--color-accent-secondary)_70%,white)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
           >
-            {isSubmitting ? (language === 'en' ? 'Activating...' : 'Activando...') : language === 'en' ? 'Activate' : 'Activar'}
+            {isSubmitting ? copy.submitting : copy.confirm}
           </button>
         </div>
       </section>

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -619,6 +619,7 @@ export default function DashboardV3Page() {
 
   const handleActivateModerationSuggestion = useCallback(async () => {
     if (selectedModerationSuggestions.length === 0) {
+      resolveModerationSuggestion();
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Bring the post-onboarding `ModerationOnboardingSuggestion` modal visually and semantically in line with the Quick Start moderation screen without changing onboarding flow or backend behavior. 
- Replace the legacy large SVG cards and badge-style UI that had contrast/semantics issues with the compact emoji + description + switch pattern used by Quick Start.

### Description
- Replaced the old SVG-based card grid with a Quick Start style list using emojis (`🍬`, `🚭`, `🍷`), description text and right-side switch elements in `ModerationOnboardingSuggestion.tsx`, reusing `quickstart-moderation-option`, `quickstart-moderation-toggle`, `quickstart-primary-cta`, `quickstart-premium-card` and `onboarding-surface-base` styles. 
- Updated modal copy to match `QuickStartModerationStep.tsx` (ES/EN): title/subtitle/hint, per-option descriptions, footer hint and CTAs (`Ahora no` / `Continuar` / `Not now` / `Continue`) and the in-progress label. 
- Made the primary CTA only disabled while `isSubmitting` (removed the `selected.length === 0` disable rule) so users can continue without enabling any trackers. 
- Kept the component props surface (`open`, `language`, `selected`, `onToggle`, `onActivate`, `onSkip`, `isSubmitting`) intact for minimal API change. 
- Adjusted `handleActivateModerationSuggestion` in `DashboardV3.tsx` to call `resolveModerationSuggestion()` and close the modal when `selectedModerationSuggestions.length === 0`, and retain existing activation behavior when one or more trackers are selected.

### Testing
- Ran `npm run lint` and the lint step completed successfully. 
- Ran `npm run typecheck` which failed due to pre-existing TypeScript errors elsewhere in the repository and not introduced by this change (typecheck output contains unrelated errors in other files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2804d521c83329aa471d2478fe4c4)