### PR TITLE
Use existing paso1 image for Landing V2 step 1 visual

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -3823,6 +3823,50 @@
   -webkit-backdrop-filter: blur(14px);
 }
 
+.landing .v2-method-visual--image {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  overflow: visible;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.landing .v2-method-visual.v2-method-visual--image::before,
+.landing .v2-method-visual.v2-method-visual--image::after {
+  content: none;
+}
+
+.landing .v2-method-visual-image {
+  display: block;
+  width: min(100%, 520px);
+  height: auto;
+  object-fit: contain;
+  animation: v2-method-step-image-float 5.5s ease-in-out infinite;
+  will-change: transform;
+}
+
+@keyframes v2-method-step-image-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-12px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing .v2-method-visual-image {
+    animation: none;
+  }
+}
+
 .landing .v2-method-visual::before {
   content: "";
   position: absolute;
@@ -3850,6 +3894,14 @@
   box-shadow:
     0 24px 62px rgba(64, 54, 104, 0.12),
     inset 0 1px 0 rgba(255, 255, 255, 0.72);
+}
+
+.landing[data-theme-mode="light"] .v2-method-visual--image {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .landing[data-theme-mode="light"] .v2-method-step-badge {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -416,11 +416,22 @@ function LandingV2NarrativeMethod({ how }: { how: LandingCopy["how"] }) {
               </AdaptiveText>
             </div>
           );
-          const visualBlock = (
-            <div className="v2-method-visual" aria-hidden>
-              <div className="v2-method-visual-glow" />
-            </div>
-          );
+          const visualBlock =
+            index === 0 ? (
+              <div className="v2-method-visual v2-method-visual--image" aria-hidden>
+                <img
+                  src="/landing/paso1.png"
+                  alt=""
+                  className="v2-method-visual-image"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </div>
+            ) : (
+              <div className="v2-method-visual" aria-hidden>
+                <div className="v2-method-visual-glow" />
+              </div>
+            );
 
           return (
             <article


### PR DESCRIPTION
### Motivation
- Reemplazar el placeholder visual blanco del Paso 1 en la sección “A method that changes with you.” por la imagen pública ya existente para que el diseño muestre exactamente `public/landing/paso1.png` sin crear ni mover assets.
- Mantener el comportamiento y layout existente para Steps 2–4, preservando el alternado texto + visual.

### Description
- En `apps/web/src/pages/Landing.tsx` el bloque visual ahora es condicional: si `index === 0` renderiza un contenedor con la imagen pública referenciada como `src="/landing/paso1.png"`, y para otros índices se mantiene el placeholder existente con `.v2-method-visual-glow`.
- En `apps/web/src/pages/Landing.css` se añadieron reglas para `.v2-method-visual--image` y `.v2-method-visual-image` que remueven background, border, box-shadow, backdrop y padding del contenedor, y evitan pseudo-elementos que generaban marco; también se añadió una animación vertical sutil `@keyframes v2-method-step-image-float` y soporte para `prefers-reduced-motion`.
- Se agregó un override para `data-theme-mode="light"` que evita que el estilo claro global re-aplique fondo/borde al contenedor de la imagen.
- No se añadieron, renombraron ni copiaron assets; la imagen usada es `apps/web/public/landing/paso1.png` y se referencia desde la raíz pública como `src="/landing/paso1.png"`.

### Testing
- Ejecuté `npm -w @innerbloom/web run build` y la compilación de producción con Vite completó correctamente (build ✅).
- Ejecuté `npm -w @innerbloom/web run typecheck` y el chequeo de tipos falló por errores TypeScript preexistentes en otras áreas no relacionadas con este cambio (typecheck ⚠️ — falla por errores ajenos a la modificación de la landing).
- Intenté validación visual automatizada con Playwright (captura de `http://localhost:4174/landing-v2`), pero la instalación de navegadores falló por restricción de descarga (`npx playwright install chromium` devolvió HTTP 403), por lo que no fue posible generar la captura (Playwright ⚠️).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb83bf2fe48332833e0c099da1416f)