### PR TITLE
Fix official landing visual parity with /v3

### DIFF
--- a/apps/web/src/components/landing/HeroPhoneShowcase.module.css
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.module.css
@@ -302,7 +302,7 @@
 }
 
 .loopSplashScene {
-  --loop-splash-wordmark-width: min(138px, calc(100% - 54px));
+  --loop-splash-wordmark-width: min(164px, calc(100% - 42px));
   position: absolute;
   inset: 10px;
   border-radius: 30px;
@@ -330,6 +330,22 @@
   animation: loopSplashOverlay 4400ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
+
+.loopSplashSceneV3 {
+  --loop-splash-wordmark-width: min(142px, calc(100% - 52px));
+}
+
+.loopSplashSceneV3 .loopSplashLockup {
+  width: min(100%, 256px);
+}
+
+.loopSplashSceneV3 .loopSplashFlower {
+  width: clamp(48px, 18cqw, 60px);
+}
+
+.loopSplashSceneV3 .loopSplashWordmark {
+  font-size: clamp(0.82rem, 5.1cqw, 1.04rem);
+}
 .loopSplashDepthGlow {
   position: absolute;
   inset: 0;
@@ -351,7 +367,7 @@
 
 .loopSplashLockup {
   position: relative;
-  width: min(100%, 252px);
+  width: min(100%, 286px);
   max-width: 100%;
   display: inline-flex;
   align-items: center;
@@ -371,7 +387,7 @@
 }
 
 .loopSplashFlower {
-  width: clamp(46px, 18cqw, 58px);
+  width: clamp(56px, 20.5cqw, 74px);
   margin-inline-end: -2px;
   flex: 0 0 auto;
   height: auto;
@@ -394,7 +410,7 @@
   max-width: var(--loop-splash-wordmark-width);
   overflow: hidden;
   white-space: nowrap;
-  font-size: clamp(0.82rem, 5.1cqw, 1.02rem);
+  font-size: clamp(0.9rem, 5.7cqw, 1.16rem);
   font-weight: 700;
   letter-spacing: 0.28em;
   text-transform: uppercase;

--- a/apps/web/src/components/landing/HeroPhoneShowcase.tsx
+++ b/apps/web/src/components/landing/HeroPhoneShowcase.tsx
@@ -321,11 +321,11 @@ function RealDashboardScene({
   );
 }
 
-function LoopSplashScene() {
+function LoopSplashScene({ variant = "default" }: { variant?: HeroPhoneShowcaseVariant }) {
   const brandCharacters = "INNERBLOOM".split("");
 
   return (
-    <section className={styles.loopSplashScene} aria-hidden>
+    <section className={`${styles.loopSplashScene} ${variant === "v3Right" ? styles.loopSplashSceneV3 : ""}`} aria-hidden>
       <div className={styles.loopSplashDepthGlow} />
       <div className={styles.loopSplashLockupShell}>
         <div className={styles.loopSplashLockup}>
@@ -423,7 +423,7 @@ export function HeroPhoneShowcase({
           aria-hidden
         />
       )}
-      {phase === "splash" ? <LoopSplashScene /> : null}
+      {phase === "splash" ? <LoopSplashScene variant={variant} /> : null}
     </PhoneFrame>
   );
 }

--- a/apps/web/src/content/landingV3Content.ts
+++ b/apps/web/src/content/landingV3Content.ts
@@ -37,6 +37,8 @@ export const LANDING_V3_CONTENT: Record<Language, LandingCopy> = {
       ...LANDING_V2_CONTENT.es.demo,
       title: 'Mira tu Journey.',
       text: 'Energía, emociones, acciones, GP y rachas en una experiencia simple de seguir.',
+      banner: 'Explora cómo se ve tu crecimiento',
+      cta: 'Explorar demo',
     },
   },
   en: {
@@ -74,6 +76,8 @@ export const LANDING_V3_CONTENT: Record<Language, LandingCopy> = {
       ...LANDING_V2_CONTENT.en.demo,
       title: 'See your Journey.',
       text: 'Energy, emotions, actions, GP, and streaks in one experience that is easy to follow.',
+      banner: 'Explore what your growth looks like',
+      cta: 'Explore demo',
     },
   },
 };

--- a/apps/web/src/content/officialLandingContent.ts
+++ b/apps/web/src/content/officialLandingContent.ts
@@ -224,9 +224,9 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
       ]
     },
     demo: {
-      title: 'Haz visible el progreso que normalmente no ves.',
+      title: 'Haz visible tu progreso',
       text: 'Innerbloom te muestra patrones, constancia y evolución para que avanzar no se sienta como todo o nada, sino como un proceso visible y real.',
-      banner: 'Explora cómo se ve tu crecimiento dentro de Innerbloom',
+      banner: 'Explora cómo se ve tu crecimiento',
       cta: 'Explorar demo'
     },
     testimonials: {
@@ -468,9 +468,9 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
       ]
     },
     demo: {
-      title: 'Make visible the progress you normally don’t see.',
+      title: 'Make visible your progress',
       text: 'Innerbloom shows you patterns, consistency, and evolution so progress doesn’t feel all-or-nothing, but visible and real.',
-      banner: 'Explore what your growth looks like inside Innerbloom',
+      banner: 'Explore what your growth looks like',
       cta: 'Explore demo'
     },
     testimonials: {

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -3661,7 +3661,8 @@
   padding: clamp(74px, 8vw, 112px) 0 clamp(64px, 7vw, 98px);
 }
 
-.landing.landing--v2-narrative .truth-problem-section {
+.landing.landing--v2-narrative .truth-problem-section,
+.landing .truth-problem--orb-layout .truth-problem-section {
   max-width: 1080px;
   gap: clamp(30px, 4vw, 54px);
 }
@@ -3672,7 +3673,8 @@
   font-size: clamp(2rem, 2.3vw + 1.25rem, 3.55rem);
 }
 
-.landing.landing--v2-narrative .truth-problem-v2-stage {
+.landing.landing--v2-narrative .truth-problem-v2-stage,
+.landing .truth-problem--orb-layout .truth-problem-v2-stage {
   width: min(1040px, 100%);
   display: grid;
   grid-template-columns: minmax(190px, 1fr) minmax(260px, 340px) minmax(190px, 1fr);
@@ -3681,7 +3683,8 @@
   gap: clamp(22px, 4vw, 54px);
 }
 
-.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static {
+.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static,
+.landing .truth-problem--orb-layout .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static {
   width: clamp(270px, 28vw, 360px);
   max-width: min(82vw, 360px);
   margin: 0;
@@ -4423,17 +4426,20 @@
 }
 
 /* V2-only refinements requested for the adaptive-life and demo sections. */
-.landing.landing--v2-narrative .truth-problem-section {
+.landing.landing--v2-narrative .truth-problem-section,
+.landing .truth-problem--orb-layout .truth-problem-section {
   max-width: 1180px;
 }
 
-.landing.landing--v2-narrative .truth-problem-v2-stage {
+.landing.landing--v2-narrative .truth-problem-v2-stage,
+.landing .truth-problem--orb-layout .truth-problem-v2-stage {
   width: min(1160px, 100%);
   grid-template-columns: minmax(180px, 0.75fr) minmax(360px, 540px) minmax(180px, 0.75fr);
   gap: clamp(12px, 2.2vw, 32px);
 }
 
-.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static {
+.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static,
+.landing .truth-problem--orb-layout .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static {
   width: clamp(405px, 38vw, 540px);
   max-width: min(88vw, 540px);
   border: none;
@@ -4444,35 +4450,38 @@
 }
 
 .landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static::before,
-.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static::after {
+.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static::after,
+.landing .truth-problem--orb-layout .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static::before,
+.landing .truth-problem--orb-layout .truth-problem-v2-stage .weather-cycle-orb.weather-cycle-orb--static::after {
   content: none;
   display: none;
 }
 
-.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb__image {
+.landing.landing--v2-narrative .truth-problem-v2-stage .weather-cycle-orb__image,
+.landing .truth-problem--orb-layout .truth-problem-v2-stage .weather-cycle-orb__image {
   width: 100%;
   height: 100%;
   object-fit: contain;
 }
 
-.landing.landing--v2-narrative .visible-progress-top--v2-text-only {
+.landing .visible-progress-top--v2-text-only {
   grid-template-columns: 1fr;
   justify-items: center;
   text-align: center;
 }
 
-.landing.landing--v2-narrative .visible-progress-top--v2-text-only .visible-progress-copy {
+.landing .visible-progress-top--v2-text-only .visible-progress-copy {
   justify-items: center;
   max-width: 760px;
   padding-top: 0;
   text-align: center;
 }
 
-.landing.landing--v2-narrative .visible-progress-top--v2-text-only .demo-title {
+.landing .visible-progress-top--v2-text-only .demo-title {
   max-width: 18ch;
 }
 
-.landing.landing--v2-narrative .visible-progress-top--v2-text-only .demo-sub {
+.landing .visible-progress-top--v2-text-only .demo-sub {
   max-width: 58ch;
 }
 

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -828,6 +828,7 @@ export default function LandingPage({
   const isV2Narrative = variant === "v2Narrative";
   const isV3Conversion = variant === "v3Conversion";
   const isNarrativeVariant = isV2Narrative || isV3Conversion;
+  const isOfficialDefault = variant === "default";
   const visibleNavLinks = copy.navLinks.filter(
     (link) => !/^\/demo$/i.test(link.href) && !/^#?demo$/i.test(link.href),
   );
@@ -1225,11 +1226,11 @@ export default function LandingPage({
         </section>
 
         <section
-          className="truth-problem section-pad reveal-on-scroll"
+          className={`truth-problem section-pad reveal-on-scroll ${isOfficialDefault ? "truth-problem--orb-layout" : ""}`}
           id="why"
         >
           <div className="container narrow truth-problem-section">
-            {isNarrativeVariant ? (
+            {isNarrativeVariant || isOfficialDefault ? (
               <>
                 <AdaptiveText
                   as="h2"
@@ -1350,7 +1351,7 @@ export default function LandingPage({
         >
           <div className="container narrow">
             <div
-              className={`visible-progress-top ${isNarrativeVariant ? "visible-progress-top--v2-text-only" : ""}`}
+              className={`visible-progress-top ${isNarrativeVariant || isOfficialDefault ? "visible-progress-top--v2-text-only" : ""}`}
             >
               <div className="visible-progress-copy">
                 <AdaptiveText as="h2" className="demo-title">
@@ -1361,7 +1362,7 @@ export default function LandingPage({
                 </AdaptiveText>
               </div>
 
-              {!isNarrativeVariant ? (
+              {!isNarrativeVariant && !isOfficialDefault ? (
                 <div className="visible-progress-module" aria-hidden>
                 <div className="visible-progress-viewport">
                   <div className="visible-progress-scene">


### PR DESCRIPTION
### Motivation
- Recover the visual weight and layout parity of the official landing (`/`) with the `/v3` variant without touching auth, analytics, routing, pricing, or demo logic.
- Make the hero phone splash, the “real problem” orb section, the “Make visible…” section, and the bottom CTA visually consistent while preserving variant-specific behavior and official copy.

### Description
- Adjusted the hero splash to be variant-aware by passing a `variant` to `LoopSplashScene` and adding a `loopSplashSceneV3` override so the official (`default`) splash is larger and centered while `/v3` keeps its sizing; changes in `HeroPhoneShowcase.tsx` and `HeroPhoneShowcase.module.css` tweak `--loop-splash-wordmark-width`, lockup size, flower size and font-size. (`apps/web/src/components/landing/HeroPhoneShowcase.tsx`, `apps/web/src/components/landing/HeroPhoneShowcase.module.css`)
- Made the official landing use the stronger orb-centered layout for the “THE REAL PROBLEM / You’re not the problem.” section by enabling the v2 orb stage markup for the `default` variant and adding a `truth-problem--orb-layout` hook used by existing `.truth-problem-v2-stage` CSS rules to avoid duplicating styles. (`apps/web/src/pages/Landing.tsx`, `apps/web/src/pages/Landing.css`)
- Simplified the official “Make visible…” section to a centered single-column layout and hid the right-side dashboard/preview module only for the official variant by reusing the `visible-progress-top--v2-text-only` pattern and gating the `visible-progress-module` render. (`apps/web/src/pages/Landing.tsx`, `apps/web/src/pages/Landing.css`)
- Updated CTA/demo banner copy in both official and `/v3` content to the exact requested strings: EN `Explore what your growth looks like` / ES `Explora cómo se ve tu crecimiento`, and adjusted demo CTA copy where applicable. (`apps/web/src/content/officialLandingContent.ts`, `apps/web/src/content/landingV3Content.ts`)
- Kept all theme (dark/light), responsive behavior, and demo/dashboard logic intact and reused existing v3 styles where possible instead of duplicating them.

### Testing
- Built the web app with `npm run build:web` (invokes `vite build`) and the build completed successfully with warnings related to CSS minification but no blocking errors. (succeeded)
- Ran type check with `npm run typecheck:web` and it failed due to pre-existing TypeScript issues in unrelated parts of the repo (these errors were present before this change and not introduced by this PR). (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01bd31abdc8322a1db79fd093beaac)