### PR TITLE
Refine dark mode surface hierarchy

### DIFF
--- a/apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx
+++ b/apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx
@@ -144,7 +144,7 @@ export function DailyCultivationSection({ userId }: DailyCultivationSectionProps
 
       {status === 'success' && activeBucket && activeBucket.days.length > 0 && (
         <div className="space-y-4">
-          <div className="ib-card-contour-shadow rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4">
+          <div className="ib-card-contour-shadow rounded-ib-md border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] p-4">
             <LineChart days={activeBucket.days} language={language} />
           </div>
           <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-[color:var(--color-text-subtle)]">

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
@@ -198,7 +198,7 @@ export function LegacyStreaksPanel({ userId }: LegacyStreaksPanelProps) {
             La API actual aún no expone <code className="rounded bg-[color:var(--color-overlay-2)] px-1 py-px text-[10px]">daily_log_raw</code>. Listamos tus tareas activas y calculamos el GP semanal total como referencia.
           </p>
 
-          <div className="rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4">
+          <div className="rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-panel)] p-4">
             <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">GP total últimos 7 días</p>
             <p className="mt-2 text-2xl font-semibold text-[color:var(--color-slate-100)]">{weeklyXp.toLocaleString('es-AR')} GP</p>
             <p className="mt-1 text-xs text-[color:var(--color-slate-400)]">Filtro: {pillarFilter} · Alcance: {scopeFilter === 'week' ? 'Semana' : scopeFilter === 'month' ? 'Mes' : '3 meses'}</p>
@@ -206,7 +206,7 @@ export function LegacyStreaksPanel({ userId }: LegacyStreaksPanelProps) {
 
           <div className="space-y-3">
             {filteredTasks.slice(0, 8).map((task) => (
-              <article key={task.id} className="rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4">
+              <article key={task.id} className="rounded-ib-md border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] p-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
                     <p className="font-semibold text-[color:var(--color-slate-100)]">{task.title}</p>
@@ -524,7 +524,7 @@ function TaskItem({
   return (
     <article
       className={cx(
-        'ib-card-contour-shadow flex flex-col gap-1.5 rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-2.5 text-[color:var(--color-slate-200)] transition hover:border-violet-300/50 hover:bg-[color:var(--color-overlay-2)] md:gap-2 md:p-3',
+        'ib-card-contour-shadow flex flex-col gap-1.5 rounded-ib-md border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] p-2.5 text-[color:var(--color-slate-200)] transition hover:border-violet-300/50 hover:bg-[color:var(--ib-surface-card-hover)] md:gap-2 md:p-3',
         item.highlight && 'border-violet-400/60 bg-violet-400/10 shadow-[0_8px_26px_rgba(99,102,241,0.3)]',
       )}
       aria-label={`Streak ${item.name}, ${item.weeklyDone} of ${item.weeklyGoal} this week, ${streakDays} consecutive days`}
@@ -938,7 +938,7 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, avatarProfile, fo
           {isLoading ? (
             <div className="grid grid-cols-1 gap-3">
               {Array.from({ length: 3 }).map((_, index) => (
-                <div key={`top-skeleton-${index}`} className="h-24 animate-pulse rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]" />
+                <div key={`top-skeleton-${index}`} className="h-24 animate-pulse rounded-ib-md border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)]" />
               ))}
             </div>
           ) : (
@@ -1004,7 +1004,7 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, avatarProfile, fo
             {showTasksSkeleton ? (
               <div className="grid grid-cols-1 gap-3">
                 {Array.from({ length: 4 }).map((_, index) => (
-                  <div key={`task-skeleton-${index}`} className="h-24 animate-pulse rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]" />
+                  <div key={`task-skeleton-${index}`} className="h-24 animate-pulse rounded-ib-md border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)]" />
                 ))}
               </div>
             ) : (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -34,23 +34,39 @@
     --onboarding-premium-overlay-soft: rgba(255, 255, 255, 0.06);
     --onboarding-premium-overlay-base: rgba(255, 255, 255, 0.1);
 
-    --color-surface: #010409;
-    --color-surface-muted: #05070b;
-    --color-surface-elevated: #0b0f14;
-    --color-surface-highlight: #11161d;
+    --ib-dark-surface-app: #010409;
+    --ib-dark-surface-section: #05080d;
+    --ib-dark-surface-panel: #0a0f16;
+    --ib-dark-surface-card: #121820;
+    --ib-dark-surface-card-hover: #171f2a;
+    --ib-dark-surface-card-active: #1b2532;
+    --ib-surface-app: var(--ib-dark-surface-app);
+    --ib-surface-section: var(--ib-dark-surface-section);
+    --ib-surface-panel: var(--ib-dark-surface-panel);
+    --ib-surface-card: var(--ib-dark-surface-card);
+    --ib-surface-card-hover: var(--ib-dark-surface-card-hover);
+    --ib-surface-card-active: var(--ib-dark-surface-card-active);
+    --surface-app: var(--ib-surface-app);
+    --surface-section: var(--ib-surface-section);
+    --surface-card: var(--ib-surface-card);
+    --surface-elevated: var(--ib-surface-panel);
+    --color-surface: var(--ib-surface-app);
+    --color-surface-muted: var(--ib-surface-section);
+    --color-surface-elevated: var(--ib-surface-panel);
+    --color-surface-highlight: var(--ib-surface-card);
     --color-text: #f8fafc;
     --color-text-muted: #cbd5f5;
     --color-text-subtle: #94a3b8;
     --color-accent-primary: #38bdf8;
     --color-accent-secondary: #8b5cf6;
-    --color-overlay-1: rgba(255, 255, 255, 0.04);
-    --color-overlay-2: rgba(255, 255, 255, 0.08);
-    --color-overlay-3: rgba(255, 255, 255, 0.12);
+    --color-overlay-1: rgba(255, 255, 255, 0.055);
+    --color-overlay-2: rgba(255, 255, 255, 0.09);
+    --color-overlay-3: rgba(255, 255, 255, 0.13);
     --color-overlay-4: rgba(255, 255, 255, 0.16);
     --color-overlay-5: rgba(255, 255, 255, 0.22);
-    --color-border-subtle: rgba(255, 255, 255, 0.075);
-    --color-border-soft: rgba(255, 255, 255, 0.115);
-    --color-border-strong: rgba(255, 255, 255, 0.18);
+    --color-border-subtle: rgba(255, 255, 255, 0.09);
+    --color-border-soft: rgba(255, 255, 255, 0.13);
+    --color-border-strong: rgba(255, 255, 255, 0.19);
     --color-text-strong: #ffffff;
     --color-text-dim: rgba(255, 255, 255, 0.7);
     --color-text-faint: rgba(255, 255, 255, 0.6);
@@ -115,8 +131,8 @@
     --color-quickaccess-cta-disabled-text: rgba(224, 231, 255, 0.62);
     --color-card-gradient: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.96),
-      rgba(5, 7, 11, 0.98)
+      color-mix(in srgb, var(--ib-surface-panel) 96%, white 4%),
+      color-mix(in srgb, var(--ib-surface-section) 98%, black 2%)
     );
     --color-card-highlight-gradient: radial-gradient(
       ellipse at top,
@@ -128,16 +144,16 @@
     --color-card-border: var(--color-border-subtle);
     --color-glass-surface: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.88),
-      rgba(5, 7, 11, 0.82)
+      color-mix(in srgb, var(--ib-surface-panel) 88%, transparent),
+      color-mix(in srgb, var(--ib-surface-section) 82%, transparent)
     );
     --color-glow-soft: rgba(139, 154, 180, 0.09);
     --shadow-elev-1: 0 8px 20px rgba(0, 0, 0, 0.28);
     --shadow-elev-2: 0 14px 36px rgba(2, 6, 23, 0.34);
     --glass-bg: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.88),
-      rgba(5, 7, 11, 0.82)
+      color-mix(in srgb, var(--ib-surface-panel) 88%, transparent),
+      color-mix(in srgb, var(--ib-surface-section) 82%, transparent)
     );
     --glass-border: rgba(255, 255, 255, 0.085);
     --ib-premium-divider: color-mix(
@@ -161,23 +177,39 @@
 
   :root[data-theme="dark"] {
     color-scheme: dark;
-    --color-surface: #010409;
-    --color-surface-muted: #05070b;
-    --color-surface-elevated: #0b0f14;
-    --color-surface-highlight: #11161d;
+    --ib-dark-surface-app: #010409;
+    --ib-dark-surface-section: #05080d;
+    --ib-dark-surface-panel: #0a0f16;
+    --ib-dark-surface-card: #121820;
+    --ib-dark-surface-card-hover: #171f2a;
+    --ib-dark-surface-card-active: #1b2532;
+    --ib-surface-app: var(--ib-dark-surface-app);
+    --ib-surface-section: var(--ib-dark-surface-section);
+    --ib-surface-panel: var(--ib-dark-surface-panel);
+    --ib-surface-card: var(--ib-dark-surface-card);
+    --ib-surface-card-hover: var(--ib-dark-surface-card-hover);
+    --ib-surface-card-active: var(--ib-dark-surface-card-active);
+    --surface-app: var(--ib-surface-app);
+    --surface-section: var(--ib-surface-section);
+    --surface-card: var(--ib-surface-card);
+    --surface-elevated: var(--ib-surface-panel);
+    --color-surface: var(--ib-surface-app);
+    --color-surface-muted: var(--ib-surface-section);
+    --color-surface-elevated: var(--ib-surface-panel);
+    --color-surface-highlight: var(--ib-surface-card);
     --color-text: #f8fafc;
     --color-text-muted: #cbd5f5;
     --color-text-subtle: #94a3b8;
     --color-accent-primary: #38bdf8;
     --color-accent-secondary: #8b5cf6;
-    --color-overlay-1: rgba(255, 255, 255, 0.04);
-    --color-overlay-2: rgba(255, 255, 255, 0.08);
-    --color-overlay-3: rgba(255, 255, 255, 0.12);
+    --color-overlay-1: rgba(255, 255, 255, 0.055);
+    --color-overlay-2: rgba(255, 255, 255, 0.09);
+    --color-overlay-3: rgba(255, 255, 255, 0.13);
     --color-overlay-4: rgba(255, 255, 255, 0.16);
     --color-overlay-5: rgba(255, 255, 255, 0.22);
-    --color-border-subtle: rgba(255, 255, 255, 0.075);
-    --color-border-soft: rgba(255, 255, 255, 0.115);
-    --color-border-strong: rgba(255, 255, 255, 0.18);
+    --color-border-subtle: rgba(255, 255, 255, 0.09);
+    --color-border-soft: rgba(255, 255, 255, 0.13);
+    --color-border-strong: rgba(255, 255, 255, 0.19);
     --color-text-strong: #ffffff;
     --color-text-dim: rgba(255, 255, 255, 0.7);
     --color-text-faint: rgba(255, 255, 255, 0.6);
@@ -219,8 +251,8 @@
     --color-quickaccess-cta-disabled-text: rgba(224, 231, 255, 0.62);
     --color-card-gradient: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.96),
-      rgba(5, 7, 11, 0.98)
+      color-mix(in srgb, var(--ib-surface-panel) 96%, white 4%),
+      color-mix(in srgb, var(--ib-surface-section) 98%, black 2%)
     );
     --color-card-highlight-gradient: radial-gradient(
       ellipse at top,
@@ -232,16 +264,16 @@
     --color-card-border: var(--color-border-subtle);
     --color-glass-surface: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.88),
-      rgba(5, 7, 11, 0.82)
+      color-mix(in srgb, var(--ib-surface-panel) 88%, transparent),
+      color-mix(in srgb, var(--ib-surface-section) 82%, transparent)
     );
     --color-glow-soft: rgba(139, 154, 180, 0.09);
     --shadow-elev-1: 0 8px 20px rgba(0, 0, 0, 0.28);
     --shadow-elev-2: 0 14px 36px rgba(2, 6, 23, 0.34);
     --glass-bg: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.88),
-      rgba(5, 7, 11, 0.82)
+      color-mix(in srgb, var(--ib-surface-panel) 88%, transparent),
+      color-mix(in srgb, var(--ib-surface-section) 82%, transparent)
     );
     --glass-border: rgba(255, 255, 255, 0.085);
   }
@@ -255,10 +287,20 @@
         rgba(148, 163, 184, 0) 62%
       ),
       linear-gradient(180deg, #f8fafc 0%, #f4f6f8 52%, #eef2f6 100%);
-    --color-surface: #f7f8fa;
-    --color-surface-muted: #f1f3f6;
-    --color-surface-elevated: #ffffff;
-    --color-surface-highlight: #fafbfc;
+    --ib-surface-app: #f7f8fa;
+    --ib-surface-section: #f1f3f6;
+    --ib-surface-panel: #ffffff;
+    --ib-surface-card: #fafbfc;
+    --ib-surface-card-hover: #f3f6fb;
+    --ib-surface-card-active: #edf2f8;
+    --surface-app: var(--ib-surface-app);
+    --surface-section: var(--ib-surface-section);
+    --surface-card: var(--ib-surface-card);
+    --surface-elevated: var(--ib-surface-panel);
+    --color-surface: var(--ib-surface-app);
+    --color-surface-muted: var(--ib-surface-section);
+    --color-surface-elevated: var(--ib-surface-panel);
+    --color-surface-highlight: var(--ib-surface-card);
     --color-text: #0f172a;
     --color-text-muted: #334155;
     --color-text-subtle: #64748b;
@@ -7310,12 +7352,8 @@
   }
   [data-light-scope="daily-quest"].ib-daily-quest-shell {
     color: var(--color-text);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    background-image: linear-gradient(
-      180deg,
-      rgba(11, 15, 20, 0.97),
-      rgba(5, 7, 11, 0.98)
-    );
+    border: 1px solid var(--color-border-subtle);
+    background-image: var(--color-card-gradient);
     box-shadow:
       0 34px 82px rgba(0, 0, 0, 0.56),
       inset 0 1px 0 rgba(255, 255, 255, 0.05);
@@ -7323,11 +7361,11 @@
 
   [data-light-scope="daily-quest"] .ib-daily-quest-header,
   [data-light-scope="daily-quest"] .ib-daily-quest-footer {
-    border-color: rgba(255, 255, 255, 0.07);
+    border-color: var(--color-border-subtle);
     background-image: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.03),
-      rgba(255, 255, 255, 0.015)
+      color-mix(in srgb, var(--ib-surface-panel) 90%, transparent),
+      color-mix(in srgb, var(--ib-surface-section) 86%, transparent)
     );
   }
 
@@ -7336,11 +7374,11 @@
   [data-light-scope="daily-quest"] .ib-daily-quest-secondary-btn,
   [data-light-scope="daily-quest"] .ib-daily-quest-close-btn,
   [data-light-scope="daily-quest"] .ib-daily-quest-emotion-chip--inactive {
-    border-color: rgba(255, 255, 255, 0.08);
+    border-color: var(--color-border-soft);
     background-image: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.03),
-      rgba(255, 255, 255, 0.015)
+      color-mix(in srgb, var(--ib-surface-card) 96%, white 4%),
+      color-mix(in srgb, var(--ib-surface-card) 92%, black 8%)
     );
   }
 
@@ -7350,16 +7388,16 @@
   [data-light-scope="daily-quest"] .ib-daily-quest-emotion-chip--inactive:hover {
     background-image: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.09),
-      rgba(255, 255, 255, 0.04)
+      color-mix(in srgb, var(--ib-surface-card-hover) 96%, white 4%),
+      color-mix(in srgb, var(--ib-surface-card-hover) 92%, black 8%)
     );
   }
 
   [data-light-scope="daily-quest"] .ib-daily-quest-task-row--selected {
     background-image: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.12),
-      rgba(255, 255, 255, 0.05)
+      color-mix(in srgb, var(--ib-surface-card-active) 96%, white 4%),
+      color-mix(in srgb, var(--ib-surface-card-active) 92%, black 8%)
     );
   }
 

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -1705,7 +1705,7 @@ function ProfileErrorState({ onRetry, error }: ProfileErrorStateProps) {
 function DashboardFallback() {
   return (
     <div className="mt-8 space-y-6">
-      <section className="rounded-3xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-6 text-[color:var(--color-slate-200)] shadow-glow">
+      <section className="rounded-3xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-panel)] p-6 text-[color:var(--color-slate-200)] shadow-glow">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-slate-400)]">
           Vista previa sin conexión
         </p>
@@ -1789,7 +1789,7 @@ function DashboardFallback() {
             className="min-h-[180px]"
           >
             <div className="space-y-2 text-xs text-[color:var(--color-slate-200)]">
-              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3">
+              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">
                   Siguiente badge
                 </p>
@@ -1797,7 +1797,7 @@ function DashboardFallback() {
                   Disponible al reconectar
                 </p>
               </div>
-              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3">
+              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">
                   Último logro
                 </p>
@@ -1813,7 +1813,7 @@ function DashboardFallback() {
 
 function FallbackMetric({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-center justify-between rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-3 py-2">
+    <div className="flex items-center justify-between rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-3 py-2">
       <span className="text-[11px] font-medium uppercase tracking-[0.22em] text-[color:var(--color-slate-400)]">
         {label}
       </span>

--- a/styles/theme-tokens.css
+++ b/styles/theme-tokens.css
@@ -16,10 +16,16 @@
   /* Light mode tokens extracted from Dashboard-v3 visual system */
 
   /* SURFACES */
-  --surface-app: #f8fafc;
-  --surface-section: #f1f5f9;
-  --surface-card: #ffffff;
-  --surface-elevated: #f8faff;
+  --ib-surface-app: #f8fafc;
+  --ib-surface-section: #f1f5f9;
+  --ib-surface-panel: #ffffff;
+  --ib-surface-card: #f8faff;
+  --ib-surface-card-hover: #f3f6fb;
+  --ib-surface-card-active: #edf2f8;
+  --surface-app: var(--ib-surface-app);
+  --surface-section: var(--ib-surface-section);
+  --surface-card: var(--ib-surface-card);
+  --surface-elevated: var(--ib-surface-panel);
 
   /* TEXT */
   --text-primary: #0f172a;
@@ -57,10 +63,22 @@
   /* Dark mode overrides extracted from Dashboard-v3 visual system */
 
   /* SURFACES */
-  --surface-app: #0f172a;
-  --surface-section: #111c33;
-  --surface-card: rgba(255, 255, 255, 0.05);
-  --surface-elevated: #182640;
+  --ib-dark-surface-app: #010409;
+  --ib-dark-surface-section: #05080d;
+  --ib-dark-surface-panel: #0a0f16;
+  --ib-dark-surface-card: #121820;
+  --ib-dark-surface-card-hover: #171f2a;
+  --ib-dark-surface-card-active: #1b2532;
+  --ib-surface-app: var(--ib-dark-surface-app);
+  --ib-surface-section: var(--ib-dark-surface-section);
+  --ib-surface-panel: var(--ib-dark-surface-panel);
+  --ib-surface-card: var(--ib-dark-surface-card);
+  --ib-surface-card-hover: var(--ib-dark-surface-card-hover);
+  --ib-surface-card-active: var(--ib-dark-surface-card-active);
+  --surface-app: var(--ib-surface-app);
+  --surface-section: var(--ib-surface-section);
+  --surface-card: var(--ib-surface-card);
+  --surface-elevated: var(--ib-surface-panel);
 
   /* TEXT */
   --text-primary: #f8fafc;
@@ -69,8 +87,8 @@
   --text-disabled: rgba(255, 255, 255, 0.6);
 
   /* BORDERS */
-  --border-subtle: rgba(255, 255, 255, 0.1);
-  --border-default: rgba(255, 255, 255, 0.2);
+  --border-subtle: rgba(255, 255, 255, 0.09);
+  --border-default: rgba(255, 255, 255, 0.13);
 
   /* ACCENTS */
   --accent-primary: #38bdf8;


### PR DESCRIPTION
### Motivation
- Alinear y mejorar la jerarquía de negros/superficies del dark mode para que paneles y cards se distingan con más nitidez sin tocar colores de marca, textos, layout ni lógica.  
- Detecté duplicación y mezcla de tokens entre `styles/theme-tokens.css` y `apps/web/src/index.css` que dificultaba un escalado semántico reusable.  
- Antes de aplicar cambios identifiqué qué componentes usan `--color-overlay-1` como superficie principal para corregirlos donde la separación de capas era insuficiente.

### Description
- Añadí una escala semántica de superficies `--ib-...` (app, section, panel, card, card-hover, card-active) y mapeé los tokens legacy (`--surface-*`, `--color-surface*`) a esa escala para light y dark, centralizándolo en `styles/theme-tokens.css` y en `apps/web/src/index.css`.  
- Ajusté opacidades de overlays y bordes (`--color-overlay-1/2/3`, `--color-border-subtle/soft/strong`) y refactoricé `--color-card-gradient`, `--color-glass-surface` y `--glass-bg` para usar la nueva escala semántica y mantener un look premium y oscuro.  
- Reemplacé usos críticos de `bg-[color:var(--color-overlay-1)]` por tokens semánticos en componentes del dashboard: `StreaksPanel` (panel, task cards, skeletons), `DailyCultivationSection` (card del chart), `DashboardV3` fallback y variantes de LegacyCard / LegacyPanel para que la separación de capas sea más evidente.  
- Cambios limitados a tokens y clases CSS; no se modificó copy, layout, lógica, spacing ni colores de marca/accent ni gradients de progreso.

(Resumen breve solicitado)
- Tokens duplicados/solapados encontrados: `--surface-app`, `--surface-section`, `--surface-card`, `--surface-elevated` y la familia `--color-surface*`, `--color-overlay-*`, `--color-border-*`, `--color-card-gradient`, `--color-glass-surface` estaban definidos tanto en `styles/theme-tokens.css` como en `apps/web/src/index.css`.  
- Tokens cambiados/introducidos: `--ib-dark-surface-*` y `--ib-surface-*` (app/section/panel/card/card-hover/card-active) y mapeo de `--surface-*` / `--color-surface-*` a esos tokens; además ajustes a `--color-overlay-1/2/3`, `--color-border-subtle/soft/strong`, `--color-card-gradient`, `--color-glass-surface` y `--glass-bg`.  
- Componentes impactados: `apps/web/src/components/dashboard-v3/StreaksPanel.tsx`, `apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx`, `apps/web/src/pages/DashboardV3.tsx`, `apps/web/src/components/DailyQuestModal.tsx` (estilos Daily Quest vía index.css) y tokens globales (`styles/theme-tokens.css`, `apps/web/src/index.css`).  
- Hardcodes detectados para migrar después: selectores y gradientes con `rgba(...)`/hex en componentes como `dashboard-menu-shell`, `reminder-scheduler` select styles y otras reglas específicas de `daily-quest` que conservan gradientes hardcodeados fuera del nuevo esquema semántico.

### Testing
- `git diff --check` se ejecutó y no reportó errores en los cambios aplicados.  
- `npm run typecheck:web` se ejecutó y falló por errores TypeScript preexistentes en el repo que no están relacionados con este ajuste de tokens (por ejemplo exports de Clerk y target lib para `replaceAll`).  
- `npm -w @innerbloom/web run build` se ejecutó y completó con éxito; Vite mostró warnings de minificación/size que ya existían pero el build produjo los assets.  
- Intenté capturar una screenshot de la demo con Playwright pero la acción quedó bloqueada porque los navegadores de Playwright no están instalados en el entorno; la vista previa de Vite quedó disponible en `http://127.0.0.1:4173/` durante pruebas locales.

Si preferís, puedo: 1) revertir o matizar algún valor de superficie (más o menos contraste), 2) extraer los tokens `--ib-*` a un archivo separado para documentación, o 3) abrir follow-up PR para migrar hardcodes pendientes a tokens semánticos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b47aa39c83329c51ed37b54c93bd)