### PR TITLE
Landing v2: Reorder & restyle problem orb on mobile with subtle float

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -3589,7 +3589,6 @@
 
   .landing .weather-cycle-orb {
     --orb-size: clamp(112px, 32vw, 148px);
-    order: -1;
   }
 
   .landing .truth-problem-title--outside {
@@ -3601,6 +3600,10 @@
   .landing .weather-icon,
   .landing .weather-cycle-orb__ambient {
     transition: none;
+  }
+
+  .landing .weather-cycle-orb.weather-cycle-orb--static {
+    animation: none;
   }
 }
 
@@ -3617,6 +3620,7 @@
   background: transparent;
   box-shadow: none;
   isolation: isolate;
+  animation: landing-orb-float 5s ease-in-out infinite alternate;
 }
 
 .landing .weather-cycle-orb.weather-cycle-orb--static::before,
@@ -3636,11 +3640,16 @@
 
 @media (max-width: 840px) {
   .landing .weather-cycle-orb.weather-cycle-orb--static {
-    width: clamp(165px, 48vw, 230px);
+    width: clamp(108px, 31vw, 150px);
   }
 
   .landing .weather-cycle-orb__image {
     width: 110%;
     height: 110%;
   }
+}
+
+@keyframes landing-orb-float {
+  0% { transform: translateY(-4px); }
+  100% { transform: translateY(4px); }
 }


### PR DESCRIPTION
### Motivation
- Ensure on mobile the circular day/night visual appears after the main title (`Tu vida cambia. Tu rutina debería acompañarte.`) and before the explanatory bullets to match the requested content order. 
- Remove the visible pill/card treatment so the orb appears “suelto” while preserving layout structure for desktop. 
- Reduce the orb footprint on small screens to improve proportion and avoid overlapping text, and add a subtle floating motion that respects `prefers-reduced-motion`.

### Description
- Removed the mobile `order: -1` for the orb and adjusted responsive layout so the content order on mobile is eyebrow → title → orb → bullets while keeping the desktop grid intact. 
- Kept the visual wrapper present for layout but ensured it is visually neutral by preserving `background: transparent`, `box-shadow: none`, and no pseudo-elements. 
- Reduced mobile orb size via `width: clamp(108px, 31vw, 150px)` to approximate a ~65% visual size on narrow viewports. 
- Added a subtle floating animation `@keyframes landing-orb-float` (`translateY(-4px)` ↔ `translateY(4px)`, `5s`, `ease-in-out`, `infinite alternate`) and disabled it under `@media (prefers-reduced-motion: reduce)`.
- Changes are scoped to `apps/web/src/pages/Landing.css` and apply to `/v2` because `LandingV2` reuses `Landing` (no copy/CTA/navigation changes). 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8dad0b4388332b322ee03a9f5cc0c)