### PR TITLE
Add monthly maintenance watchdog to run missing monthly jobs on startup and interval

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,7 @@ import fastifyRawBody from 'fastify-raw-body';
 import app from './app.js';
 import { dbReady, endPool } from './db.js';
 import { logRegisteredRoutes } from './lib/route-logger.js';
+import { runMonthlyMaintenanceWatchdog } from './services/monthlyMaintenanceWatchdog.js';
 
 const fastify = Fastify({
   logger: true,
@@ -48,6 +49,22 @@ async function start(): Promise<void> {
     await configureServer;
     await fastify.listen({ port, host });
     fastify.log.info(`API listening on http://${host}:${port}`);
+
+    const watchdogEnabled = process.env.ENABLE_MONTHLY_WATCHDOG !== '0';
+    if (watchdogEnabled) {
+      void runMonthlyMaintenanceWatchdog(new Date()).catch((error: unknown) => {
+        fastify.log.error({ err: error }, 'Monthly maintenance watchdog failed on startup');
+      });
+
+      const intervalMs = 6 * 60 * 60 * 1000;
+      const interval = setInterval(() => {
+        void runMonthlyMaintenanceWatchdog(new Date()).catch((error: unknown) => {
+          fastify.log.error({ err: error }, 'Monthly maintenance watchdog failed on interval');
+        });
+      }, intervalMs);
+
+      interval.unref();
+    }
   } catch (error) {
     fastify.log.error({ err: error }, 'Unable to start server');
     process.exit(1);

--- a/apps/api/src/services/monthlyMaintenanceWatchdog.ts
+++ b/apps/api/src/services/monthlyMaintenanceWatchdog.ts
@@ -1,0 +1,64 @@
+import { pool } from '../db.js';
+import { runMonthlyTaskDifficultyCalibration } from './taskDifficultyCalibrationService.js';
+import { runUserMonthlyModeUpgradeAggregation } from './modeUpgradeMonthlyAggregationService.js';
+import { runMonthlyHabitAchievementDetection } from './habitAchievementService.js';
+
+const WATCHDOG_LOCK_KEY = 928374651;
+
+function toPeriodKey(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+function previousMonthPeriodKey(now: Date): string {
+  return toPeriodKey(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1)));
+}
+
+async function alreadyProcessed(periodKey: string): Promise<boolean> {
+  const result = await pool.query<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1
+         FROM user_monthly_mode_upgrade_stats
+        WHERE period_key = $1
+      ) AS exists`,
+    [periodKey],
+  );
+
+  return Boolean(result.rows[0]?.exists);
+}
+
+export async function runMonthlyMaintenanceWatchdog(now: Date = new Date()): Promise<void> {
+  const lock = await pool.query<{ locked: boolean }>('SELECT pg_try_advisory_lock($1) AS locked', [WATCHDOG_LOCK_KEY]);
+  const hasLock = Boolean(lock.rows[0]?.locked);
+
+  if (!hasLock) {
+    return;
+  }
+
+  try {
+    const periodKey = previousMonthPeriodKey(now);
+    const isAlreadyProcessed = await alreadyProcessed(periodKey);
+
+    if (isAlreadyProcessed) {
+      return;
+    }
+
+    const calibration = await runMonthlyTaskDifficultyCalibration(now);
+    const aggregation = await runUserMonthlyModeUpgradeAggregation({ now, periodKey });
+
+    await runMonthlyHabitAchievementDetection({
+      now,
+      periodStart: aggregation.periodStart,
+      nextPeriodStart: aggregation.nextPeriodStart,
+    });
+
+    console.info('[monthly-maintenance-watchdog] recovered missing monthly run', {
+      periodKey,
+      evaluated: calibration.evaluated,
+      adjusted: calibration.adjusted,
+      processed: aggregation.processed,
+    });
+  } finally {
+    await pool.query('SELECT pg_advisory_unlock($1)', [WATCHDOG_LOCK_KEY]);
+  }
+}
+


### PR DESCRIPTION
### Motivation

- Ensure monthly aggregation and maintenance tasks run even if a scheduled job was missed by detecting and recovering the previous month’s run.

### Description

- Introduce a new `runMonthlyMaintenanceWatchdog` service in `apps/api/src/services/monthlyMaintenanceWatchdog.ts` that acquires a Postgres advisory lock, checks whether the previous month was already processed, and invokes `runMonthlyTaskDifficultyCalibration`, `runUserMonthlyModeUpgradeAggregation`, and `runMonthlyHabitAchievementDetection` when recovery is necessary.
- Wire the watchdog into the API startup in `apps/api/src/index.ts` so it runs once on startup and then periodically every 6 hours, with the interval `unref()`-ed to avoid blocking shutdown. The watchdog can be disabled via the `ENABLE_MONTHLY_WATCHDOG` environment variable set to `0`.
- Use a constant advisory lock key (`WATCHDOG_LOCK_KEY`) to ensure only one instance performs recovery and always release the lock after the run; add basic logging for success/failure cases.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f85595ebbc8332ae1fb67a26275607)