### PR TITLE
Align `/` and `/v3` footer social layout and copy

### DIFF
--- a/apps/web/src/content/officialLandingContent.ts
+++ b/apps/web/src/content/officialLandingContent.ts
@@ -294,7 +294,7 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
       startJourney: 'Crear mi plan adaptativo',
       guidedDemo: 'Demos'
     },
-    footer: { copyright: '©️ Gamification Journey', faq: 'FAQ' }
+    footer: { copyright: '© Innerbloom. All rights reserved.', faq: 'FAQ' }
   },
   en: {
     navLinks: [],
@@ -538,6 +538,6 @@ export const OFFICIAL_LANDING_CONTENT: Record<Language, LandingCopy> = {
       startJourney: 'Create my adaptive plan',
       guidedDemo: 'Demos'
     },
-    footer: { copyright: '©️ Gamification Journey', faq: 'FAQ' }
+    footer: { copyright: '© Innerbloom. All rights reserved.', faq: 'FAQ' }
   }
 };

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -2398,7 +2398,7 @@
 
 .landing .footer {
   border-top: 1px solid var(--line);
-  padding: 32px 18px;
+  padding: 32px 18px clamp(84px, 10vw, 120px);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -2409,7 +2409,10 @@
 
 .landing .footer-links {
   display: flex;
-  gap: 16px;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 16px;
+  padding-right: clamp(96px, 8vw, 132px);
 }
 
 .landing .footer-links a {
@@ -2548,9 +2551,10 @@
 .landing .footer-community-link {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
   min-height: 36px;
-  padding: 6px 10px;
+  min-width: 36px;
+  padding: 6px;
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, currentColor 16%, transparent);
   transition:
@@ -2560,14 +2564,15 @@
 }
 
 .landing .footer-community-link svg {
-  width: 14px;
-  height: 14px;
+  width: 20px;
+  height: 20px;
   opacity: 0.82;
   flex: 0 0 auto;
 }
 
-.landing .footer-community-link span {
-  line-height: 1.1;
+.landing .footer-community-link--reddit svg {
+  width: 26px;
+  height: 26px;
 }
 
 .landing .footer-community-link:hover {
@@ -2641,6 +2646,14 @@
   .landing .landing-back-to-top {
     right: 16px;
     bottom: 16px;
+  }
+
+  .landing .footer {
+    padding-bottom: 76px;
+  }
+
+  .landing .footer-links {
+    padding-right: 0;
   }
 }
 

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -2082,12 +2082,14 @@ export default function LandingPage({
             {language === "es" ? "Cookies" : "Cookies"}
           </button>
           <a
-            className="footer-community-link"
+            className="footer-community-link footer-community-link--reddit"
             data-analytics-cta="join_subreddit"
             data-analytics-location="footer"
             href="https://www.reddit.com/r/InnerbloomJourney/"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="Join our subreddit"
+            title="Join our subreddit"
           >
             <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <path
@@ -2095,7 +2097,6 @@ export default function LandingPage({
                 fill="currentColor"
               />
             </svg>
-            <span>Join our subreddit</span>
           </a>
           <a
             className="footer-community-link"
@@ -2104,6 +2105,8 @@ export default function LandingPage({
             href={DISCORD_URL}
             target="_blank"
             rel="noreferrer"
+            aria-label="Join us on Discord"
+            title="Join us on Discord"
           >
             <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <path
@@ -2111,7 +2114,6 @@ export default function LandingPage({
                 fill="currentColor"
               />
             </svg>
-            <span>{language === "es" ? "Únete a Discord" : "Join us on Discord"}</span>
           </a>
         </nav>
       </footer>


### PR DESCRIPTION
### Motivation
- Unificar el footer de la landing oficial `/` y la landing V3 `/v3` para que compartan el mismo diseño y copy de derechos.
- Evitar que el botón flotante `Top` se superponga con los enlaces de comunidad en desktop y mobile sin resolverlo únicamente con `z-index`.
- Hacer que los enlaces de Reddit y Discord en el footer sean icon-only manteniendo accesibilidad.
- Ajustar la escala visual del icono de Reddit para que sea ~30% más grande que Discord.

### Description
- Replaced visible footer pills for Reddit/Discord with icon-only links in `apps/web/src/pages/Landing.tsx`, keeping `aria-label` and `title` attributes and adding a specific `footer-community-link--reddit` class for Reddit.
- Updated `apps/web/src/pages/Landing.css` to reserve space so the fixed `Top` button no longer covers footer items by adding a desktop right-side reserve (`padding-right: clamp(96px, 8vw, 132px)`), increasing footer padding, enabling wrap for `.footer-links`, and adding mobile overrides (`padding-bottom` and removing the right reserve on small screens).
- Restyled community buttons to compact icon-only buttons: base SVG size set to `20px` and Reddit SVG set to `26px` to meet the ~30% size increase requirement, while keeping the button footprint small and accessible.
- Standardized the official landing copyright strings in `apps/web/src/content/officialLandingContent.ts` (ES/EN) to exactly: `© Innerbloom. All rights reserved.`
- No new dependencies added and no changes made to auth, routing, analytics, onboarding or other unrelated flows.

### Testing
- Ran `npm run -s lint` and it passed.
- Ran `npm run -s build` and the build completed successfully (minor CSS warnings reported during minification but no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01db9d47b4832296dc1fc8c2ca82be)