### PR TITLE
Refine Landing V2: update problem copy, remove demo mockup and V2-scoped visual tweaks

### DIFF
--- a/apps/web/src/content/landingV2Content.ts
+++ b/apps/web/src/content/landingV2Content.ts
@@ -12,7 +12,7 @@ export const LANDING_V2_CONTENT: Record<Language, LandingCopy> = {
       alt: 'Mockup del dashboard real de Innerbloom en móvil.',
     },
     problem: {
-      title: 'Tu vida cambia. Tu rutina debería acompañarte.',
+      title: 'Si tu vida cambia, tu rutina debería acompañarte.',
       leftPrimary: 'Cuando arrancás',
       leftSecondary: 'Te ayuda a empezar con hábitos posibles.',
       rightPrimary: 'Cuando cuesta',
@@ -132,7 +132,7 @@ export const LANDING_V2_CONTENT: Record<Language, LandingCopy> = {
       alt: 'Innerbloom real dashboard phone mockup.',
     },
     problem: {
-      title: 'Your life changes. Your routine should keep up.',
+      title: 'When your life changes, your routine should keep up.',
       leftPrimary: 'When you begin',
       leftSecondary: 'It helps you start with habits you can actually sustain.',
       rightPrimary: 'When life gets hard',
@@ -180,7 +180,7 @@ export const LANDING_V2_CONTENT: Record<Language, LandingCopy> = {
     demo: {
       title: 'See how your Journey grows.',
       text: 'Tasks, GP, streaks, emotions, and balance in one experience that’s easy to follow.',
-      banner: 'Real product. Real progress.',
+      banner: 'Real product, real progress.',
       cta: 'View demo',
     },
     testimonials: {

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -3934,3 +3934,117 @@
     border-radius: 26px;
   }
 }
+
+/* V2-only refinements requested for the adaptive-life and demo sections. */
+.landing.landing--v2-narrative .truth-problem-section {
+  max-width: 1180px;
+}
+
+.landing.landing--v2-narrative .truth-problem-v2-stage {
+  width: min(1160px, 100%);
+  grid-template-columns: minmax(180px, 0.75fr) minmax(360px, 540px) minmax(180px, 0.75fr);
+  gap: clamp(12px, 2.2vw, 32px);
+}
+
+.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static {
+  width: clamp(405px, 38vw, 540px);
+  max-width: min(88vw, 540px);
+  border: none;
+  outline: none;
+  box-shadow: none;
+  background: transparent;
+  padding: 0;
+}
+
+.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static::before,
+.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static::after {
+  content: none;
+  display: none;
+}
+
+.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb__image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.landing.landing--v2-narrative .visible-progress-top--v2-text-only {
+  grid-template-columns: 1fr;
+  justify-items: center;
+  text-align: center;
+}
+
+.landing.landing--v2-narrative .visible-progress-top--v2-text-only .visible-progress-copy {
+  justify-items: center;
+  max-width: 760px;
+  padding-top: 0;
+  text-align: center;
+}
+
+.landing.landing--v2-narrative .visible-progress-top--v2-text-only .demo-title {
+  max-width: 18ch;
+}
+
+.landing.landing--v2-narrative .visible-progress-top--v2-text-only .demo-sub {
+  max-width: 58ch;
+}
+
+.landing.landing--v2-narrative .feature-showcase .container {
+  gap: clamp(12px, 1.5vw, 18px);
+}
+
+.landing.landing--v2-narrative .demo-bridge {
+  width: min(100%, 760px);
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: clamp(5px, 0.6vw, 7px) clamp(7px, 0.8vw, 10px);
+  gap: clamp(8px, 1vw, 12px);
+  border-radius: 999px;
+}
+
+.landing.landing--v2-narrative .demo-bridge::before {
+  inset: -3px 2px -4px;
+  border-radius: 999px;
+  filter: blur(8px);
+}
+
+.landing.landing--v2-narrative .demo-bridge::after {
+  border-radius: 999px;
+}
+
+.landing.landing--v2-narrative .demo-bridge-copy {
+  padding-left: clamp(8px, 1vw, 12px);
+  line-height: 1.25;
+}
+
+.landing.landing--v2-narrative .demo-actions .ib-primary-button {
+  padding: 0.48rem 0.9rem;
+  min-height: 34px;
+}
+
+@media (max-width: 840px) {
+  .landing.landing--v2-narrative .truth-problem-v2-stage {
+    grid-template-columns: 1fr;
+  }
+
+  .landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static {
+    width: clamp(285px, 76vw, 417px);
+    max-width: 92vw;
+  }
+
+  .landing.landing--v2-narrative .demo-bridge {
+    width: min(100%, 520px);
+    grid-template-columns: 1fr;
+    justify-items: center;
+    padding: 8px 9px;
+    gap: 7px;
+  }
+
+  .landing.landing--v2-narrative .demo-bridge-copy {
+    padding-left: 0;
+    text-align: center;
+  }
+
+  .landing.landing--v2-narrative .demo-actions {
+    justify-content: center;
+  }
+}

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -979,7 +979,9 @@ export default function LandingPage({
           id="demo"
         >
           <div className="container narrow">
-            <div className="visible-progress-top">
+            <div
+              className={`visible-progress-top ${isV2Narrative ? "visible-progress-top--v2-text-only" : ""}`}
+            >
               <div className="visible-progress-copy">
                 <AdaptiveText as="h2" className="demo-title">
                   {copy.demo.title}
@@ -989,7 +991,8 @@ export default function LandingPage({
                 </AdaptiveText>
               </div>
 
-              <div className="visible-progress-module" aria-hidden>
+              {!isV2Narrative ? (
+                <div className="visible-progress-module" aria-hidden>
                 <div className="visible-progress-viewport">
                   <div className="visible-progress-scene">
                     <div className="visible-scene-region visible-scene-region--balance visible-scene-fragment visible-scene-fragment--radar">
@@ -1293,7 +1296,8 @@ export default function LandingPage({
                     </div>
                   </div>
                 </div>
-              </div>
+                </div>
+              ) : null}
             </div>
 
             <div className="demo-bridge">


### PR DESCRIPTION
### Motivation
- Align V2 copy and visuals with the requested product direction for the adaptive-life/problem and demo sections while keeping the official `/` landing untouched. 
- Remove the right-side demo mockup for the V2 narrative variant so the demo area becomes text-first and the CTA remains intact.

### Description
- Copy: changed the V2 problem titles in Spanish and English to the requested phrasing in `apps/web/src/content/landingV2Content.ts` and adjusted the English demo banner punctuation. 
- Demo layout: hid the entire visual mockup/screenshot module when `variant === 'v2Narrative'` by conditionally rendering the visual block in `apps/web/src/pages/Landing.tsx` so the demo section shows centered title, subtitle and the CTA bar only. 
- Visual orb and CTA pill: added V2-scoped CSS in `apps/web/src/pages/Landing.css` to remove the wrapper border/outline/box-shadow/background/padding for the weather orb, increase its size (~50% larger in the V2 scope), keep the orb image `object-fit: contain`, and make the demo CTA bar compact and pill-shaped with mobile-friendly stacking. 
- Scope and routes: changes are guarded by the V2 narrative variant only; the official `/` route and behavior were not modified and no new routes were created. 
- Files modified: `apps/web/src/content/landingV2Content.ts`, `apps/web/src/pages/Landing.tsx`, `apps/web/src/pages/Landing.css`.

### Testing
- Started the dev server with `npm -w @innerbloom/web run dev` and verified `/` and `/v2` returned `200` via `curl` smoke checks. 
- Built the web app with `npm -w @innerbloom/web run build` which completed successfully; Vite/PostCSS produced existing warnings about CSS minification and chunk sizes but the build artifacts were created. 
- Ran `npm -w @innerbloom/web run typecheck` which failed due to pre-existing, unrelated TypeScript errors elsewhere in the repo (Clerk localization/runtime types, preview achievement typing, test expectations, and lib `replaceAll`/lib target), so typecheck errors are not caused by these landing changes. 
- Attempted visual verification with Playwright screenshots (desktop + mobile 390px) but browser download failed during `npx playwright install chromium` (CDN returned `403`), so automated screenshots could not be produced in this environment. 

Commit: `Refine landing V2 problem and demo sections` (changes staged and committed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb35fdeeac8332806dd8675e37745a)