### PR TITLE
Polish habit development previews

### DIFF
--- a/apps/web/src/components/dashboard-v3/PreviewAchievementCard.tsx
+++ b/apps/web/src/components/dashboard-v3/PreviewAchievementCard.tsx
@@ -23,6 +23,7 @@ type MonthNodeProps = {
   entry: NormalizedRecentMonth;
   language: PostLoginLanguage;
   compact?: boolean;
+  variant?: 'default' | 'landing';
 };
 
 const statusConfig = {
@@ -106,13 +107,13 @@ function getMonthTone(state: string | null | undefined): string {
   if (normalized === 'strong' || normalized === 'valid' || normalized === 'achieved') {
     return 'bg-emerald-400 text-white';
   }
-  if (normalized === 'building' || normalized === 'pending' || normalized === 'weak' || normalized === 'floor_only') {
+  if (normalized === 'building' || normalized === 'pending' || normalized === 'floor_only') {
     return 'bg-amber-400 text-amber-950';
   }
   if (normalized.startsWith('projected')) {
     return 'bg-indigo-900 text-indigo-100';
   }
-  if (normalized === 'invalid' || normalized === 'bad' || normalized === 'locked') {
+  if (normalized === 'weak' || normalized === 'invalid' || normalized === 'bad' || normalized === 'locked') {
     return 'bg-rose-500 text-white';
   }
   return 'bg-white/10 text-[color:var(--color-slate-300)]';
@@ -121,42 +122,55 @@ function getMonthTone(state: string | null | undefined): string {
 function getMonthSymbol(monthState: string | null | undefined): string {
   const normalized = String(monthState ?? '').toLowerCase();
   if (normalized === 'strong' || normalized === 'valid' || normalized === 'achieved') return '✓';
-  if (normalized === 'building' || normalized === 'pending' || normalized === 'weak' || normalized === 'floor_only') return '•';
+  if (normalized === 'building' || normalized === 'pending' || normalized === 'floor_only') return '•';
   if (normalized.startsWith('projected')) return '~';
-  if (normalized === 'invalid' || normalized === 'bad' || normalized === 'locked') return '✕';
+  if (normalized === 'weak' || normalized === 'invalid' || normalized === 'bad' || normalized === 'locked') return '✕';
   return '○';
 }
 
 function formatCompletionRatePercent(rate: number | null | undefined): string {
   if (typeof rate !== 'number' || !Number.isFinite(rate)) return '--';
   const safeRate = Math.max(0, rate);
-  return `${Math.round(safeRate * 100)}%`;
+  const percent = safeRate > 3 ? safeRate : safeRate * 100;
+  return `${Math.round(percent)}%`;
 }
 
 function getMonthMetric(value: number | null | undefined): string {
   return formatCompletionRatePercent(value);
 }
 
-function RecentMonthNode({ entry, language, compact = false }: MonthNodeProps) {
+function RecentMonthNode({ entry, language, compact = false, variant = 'default' }: MonthNodeProps) {
   const monthSymbol = getMonthSymbol(entry.state);
   const normalized = String(entry.state ?? '').toLowerCase();
   const isProjected = normalized.startsWith('projected');
-  const isBuilding = normalized === 'building' || normalized === 'pending' || normalized === 'weak' || normalized === 'floor_only';
+  const isBuilding = normalized === 'building' || normalized === 'pending' || normalized === 'floor_only';
+  const isLanding = variant === 'landing';
   return (
     <div
       key={`${entry.key}-${entry.value ?? 0}`}
       data-testid="recent-month-item"
       className={cx(
-        'mt-1 flex shrink-0 flex-col items-center gap-1 py-0',
-        compact ? 'h-[3.8rem] w-[2.35rem] sm:h-[4rem] sm:w-[2.65rem]' : 'h-[4.8rem] w-[3.1rem] sm:h-[4.95rem] sm:w-[3.45rem]',
+        'mt-1 flex shrink-0 flex-col items-center py-0',
+        isLanding ? 'gap-1.5' : 'gap-1',
+        isLanding
+          ? compact
+            ? 'h-[4.2rem] w-[2.7rem] sm:h-[4.45rem] sm:w-[2.95rem]'
+            : 'h-[5.25rem] w-[3.6rem] sm:h-[5.5rem] sm:w-[3.85rem]'
+          : compact
+            ? 'h-[3.8rem] w-[2.35rem] sm:h-[4rem] sm:w-[2.65rem]'
+            : 'h-[4.8rem] w-[3.1rem] sm:h-[4.95rem] sm:w-[3.45rem]',
       )}
     >
       <div
         data-testid="recent-month-node"
         className={cx(
-          compact
-            ? 'relative inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold leading-none shadow-[0_7px_16px_rgba(5,10,35,0.34)] sm:h-7 sm:w-7 sm:text-sm'
-            : 'relative inline-flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold leading-none shadow-[0_7px_16px_rgba(5,10,35,0.34)] sm:h-9 sm:w-9 sm:text-base',
+          isLanding
+            ? compact
+              ? 'relative inline-flex h-8 w-8 items-center justify-center rounded-full text-base font-black leading-none shadow-[0_9px_20px_rgba(5,10,35,0.38)] sm:h-9 sm:w-9 sm:text-lg'
+              : 'relative inline-flex h-10 w-10 items-center justify-center rounded-full text-xl font-black leading-none shadow-[0_10px_22px_rgba(5,10,35,0.4)] sm:h-11 sm:w-11 sm:text-2xl'
+            : compact
+              ? 'relative inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold leading-none shadow-[0_7px_16px_rgba(5,10,35,0.34)] sm:h-7 sm:w-7 sm:text-sm'
+              : 'relative inline-flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold leading-none shadow-[0_7px_16px_rgba(5,10,35,0.34)] sm:h-9 sm:w-9 sm:text-base',
           getMonthTone(entry.state),
         )}
         aria-label={`${entry.periodKey ?? 'unknown'}-${entry.state ?? 'unknown'}`}
@@ -166,21 +180,21 @@ function RecentMonthNode({ entry, language, compact = false }: MonthNodeProps) {
           <span
             className={cx(
               'inline-flex rounded-full border-2 border-indigo-100/80 border-t-transparent animate-spin',
-              compact ? 'h-3.5 w-3.5' : 'h-4 w-4',
+              isLanding ? (compact ? 'h-4 w-4' : 'h-5 w-5') : compact ? 'h-3.5 w-3.5' : 'h-4 w-4',
             )}
             aria-hidden
           />
         ) : isBuilding ? (
-          <span className={cx('inline-flex rounded-full bg-amber-50', compact ? 'h-1.5 w-1.5' : 'h-2 w-2')} aria-hidden />
+          <span className={cx('inline-flex rounded-full bg-amber-50', isLanding ? (compact ? 'h-2 w-2' : 'h-2.5 w-2.5') : compact ? 'h-1.5 w-1.5' : 'h-2 w-2')} aria-hidden />
         ) : (
           monthSymbol
         )}
       </div>
-      <span className={cx('text-[color:var(--color-slate-300)] leading-none', compact ? 'text-[9px]' : 'text-[10px]')} data-testid="recent-month-label">
+      <span className={cx('leading-none', isLanding ? (compact ? 'text-[12px] text-[color:var(--color-text-muted)] dark:text-slate-300' : 'text-sm text-[color:var(--color-text-muted)] dark:text-slate-300') : compact ? 'text-[9px] text-[color:var(--color-slate-300)]' : 'text-[10px] text-[color:var(--color-slate-300)]')} data-testid="recent-month-label">
         {entry.periodKey ? monthLabel(entry.periodKey, language) : language === 'es' ? 'Sin mes' : 'No month'}
       </span>
       <span
-        className={cx('font-semibold leading-none text-[color:var(--color-slate-300)]', compact ? 'text-[9px]' : 'text-[10px]')}
+        className={cx('font-semibold leading-none', isLanding ? (compact ? 'text-sm text-[color:var(--color-text)] dark:text-slate-50' : 'text-base text-[color:var(--color-text)] dark:text-slate-50') : compact ? 'text-[9px] text-[color:var(--color-slate-100)]' : 'text-[10px] text-[color:var(--color-slate-100)]')}
         data-testid="recent-month-progress"
       >
         {getMonthMetric(entry.value)}
@@ -194,14 +208,19 @@ export function PreviewAchievementCard({
   language,
   size = 'default',
   surface = 'default',
+  variant = 'default',
+  showInfoControls = true,
 }: {
   previewAchievement: PreviewAchievement;
   language: PostLoginLanguage;
   size?: 'default' | 'compact';
   surface?: 'default' | 'ghost';
+  variant?: 'default' | 'landing';
+  showInfoControls?: boolean;
 }) {
   const isCompact = size === 'compact';
   const isGhostSurface = surface === 'ghost';
+  const isLanding = variant === 'landing';
   const tone = getStatusTone(previewAchievement.status);
   const score = Math.max(0, Math.min(100, Math.round(Number(previewAchievement.score ?? 0))));
   const scoreLabel = 'Score';
@@ -278,38 +297,44 @@ export function PreviewAchievementCard({
   return (
     <section
       className={cx(
-        'overflow-visible rounded-2xl',
-        isGhostSurface ? 'border-transparent bg-transparent shadow-none' : 'border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] shadow-inner',
-        isCompact ? 'p-2.5 pb-4' : 'p-3 pb-4',
+        'overflow-visible',
+        isLanding ? 'rounded-[1.55rem]' : 'rounded-2xl',
+        isGhostSurface
+          ? 'border-transparent bg-transparent shadow-none'
+          : isLanding
+            ? 'border border-[color:var(--color-border-subtle)] bg-[color:var(--color-surface-elevated)] shadow-[var(--color-card-shadow)] dark:border-white/10 dark:bg-gradient-to-b dark:from-[rgba(7,10,16,0.96)] dark:to-[rgba(8,12,18,0.9)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]'
+            : 'border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] shadow-inner',
+        isLanding ? (isCompact ? 'p-2.5 pb-3 sm:p-3' : 'p-4 pb-4 sm:p-5') : isCompact ? 'p-2.5 pb-4' : 'p-3 pb-4',
       )}
     >
-      <div className={cx('flex flex-col items-center', isCompact ? 'gap-1.5' : 'gap-2')}>
+      <div className={cx('flex flex-col items-center', isLanding ? (isCompact ? 'gap-2' : 'gap-3') : isCompact ? 'gap-1.5' : 'gap-2')}>
         <div className="w-full space-y-2 text-left">
-          <p className={cx('font-semibold uppercase tracking-[0.08em] text-[color:var(--color-slate-100)]', isCompact ? 'text-[13px]' : 'text-sm')}>
+          <p className={cx('font-semibold uppercase', isLanding ? 'text-[11px] tracking-[0.22em] text-[color:var(--color-text-muted)] dark:text-slate-300' : isCompact ? 'text-[13px] tracking-[0.08em] text-[color:var(--color-slate-100)]' : 'text-sm tracking-[0.08em] text-[color:var(--color-slate-100)]')}>
             {language === 'es' ? 'Desarrollo del hábito' : 'Habit development'}
           </p>
-          {previewAchievement.consolidationStrength != null && (
+          {previewAchievement.consolidationStrength != null && !isLanding && (
             <p className="text-[11px] text-[color:var(--color-slate-300)]">
               {language === 'es' ? 'Consolidación' : 'Consolidation'} · {Math.max(0, Math.min(100, Math.round(previewAchievement.consolidationStrength)))}%
             </p>
           )}
         </div>
         <div className="mx-auto flex w-full shrink-0 flex-col items-center" data-tour-anchor="achievement-preview-overview">
-          <span className={cx('inline-flex items-center rounded-full font-semibold', isCompact ? 'px-2.5 py-0.5 text-[11px]' : 'px-3 py-1 text-xs', tone.chip)}>
+          <span className={cx('inline-flex items-center rounded-full font-semibold', isLanding ? (isCompact ? 'px-2.5 py-0.5 text-xs' : 'px-4 py-1.5 text-sm') : isCompact ? 'px-2.5 py-0.5 text-[11px]' : 'px-3 py-1 text-xs', tone.chip)}>
             {tone.label[language]}
           </span>
           <div
             className={cx(
-              'mt-2 flex w-full items-center justify-center md:col-start-2 md:justify-self-center',
-              isCompact ? 'gap-2 sm:gap-2.5' : 'gap-3 sm:gap-4',
-              'flex-wrap sm:flex-nowrap',
+              'mt-2 w-full items-center justify-center md:col-start-2 md:justify-self-center',
+              isLanding
+                ? cx('flex flex-nowrap', isCompact ? 'gap-4 sm:gap-5' : 'gap-8 sm:gap-10')
+                : cx('flex', isCompact ? 'gap-2 sm:gap-2.5' : 'gap-3 sm:gap-4', 'flex-wrap sm:flex-nowrap'),
             )}
             data-testid="score-block"
             data-tour-anchor="achievement-preview-score"
           >
-            <div className="relative shrink-0" ref={scoreTooltipRef}>
+            <div className={cx('relative shrink-0', isLanding && 'justify-self-center')} ref={scoreTooltipRef}>
               <svg
-                className={isCompact ? 'h-20 w-20 sm:h-24 sm:w-24' : 'h-24 w-24 sm:h-28 sm:w-28'}
+                className={isLanding ? (isCompact ? 'h-28 w-28 sm:h-32 sm:w-32' : 'h-[8.5rem] w-[8.5rem] sm:h-[9.5rem] sm:w-[9.5rem]') : isCompact ? 'h-20 w-20 sm:h-24 sm:w-24' : 'h-24 w-24 sm:h-28 sm:w-28'}
                 viewBox="0 0 120 120"
                 role="img"
                 aria-label={`preview achievement score ${score}`}
@@ -347,25 +372,27 @@ export function PreviewAchievementCard({
                 />
               </svg>
               <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
-                <span className="text-[30px] font-semibold leading-none text-[color:var(--color-text)] sm:text-[32px]">{score}</span>
-                <span data-testid="score-affordance" className="mt-1 inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-slate-300)]">
+                <span className={cx('font-semibold leading-none', isLanding ? (isCompact ? 'text-[48px] text-[color:var(--color-text)] dark:text-slate-50 sm:text-[56px]' : 'text-[60px] text-[color:var(--color-text)] dark:text-slate-50 sm:text-[68px]') : 'text-[30px] text-[color:var(--color-text)] sm:text-[32px]')}>{score}</span>
+                <span data-testid="score-affordance" className={cx('mt-1 inline-flex items-center gap-1 uppercase', isLanding ? 'text-[11px] tracking-[0.2em] text-[color:var(--color-text-muted)] dark:text-slate-300' : 'text-[10px] tracking-[0.12em] text-[color:var(--color-slate-300)]')}>
                   <span className="font-semibold">{scoreLabel}</span>
                   <span className="sr-only">{language === 'es' ? 'fuerza actual del hábito' : 'current habit strength'}</span>
                 </span>
               </div>
-              <div className="absolute left-1/2 top-[70%] inline-flex -translate-x-1/2 items-center gap-1 text-[10px] text-[color:var(--color-slate-400)]">
-                <button
-                  type="button"
-                  onClick={() => setIsScoreTooltipOpen((prev) => !prev)}
-                  onFocus={() => setIsScoreTooltipOpen(true)}
-                  aria-label={language === 'es' ? 'Qué significa este score' : 'What this score means'}
-                  className="inline-flex h-3 w-3 items-center justify-center rounded-full border border-white/60 bg-white/20 text-[7px] font-semibold text-white shadow-[0_7px_18px_rgba(8,12,24,0.52)] backdrop-blur-xl sm:h-3.5 sm:w-3.5 sm:text-[8px]"
-                  data-testid="score-info-dot"
-                  aria-describedby={isScoreTooltipOpen ? scoreTooltipId : undefined}
-                >
-                  i
-                </button>
-              </div>
+              {showInfoControls && (
+                <div className={cx('absolute left-1/2 inline-flex -translate-x-1/2 items-center gap-1 text-[10px]', isLanding ? 'top-[72%] text-[color:var(--color-text-muted)] dark:text-slate-300' : 'top-[70%] text-[color:var(--color-slate-400)]')}>
+                  <button
+                    type="button"
+                    onClick={() => setIsScoreTooltipOpen((prev) => !prev)}
+                    onFocus={() => setIsScoreTooltipOpen(true)}
+                    aria-label={language === 'es' ? 'Qué significa este score' : 'What this score means'}
+                    className="inline-flex h-3 w-3 items-center justify-center rounded-full border border-white/60 bg-white/20 text-[7px] font-semibold text-white shadow-[0_7px_18px_rgba(8,12,24,0.52)] backdrop-blur-xl sm:h-3.5 sm:w-3.5 sm:text-[8px]"
+                    data-testid="score-info-dot"
+                    aria-describedby={isScoreTooltipOpen ? scoreTooltipId : undefined}
+                  >
+                    i
+                  </button>
+                </div>
+              )}
               {isScoreTooltipOpen && (
                 <div
                   id={scoreTooltipId}
@@ -378,9 +405,9 @@ export function PreviewAchievementCard({
                 </div>
               )}
             </div>
-            <div className={cx('relative flex items-center px-1 py-1', isCompact ? 'h-24 sm:h-28' : 'h-32 sm:h-36')} data-testid="score-range-rail" data-tour-anchor="achievement-preview-scale">
-              <div className={cx('relative h-full', isCompact ? 'w-[3.35rem]' : 'w-[3.65rem]')}>
-                <div className="absolute bottom-1 left-3.5 top-1 w-2 overflow-hidden rounded-full bg-white/10">
+            <div className={cx('relative flex items-center px-1 py-1', isLanding ? (isCompact ? 'h-32 sm:h-36' : 'h-[8.5rem] sm:h-[9.5rem]') : isCompact ? 'h-24 sm:h-28' : 'h-32 sm:h-36')} data-testid="score-range-rail" data-tour-anchor="achievement-preview-scale">
+              <div className={cx('relative h-full', isLanding ? 'w-[3.6rem]' : isCompact ? 'w-[3.35rem]' : 'w-[3.65rem]')}>
+                <div className={cx('absolute bottom-1 top-1 overflow-hidden rounded-full bg-white/10', isLanding ? 'left-4 w-2.5' : 'left-3.5 w-2')}>
                   <button
                     type="button"
                     className="absolute inset-x-0 top-0 h-[20%] bg-emerald-400 focus:outline-none"
@@ -404,17 +431,17 @@ export function PreviewAchievementCard({
                     aria-hidden
                   />
                 </div>
-                <span className="absolute left-0 top-0 text-[8px] text-[color:var(--color-slate-400)]">100</span>
-                <span className="absolute left-0 top-[20%] -translate-y-1/2 text-[8px] text-[color:var(--color-slate-300)]">80</span>
-                <span className="absolute left-0 top-[50%] -translate-y-1/2 text-[8px] text-[color:var(--color-slate-300)]">50</span>
-                <span className="absolute left-0 bottom-0 text-[8px] text-[color:var(--color-slate-500)]">0</span>
-                <span className={cx('absolute top-[3%] text-left text-[9px] font-medium leading-none text-[color:var(--color-slate-300)]', isCompact ? 'left-[1.95rem]' : 'left-[2.05rem]')}>
+                <span className={cx('absolute left-0 top-0', isLanding ? 'text-[11px] text-[color:var(--color-text-muted)] dark:text-slate-300' : 'text-[8px] text-[color:var(--color-slate-400)]')}>100</span>
+                <span className={cx('absolute left-0 top-[20%] -translate-y-1/2', isLanding ? 'text-[11px] text-[color:var(--color-text-muted)] dark:text-slate-300' : 'text-[8px] text-[color:var(--color-slate-300)]')}>80</span>
+                <span className={cx('absolute left-0 top-[50%] -translate-y-1/2', isLanding ? 'text-[11px] text-[color:var(--color-text-muted)] dark:text-slate-300' : 'text-[8px] text-[color:var(--color-slate-300)]')}>50</span>
+                <span className={cx('absolute left-0 bottom-0', isLanding ? 'text-[11px] text-[color:var(--color-text-subtle)] dark:text-slate-400' : 'text-[8px] text-[color:var(--color-slate-500)]')}>0</span>
+                <span className={cx('absolute top-[3%] text-left font-medium leading-none text-[color:var(--color-slate-300)]', isLanding ? 'hidden' : isCompact ? 'left-[1.95rem] text-[9px]' : 'left-[2.05rem] text-[9px]')}>
                   {rangeLabels.strong}
                 </span>
-                <span className={cx('absolute top-[50%] -translate-y-1/2 text-left text-[9px] font-medium leading-none text-[color:var(--color-slate-300)]', isCompact ? 'left-[1.95rem]' : 'left-[2.05rem]')}>
+                <span className={cx('absolute top-[50%] -translate-y-1/2 text-left font-medium leading-none text-[color:var(--color-slate-300)]', isLanding ? 'hidden' : isCompact ? 'left-[1.95rem] text-[9px]' : 'left-[2.05rem] text-[9px]')}>
                   {rangeLabels.building}
                 </span>
-                <span className={cx('absolute bottom-[3%] text-left text-[9px] font-medium leading-none text-[color:var(--color-slate-300)]', isCompact ? 'left-[1.95rem]' : 'left-[2.05rem]')}>
+                <span className={cx('absolute bottom-[3%] text-left font-medium leading-none text-[color:var(--color-slate-300)]', isLanding ? 'hidden' : isCompact ? 'left-[1.95rem] text-[9px]' : 'left-[2.05rem] text-[9px]')}>
                   {rangeLabels.fragile}
                 </span>
               </div>
@@ -423,10 +450,10 @@ export function PreviewAchievementCard({
         </div>
       </div>
 
-      <div className={cx(isCompact ? 'mt-2.5 space-y-1.5' : 'mt-3 space-y-2')}>
+      <div className={cx(isLanding ? (isCompact ? 'mt-1.5 space-y-1.5' : 'mt-3 space-y-2') : isCompact ? 'mt-2.5 space-y-1.5' : 'mt-3 space-y-2')}>
         {orderedRecentMonths.length > 0 && (
           <div className="px-0 py-0" data-tour-anchor="achievement-preview-months-section">
-            <div className="flex items-center gap-1.5">
+            <div className={cx('flex items-center gap-1.5', isLanding && 'sr-only')}>
               <p className={cx('font-semibold uppercase tracking-[0.08em] text-[color:var(--color-slate-100)]', isCompact ? 'text-[13px]' : 'text-sm')}>
                 {language === 'es' ? 'Resultado últimos meses' : 'Last months result'}
               </p>
@@ -447,33 +474,48 @@ export function PreviewAchievementCard({
                 </div>
               </details>
             </div>
-            <div className="w-full overflow-x-auto pb-2 pt-1" data-testid="recent-timeline" data-tour-anchor="achievement-preview-months">
+            <div className={cx('w-full overflow-x-auto pb-2 pt-1', isLanding && 'overflow-visible pb-0')} data-testid="recent-timeline" data-tour-anchor="achievement-preview-months">
               <div
-                className={cx(
-                  'flex items-end gap-0.5 md:gap-1',
+	                className={cx(
+	                  isLanding
+	                    ? 'mx-auto flex w-fit max-w-full items-end gap-2 rounded-[1.7rem] bg-transparent px-4 py-3 sm:gap-3 sm:px-5'
+	                    : 'flex items-end gap-0.5 md:gap-1',
                   shouldCenterRecentTimeline ? 'justify-center' : 'justify-start',
                   shouldUseOverflowTrack ? 'min-w-max' : 'w-full',
                 )}
                 data-testid="recent-timeline-track"
               >
                 {leadingMonths.map((entry) => (
-                  <RecentMonthNode key={`${entry.key}-${entry.value ?? 0}`} entry={entry} language={language} compact={isCompact} />
+                  <RecentMonthNode key={`${entry.key}-${entry.value ?? 0}`} entry={entry} language={language} compact={isCompact} variant={variant} />
                 ))}
                 {hasGroupedWindow && (
-                  <div
-                    className="relative flex items-end gap-0.5 rounded-xl bg-indigo-400/10 px-0.5 pb-1 pt-[1.1rem] shadow-[0_0_18px_rgba(99,102,241,0.12)] sm:gap-1 md:gap-1"
+	                  <div
+	                    className={cx(
+	                      'relative flex items-end gap-0.5 rounded-xl bg-indigo-400/10 px-0.5 pb-1 pt-[1.1rem] shadow-[0_0_18px_rgba(99,102,241,0.12)] sm:gap-1 md:gap-1',
+	                      isLanding && 'rounded-none bg-transparent px-0 pb-0 pt-5 shadow-none',
+	                    )}
                     data-testid="seal-window-group"
                     data-window-start={lastThreeStart}
                     data-window-end={lastThreeEnd - 1}
                     data-tour-anchor="achievement-preview-active-window"
                   >
-                    <p className="pointer-events-none absolute left-1/2 top-0.5 -translate-x-1/2 text-[8px] font-medium uppercase tracking-[0.09em] text-[color:var(--color-slate-400)]">
-                      {windowTitle}
-                    </p>
+	                    {isLanding ? (
+	                      <div className="pointer-events-none absolute left-1/2 top-0 flex w-[calc(100%-0.8rem)] -translate-x-1/2 items-center gap-2" aria-hidden>
+	                        <span className="h-px flex-1 bg-[color:var(--color-text-muted)]/80 dark:bg-white/25" />
+	                        <span className="whitespace-nowrap text-[8px] font-semibold uppercase tracking-[0.12em] text-[color:var(--color-text-subtle)] dark:text-slate-400">
+	                          {windowTitle}
+	                        </span>
+	                        <span className="h-px flex-1 bg-[color:var(--color-text-muted)]/80 dark:bg-white/25" />
+	                      </div>
+	                    ) : (
+	                      <p className="pointer-events-none absolute left-1/2 top-0.5 -translate-x-1/2 whitespace-nowrap text-[8px] font-medium uppercase tracking-[0.09em] text-[color:var(--color-slate-400)]">
+	                        {windowTitle}
+	                      </p>
+	                    )}
                     {groupedMonths.map((entry) => (
-                      <RecentMonthNode key={`${entry.key}-${entry.value ?? 0}`} entry={entry} language={language} compact={isCompact} />
+                      <RecentMonthNode key={`${entry.key}-${entry.value ?? 0}`} entry={entry} language={language} compact={isCompact} variant={variant} />
                     ))}
-                    {groupedProjectedMonth && <span className="absolute -bottom-3 right-1 text-[9px] text-[color:var(--color-slate-400)]">{language === 'es' ? 'proyectado' : 'projected'}</span>}
+                    {groupedProjectedMonth && <span className={cx('absolute -bottom-3 right-1 text-[9px]', isLanding ? 'text-[color:var(--color-text-muted)] dark:text-slate-300' : 'text-[color:var(--color-slate-400)]')}>{language === 'es' ? 'proyectado' : 'projected'}</span>}
                   </div>
                 )}
               </div>

--- a/apps/web/src/components/dashboard-v3/RewardsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/RewardsSection.tsx
@@ -34,6 +34,14 @@ const REWARDS_PILLAR_ORDER = [
   { code: "SOUL", name: "Soul" },
 ] as const;
 
+function scrollElementToLeft(element: HTMLElement, left: number, behavior: ScrollBehavior) {
+  if (typeof element.scrollTo === "function") {
+    element.scrollTo({ left, behavior });
+    return;
+  }
+  element.scrollLeft = left;
+}
+
 type AchievementViewMode = "shelves" | "carousel";
 
 interface RewardsSectionProps {
@@ -1032,7 +1040,7 @@ function AchievedShelf({
     setFlippedCarouselHabitId(null);
     setActiveCarouselIndex(0);
     if (carouselTrackRef.current) {
-      carouselTrackRef.current.scrollTo({ left: 0, behavior: "auto" });
+      scrollElementToLeft(carouselTrackRef.current, 0, "auto");
     }
   }, [activePillarCode, carouselTrackRef, setActiveCarouselIndex]);
 
@@ -1068,10 +1076,7 @@ function AchievedShelf({
       const itemLeft = target.offsetLeft;
       const centeredLeft =
         itemLeft - (horizontalContainer.clientWidth - target.clientWidth) / 2;
-      horizontalContainer.scrollTo({
-        left: Math.max(0, centeredLeft),
-        behavior: "auto",
-      });
+      scrollElementToLeft(horizontalContainer, Math.max(0, centeredLeft), "auto");
     }
   }, []);
 
@@ -1095,10 +1100,7 @@ function AchievedShelf({
       if (preventPageScrollOnProgrammaticFocus) {
         const centeredLeft =
           targetCard.offsetLeft - (track.clientWidth - targetCard.clientWidth) / 2;
-        track.scrollTo({
-          left: Math.max(0, centeredLeft),
-          behavior,
-        });
+        scrollElementToLeft(track, Math.max(0, centeredLeft), behavior);
       } else if (typeof targetCard.scrollIntoView === "function") {
         targetCard.scrollIntoView({
           behavior,
@@ -1825,6 +1827,8 @@ function LockedAchievementHabitDevelopment({
           language={language}
           size={compact ? "compact" : "default"}
           surface={embedded ? "ghost" : "default"}
+          variant="landing"
+          showInfoControls={!embedded}
         />
       </div>
     );
@@ -1948,6 +1952,7 @@ function NotAchievedPreviewOverlay({
               previewAchievement={previewAchievement}
               language={language}
               size={compact ? "compact" : "default"}
+              variant="landing"
             />
           ) : null}
           {(status === "success" || isLocalPreview) && !previewAchievement ? (

--- a/apps/web/src/components/dashboard-v3/StreakTaskInsightsModal.tsx
+++ b/apps/web/src/components/dashboard-v3/StreakTaskInsightsModal.tsx
@@ -102,6 +102,19 @@ function getRecalibrationActionLabel(action: RecalibrationAction, t: Translate):
   return t('dashboard.streakTaskInsights.recalibration.action.keep');
 }
 
+function getRecalibrationChipLabel(action: RecalibrationAction, language: PostLoginLanguage): string {
+  if (action === 'down') {
+    return language === 'es' ? 'Bajó la dificultad' : 'Difficulty lowered';
+  }
+  if (action === 'up') {
+    return language === 'es' ? 'Subió la dificultad' : 'Difficulty increased';
+  }
+  if (action === 'keep') {
+    return language === 'es' ? 'Se mantuvo' : 'Kept';
+  }
+  return language === 'es' ? 'Sin ajuste reciente' : 'No recent adjustment';
+}
+
 function localizeDifficultyChipLabel(
   difficulty: string | null | undefined,
   locale: PostLoginLanguage,
@@ -124,68 +137,78 @@ function RecalibrationTrendIndicator({
   latest,
   eligible,
   tooltipLabel,
-  onToggleTooltip,
-  onOpenTooltip,
-  tooltipOpen,
-  onCloseTooltip,
+  expandedLabel,
   tooltipId,
 }: {
   latest: RecalibrationRecord | null;
   eligible: boolean;
   tooltipLabel: string;
-  onToggleTooltip: () => void;
-  onOpenTooltip: () => void;
-  tooltipOpen: boolean;
-  onCloseTooltip: () => void;
+  expandedLabel: string;
   tooltipId: string;
 }) {
   const action = normalizeRecalibrationAction(latest?.action);
 
-  const config: Record<Exclude<RecalibrationAction, 'none'>, { icon: string; tone: string }> = {
-    down: { icon: '↓', tone: 'border-emerald-500/70 bg-emerald-300 text-emerald-950 dark:border-emerald-400/60 dark:bg-emerald-500 dark:text-emerald-950' },
-    keep: { icon: '•', tone: 'border-amber-500/70 bg-amber-300 text-amber-950 dark:border-amber-400/60 dark:bg-amber-400 dark:text-amber-950' },
-    up: { icon: '↑', tone: 'border-rose-500/70 bg-rose-300 text-rose-950 dark:border-rose-400/60 dark:bg-rose-500 dark:text-rose-950' },
+  const config: Record<Exclude<RecalibrationAction, 'none'>, { icon: string; tone: string; glow: string }> = {
+    down: {
+      icon: '↓',
+      tone: 'border-emerald-300/70 bg-emerald-400 text-emerald-950 dark:border-emerald-300/70 dark:bg-emerald-500 dark:text-emerald-950',
+      glow: 'shadow-[0_0_0_3px_rgba(16,185,129,0.18),0_10px_24px_rgba(16,185,129,0.28)]',
+    },
+    keep: {
+      icon: '•',
+      tone: 'border-amber-300/80 bg-amber-300 text-amber-950 dark:border-amber-300/80 dark:bg-amber-400 dark:text-amber-950',
+      glow: 'shadow-[0_0_0_3px_rgba(251,191,36,0.16),0_10px_24px_rgba(251,191,36,0.22)]',
+    },
+    up: {
+      icon: '↑',
+      tone: 'border-rose-300/75 bg-rose-400 text-rose-950 dark:border-rose-300/70 dark:bg-rose-500 dark:text-rose-950',
+      glow: 'shadow-[0_0_0_3px_rgba(244,63,94,0.17),0_10px_24px_rgba(244,63,94,0.26)]',
+    },
   };
 
   const fallback = !latest || action === 'none' || !eligible;
+  const [isExpanded, setIsExpanded] = useState(false);
+  const autoPreviewKey = `${latest?.recalibratedAt ?? latest?.periodStart ?? latest?.periodEnd ?? 'none'}-${action}-${eligible ? 'eligible' : 'blocked'}`;
 
   useEffect(() => {
-    if (!tooltipOpen) return;
-    const listener = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      if (!target?.closest('[data-recalibration-tooltip]')) {
-        onCloseTooltip();
-      }
-    };
-    document.addEventListener('mousedown', listener);
-    return () => document.removeEventListener('mousedown', listener);
-  }, [onCloseTooltip, tooltipOpen]);
+    if (fallback) {
+      setIsExpanded(false);
+      return;
+    }
+    setIsExpanded(true);
+    const timeout = window.setTimeout(() => setIsExpanded(false), 1500);
+    return () => window.clearTimeout(timeout);
+  }, [autoPreviewKey, fallback]);
 
   return (
     <div className="relative" data-recalibration-tooltip>
       <button
         type="button"
-        onClick={onToggleTooltip}
-        onMouseEnter={onOpenTooltip}
-        onMouseLeave={onCloseTooltip}
+        onClick={() => setIsExpanded((current) => !current)}
         className={cx(
-          'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/50',
-          fallback ? 'border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] text-[color:var(--color-slate-300)]' : config[action].tone,
+          'inline-flex h-7 shrink-0 items-center overflow-hidden rounded-full border text-xs font-bold leading-none transition-[width,max-width,box-shadow,filter] duration-300 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/50',
+          isExpanded ? 'w-[9.5rem] max-w-[9.5rem] pr-3' : 'w-7 max-w-7 justify-start pr-0',
+          fallback
+            ? 'border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] text-[color:var(--color-slate-300)] shadow-[0_0_0_3px_rgba(148,163,184,0.10)]'
+            : `${config[action].tone} ${config[action].glow}`,
         )}
         aria-label={tooltipLabel}
-        aria-describedby={tooltipOpen ? tooltipId : undefined}
+        aria-expanded={isExpanded}
+        aria-describedby={isExpanded ? tooltipId : undefined}
       >
-        {fallback ? '•' : config[action].icon}
-      </button>
-      {tooltipOpen && (
-        <div
+        <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center text-base font-black leading-none" aria-hidden>
+          {fallback ? '•' : config[action].icon}
+        </span>
+        <span
           id={tooltipId}
-          role="tooltip"
-          className="absolute left-0 top-8 z-20 w-64 max-w-[calc(100vw-3rem)] rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-surface)] p-2 text-xs text-[color:var(--color-slate-200)] shadow-xl"
+          className={cx(
+            'whitespace-nowrap transition-opacity duration-200',
+            isExpanded ? 'opacity-100' : 'pointer-events-none opacity-0',
+          )}
         >
-          {tooltipLabel}
-        </div>
-      )}
+          {fallback ? tooltipLabel : expandedLabel}
+        </span>
+      </button>
     </div>
   );
 }
@@ -568,8 +591,8 @@ export function TaskInsightsModal({
   const recalibrationHistory = (recalibration?.history ?? []).slice(0, 3);
   const recalibrationLatest = recalibration?.latest ?? recalibrationHistory[0] ?? null;
   const isRecalibrationEligible = recalibration?.eligible ?? Boolean(recalibrationLatest || recalibrationHistory.length);
-  const [isRecalibrationTooltipOpen, setIsRecalibrationTooltipOpen] = useState(false);
   const recalibrationTooltipId = useId();
+  const recalibrationAction = normalizeRecalibrationAction(recalibrationLatest?.action);
 
   const xpPerCompletion = useMemo(() => {
     if (monthTotal > 0 && monthXp > 0) {
@@ -669,10 +692,7 @@ export function TaskInsightsModal({
                     ? t('dashboard.streakTaskInsights.recalibration.tooltip.latest')
                     : t('dashboard.streakTaskInsights.recalibration.tooltip.empty')
                 }
-                tooltipOpen={isRecalibrationTooltipOpen}
-                onToggleTooltip={() => setIsRecalibrationTooltipOpen((prev) => !prev)}
-                onOpenTooltip={() => setIsRecalibrationTooltipOpen(true)}
-                onCloseTooltip={() => setIsRecalibrationTooltipOpen(false)}
+                expandedLabel={getRecalibrationChipLabel(recalibrationAction, language)}
                 tooltipId={recalibrationTooltipId}
               />
             </div>
@@ -696,7 +716,7 @@ export function TaskInsightsModal({
               <div className="space-y-3">
                 <div className="flex flex-wrap items-start justify-between gap-2">
                   <div className="space-y-1">
-                    <p className="text-sm font-semibold text-[color:var(--color-slate-100)]">{t('dashboard.streakTaskInsights.activity')}</p>
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--color-text-muted)] dark:text-slate-300">{t('dashboard.streakTaskInsights.activity')}</p>
                     <div className="flex justify-center">
                       <div className="inline-flex w-full max-w-[240px] items-center justify-between gap-1 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-0.5 text-[11px] font-semibold text-[color:var(--color-slate-100)]">
                         {[
@@ -755,12 +775,12 @@ export function TaskInsightsModal({
               </div>
             )}
             {status === 'success' && previewAchievement && (
-              <PreviewAchievementCard previewAchievement={previewAchievement} language={language} />
+              <PreviewAchievementCard previewAchievement={previewAchievement} language={language} variant="landing" />
             )}
             {status === 'success' && !previewAchievement && (
               <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 shadow-inner">
                 <div className="flex items-center justify-between gap-2">
-                  <p className="text-sm font-semibold text-[color:var(--color-slate-100)]">{t('dashboard.streakTaskInsights.weeklyProgress')}</p>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--color-text-muted)] dark:text-slate-300">{t('dashboard.streakTaskInsights.weeklyProgress')}</p>
                   <span className="text-xs text-[color:var(--color-slate-400)]">{t('dashboard.streakTaskInsights.goal', { goal: weeklyGoal })}</span>
                 </div>
                 <WeeklyCompletionDonut
@@ -781,7 +801,7 @@ export function TaskInsightsModal({
 
             <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 shadow-inner">
               <div className="flex items-center justify-between gap-2">
-                <p className="text-sm font-semibold text-[color:var(--color-slate-100)]">{t('dashboard.streakTaskInsights.recalibration.title')}</p>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--color-text-muted)] dark:text-slate-300">{t('dashboard.streakTaskInsights.recalibration.title')}</p>
                 {recalibrationLatest?.recalibratedAt && (
                   <span className="text-[11px] text-[color:var(--color-slate-400)]">
                     {t('dashboard.streakTaskInsights.recalibration.latest', { date: formatCompactDate(recalibrationLatest.recalibratedAt, language) })}

--- a/apps/web/src/components/dashboard-v3/__tests__/PreviewAchievementCard.test.tsx
+++ b/apps/web/src/components/dashboard-v3/__tests__/PreviewAchievementCard.test.tsx
@@ -77,7 +77,7 @@ describe('PreviewAchievementCard', () => {
       expect(node.className).not.toContain(' border ');
     });
     expect(within(months[0]).getByText('✓')).toBeInTheDocument();
-    expect(within(months[1]).getByLabelText('2026-02-weak').querySelector('.bg-amber-50')).not.toBeNull();
+    expect(within(months[1]).getByText('✕')).toBeInTheDocument();
     expect(within(months[2]).getByText('✕')).toBeInTheDocument();
     expect(within(months[3]).getByLabelText('2026-04-projected_valid').querySelector('.animate-spin')).not.toBeNull();
     expect(within(months[0]).getByText('ene')).toBeInTheDocument();

--- a/apps/web/src/data/demoLogrosData.ts
+++ b/apps/web/src/data/demoLogrosData.ts
@@ -283,14 +283,13 @@ export function getDemoLogrosPreviewByTaskId(_language: PostLoginLanguage): Reco
       status: 'fragile',
       consolidationStrength: 41,
       recentMonths: [
-        { periodKey: '2025-12', completionRate: 0.28, state: 'invalid', closed: true },
-        { periodKey: '2026-01', completionRate: 0.43, state: 'weak', closed: true },
-        { periodKey: '2026-02', completionRate: 0.51, state: 'building', closed: true },
-        { periodKey: '2026-03', completionRate: 0.49, state: 'floor_only', closed: true },
-        { periodKey: '2026-04', projectedCompletionRate: 0.58, state: 'projected_floor_only', closed: false },
+        { periodKey: '2026-02', completionRate: 0.4, state: 'weak', closed: true },
+        { periodKey: '2026-03', completionRate: 0.68, state: 'building', closed: true },
+        { periodKey: '2026-04', completionRate: 1.08, state: 'valid', closed: true },
+        { periodKey: '2026-05', projectedCompletionRate: 0.58, state: 'projected_floor_only', closed: false },
       ],
       windowProximity: {
-        slots: ['invalid', 'floor_only', 'projected_floor_only'],
+        slots: ['invalid', 'floor_only', 'valid', 'projected_floor_only'],
       },
     },
     'task-family-call': {
@@ -298,14 +297,13 @@ export function getDemoLogrosPreviewByTaskId(_language: PostLoginLanguage): Reco
       status: 'building',
       consolidationStrength: 69,
       recentMonths: [
-        { periodKey: '2025-12', completionRate: 0.38, state: 'weak', closed: true },
-        { periodKey: '2026-01', completionRate: 0.61, state: 'building', closed: true },
-        { periodKey: '2026-02', completionRate: 0.8, state: 'strong', closed: true },
-        { periodKey: '2026-03', completionRate: 0.7, state: 'building', closed: true },
-        { periodKey: '2026-04', projectedCompletionRate: 0.77, state: 'projected_valid', closed: false },
+        { periodKey: '2026-02', completionRate: 0.4, state: 'weak', closed: true },
+        { periodKey: '2026-03', completionRate: 0.68, state: 'building', closed: true },
+        { periodKey: '2026-04', completionRate: 1.08, state: 'valid', closed: true },
+        { periodKey: '2026-05', projectedCompletionRate: 0.77, state: 'projected_valid', closed: false },
       ],
       windowProximity: {
-        slots: ['floor_only', 'valid', 'valid'],
+        slots: ['invalid', 'floor_only', 'valid', 'projected_valid'],
       },
     },
     'task-english': {
@@ -313,10 +311,10 @@ export function getDemoLogrosPreviewByTaskId(_language: PostLoginLanguage): Reco
       status: 'strong',
       consolidationStrength: 81,
       recentMonths: [
-        { periodKey: '2025-12', completionRate: 0.67, state: 'building', closed: true },
-        { periodKey: '2026-01', completionRate: 0.84, state: 'strong', closed: true },
-        { periodKey: '2026-02', completionRate: 0.85, state: 'strong', closed: true },
-        { periodKey: '2026-03', completionRate: 0.88, state: 'strong', closed: true },
+        { periodKey: '2026-02', completionRate: 0.4, state: 'weak', closed: true },
+        { periodKey: '2026-03', completionRate: 0.68, state: 'building', closed: true },
+        { periodKey: '2026-04', completionRate: 1.08, state: 'valid', closed: true },
+        { periodKey: '2026-05', projectedCompletionRate: 0.88, state: 'projected_valid', closed: false },
       ],
     },
   } as Record<string, NonNullable<TaskInsightsResponse['previewAchievement']>>;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1730,6 +1730,89 @@ const DEMO_USER_TASKS: UserTask[] = [
   { id: 'task-cena', title: 'Cena antes de las 22hs', pillarId: 'Body', traitId: null, statId: 'Nutrición', difficultyId: '2', isActive: true, xp: 45, createdAt: null, updatedAt: null, completedAt: null, archivedAt: null },
 ];
 
+type DemoRecalibrationAction = NonNullable<StreakPanelTask['latestRecalibrationAction']>;
+
+const DEMO_TASK_RECALIBRATION_ACTIONS: Record<string, DemoRecalibrationAction> = {
+  'task-correr': 'down',
+  'task-no-dulces': 'up',
+  'task-gym': 'keep',
+  'task-pantallas': 'down',
+  'task-ayuno': 'keep',
+  'task-cena': 'up',
+};
+
+const DEMO_DIFFICULTY_LABELS: Record<DemoRecalibrationAction, string> = {
+  down: 'Fácil',
+  keep: 'Media',
+  up: 'Difícil',
+};
+
+function getDemoRecalibrationAction(taskId: string): DemoRecalibrationAction {
+  return DEMO_TASK_RECALIBRATION_ACTIONS[taskId] ?? 'keep';
+}
+
+function getDemoDifficultyLabel(taskId: string): string {
+  return DEMO_DIFFICULTY_LABELS[getDemoRecalibrationAction(taskId)];
+}
+
+function getDemoRecalibration(taskId: string): NonNullable<TaskInsightsResponse['recalibration']> {
+  const action = getDemoRecalibrationAction(taskId);
+  const completionRate = action === 'down' ? 0.9 : action === 'up' ? 0.36 : 0.68;
+  const expectedTarget = action === 'down' ? 10 : action === 'up' ? 8 : 6;
+  const completions = Math.round(expectedTarget * completionRate);
+  const periodLabel = '2026-04';
+  const reason =
+    action === 'down'
+      ? 'La tasa de cumplimiento fue alta y la próxima dificultad baja para sostener consistencia.'
+      : action === 'up'
+        ? 'La tasa de cumplimiento quedó baja y la próxima dificultad sube para recalibrar el objetivo.'
+        : 'La tasa de cumplimiento quedó en rango y la dificultad se mantiene.';
+  const latest = {
+    action,
+    periodLabel,
+    periodStart: '2026-04-01',
+    periodEnd: '2026-04-30',
+    expectedTarget,
+    completions,
+    completionRate,
+    ruleMatched: action === 'down' ? 'high_completion' : action === 'up' ? 'low_completion' : 'stable_completion',
+    reason,
+    clampApplied: false,
+    clampReason: null,
+    recalibratedAt: '2026-05-01T00:00:00.000Z',
+  };
+  return { eligible: true, latest, history: [latest] };
+}
+
+function getDemoPreviewAchievement(taskId: string): NonNullable<TaskInsightsResponse['previewAchievement']> {
+  const action = getDemoRecalibrationAction(taskId);
+  const score = action === 'down' ? 89 : action === 'up' ? 44 : 74;
+  const status = action === 'down' ? 'strong' : action === 'up' ? 'fragile' : 'building';
+  return {
+    score,
+    status,
+    consolidationStrength: action === 'down' ? 84 : action === 'up' ? 38 : 66,
+    windowProximity: {
+      slots: ['invalid', 'floor_only', 'valid', 'projected_valid'],
+    },
+    currentMonth: {
+      periodKey: '2026-05',
+      completionRateSoFar: 0.73,
+      projectedMonthEndRate: 0.88,
+      expectedTargetSoFar: 6,
+      completionsDoneSoFar: 5,
+      expectedTargetMonthEnd: 8,
+      projectedCompletionsMonthEnd: 7,
+    },
+    recentMonths: [
+      { periodKey: '2026-02', completionRate: 0.4, state: 'weak', closed: true },
+      { periodKey: '2026-03', completionRate: 0.68, state: 'building', closed: true },
+      { periodKey: '2026-04', completionRate: 1.08, state: 'valid', closed: true },
+      { periodKey: '2026-05', projectedCompletionRate: 0.88, state: 'projected_valid', closed: false },
+    ],
+  };
+}
+
 function cloneDemo<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
@@ -2571,13 +2654,25 @@ export type TaskInsightsResponse = {
             id?: string | null;
             label?: string | null;
             state?: 'locked' | 'pending' | 'valid' | 'achieved' | string | null;
-          }
+        }
       >;
+    } | null;
+    currentMonth?: {
+      periodKey?: string | null;
+      completionRateSoFar?: number | null;
+      projectedMonthEndRate?: number | null;
+      expectedTargetSoFar?: number | null;
+      completionsDoneSoFar?: number | null;
+      expectedTargetMonthEnd?: number | null;
+      projectedCompletionsMonthEnd?: number | null;
     } | null;
     recentMonths?: Array<{
       periodKey?: string | null;
       month?: string | null;
       value?: number | null;
+      completionRate?: number | null;
+      projectedCompletionRate?: number | null;
+      closed?: boolean | null;
       state?: 'weak' | 'building' | 'strong' | 'locked' | 'valid' | string | null;
     }>;
   } | null;
@@ -2619,14 +2714,14 @@ export async function getUserStreakPanel(
   params: { pillar: StreakPanelPillar; range: StreakPanelRange; mode?: string; query?: string },
 ): Promise<StreakPanelResponse> {
   if (isDashboardDemoModeEnabled()) {
-    const tasks: StreakPanelTask[] = [
-      { id: 'task-correr', name: '10.000 pasos / Correr', stat: 'Movilidad', weekDone: 2, streakDays: 4, metrics: { week: { count: 2, xp: 110 }, month: { count: 11, xp: 560, weeks: [2, 4, 3, 2] }, qtr: { count: 31, xp: 1540, weeks: [2, 4, 3, 2, 5, 3], weekTotals: [2, 4, 3, 2, 5, 3] } } },
-      { id: 'task-no-dulces', name: 'No dulces', stat: 'Nutrición', weekDone: 0, streakDays: 0, metrics: { week: { count: 0, xp: 0 }, month: { count: 3, xp: 130, weeks: [0, 1, 1, 1] }, qtr: { count: 9, xp: 390, weeks: [0, 1, 1, 1, 2, 4], weekTotals: [0, 1, 1, 1, 2, 4] } } },
-      { id: 'task-gym', name: 'gym', stat: 'Energía', weekDone: 0, streakDays: 0, metrics: { week: { count: 0, xp: 0 }, month: { count: 5, xp: 250, weeks: [1, 2, 1, 1] }, qtr: { count: 14, xp: 700, weeks: [1, 2, 1, 1, 4, 5], weekTotals: [1, 2, 1, 1, 4, 5] } } },
-      { id: 'task-pantallas', name: '20` Sin pantallas antes de dormir', stat: 'Recuperación', weekDone: 0, streakDays: 0, metrics: { week: { count: 0, xp: 0 }, month: { count: 6, xp: 210, weeks: [1, 1, 2, 2] }, qtr: { count: 12, xp: 420, weeks: [1, 1, 2, 2, 3, 3], weekTotals: [1, 1, 2, 2, 3, 3] } } },
-      { id: 'task-ayuno', name: 'Ayuno hasta las 14hs', stat: 'Nutrición', weekDone: 2, streakDays: 2, metrics: { week: { count: 2, xp: 90 }, month: { count: 9, xp: 405, weeks: [2, 2, 3, 2] }, qtr: { count: 26, xp: 1170, weeks: [2, 2, 3, 2, 7, 10], weekTotals: [2, 2, 3, 2, 7, 10] } } },
-      { id: 'task-cena', name: 'Cena antes de las 22hs', stat: 'Nutrición', weekDone: 2, streakDays: 2, metrics: { week: { count: 2, xp: 90 }, month: { count: 8, xp: 360, weeks: [2, 2, 2, 2] }, qtr: { count: 22, xp: 990, weeks: [2, 2, 2, 2, 7, 7], weekTotals: [2, 2, 2, 2, 7, 7] } } },
-    ];
+	    const tasks: StreakPanelTask[] = [
+	      { id: 'task-correr', name: '10.000 pasos / Correr', stat: 'Movilidad', difficultyLabel: getDemoDifficultyLabel('task-correr'), latestRecalibrationAction: getDemoRecalibrationAction('task-correr'), weekDone: 2, streakDays: 4, metrics: { week: { count: 2, xp: 110 }, month: { count: 11, xp: 560, weeks: [2, 4, 3, 2] }, qtr: { count: 31, xp: 1540, weeks: [2, 4, 3, 2, 5, 3], weekTotals: [2, 4, 3, 2, 5, 3] } } },
+	      { id: 'task-no-dulces', name: 'No dulces', stat: 'Nutrición', difficultyLabel: getDemoDifficultyLabel('task-no-dulces'), latestRecalibrationAction: getDemoRecalibrationAction('task-no-dulces'), weekDone: 0, streakDays: 0, metrics: { week: { count: 0, xp: 0 }, month: { count: 3, xp: 130, weeks: [0, 1, 1, 1] }, qtr: { count: 9, xp: 390, weeks: [0, 1, 1, 1, 2, 4], weekTotals: [0, 1, 1, 1, 2, 4] } } },
+	      { id: 'task-gym', name: 'gym', stat: 'Energía', difficultyLabel: getDemoDifficultyLabel('task-gym'), latestRecalibrationAction: getDemoRecalibrationAction('task-gym'), weekDone: 0, streakDays: 0, metrics: { week: { count: 0, xp: 0 }, month: { count: 5, xp: 250, weeks: [1, 2, 1, 1] }, qtr: { count: 14, xp: 700, weeks: [1, 2, 1, 1, 4, 5], weekTotals: [1, 2, 1, 1, 4, 5] } } },
+	      { id: 'task-pantallas', name: '20` Sin pantallas antes de dormir', stat: 'Recuperación', difficultyLabel: getDemoDifficultyLabel('task-pantallas'), latestRecalibrationAction: getDemoRecalibrationAction('task-pantallas'), weekDone: 0, streakDays: 0, metrics: { week: { count: 0, xp: 0 }, month: { count: 6, xp: 210, weeks: [1, 1, 2, 2] }, qtr: { count: 12, xp: 420, weeks: [1, 1, 2, 2, 3, 3], weekTotals: [1, 1, 2, 2, 3, 3] } } },
+	      { id: 'task-ayuno', name: 'Ayuno hasta las 14hs', stat: 'Nutrición', difficultyLabel: getDemoDifficultyLabel('task-ayuno'), latestRecalibrationAction: getDemoRecalibrationAction('task-ayuno'), weekDone: 2, streakDays: 2, metrics: { week: { count: 2, xp: 90 }, month: { count: 9, xp: 405, weeks: [2, 2, 3, 2] }, qtr: { count: 26, xp: 1170, weeks: [2, 2, 3, 2, 7, 10], weekTotals: [2, 2, 3, 2, 7, 10] } } },
+	      { id: 'task-cena', name: 'Cena antes de las 22hs', stat: 'Nutrición', difficultyLabel: getDemoDifficultyLabel('task-cena'), latestRecalibrationAction: getDemoRecalibrationAction('task-cena'), weekDone: 2, streakDays: 2, metrics: { week: { count: 2, xp: 90 }, month: { count: 8, xp: 360, weeks: [2, 2, 2, 2] }, qtr: { count: 22, xp: 990, weeks: [2, 2, 2, 2, 7, 7], weekTotals: [2, 2, 2, 2, 7, 7] } } },
+	    ];
     const topStreaks = tasks
       .filter((entry) => (params.pillar === 'Body' ? true : params.pillar === 'Mind' ? entry.id === 'task-pantallas' : entry.id === 'task-no-dulces'))
       .sort((a, b) => b.streakDays - a.streakDays)
@@ -2657,7 +2752,13 @@ export async function getTaskInsights(
   if (isDashboardDemoModeEnabled()) {
     const task = DEMO_USER_TASKS.find((entry) => entry.id === taskId);
     return {
-      task: { id: taskId, name: task?.title ?? 'Task demo', stat: task?.statId ?? null, description: 'Detalle de hábito en modo demo.' },
+      task: {
+        id: taskId,
+        name: task?.title ?? 'Task demo',
+        stat: task?.statId ?? null,
+        description: 'Detalle de hábito en modo demo.',
+        difficultyLabel: getDemoDifficultyLabel(taskId),
+      },
       month: { totalCount: 9, totalXp: 405, days: [
         { date: '2026-02-03', count: 1 }, { date: '2026-02-05', count: 1 }, { date: '2026-02-08', count: 2 },
         { date: '2026-02-13', count: 1 }, { date: '2026-02-16', count: 1 }, { date: '2026-02-20', count: 1 },
@@ -2674,20 +2775,8 @@ export async function getTaskInsights(
           { weekStart: '2026-02-23', weekEnd: '2026-03-01', count: 3, hit: true },
         ],
       },
-      previewAchievement: {
-        score: 74,
-        status: 'building',
-        consolidationStrength: 66,
-        windowProximity: {
-          slots: ['valid', 'floor_only', 'projected_invalid'],
-        },
-        recentMonths: [
-          { periodKey: '2025-12', value: 42, state: 'weak' },
-          { periodKey: '2026-01', value: 61, state: 'building' },
-          { periodKey: '2026-02', value: 74, state: 'building' },
-        ],
-      },
-      recalibration: { eligible: true },
+      previewAchievement: getDemoPreviewAchievement(taskId),
+      recalibration: getDemoRecalibration(taskId),
     };
   }
   const normalized: Record<string, string | undefined> = {


### PR DESCRIPTION
## Summary
- Simplifies the habit development preview used in task details and locked achievements with the v3-style visual treatment, active-window marker, corrected month states, and light/dark token handling.
- Adds the animated/tappable recalibration chip in the task detail header so the latest adjustment opens briefly, then collapses to the correct icon.
- Updates demo preview data and API types so demo flows show down/up/keep difficulty adjustments and all month states.

## Verification
- `pnpm --filter @innerbloom/web exec vitest run src/components/dashboard-v3/__tests__/PreviewAchievementCard.test.tsx src/components/dashboard-v3/__tests__/StreakTaskInsightsModal.test.tsx`

Note: repository-wide typecheck still has pre-existing unrelated failures in Clerk/demo/avatar/landing files, so this PR was verified with focused component tests.