### PR TITLE
V3 landing: add kickers, update demo/testimonials copy, and hide post-demo sections

### DIFF
--- a/apps/web/src/content/landingV3Content.ts
+++ b/apps/web/src/content/landingV3Content.ts
@@ -6,6 +6,7 @@ export const LANDING_V3_CONTENT: Record<Language, LandingCopy> = {
     ...LANDING_V2_CONTENT.es,
     how: {
       ...LANDING_V2_CONTENT.es.how,
+      kicker: 'EL SISTEMA',
       steps: [
         {
           title: 'Empieza posible, no perfecto.',
@@ -35,16 +36,21 @@ export const LANDING_V3_CONTENT: Record<Language, LandingCopy> = {
     },
     demo: {
       ...LANDING_V2_CONTENT.es.demo,
-      title: 'Mira tu Journey.',
+      title: 'Haz visible tu progreso',
       text: 'Energía, emociones, acciones, GP y rachas en una experiencia simple de seguir.',
       banner: 'Explora cómo se ve tu crecimiento',
       cta: 'Explorar demo',
+    },
+    testimonials: {
+      ...LANDING_V2_CONTENT.es.testimonials,
+      title: 'Primeras experiencias',
     },
   },
   en: {
     ...LANDING_V2_CONTENT.en,
     how: {
       ...LANDING_V2_CONTENT.en.how,
+      kicker: 'THE SYSTEM',
       steps: [
         {
           title: 'Start possible, not perfect.',
@@ -74,10 +80,14 @@ export const LANDING_V3_CONTENT: Record<Language, LandingCopy> = {
     },
     demo: {
       ...LANDING_V2_CONTENT.en.demo,
-      title: 'See your Journey.',
+      title: 'Make visible your progress',
       text: 'Energy, emotions, actions, GP, and streaks in one experience that is easy to follow.',
       banner: 'Explore what your growth looks like',
       cta: 'Explore demo',
+    },
+    testimonials: {
+      ...LANDING_V2_CONTENT.en.testimonials,
+      title: 'Early experience',
     },
   },
 };

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -425,6 +425,7 @@ function LandingNarrativeMethod({
   return (
     <div className="v2-method-shell">
       <div className="v2-method-heading">
+        <p className="how-kicker">{how.kicker}</p>
         <AdaptiveText as="h2">{how.title}</AdaptiveText>
         <AdaptiveText as="p" className="section-sub v2-method-intro">
           {how.intro}
@@ -776,6 +777,7 @@ function LandingV3ConversionMethod({ how, language }: { how: LandingCopy["how"];
   return (
     <div className="v2-method-shell v3-method-shell">
       <div className="v2-method-heading">
+        <p className="how-kicker">{how.kicker}</p>
         <AdaptiveText as="h2">{how.title}</AdaptiveText>
         <AdaptiveText as="p" className="section-sub v2-method-intro">
           {how.intro}
@@ -1232,6 +1234,11 @@ export default function LandingPage({
           <div className="container narrow truth-problem-section">
             {isNarrativeVariant || isOfficialDefault ? (
               <>
+                {isV3Conversion ? (
+                  <p className="section-kicker">
+                    {language === "es" ? "EL PROBLEMA PRINCIPAL" : "THE MAIN PROBLEM"}
+                  </p>
+                ) : null}
                 <AdaptiveText
                   as="h2"
                   className="truth-problem-title truth-problem-title--outside"
@@ -1354,6 +1361,7 @@ export default function LandingPage({
               className={`visible-progress-top ${isNarrativeVariant || isOfficialDefault ? "visible-progress-top--v2-text-only" : ""}`}
             >
               <div className="visible-progress-copy">
+                {isV3Conversion ? <p className="section-kicker">DEMO</p> : null}
                 <AdaptiveText as="h2" className="demo-title">
                   {copy.demo.title}
                 </AdaptiveText>
@@ -1687,6 +1695,8 @@ export default function LandingPage({
           </div>
         </section>
 
+        {isV3Conversion ? null : (
+          <>
         <section className="why section-pad reveal-on-scroll" id="pillars">
           <div className="container narrow">
             <p className="section-kicker">{copy.pillars.kicker}</p>
@@ -1834,6 +1844,9 @@ export default function LandingPage({
             </div>
           </div>
         </section>
+
+          </>
+        )}
 
         <section
           className="testimonials section-pad reveal-on-scroll"


### PR DESCRIPTION
### Motivation
- Surface clear pre-titles (kickers) in the V3 conversion flow to match the visual hierarchy used elsewhere (e.g. PILLARS). 
- Adjust demo and testimonials copy to the requested V3 wording without touching other landing variants. 
- Shorten the V3 flow by not rendering pillars / weekly rhythm / modes after demo for the `v3Conversion` variant only.

### Description
- Updated `apps/web/src/content/landingV3Content.ts` to override V3 copy for `how.kicker`, `demo.title`, and `testimonials.title` in both `en` and `es` locales. 
- Modified `apps/web/src/pages/Landing.tsx` to render the problem pre-title above the problem title only when `isV3Conversion` is true, using the existing kicker styling classes. 
- Render the method kicker inside the V3 method component and add a `DEMO` kicker above the demo title for `v3Conversion`, reusing existing classes (`how-kicker` / `section-kicker`). 
- Prevent rendering of `pillars`, `LabsWeeklyRhythmSystemSection` (rhythms) and the `modes` section when `isV3Conversion === true`, while keeping demo and testimonials unchanged. 
- All changes were scoped to the V3 content overrides and conditional rendering; no routes, auth, analytics, pricing, onboarding, or dashboard logic were modified.

### Testing
- Ran `npm run build:web`, which completed successfully and produced the web build. 
- Ran `npm run typecheck:web`, which reported repository-wide TypeScript errors unrelated to the V3 changes; these typecheck failures pre-existed and are outside the scope of this PR. 
- Manual inspection of modified files: `apps/web/src/content/landingV3Content.ts` and `apps/web/src/pages/Landing.tsx` to ensure changes are limited to the V3 variant and styling classes were reused.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ccfe3b108322bfe9d8639d5bd8cd)