### PR TITLE
Refactor native welcome layout and responsive visuals; tweak mobile action sizing

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -640,12 +640,29 @@
   }
 
   .native-welcome-carousel {
+    --native-welcome-shell-height: clamp(320px, 48dvh, 460px);
+    --native-welcome-visual-viewport-height: clamp(278px, 41dvh, 390px);
+    --native-welcome-visual-scale: 0.68;
+    --native-welcome-visual-y: 0px;
     display: flex;
     min-height: 0;
     height: 100%;
     flex: 1;
     flex-direction: column;
     gap: clamp(0.24rem, 0.78dvh, 0.45rem);
+  }
+  .native-welcome-frame {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+
+  .native-welcome-main {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
   }
 
   .native-welcome-copy {
@@ -677,6 +694,8 @@
     position: relative;
     min-height: 0;
     flex: 1;
+    height: var(--native-welcome-shell-height);
+    max-height: 100%;
     overflow: hidden;
     border-radius: 1.5rem;
     border: 1px solid rgba(191, 219, 254, 0.04);
@@ -691,7 +710,7 @@
   }
 
   .native-welcome-visual-shell .v3-step-visual {
-    --v3-method-visual-viewport-height: min(45dvh, 360px);
+    --v3-method-visual-viewport-height: var(--native-welcome-visual-viewport-height);
     margin-inline: auto;
     width: min(100%, 460px);
     max-width: 460px;
@@ -702,14 +721,20 @@
     margin: 0;
   }
 
-  .native-welcome-visual-shell .v3-method-quickstart__scene { transform: scale(0.82); }
-  .native-welcome-visual-shell .v3-method-streaks__tilt { transform: scale(0.96); transform-origin: center 54%; }
-  .native-welcome-visual-shell .v3-adjustment-demo { transform: scale(0.96); transform-origin: center 56%; }
-  .native-welcome-visual-shell .v3-method-logros__scene { transform: scale(0.88); transform-origin: center 55%; width: min(116%, 530px); margin-left: auto; margin-right: auto; }
+  .native-welcome-visual-shell .v3-method-quickstart__scene { transform: translateY(var(--native-welcome-visual-y)) scale(var(--native-welcome-visual-scale)); transform-origin: center top; }
+  .native-welcome-visual-shell .v3-method-streaks__tilt { transform: translateY(var(--native-welcome-visual-y)) scale(var(--native-welcome-visual-scale)); transform-origin: center top; }
+  .native-welcome-visual-shell .v3-adjustment-demo { transform: translateY(var(--native-welcome-visual-y)) scale(var(--native-welcome-visual-scale)); transform-origin: center top; }
+  .native-welcome-visual-shell .v3-method-logros__scene { transform: scale(0.74); transform-origin: center 54%; width: min(116%, 530px); margin-left: auto; margin-right: auto; }
 
-  .native-welcome-carousel[data-native-step="1"] .native-welcome-visual-shell .v3-method-quickstart__scene {
-    transform: scale(0.8);
-    transform-origin: center 44%;
+  .native-welcome-actions {
+    --native-welcome-actions-shift: clamp(4px, 0.8dvh, 12px);
+    transform: translateY(var(--native-welcome-actions-shift));
+    padding-bottom: clamp(0.08rem, 0.35dvh, 0.25rem);
+  }
+
+  .native-welcome-carousel[data-native-step="1"] {
+    --native-welcome-visual-scale: 0.46;
+    --native-welcome-visual-y: 4px;
   }
   .native-welcome-carousel[data-native-step="1"] .native-welcome-visual-shell .v3-method-quickstart__titles {
     margin-bottom: 0.08rem;
@@ -728,22 +753,22 @@
     inset: auto 0 clamp(0.32rem, 1.2dvh, 0.6rem) 0;
   }
 
-  .native-welcome-carousel[data-native-step="2"] .native-welcome-visual-shell .v3-method-streaks__tilt {
-    transform: scale(1.15);
-    transform-origin: center 56%;
+  .native-welcome-carousel[data-native-step="2"] {
+    --native-welcome-visual-scale: 0.61;
+    --native-welcome-visual-y: 2px;
   }
   .native-welcome-carousel[data-native-step="2"] .native-welcome-visual-shell [data-light-scope="dashboard-v3"] {
     overflow: visible;
   }
 
-  .native-welcome-carousel[data-native-step="3"] .native-welcome-visual-shell .v3-adjustment-demo {
-    transform: scale(1.05);
-    transform-origin: center 61%;
+  .native-welcome-carousel[data-native-step="3"] {
+    --native-welcome-visual-scale: 0.68;
+    --native-welcome-visual-y: 0px;
   }
 
-  .native-welcome-carousel[data-native-step="4"] .native-welcome-visual-shell .v3-method-logros__scene {
-    transform: scale(1.06);
-    transform-origin: center 56%;
+  .native-welcome-carousel[data-native-step="4"] {
+    --native-welcome-visual-scale: 0.74;
+    --native-welcome-visual-y: 0px;
   }
 
   .native-welcome-carousel-controls {
@@ -780,13 +805,60 @@
     transform-origin: left center;
     animation: native-welcome-progress linear forwards;
   }
-@media (max-height: 760px) {
+@media (max-height: 820px) {
     .native-welcome-carousel {
-      gap: 0.55rem;
+      gap: clamp(0.2rem, 0.6dvh, 0.34rem);
+      --native-welcome-shell-height: clamp(280px, 42dvh, 360px);
     }
 
-    .native-welcome-copy h1 {
-      font-size: clamp(1.14rem, 2.2dvh, 1.28rem);
+    .native-welcome-visual-shell .v3-step-visual {
+      --native-welcome-visual-viewport-height: clamp(238px, 36dvh, 310px);
+    }
+
+    .native-welcome-actions {
+      --native-welcome-actions-shift: clamp(2px, 0.45dvh, 8px);
+    }
+
+    .native-welcome-carousel[data-native-step="1"] {
+      --native-welcome-visual-scale: 0.42;
+    }
+
+    .native-welcome-carousel[data-native-step="2"] {
+      --native-welcome-visual-scale: 0.58;
+    }
+
+  }
+
+  @media (min-height: 900px) {
+    .native-welcome-carousel {
+      gap: clamp(0.28rem, 0.92dvh, 0.54rem);
+      --native-welcome-shell-height: clamp(380px, 52dvh, 520px);
+    }
+
+    .native-welcome-visual-shell .v3-step-visual {
+      --native-welcome-visual-viewport-height: clamp(320px, 45dvh, 420px);
+    }
+
+    .native-welcome-actions {
+      --native-welcome-actions-shift: clamp(4px, 0.75dvh, 10px);
+    }
+
+    .native-welcome-carousel[data-native-step="1"] {
+      --native-welcome-visual-scale: 0.5;
+    }
+
+    .native-welcome-carousel[data-native-step="2"] {
+      --native-welcome-visual-scale: 0.64;
+    }
+  }
+
+  @media (min-height: 980px) {
+    .native-welcome-carousel {
+      --native-welcome-shell-height: clamp(420px, 54dvh, 560px);
+    }
+
+    .native-welcome-visual-shell .v3-step-visual {
+      --native-welcome-visual-viewport-height: clamp(350px, 47dvh, 450px);
     }
   }
 }

--- a/apps/web/src/mobile/MobileAppEntry.tsx
+++ b/apps/web/src/mobile/MobileAppEntry.tsx
@@ -198,7 +198,7 @@ function MobileWelcome() {
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(5,11,47,0.18)_0%,rgba(5,11,47,0.1)_38%,rgba(5,11,47,0.68)_100%)]"
       />
-      <div className="relative z-10 flex h-full w-full max-w-md flex-col">
+      <div className="native-welcome-frame relative z-10 flex h-full w-full max-w-md flex-col">
         <div className="shrink-0 pt-[clamp(0.25rem,1.1dvh,0.75rem)] text-center">
           <div className="flex items-center justify-center text-[clamp(0.82rem,2.1dvh,1.06rem)] font-semibold uppercase tracking-[0.42em] text-white/66">
             <BrandWordmark className="gap-3.5" textClassName="tracking-[0.42em]" iconClassName="h-[3.2em]" />
@@ -206,21 +206,21 @@ function MobileWelcome() {
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col pb-[clamp(0.2rem,1dvh,0.55rem)] pt-[clamp(0.45rem,1.45dvh,0.85rem)]">
-          <div className="flex min-h-0 flex-1 flex-col">
+          <div className="native-welcome-main flex min-h-0 flex-1 flex-col">
             <NativeWelcomeCarousel language={language} />
 
-            <div className="mt-auto space-y-[clamp(0.5rem,1.35dvh,0.7rem)] px-2 pt-[clamp(0.8rem,2.5dvh,1.45rem)]">
+            <div className="native-welcome-actions mt-auto space-y-[clamp(0.5rem,1.35dvh,0.7rem)] px-2 pt-[clamp(0.8rem,2.5dvh,1.45rem)]">
               <button
                 type="button"
                 onClick={() => void openNativeAuth('sign-up')}
-                className="inline-flex w-full items-center justify-center rounded-full bg-[#7c3aed] px-5 py-[clamp(0.75rem,1.8dvh,0.875rem)] text-sm font-semibold text-white shadow-[0_20px_44px_rgba(124,58,237,0.35)] transition hover:bg-[#8b5cf6]"
+                className="inline-flex w-full items-center justify-center rounded-full bg-[#7c3aed] px-5 py-[clamp(0.7rem,1.68dvh,0.82rem)] text-sm font-semibold text-white shadow-[0_20px_44px_rgba(124,58,237,0.35)] transition hover:bg-[#8b5cf6]"
               >
                 {copy.signUp}
               </button>
               <button
                 type="button"
                 onClick={() => void openNativeGoogleAuth()}
-                className="inline-flex w-full items-center justify-center gap-3 rounded-full border border-slate-200/90 bg-white px-5 py-[clamp(0.75rem,1.8dvh,0.875rem)] text-sm font-semibold text-slate-900 shadow-[0_20px_44px_rgba(15,23,42,0.22)] transition hover:bg-slate-50"
+                className="inline-flex w-full items-center justify-center gap-3 rounded-full border border-slate-200/90 bg-white px-5 py-[clamp(0.7rem,1.68dvh,0.82rem)] text-sm font-semibold text-slate-900 shadow-[0_20px_44px_rgba(15,23,42,0.22)] transition hover:bg-slate-50"
               >
                 <svg
                   viewBox="0 0 48 48"
@@ -239,7 +239,7 @@ function MobileWelcome() {
               <button
                 type="button"
                 onClick={() => void openNativeAuth('sign-in')}
-                className="inline-flex w-full items-center justify-center rounded-full border border-white/18 bg-white/8 px-5 py-[clamp(0.75rem,1.8dvh,0.875rem)] text-sm font-semibold text-white transition hover:bg-white/12"
+                className="inline-flex w-full items-center justify-center rounded-full border border-white/18 bg-white/8 px-5 py-[clamp(0.7rem,1.68dvh,0.82rem)] text-sm font-semibold text-white transition hover:bg-white/12"
               >
                 {copy.signIn}
               </button>


### PR DESCRIPTION
### Motivation
- Improve the native welcome carousel's layout, scaling and responsiveness to produce more consistent visual framing across viewport heights.
- Separate structural wrappers in the mobile entry to provide clearer styling hooks for the welcome frame, main area, and action region.
- Slightly refine action button vertical padding to better match the adjusted visual scale and spacing.

### Description
- Add CSS variables and new classes (`.native-welcome-frame`, `.native-welcome-main`, `.native-welcome-actions`) to control shell height, visual viewport height, visual scale/offset, and actions shift, and wire them into the existing `.native-welcome-carousel` and step-specific rules.
- Replace several static `transform: scale(...)` rules with `translateY(...) scale(...)` driven by the new variables and update transform origins for consistent centering; introduce responsive overrides for different height ranges (`@media (max-height: 820px)`, `@media (min-height: 900px)`, `@media (min-height: 980px)`).
- Update the mobile entry component (`MobileAppEntry.tsx`) to apply the new structural class names and reduce vertical padding in the action buttons (`py-[clamp(...)]` adjustments) to better align with the responsive visual scaling.

### Testing
- Ran a development build with `yarn build` and the build completed successfully.
- Ran unit tests with `yarn test` and all tests passed.
- Ran linter checks with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d6dec2108322b4e3862531a2940d)