### PR TITLE
Add Discord CTA, footer link and Back-to-Top button; style tweaks to Landing page

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -2030,21 +2030,21 @@
   isolation: isolate;
   margin: 2px auto 0;
   width: min(100%, 980px);
-  padding: clamp(13px, 1.6vw, 17px) clamp(15px, 2vw, 22px);
+  padding: clamp(11px, 1.4vw, 14px) clamp(14px, 1.8vw, 20px);
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: clamp(12px, 1.8vw, 20px);
+  gap: clamp(10px, 1.6vw, 16px);
 }
 
 .landing .demo-bridge::before {
   content: "";
   position: absolute;
-  inset: -7px 4px -8px;
+  inset: -6px 4px -7px;
   z-index: -2;
   border-radius: var(--landing-glass-radius-md);
   background: var(--landing-glass-glow);
-  filter: blur(11px);
+  filter: blur(10px);
 }
 
 .landing .demo-bridge::after {
@@ -2052,9 +2052,9 @@
   position: absolute;
   inset: 0;
   z-index: -1;
-  border-radius: var(--landing-glass-radius-md);
+  border-radius: 24px;
   background: var(--landing-glass-bg);
-  border: 1px solid var(--landing-glass-border);
+  border: 1px solid rgba(199, 178, 255, 0.2);
   box-shadow: var(--landing-glass-shadow);
 }
 
@@ -2077,9 +2077,9 @@
 
 .landing .demo-bridge-copy {
   margin: 0;
-  font-size: 0.91rem;
+  font-size: 0.89rem;
   color: rgba(229, 239, 255, 0.86);
-  line-height: 1.5;
+  line-height: 1.42;
 }
 
 .landing .demo-actions {
@@ -2579,6 +2579,69 @@
 .landing .footer-community-link:focus-visible {
   outline: 2px solid #120a1c;
   outline-offset: 2px;
+}
+
+.landing .landing-discord-cta {
+  margin: 14px auto 0;
+  max-width: 52ch;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: var(--subtle);
+}
+
+.landing .landing-discord-cta a {
+  color: inherit;
+  font-weight: 700;
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, currentColor 42%, transparent);
+}
+
+.landing .landing-discord-cta a:hover {
+  color: var(--ink);
+  border-bottom-color: color-mix(in srgb, currentColor 72%, transparent);
+}
+
+.landing .landing-back-to-top {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 35;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ink) 18%, transparent);
+  background: color-mix(in srgb, var(--bg) 56%, transparent);
+  color: var(--ink);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: 0 8px 22px rgba(8, 9, 18, 0.2);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  transition: transform 150ms ease, background-color 150ms ease;
+}
+
+.landing .landing-back-to-top:hover {
+  transform: translateY(-1px);
+}
+
+.landing[data-theme-mode="light"] .landing-back-to-top {
+  background: rgba(255, 255, 255, 0.78);
+  color: rgba(56, 41, 89, 0.96);
+  border-color: rgba(156, 129, 214, 0.28);
+}
+
+.landing[data-theme-mode="dark"] .landing-back-to-top {
+  background: rgba(12, 13, 26, 0.72);
+}
+
+@media (max-width: 768px) {
+  .landing .landing-back-to-top {
+    right: 16px;
+    bottom: 16px;
+  }
 }
 
 @keyframes meshFloat {
@@ -3948,10 +4011,6 @@
   max-width: 760px;
   margin-left: auto;
   margin-right: auto;
-}
-
-.landing.landing--v3-conversion .demo-bridge {
-  border-color: rgba(199, 178, 255, 0.2);
 }
 
 .landing .v3-method-card-grid {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -181,6 +181,46 @@ function splitPillarCopy(copy: string, language: Language) {
   return { definition, examples };
 }
 
+const DISCORD_URL = "https://discord.gg/wds35ykK";
+
+const DISCORD_CTA_COPY: Record<Language, { lead: string; link: string }> = {
+  en: {
+    lead: "Got questions or feedback?",
+    link: "Join us on Discord.",
+  },
+  es: {
+    lead: "¿Tienes preguntas o feedback?",
+    link: "Únete a nuestro Discord.",
+  },
+};
+
+function BackToTopButton({ language }: { language: Language }) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 500);
+    };
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      type="button"
+      className="landing-back-to-top"
+      aria-label={language === "es" ? "Volver arriba" : "Back to top"}
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+    >
+      <span aria-hidden="true">↑</span>
+      <span>Top</span>
+    </button>
+  );
+}
+
 const EMOTION_HEATMAP_ROWS: Array<
   Array<"calm" | "happy" | "focus" | "stress" | "neutral">
 > = [
@@ -1997,6 +2037,12 @@ export default function LandingPage({
                 </>
               )}
             </div>
+            <p className="landing-discord-cta">
+              {DISCORD_CTA_COPY[language].lead}{" "}
+              <a href={DISCORD_URL} target="_blank" rel="noreferrer">
+                {DISCORD_CTA_COPY[language].link}
+              </a>
+            </p>
           </div>
         </section>
       </main>
@@ -2051,8 +2097,25 @@ export default function LandingPage({
             </svg>
             <span>Join our subreddit</span>
           </a>
+          <a
+            className="footer-community-link"
+            data-analytics-cta="join_discord"
+            data-analytics-location="footer"
+            href={DISCORD_URL}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M20.32 4.37a18.3 18.3 0 0 0-4.63-1.47.08.08 0 0 0-.08.04c-.2.36-.42.84-.58 1.22a17 17 0 0 0-5.06 0 12 12 0 0 0-.59-1.22.08.08 0 0 0-.08-.04A18.27 18.27 0 0 0 4.7 4.37a.07.07 0 0 0-.03.03C1.73 8.79.93 13.07 1.32 17.3a.1.1 0 0 0 .04.07 18.4 18.4 0 0 0 5.68 2.9.08.08 0 0 0 .09-.03c.44-.6.84-1.24 1.18-1.91a.08.08 0 0 0-.04-.11 12 12 0 0 1-1.8-.86.08.08 0 0 1-.01-.13q.19-.14.39-.3a.07.07 0 0 1 .08-.01c3.77 1.72 7.85 1.72 11.58 0a.07.07 0 0 1 .08.01q.2.17.39.3a.08.08 0 0 1-.01.13 12 12 0 0 1-1.8.86.08.08 0 0 0-.04.11c.35.67.74 1.3 1.18 1.9a.08.08 0 0 0 .09.04 18.34 18.34 0 0 0 5.69-2.9.08.08 0 0 0 .04-.07c.47-4.89-.79-9.14-3.36-12.9a.06.06 0 0 0-.03-.03M8.02 14.72c-1.14 0-2.08-1.05-2.08-2.34s.92-2.34 2.08-2.34 2.1 1.06 2.08 2.34-.92 2.34-2.08 2.34m7.67 0c-1.14 0-2.08-1.05-2.08-2.34s.92-2.34 2.08-2.34 2.1 1.06 2.08 2.34-.92 2.34-2.08 2.34"
+                fill="currentColor"
+              />
+            </svg>
+            <span>{language === "es" ? "Únete a Discord" : "Join us on Discord"}</span>
+          </a>
         </nav>
       </footer>
+      <BackToTopButton language={language} />
       <CookieConsentBanner
         language={language}
         isOpen={isCookiePanelOpen}


### PR DESCRIPTION
### Motivation
- Add a visible Discord call-to-action and community link to help users ask questions and give feedback, with Spanish localization. 
- Provide a persistent, accessible back-to-top control for improved UX on long landing pages. 
- Adjust landing visual spacing, radii, and subtle color/border values to fine-tune the hero/demo appearance.

### Description
- Introduced `DISCORD_URL` and `DISCORD_CTA_COPY` constants and added a localized Discord CTA paragraph in the next/CTA section using `DISCORD_CTA_COPY[language]`.
- Added a Discord community link to the footer with an inline SVG icon and localized label.
- Implemented a `BackToTopButton` React component that shows after scrolling (`window.scrollY > 500`) and smooth-scrolls to top, and rendered it before the cookie banner.
- Updated `Landing.css` with new rules for `.landing-discord-cta` and `.landing-back-to-top` (theme variants, responsive placement, hover states, and backdrop blur) and tweaked multiple landing styles (demo-bridge padding/gap, pseudo-element inset/blur, border-radius and border color changes, and minor font-size/line-height adjustments).

### Testing
- Ran the project unit tests with `yarn test`, which completed successfully.
- Verified the TypeScript build with `yarn build` (production build), which succeeded.
- Ran the type-check step with `tsc --noEmit` to ensure no type errors, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d42f5c248322ba4953dd8c0c8c80)