### PR TITLE
Add admin monthly pipeline replay (user-scoped)

### DIFF
--- a/apps/api/src/modules/admin/admin.handlers.ts
+++ b/apps/api/src/modules/admin/admin.handlers.ts
@@ -107,6 +107,15 @@ const jobIdParamSchema = z.object({
 const reminderSendBody = reminderSendBodySchema.default({ channel: 'email' });
 const feedbackDefinitionParamsSchema = z.object({ id: z.string().min(1) });
 
+const monthlyPipelineRunBodySchema = z.object({
+  periodKey: z
+    .string()
+    .trim()
+    .regex(/^\d{4}-\d{2}$/, { message: 'periodKey must be YYYY-MM' }),
+  force: z.coerce.boolean().default(false),
+  userId: z.string().uuid({ message: 'Invalid user id' }).optional(),
+});
+
 export const getAdminUsers = asyncHandler(async (req: Request, res: Response) => {
   const query = listUsersQuerySchema.parse(req.query);
   const result = await listUsers(query);
@@ -451,11 +460,12 @@ export const getAdminMonthlyPipelineStatus = asyncHandler(async (req: Request, r
 });
 
 export const postAdminMonthlyPipelineRun = asyncHandler(async (req: Request, res: Response) => {
-  const periodKey = String(req.body?.periodKey ?? '');
-  const force = Boolean(req.body?.force ?? false);
-  if (!/^\d{4}-\d{2}$/.test(periodKey)) {
-    throw new HttpError(400, 'invalid_period_key', 'periodKey must be YYYY-MM');
-  }
-  const result = await runMonthlyPipelineForPeriod({ periodKey, force, now: new Date() });
+  const body = monthlyPipelineRunBodySchema.parse(req.body ?? {});
+  const result = await runMonthlyPipelineForPeriod({
+    periodKey: body.periodKey,
+    force: body.force,
+    userId: body.userId,
+    now: new Date(),
+  });
   res.json({ ok: true, ...result });
 });

--- a/apps/api/src/modules/admin/admin.routes.test.ts
+++ b/apps/api/src/modules/admin/admin.routes.test.ts
@@ -17,6 +17,7 @@ const {
   mockResolveModeById,
   mockChangeUserGameMode,
   mockRunRetroactiveHabitAchievement,
+  mockRunMonthlyPipelineForPeriod,
 } = vi.hoisted(() => ({
   mockQuery: vi.fn<(sql: string, params?: unknown[]) => Promise<{ rows: QueryRow[] }>>(),
   authMiddlewareMock: (req: Request, _res: Response, next: NextFunction) => {
@@ -79,6 +80,23 @@ const {
     ignored: 1,
     errors: 0,
   })),
+  mockRunMonthlyPipelineForPeriod: vi.fn(async (params: { periodKey: string; force?: boolean; userId?: string; now?: Date }) => ({
+    periodKey: params.periodKey,
+    attempt: 2,
+    userId: params.userId ?? null,
+    calibration: { evaluated: 3, adjusted: 1, skipped: 0, ignored: 0, actionBreakdown: { up: 1, keep: 1, down: 1 }, errors: [] },
+    aggregation: { periodKey: params.periodKey, periodStart: '2026-04-01', nextPeriodStart: '2026-05-01', scope: params.userId ? 'single_user' : 'all_users', processed: params.userId ? 1 : 3, persisted: params.userId ? 1 : 3 },
+    habitAchievement: {
+      expiredResolved: 0,
+      evaluated: 1,
+      qualified: 1,
+      pendingCreated: 1,
+      skipped: 0,
+      ignored: 0,
+      errors: 0,
+      outcomes: [{ taskId: 'task-1', userId: params.userId ?? 'user-1', outcome: 'qualified_pending_created', reason: null, detectedPeriodEnd: '2026-04-30', monthsEvaluated: 3, sources: ['cron'] }],
+    },
+  })),
 }));
 
 vi.mock('../../db.js', () => ({
@@ -130,6 +148,11 @@ vi.mock('../../services/habitAchievementService.js', () => ({
   runRetroactiveHabitAchievementDetection: (...args: unknown[]) => mockRunRetroactiveHabitAchievement(...args),
 }));
 
+vi.mock('../../services/monthlyPipelineService.js', () => ({
+  getMonthlyPipelineStatus: vi.fn(async () => null),
+  runMonthlyPipelineForPeriod: (...args: unknown[]) => mockRunMonthlyPipelineForPeriod(...args),
+}));
+
 import app from '../../app.js';
 
 describe('Admin routes', () => {
@@ -144,6 +167,7 @@ describe('Admin routes', () => {
     mockResolveModeById.mockClear();
     mockChangeUserGameMode.mockClear();
     mockRunRetroactiveHabitAchievement.mockClear();
+    mockRunMonthlyPipelineForPeriod.mockClear();
     mockTrigger.mockReturnValue('corr-force');
     clearTaskgenEvents();
     mockQuery.mockImplementation(async (sql: string) => {
@@ -898,6 +922,64 @@ describe('Admin routes', () => {
     expect(mockRunModeUpgradeAggregation).toHaveBeenCalledWith({
       userId: '00000000-0000-4000-8000-000000000001',
       periodKey: '2026-01',
+    });
+  });
+
+
+
+  it('runs monthly pipeline replay with force=true for all users', async () => {
+    const response = await request(app)
+      .post('/api/admin/monthly-pipeline/run')
+      .set('Authorization', 'Bearer token')
+      .send({ periodKey: '2026-04', force: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      periodKey: '2026-04',
+      userId: null,
+      habitAchievement: {
+        evaluated: 1,
+        qualified: 1,
+        pendingCreated: 1,
+        skipped: 0,
+        ignored: 0,
+        errors: 0,
+      },
+    });
+    expect(mockRunMonthlyPipelineForPeriod).toHaveBeenCalledWith({
+      periodKey: '2026-04',
+      force: true,
+      userId: undefined,
+      now: expect.any(Date),
+    });
+  });
+
+  it('runs monthly pipeline replay with force=true for a selected user', async () => {
+    const response = await request(app)
+      .post('/api/admin/monthly-pipeline/run')
+      .set('Authorization', 'Bearer token')
+      .send({ periodKey: '2026-04', force: true, userId: '00000000-0000-4000-8000-000000000001' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      periodKey: '2026-04',
+      userId: '00000000-0000-4000-8000-000000000001',
+      habitAchievement: {
+        outcomes: [
+          expect.objectContaining({
+            userId: '00000000-0000-4000-8000-000000000001',
+            outcome: 'qualified_pending_created',
+          }),
+        ],
+      },
+    });
+    expect(mockRunMonthlyPipelineForPeriod).toHaveBeenCalledWith({
+      periodKey: '2026-04',
+      force: true,
+      userId: '00000000-0000-4000-8000-000000000001',
+      now: expect.any(Date),
     });
   });
 

--- a/apps/api/src/services/__tests__/monthlyPipelineService.test.ts
+++ b/apps/api/src/services/__tests__/monthlyPipelineService.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockQuery,
+  mockRunMonthlyCalibration,
+  mockRunMonthlyCalibrationForUser,
+  mockRunModeUpgradeAggregation,
+  mockRunMonthlyHabitAchievementDetection,
+} = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockRunMonthlyCalibration: vi.fn(async () => ({
+    evaluated: 10,
+    adjusted: 2,
+    skipped: 1,
+    ignored: 0,
+    actionBreakdown: { up: 1, keep: 7, down: 2 },
+    errors: [],
+  })),
+  mockRunMonthlyCalibrationForUser: vi.fn(async () => ({
+    evaluated: 1,
+    adjusted: 1,
+    skipped: 0,
+    ignored: 0,
+    actionBreakdown: { up: 0, keep: 0, down: 1 },
+    errors: [],
+  })),
+  mockRunModeUpgradeAggregation: vi.fn(async (options: { periodKey: string; userId?: string }) => ({
+    periodKey: options.periodKey,
+    periodStart: '2026-04-01',
+    nextPeriodStart: '2026-05-01',
+    scope: options.userId ? 'single_user' : 'all_users',
+    processed: options.userId ? 1 : 5,
+    persisted: options.userId ? 1 : 5,
+  })),
+  mockRunMonthlyHabitAchievementDetection: vi.fn(async () => ({
+    expiredResolved: 0,
+    evaluated: 1,
+    qualified: 1,
+    pendingCreated: 1,
+    skipped: 0,
+    ignored: 0,
+    errors: 0,
+    outcomes: [
+      {
+        taskId: 'task-1',
+        userId: '00000000-0000-4000-8000-000000000001',
+        outcome: 'qualified_pending_created',
+        reason: null,
+        detectedPeriodEnd: '2026-04-30',
+        monthsEvaluated: 3,
+        sources: ['cron'],
+      },
+    ],
+  })),
+}));
+
+vi.mock('../../db.js', () => ({
+  pool: { query: (...args: unknown[]) => mockQuery(...args) },
+}));
+
+vi.mock('../taskDifficultyCalibrationService.js', () => ({
+  runMonthlyTaskDifficultyCalibration: (...args: unknown[]) => mockRunMonthlyCalibration(...args),
+  runMonthlyTaskDifficultyCalibrationForUser: (...args: unknown[]) => mockRunMonthlyCalibrationForUser(...args),
+}));
+
+vi.mock('../modeUpgradeMonthlyAggregationService.js', () => ({
+  runUserMonthlyModeUpgradeAggregation: (...args: unknown[]) => mockRunModeUpgradeAggregation(...args),
+}));
+
+vi.mock('../habitAchievementService.js', () => ({
+  runMonthlyHabitAchievementDetection: (...args: unknown[]) => mockRunMonthlyHabitAchievementDetection(...args),
+}));
+
+import { runMonthlyPipelineForPeriod } from '../monthlyPipelineService.js';
+
+describe('runMonthlyPipelineForPeriod', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockRunMonthlyCalibration.mockClear();
+    mockRunMonthlyCalibrationForUser.mockClear();
+    mockRunModeUpgradeAggregation.mockClear();
+    mockRunMonthlyHabitAchievementDetection.mockClear();
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes('pg_try_advisory_lock')) return { rows: [{ locked: true }] };
+      if (sql.includes('SELECT status, attempt_count FROM monthly_pipeline_runs')) {
+        return { rows: [{ status: 'succeeded', attempt_count: 1 }] };
+      }
+      return { rows: [] };
+    });
+  });
+
+  it('reruns a succeeded period with force=true for all users', async () => {
+    const now = new Date('2026-05-06T00:00:00.000Z');
+    const result = await runMonthlyPipelineForPeriod({ periodKey: '2026-04', force: true, now });
+
+    expect(result).toMatchObject({ periodKey: '2026-04', attempt: 2, userId: null });
+    expect(mockRunMonthlyCalibration).toHaveBeenCalledWith(now);
+    expect(mockRunMonthlyCalibrationForUser).not.toHaveBeenCalled();
+    expect(mockRunModeUpgradeAggregation).toHaveBeenCalledWith({ now, periodKey: '2026-04', userId: undefined });
+    expect(mockRunMonthlyHabitAchievementDetection).toHaveBeenCalledWith({
+      now,
+      periodStart: '2026-04-01',
+      nextPeriodStart: '2026-05-01',
+      userId: undefined,
+    });
+  });
+
+  it('propagates userId to user-scoped monthly stages', async () => {
+    const now = new Date('2026-05-06T00:00:00.000Z');
+    const userId = '00000000-0000-4000-8000-000000000001';
+    const result = await runMonthlyPipelineForPeriod({ periodKey: '2026-04', force: true, userId, now });
+
+    expect(result).toMatchObject({ periodKey: '2026-04', attempt: 2, userId });
+    expect(mockRunMonthlyCalibration).not.toHaveBeenCalled();
+    expect(mockRunMonthlyCalibrationForUser).toHaveBeenCalledWith({ userId, now });
+    expect(mockRunModeUpgradeAggregation).toHaveBeenCalledWith({ now, periodKey: '2026-04', userId });
+    expect(mockRunMonthlyHabitAchievementDetection).toHaveBeenCalledWith({
+      now,
+      periodStart: '2026-04-01',
+      nextPeriodStart: '2026-05-01',
+      userId,
+    });
+  });
+});

--- a/apps/api/src/services/monthlyPipelineService.ts
+++ b/apps/api/src/services/monthlyPipelineService.ts
@@ -1,5 +1,8 @@
 import { pool } from '../db.js';
-import { runMonthlyTaskDifficultyCalibration } from './taskDifficultyCalibrationService.js';
+import {
+  runMonthlyTaskDifficultyCalibration,
+  runMonthlyTaskDifficultyCalibrationForUser,
+} from './taskDifficultyCalibrationService.js';
 import { runUserMonthlyModeUpgradeAggregation } from './modeUpgradeMonthlyAggregationService.js';
 import { runMonthlyHabitAchievementDetection } from './habitAchievementService.js';
 
@@ -34,9 +37,10 @@ async function upsertPendingRun(periodKey: string): Promise<void> {
   );
 }
 
-export async function runMonthlyPipelineForPeriod(params: { periodKey?: string; now?: Date; force?: boolean }) {
+export async function runMonthlyPipelineForPeriod(params: { periodKey?: string; now?: Date; force?: boolean; userId?: string }) {
   const now = params.now ?? new Date();
   const periodKey = params.periodKey ?? previousMonthPeriodKey(now);
+  const userId = params.userId;
   const lockKey = lockKeyForPeriod(periodKey);
   const lock = await pool.query<{ locked: boolean }>('SELECT pg_try_advisory_lock($1) AS locked', [lockKey]);
   if (!lock.rows[0]?.locked) return { periodKey, skipped: true, reason: 'period_locked' as const };
@@ -71,19 +75,26 @@ export async function runMonthlyPipelineForPeriod(params: { periodKey?: string; 
 
     stage = 'growth_calibration';
     console.info('[monthly-pipeline] stage started', { periodKey, stage, attempt });
-    const calibration = await runMonthlyTaskDifficultyCalibration(now);
+    const calibration = userId
+      ? await runMonthlyTaskDifficultyCalibrationForUser({ userId, now })
+      : await runMonthlyTaskDifficultyCalibration(now);
     metadata.calibration = calibration;
     console.info('[monthly-pipeline] stage completed', { periodKey, stage, attempt, evaluated: calibration.evaluated, adjusted: calibration.adjusted });
 
     stage = 'mode_upgrade_aggregation';
     console.info('[monthly-pipeline] stage started', { periodKey, stage, attempt });
-    const aggregation = await runUserMonthlyModeUpgradeAggregation({ now, periodKey });
+    const aggregation = await runUserMonthlyModeUpgradeAggregation({ now, periodKey, userId });
     metadata.aggregation = aggregation;
     console.info('[monthly-pipeline] stage completed', { periodKey, stage, attempt, processed: aggregation.processed });
 
     stage = 'habit_achievement';
     console.info('[monthly-pipeline] stage started', { periodKey, stage, attempt });
-    const habit = await runMonthlyHabitAchievementDetection({ now, periodStart: aggregation.periodStart, nextPeriodStart: aggregation.nextPeriodStart });
+    const habit = await runMonthlyHabitAchievementDetection({
+      now,
+      periodStart: aggregation.periodStart,
+      nextPeriodStart: aggregation.nextPeriodStart,
+      userId,
+    });
     metadata.habitAchievement = habit;
     console.info('[monthly-pipeline] stage completed', {
       periodKey,
@@ -104,7 +115,7 @@ export async function runMonthlyPipelineForPeriod(params: { periodKey?: string; 
       [periodKey, stage, JSON.stringify(metadata)],
     );
     console.info('[monthly-pipeline] succeeded', { periodKey, attempt });
-    return { periodKey, attempt, calibration, aggregation, habitAchievement: habit };
+    return { periodKey, attempt, userId: userId ?? null, calibration, aggregation, habitAchievement: habit };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown_error';
     await pool.query(

--- a/apps/web/src/lib/adminApi.ts
+++ b/apps/web/src/lib/adminApi.ts
@@ -8,6 +8,7 @@ import type {
   AdminModeUpgradeCtaOverride,
   AdminHabitAchievementRetroactiveRunResponse,
   AdminHabitAchievementDiagnosticsResponse,
+  AdminMonthlyPipelineRunResponse,
   AdminUser,
   AdminUserSubscriptionResponse,
   SubscriptionStatus,
@@ -238,6 +239,35 @@ export async function clearAdminModeUpgradeCtaOverride(userId: string) {
   }
 
   return response.json() as Promise<{ ok: boolean }>;
+}
+
+
+export async function runAdminMonthlyPipeline(payload: { periodKey: string; force?: boolean; userId?: string }) {
+  const url = buildApiUrl('/admin/monthly-pipeline/run');
+  const response = await apiAuthorizedFetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      periodKey: payload.periodKey,
+      force: payload.force,
+      userId: payload.userId,
+    }),
+  });
+
+  if (!response.ok) {
+    let body: unknown = null;
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+    throw new ApiError(response.status, body, url);
+  }
+
+  return response.json() as Promise<AdminMonthlyPipelineRunResponse>;
 }
 
 export async function runAdminMonthlyReview(userId: string) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -237,6 +237,42 @@ export type AdminModeUpgradeAnalysis = {
   tasks: AdminModeUpgradeTask[];
 };
 
+
+export type AdminMonthlyPipelineRunResponse = {
+  ok: boolean;
+  periodKey: string;
+  attempt?: number;
+  skipped?: boolean;
+  reason?: 'period_locked' | 'already_succeeded';
+  userId?: string | null;
+  calibration?: {
+    evaluated: number;
+    adjusted: number;
+    skipped: number;
+    ignored: number;
+    actionBreakdown: { up: number; keep: number; down: number };
+    errors: unknown[];
+  };
+  aggregation?: {
+    periodKey: string;
+    periodStart: string;
+    nextPeriodStart: string;
+    scope: 'single_user' | 'all_users';
+    processed: number;
+    persisted: number;
+  };
+  habitAchievement?: {
+    expiredResolved: number;
+    evaluated: number;
+    qualified: number;
+    pendingCreated: number;
+    skipped: number;
+    ignored: number;
+    errors: number;
+    outcomes: AdminHabitAchievementTaskOutcome[];
+  };
+};
+
 export type AdminHabitAchievementRetroactiveRunResponse = {
   ok: boolean;
   source: 'admin_retroactive_habit_achievement';

--- a/apps/web/src/pages/admin2/CoreEnginePage.tsx
+++ b/apps/web/src/pages/admin2/CoreEnginePage.tsx
@@ -13,6 +13,7 @@ import {
   fetchAdminModeUpgradeCtaOverride,
   runAdminHabitAchievementRetroactive,
   runAdminModeUpgradeAnalysis,
+  runAdminMonthlyPipeline,
   runAdminMonthlyReview,
   runAdminTaskDifficultyCalibration,
   upsertAdminModeUpgradeCtaOverride,
@@ -29,6 +30,12 @@ const NEXT_MODE_BY_CODE: Record<'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE', 'CHILL' | '
   FLOW: 'EVOLVE',
   EVOLVE: null,
 };
+
+
+function getLastClosedMonthPeriodKey(now = new Date()): string {
+  const previousMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+  return `${previousMonth.getUTCFullYear()}-${String(previousMonth.getUTCMonth() + 1).padStart(2, '0')}`;
+}
 
 function normalizeMode(value: string | null | undefined): 'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE' | null {
   const normalized = (value ?? '').trim().toUpperCase();
@@ -60,6 +67,13 @@ export function CoreEnginePage() {
   const [analysisError, setAnalysisError] = useState<string | null>(null);
   const [runningMonthly, setRunningMonthly] = useState(false);
   const [runningRolling, setRunningRolling] = useState(false);
+
+  const [pipelinePeriodKey, setPipelinePeriodKey] = useState(() => getLastClosedMonthPeriodKey());
+  const [pipelineForce, setPipelineForce] = useState(true);
+  const [pipelineRunAllUsers, setPipelineRunAllUsers] = useState(false);
+  const [runningPipeline, setRunningPipeline] = useState(false);
+  const [pipelineResult, setPipelineResult] = useState<Awaited<ReturnType<typeof runAdminMonthlyPipeline>> | null>(null);
+  const [pipelineError, setPipelineError] = useState<string | null>(null);
 
   const [manualModeTarget, setManualModeTarget] = useState<'LOW' | 'CHILL' | 'FLOW' | 'EVOLVE'>('LOW');
   const [manualModeReason, setManualModeReason] = useState('admin_override_manual_mode_change');
@@ -175,6 +189,30 @@ export function CoreEnginePage() {
   useEffect(() => {
     void loadHabitDiagnostics();
   }, [loadHabitDiagnostics]);
+
+
+  const runMonthlyPipelineReplay = useCallback(async () => {
+    if (!selectedUser && !pipelineRunAllUsers) return;
+    setRunningPipeline(true);
+    setPipelineError(null);
+    try {
+      const result = await runAdminMonthlyPipeline({
+        periodKey: pipelinePeriodKey,
+        force: pipelineForce,
+        userId: pipelineRunAllUsers ? undefined : selectedUser?.id,
+      });
+      setPipelineResult(result);
+      if (!pipelineRunAllUsers && selectedUser) {
+        await loadModeData();
+        await loadHabitDiagnostics();
+      }
+    } catch (error) {
+      console.error(error);
+      setPipelineError('No se pudo reejecutar el monthly pipeline.');
+    } finally {
+      setRunningPipeline(false);
+    }
+  }, [loadHabitDiagnostics, loadModeData, pipelineForce, pipelinePeriodKey, pipelineRunAllUsers, selectedUser]);
 
   const runMonthly = useCallback(async () => {
     if (!selectedUser) return;
@@ -323,6 +361,79 @@ export function CoreEnginePage() {
             </button>
           </article>
         </div>
+
+
+        <article className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4 text-sm">
+          <h3 className="font-semibold">Monthly Pipeline Replay</h3>
+          <p className="text-xs text-[color:var(--admin-muted)]">
+            Reejecuta el mismo circuito mensual del cron para un período cerrado. Útil para validar Habit Achievement y Rhythm Upgrade con force=true.
+          </p>
+          <div className="mt-3 grid gap-3 text-xs md:grid-cols-4">
+            <label className="flex flex-col gap-1">
+              <span className="text-[color:var(--admin-muted)]">periodKey</span>
+              <input
+                value={pipelinePeriodKey}
+                onChange={(event) => setPipelinePeriodKey(event.target.value)}
+                placeholder="YYYY-MM"
+                className="rounded border border-[color:var(--admin-border)] bg-transparent px-2 py-1"
+              />
+            </label>
+            <label className="flex items-center gap-2 self-end">
+              <input type="checkbox" checked={pipelineForce} onChange={(event) => setPipelineForce(event.target.checked)} />
+              force
+            </label>
+            <label className="flex items-center gap-2 self-end">
+              <input type="checkbox" checked={pipelineRunAllUsers} onChange={(event) => setPipelineRunAllUsers(event.target.checked)} />
+              correr para todos
+            </label>
+            <p className="self-end rounded border border-[color:var(--admin-border)] px-2 py-1">
+              scope: <strong>{pipelineRunAllUsers ? 'all_users' : selectedUser?.id ?? 'sin selección'}</strong>
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void runMonthlyPipelineReplay()}
+            disabled={runningPipeline || (!selectedUser && !pipelineRunAllUsers) || !/^\d{4}-\d{2}$/.test(pipelinePeriodKey)}
+            className={`mt-3 ${BTN_PRIMARY}`}
+          >
+            {runningPipeline ? 'Running…' : 'Force Monthly Pipeline'}
+          </button>
+          {pipelineError ? <p className="mt-2 text-xs text-red-300">{pipelineError}</p> : null}
+          {pipelineResult ? (
+            <div className="mt-3 rounded-lg border border-[color:var(--admin-border)] p-3 text-xs">
+              <div className="grid gap-2 md:grid-cols-4">
+                <p>periodKey: <strong>{pipelineResult.periodKey}</strong></p>
+                <p>attempt: <strong>{pipelineResult.attempt ?? '—'}</strong></p>
+                <p>userId: <strong>{pipelineResult.userId ?? 'all_users'}</strong></p>
+                <p>skipped: <strong>{pipelineResult.skipped ? pipelineResult.reason ?? 'yes' : 'no'}</strong></p>
+                <p>calibration evaluated: <strong>{pipelineResult.calibration?.evaluated ?? '—'}</strong></p>
+                <p>aggregation processed: <strong>{pipelineResult.aggregation?.processed ?? '—'}</strong></p>
+                <p>aggregation scope: <strong>{pipelineResult.aggregation?.scope ?? '—'}</strong></p>
+              </div>
+              {pipelineResult.habitAchievement ? (
+                <div className="mt-3 rounded border border-[color:var(--admin-border)] p-2">
+                  <p className="font-semibold">Habit Achievement</p>
+                  <p>
+                    evaluated {pipelineResult.habitAchievement.evaluated} · qualified {pipelineResult.habitAchievement.qualified} · pendingCreated {pipelineResult.habitAchievement.pendingCreated}
+                  </p>
+                  <p>
+                    skipped {pipelineResult.habitAchievement.skipped} · ignored {pipelineResult.habitAchievement.ignored} · errors {pipelineResult.habitAchievement.errors}
+                  </p>
+                  {pipelineResult.habitAchievement.outcomes?.length ? (
+                    <div className="mt-2 max-h-36 overflow-auto rounded border border-[color:var(--admin-border)] p-2">
+                      <p className="font-semibold">first outcomes</p>
+                      {pipelineResult.habitAchievement.outcomes.slice(0, 12).map((outcome) => (
+                        <p key={`${outcome.taskId}-${outcome.outcome}-${outcome.detectedPeriodEnd ?? 'none'}`} className="text-[11px] text-[color:var(--admin-muted)]">
+                          {outcome.taskId}: {outcome.outcome} · {outcome.reason ?? 'ok'} · {outcome.detectedPeriodEnd ?? '—'} · {outcome.sources.join('+')}
+                        </p>
+                      ))}
+                    </div>
+                  ) : <p className="mt-2 text-[11px] text-[color:var(--admin-muted)]">No outcomes returned.</p>}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </article>
 
         <article className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4 text-sm">
           <div className="flex items-center justify-between gap-2">


### PR DESCRIPTION
### Motivation
- Proveer desde el admin una forma de reejecutar el pipeline mensual usando el mismo circuito del cron y poder apuntarlo a un usuario específico cuando corresponda.
- Permitir forzar reejecuciones (`force=true`) sobre períodos ya `succeeded` y mostrar resultados de Habit Achievement/Mode Upgrade en la UI para validar outcomes (por ejemplo `qualified_pending_created`).

### Description
- Extiende `runMonthlyPipelineForPeriod(params)` para aceptar `userId?: string`, propagar `userId` a stages user-scoped y usar `runMonthlyTaskDifficultyCalibrationForUser({ userId, now })` cuando aplica, además de pasar `userId` a `runUserMonthlyModeUpgradeAggregation` y `runMonthlyHabitAchievementDetection`.
- Añade validación de body en admin y manejo de la ruta: crea `monthlyPipelineRunBodySchema` y actualiza `postAdminMonthlyPipelineRun` para parsear `periodKey`, `force` y `userId` y llamar `runMonthlyPipelineForPeriod({ periodKey, force, userId, now })`.
- Tests backend: agrega `apps/api/src/services/__tests__/monthlyPipelineService.test.ts` y actualiza `apps/api/src/modules/admin/admin.routes.test.ts` para cubrir `force=true` sin `userId` y con `userId`, y para verificar que Habit Achievement recibe `userId` y que outcomes contienen `qualified_pending_created` cuando corresponde.
- Frontend: añade helper `runAdminMonthlyPipeline` en `apps/web/src/lib/adminApi.ts`, el tipo `AdminMonthlyPipelineRunResponse` en `apps/web/src/lib/types.ts`, y un bloque UI “Monthly Pipeline Replay” en `apps/web/src/pages/admin2/CoreEnginePage.tsx` con `periodKey` por defecto al último mes cerrado, `force` checkbox, scope (todos o usuario seleccionado), botón `Force Monthly Pipeline` y vista de métricas/outcomes.

### Testing
- Ejecutado `tsc --noEmit` para `@innerbloom/api` con éxito.
- Ejecutado `eslint` para `@innerbloom/api` con éxito.
- Ejecutados tests unitarios relevantes con `vitest` (files `monthlyPipelineService.test.ts` y `admin.routes.test.ts`) y ambos tests pasaron; en total los tests ejecutados en esta sesión pasaron (`24 passed`).
- `tsc --noEmit` para `@innerbloom/web` falló por errores TypeScript preexistentes no relacionados en la app web, pero las adiciones (`adminApi`, `types`, `CoreEnginePage`) fueron integradas y validadas localmente en el flujo de cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb35d7d0cc83329f8f0e3751156748)