### PR TITLE
Update level-up popup CTA copy and apply Innerbloom gradient to NotificationPopup CTA

### DIFF
--- a/apps/api/src/db/migrations/202501150001_feedback_in_app_notifications.sql
+++ b/apps/api/src/db/migrations/202501150001_feedback_in_app_notifications.sql
@@ -28,9 +28,9 @@ VALUES (
   'active',
   80,
   'Acabás de llegar al nivel {{level}}. Seguí así.',
-  'Ver recompensas',
+  'Revisar mis logros',
   '/dashboard-v3/rewards',
-  '{"level":"5","cta":"Ver recompensas"}',
+  '{"level":"5","cta":"Revisar mis logros"}',
   '{"title":"¡Subiste de nivel!","messageTemplate":"Acabás de llegar al nivel {{level}}. Seguí así.","emoji":"🏆"}'
 ),
 (

--- a/apps/web/src/components/feedback/NotificationPopup.tsx
+++ b/apps/web/src/components/feedback/NotificationPopup.tsx
@@ -106,7 +106,7 @@ export function NotificationPopup({
             <a
               href={cta.href ?? '#'}
               onClick={onCtaClick}
-              className="ib-feedback-popup-cta inline-flex w-full items-center justify-center rounded-2xl bg-gradient-to-r from-sky-400 via-indigo-400 to-fuchsia-400 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:opacity-95"
+              className="ib-feedback-popup-cta ib-daily-quest-innerbloom-gradient inline-flex w-full items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold text-white shadow-[var(--shadow-innerbloom-cta)] transition hover:opacity-95"
             >
               {cta.label}
             </a>


### PR DESCRIPTION
### Motivation
- Cambiar el texto visible del CTA del popup de subida de nivel a “Revisar mis logros” manteniendo la misma ruta y comportamiento del botón. 
- Alinear el estilo del CTA principal de `NotificationPopup` con el gradiente Innerbloom (violeta/lila/peach) reutilizando tokens/clases ya existentes.

### Description
- Actualicé `apps/api/src/db/migrations/202501150001_feedback_in_app_notifications.sql` cambiando `cta_label` de `'Ver recompensas'` a `'Revisar mis logros'` y actualicé el JSON `preview_variables` correspondiente.
- Modifiqué `apps/web/src/components/feedback/NotificationPopup.tsx` para usar la clase utilitaria `ib-daily-quest-innerbloom-gradient` y la sombra `var(--shadow-innerbloom-cta)` en el CTA principal, ajustando la clase `className` y el color de texto a blanco.
- No se cambió la ruta (`/dashboard-v3/rewards`), la lógica del botón, el botón de cerrar, la X ni el layout general.

### Testing
- Ejecuté `pnpm -C apps/web test -- NotificationPopup.test.tsx` como prueba objetivo; el runner ejecutó una porción amplia de la suite y mostró fallos preexistentes en tests no relacionados (por ejemplo `TaskEditorComponents`, `RewardsSection`, `useUserTasks`, `useDailyQuestReadiness`).
- No se identificaron fallos nuevos atribuibles a las modificaciones en `NotificationPopup.tsx` o al cambio de copy del CTA en la migración.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3eb018acc8332a55957d8cf85b7bd)