### PR TITLE
Introduce IB surface tokens and migrate components to new surface variables

### DIFF
--- a/apps/web/src/components/DailyQuestModal.tsx
+++ b/apps/web/src/components/DailyQuestModal.tsx
@@ -948,9 +948,9 @@ export const DailyQuestModal = forwardRef<DailyQuestModalHandle, DailyQuestModal
                     <div className="flex flex-col gap-6 pb-6">
                       {showSkeleton && (
                         <div className="ib-daily-quest-surface flex flex-col gap-3 rounded-2xl border p-4 text-sm text-[color:var(--color-text-faint)]">
-                          <div className="h-3 w-24 animate-pulse rounded-full bg-[color:var(--color-overlay-2)]" />
-                          <div className="h-3 w-3/4 animate-pulse rounded-full bg-[color:var(--color-overlay-2)]" />
-                          <div className="h-3 w-5/6 animate-pulse rounded-full bg-[color:var(--color-overlay-2)]" />
+                          <div className="h-3 w-24 animate-pulse rounded-full bg-[color:var(--ib-surface-card-active)]" />
+                          <div className="h-3 w-3/4 animate-pulse rounded-full bg-[color:var(--ib-surface-card-active)]" />
+                          <div className="h-3 w-5/6 animate-pulse rounded-full bg-[color:var(--ib-surface-card-active)]" />
                         </div>
                       )}
 

--- a/apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx
+++ b/apps/web/src/components/dashboard-v3/DailyCultivationSection.tsx
@@ -115,7 +115,7 @@ export function DailyCultivationSection({ userId }: DailyCultivationSectionProps
             <label className="flex items-center gap-1.5 whitespace-nowrap text-[11px] uppercase tracking-[0.12em] text-[color:var(--color-text-muted)]">
               <span className="text-[11px]">{t('dashboard.dailyCultivation.month')}</span>
               <select
-                className="w-28 rounded-ib-sm border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-xs text-[color:var(--color-text)] focus:border-white/20 focus:outline-none sm:w-32"
+                className="w-28 rounded-ib-sm border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-2 py-1 text-xs text-[color:var(--color-text)] focus:border-white/20 focus:outline-none sm:w-32"
                 value={selectedMonth ?? ''}
                 onChange={(event) => setSelectedMonth(event.target.value)}
               >
@@ -144,7 +144,7 @@ export function DailyCultivationSection({ userId }: DailyCultivationSectionProps
 
       {status === 'success' && activeBucket && activeBucket.days.length > 0 && (
         <div className="space-y-4">
-          <div className="ib-card-contour-shadow rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4">
+          <div className="ib-card-contour-shadow rounded-ib-md border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] p-4">
             <LineChart days={activeBucket.days} language={language} />
           </div>
           <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-[color:var(--color-text-subtle)]">

--- a/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
+++ b/apps/web/src/components/dashboard-v3/DashboardMenu.tsx
@@ -165,7 +165,7 @@ const DashboardMenuTrigger = forwardRef<
       ref={ref}
       type="button"
       onClick={onClick}
-      className="inline-flex items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-2 text-[color:var(--color-text)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/40"
+      className="inline-flex items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-2 text-[color:var(--color-text)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--ib-surface-card-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/40"
       aria-label={ariaLabel}
     >
       <svg
@@ -1004,7 +1004,7 @@ export function DashboardMenu({
                             <button
                               type="button"
                               onClick={handleGoToSubscription}
-                              className="flex h-11 w-full items-center gap-2 rounded-lg px-3 text-left text-sm text-[color:var(--color-text-dim)] transition hover:bg-[color:var(--color-overlay-2)]"
+                              className="flex h-11 w-full items-center gap-2 rounded-lg px-3 text-left text-sm text-[color:var(--color-text-dim)] transition hover:bg-[color:var(--ib-surface-card-hover)]"
                             >
                               <MenuIcon className="h-4 w-4 text-[color:var(--color-text-faint)]">
                                 <path d="M12 3a4 4 0 0 0-4 4v2" />
@@ -1016,7 +1016,7 @@ export function DashboardMenu({
                             <button
                               type="button"
                               onClick={handleGoToPricing}
-                              className="flex h-11 w-full items-center gap-2 rounded-lg px-3 text-left text-sm text-[color:var(--color-text-dim)] transition hover:bg-[color:var(--color-overlay-2)]"
+                              className="flex h-11 w-full items-center gap-2 rounded-lg px-3 text-left text-sm text-[color:var(--color-text-dim)] transition hover:bg-[color:var(--ib-surface-card-hover)]"
                             >
                               <MenuIcon className="h-4 w-4 text-[color:var(--color-text-faint)]">
                                 <path d="M6 19V9" />
@@ -1103,7 +1103,7 @@ export function DashboardMenu({
                           <p className="mb-1 text-xs text-[color:var(--color-widget-menu-label)]">
                             {t('dashboard.menu.availableWidgets')}
                           </p>
-                          <div className="rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]">
+                          <div className="rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)]">
                             <div className="flex items-start gap-2 px-3 py-2">
                               <button
                                 type="button"
@@ -1385,7 +1385,7 @@ export function DashboardMenu({
                                   key={mode}
                                   type="button"
                                   onClick={() => handleSelectGameMode(mode)}
-                                  className={`relative overflow-hidden rounded-2xl border px-3 py-3 text-left transition ${isSelected ? 'dashboard-menu-selection-active bg-[color:var(--color-overlay-3)]' : 'border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:bg-[color:var(--color-overlay-2)]'}`}
+                                  className={`relative overflow-hidden rounded-2xl border px-3 py-3 text-left transition ${isSelected ? 'dashboard-menu-selection-active bg-[color:var(--ib-surface-card-active)]' : 'border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] hover:bg-[color:var(--ib-surface-card-hover)]'}`}
                                 >
                                   <div className="ml-2 space-y-2">
                                     <div className="flex items-center justify-between gap-2">
@@ -1504,7 +1504,7 @@ export function DashboardMenu({
                                   key={avatarOption.avatarId}
                                   type="button"
                                   onClick={() => setSelectedAvatarId(avatarOption.avatarId)}
-                                  className={`relative overflow-hidden rounded-2xl border px-3 py-3 text-left transition ${isSelected ? 'dashboard-menu-selection-active bg-[color:var(--color-overlay-3)]' : 'border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:bg-[color:var(--color-overlay-2)]'}`}
+                                  className={`relative overflow-hidden rounded-2xl border px-3 py-3 text-left transition ${isSelected ? 'dashboard-menu-selection-active bg-[color:var(--ib-surface-card-active)]' : 'border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] hover:bg-[color:var(--ib-surface-card-hover)]'}`}
                                 >
                                   <div className="ml-2 space-y-2">
                                     <div className="flex items-center justify-between gap-2">
@@ -1628,7 +1628,7 @@ export function DashboardMenu({
                           type="button"
                           onClick={handleCloseDeleteAccount}
                           disabled={isDeletingAccount}
-                          className="flex-1 rounded-2xl border border-[color:var(--color-border-subtle)] px-3 py-3 text-sm font-semibold text-[color:var(--color-text-dim)] transition hover:bg-[color:var(--color-overlay-2)] disabled:opacity-60"
+                          className="flex-1 rounded-2xl border border-[color:var(--color-border-subtle)] px-3 py-3 text-sm font-semibold text-[color:var(--color-text-dim)] transition hover:bg-[color:var(--ib-surface-card-hover)] disabled:opacity-60"
                         >
                           {t("dashboard.menu.cancel")}
                         </button>

--- a/apps/web/src/components/dashboard-v3/EmotionChartCard.tsx
+++ b/apps/web/src/components/dashboard-v3/EmotionChartCard.tsx
@@ -882,7 +882,7 @@ export function EmotionChartCard({ userId }: EmotionChartCardProps) {
       subtitle={t('dashboard.emotionChart.lastSixMonths')}
       rightSlot={<InfoDotTarget id="emotion" placement="right" className="flex items-center" />}
     >
-      {showSkeleton && <div className="h-48 w-full animate-pulse rounded-ib-md bg-[color:var(--color-overlay-2)]" />}
+      {showSkeleton && <div className="h-48 w-full animate-pulse rounded-ib-md bg-[color:var(--ib-surface-card-active)]" />}
 
       {showError && <p className="text-sm text-rose-300">{t('dashboard.emotionChart.loadError')}</p>}
 
@@ -974,7 +974,7 @@ export function EmotionChartCard({ userId }: EmotionChartCardProps) {
           </div>
           <div ref={summaryRef} data-emotion-card="summary">
             {highlight ? (
-              <div className="summary-inner ib-card-contour-shadow w-full rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 text-left sm:p-4">
+              <div className="summary-inner ib-card-contour-shadow w-full rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 text-left sm:p-4">
                 <div
                   className="emotion-highlight-indicator h-10 w-10 shrink-0 rounded-full"
                   style={{ backgroundColor: highlight.color }}
@@ -991,7 +991,7 @@ export function EmotionChartCard({ userId }: EmotionChartCardProps) {
                 </div>
               </div>
             ) : (
-              <div className="summary-inner ib-card-contour-shadow rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 text-xs text-[color:var(--color-text-subtle)] sm:p-4">
+              <div className="summary-inner ib-card-contour-shadow rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 text-xs text-[color:var(--color-text-subtle)] sm:p-4">
                 <div className="summary-content">
                   <span className="summary-description">
                     {t('dashboard.emotionChart.insufficientData')}

--- a/apps/web/src/components/dashboard-v3/EmotionTimeline.tsx
+++ b/apps/web/src/components/dashboard-v3/EmotionTimeline.tsx
@@ -544,7 +544,7 @@ export function EmotionTimeline({ userId }: EmotionTimelineProps) {
         </div>
       </header>
 
-      {status === 'loading' && <div className="mt-6 h-48 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />}
+      {status === 'loading' && <div className="mt-6 h-48 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />}
 
       {status === 'error' && <p className="mt-6 text-sm text-rose-300">Todavía no pudimos cargar tus emociones.</p>}
 
@@ -554,7 +554,7 @@ export function EmotionTimeline({ userId }: EmotionTimelineProps) {
             {LEGEND_ITEMS.map((name) => (
               <span
                 key={name}
-                className={`flex items-center gap-2 rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-2)] px-3 py-1 text-[13px] ${
+                className={`flex items-center gap-2 rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card-active)] px-3 py-1 text-[13px] ${
                   name === 'Sin registro' ? 'text-text-subtle' : 'text-text-muted'
                 }`}
               >

--- a/apps/web/src/components/dashboard-v3/JourneyReadyModal.tsx
+++ b/apps/web/src/components/dashboard-v3/JourneyReadyModal.tsx
@@ -38,7 +38,7 @@ export function JourneyReadyModal({
         <h2 className="font-display text-2xl font-semibold text-[color:var(--color-text)]">{t('dashboard.journeyReady.title')}</h2>
         <p className="mt-2 text-sm text-[color:var(--color-text-muted)]">{t('dashboard.journeyReady.subtitle')}</p>
 
-        <div className="mt-4 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] p-3">
+        <div className="mt-4 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card-active)] p-3">
           <button type="button" onClick={() => setExpanded((value) => !value)} className="text-sm font-semibold text-[color:var(--color-text)]">
             {t('dashboard.journeyReady.viewTasks', { count: tasks.length })}
           </button>
@@ -53,7 +53,7 @@ export function JourneyReadyModal({
           ) : null}
         </div>
 
-        <div className="mt-4 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] p-3 text-sm">
+        <div className="mt-4 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card-active)] p-3 text-sm">
           <p className="font-semibold text-[color:var(--color-text)]">{t('dashboard.journeyReady.firstStep')}</p>
           <p className="text-[color:var(--color-text-muted)]">{t('dashboard.journeyReady.firstStepHelp')}</p>
         </div>

--- a/apps/web/src/components/dashboard-v3/MetricHeader.tsx
+++ b/apps/web/src/components/dashboard-v3/MetricHeader.tsx
@@ -167,7 +167,7 @@ export function MetricHeader({
               {t("dashboard.metricHeader.progress")}
             </DashboardMeta>
             <div
-              className="relative h-6 w-full overflow-hidden rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-2)] shadow-[inset_0_2px_8px_rgba(15,23,42,0.12)] sm:h-[30px]"
+              className="relative h-6 w-full overflow-hidden rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card-active)] shadow-[inset_0_2px_8px_rgba(15,23,42,0.12)] sm:h-[30px]"
               role="progressbar"
               aria-label={t("dashboard.metricHeader.progressAria")}
               aria-valuemin={0}

--- a/apps/web/src/components/dashboard-v3/MissionsV2Board.tsx
+++ b/apps/web/src/components/dashboard-v3/MissionsV2Board.tsx
@@ -636,14 +636,14 @@ function ClaimModal({
             <button
               type="button"
               onClick={onClose}
-              className="w-full rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-[color:var(--color-slate-100)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-4)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300 sm:w-auto"
+              className="w-full rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card-active)] px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-[color:var(--color-slate-100)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-4)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300 sm:w-auto"
             >
               Ver en trofeos
             </button>
             <button
               type="button"
               onClick={onClose}
-              className="w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-[color:var(--color-slate-200)] transition hover:border-[color:var(--color-border-soft)] hover:bg-[color:var(--color-overlay-2)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300 sm:w-auto"
+              className="w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-[color:var(--color-slate-200)] transition hover:border-[color:var(--color-border-soft)] hover:bg-[color:var(--ib-surface-card-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300 sm:w-auto"
             >
               Cerrar
             </button>

--- a/apps/web/src/components/dashboard-v3/ModerationEditSheet.tsx
+++ b/apps/web/src/components/dashboard-v3/ModerationEditSheet.tsx
@@ -55,14 +55,14 @@ export function ModerationEditSheet({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-full border border-[color:var(--color-border-strong)] bg-[color:var(--color-surface-muted)] px-3 py-1 text-xs font-semibold text-[color:var(--color-text-strong)] transition-colors hover:bg-[color:var(--color-overlay-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-surface-elevated)]"
+            className="rounded-full border border-[color:var(--color-border-strong)] bg-[color:var(--color-surface-muted)] px-3 py-1 text-xs font-semibold text-[color:var(--color-text-strong)] transition-colors hover:bg-[color:var(--ib-surface-card-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-surface-elevated)]"
           >
             {t('dashboard.moderation.close')}
           </button>
         </div>
 
         {isLoading || !configs ? (
-          <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4 text-sm text-[color:var(--color-text-dim)]">
+          <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-4 text-sm text-[color:var(--color-text-dim)]">
             {t('dashboard.moderation.loadingConfig')}
           </div>
         ) : (
@@ -83,7 +83,7 @@ export function ModerationEditSheet({
                       {type === 'alcohol' ? 'Alcohol' : type === 'tobacco' ? t('dashboard.moderation.tobacco') : t('dashboard.moderation.sugar')}
                     </p>
                     {isSwitchDisabled ? (
-                      <span className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[color:var(--color-text-faint)]">
+                      <span className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card-active)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[color:var(--color-text-faint)]">
                         {t('dashboard.moderation.disabled')}
                       </span>
                     ) : null}
@@ -101,7 +101,7 @@ export function ModerationEditSheet({
                       }}
                       className={`relative inline-flex h-7 w-12 items-center rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/55 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-surface-elevated)] ${
                         isSwitchDisabled
-                          ? "cursor-not-allowed border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)]"
+                          ? "cursor-not-allowed border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card-active)]"
                           : isPaused
                             ? "border-[color:var(--color-accent-primary)] bg-[color:var(--color-accent-primary)]/35"
                             : "border-[color:var(--color-border-strong)] bg-[color:var(--color-overlay-3)]"

--- a/apps/web/src/components/dashboard-v3/ModerationWidget.tsx
+++ b/apps/web/src/components/dashboard-v3/ModerationWidget.tsx
@@ -41,7 +41,7 @@ export function ModerationWidget({
 
   return (
     <section
-      className={`rounded-3xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] text-[color:var(--color-widget-menu-item-title)] shadow-[var(--shadow-elev-1)] ${compact ? "p-3" : "p-4"}`}
+      className={`rounded-3xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] text-[color:var(--color-widget-menu-item-title)] shadow-[var(--shadow-elev-1)] ${compact ? "p-3" : "p-4"}`}
       {...longPressBind}
       aria-label={t('dashboard.menu.moderation')}
     >
@@ -64,7 +64,7 @@ export function ModerationWidget({
         {enabled.map((type) => (
           <div
             key={type}
-            className="rounded-[1.35rem] border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] px-3 py-2 shadow-[var(--shadow-elev-1)]"
+            className="rounded-[1.35rem] border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card-active)] px-3 py-2 shadow-[var(--shadow-elev-1)]"
           >
             <div className="flex items-start justify-between gap-2">
               <ModerationTrackerIcon

--- a/apps/web/src/components/dashboard-v3/PreviewAchievementCard.tsx
+++ b/apps/web/src/components/dashboard-v3/PreviewAchievementCard.tsx
@@ -303,7 +303,7 @@ export function PreviewAchievementCard({
           ? 'border-transparent bg-transparent shadow-none'
           : isLanding
             ? 'border border-[color:var(--color-border-subtle)] bg-[color:var(--color-surface-elevated)] shadow-[var(--color-card-shadow)] dark:border-white/10 dark:bg-gradient-to-b dark:from-[rgba(7,10,16,0.96)] dark:to-[rgba(8,12,18,0.9)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]'
-            : 'border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] shadow-inner',
+            : 'border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] shadow-inner',
         isLanding ? (isCompact ? 'p-2.5 pb-3 sm:p-3' : 'p-4 pb-4 sm:p-5') : isCompact ? 'p-2.5 pb-4' : 'p-3 pb-4',
       )}
     >
@@ -466,7 +466,7 @@ export function PreviewAchievementCard({
                 >
                   i
                 </summary>
-                <div className="pointer-events-none absolute left-0 top-6 z-10 hidden min-w-[11rem] rounded-lg border border-white/20 bg-[color:var(--color-overlay-1)]/95 p-2 text-[10px] leading-snug text-[color:var(--color-slate-100)] shadow-xl backdrop-blur-sm group-open:block group-hover:block">
+                <div className="pointer-events-none absolute left-0 top-6 z-10 hidden min-w-[11rem] rounded-lg border border-white/20 bg-[color:var(--ib-surface-card)] p-2 text-[10px] leading-snug text-[color:var(--color-slate-100)] shadow-xl backdrop-blur-sm group-open:block group-hover:block">
                   <p>{language === 'es' ? '✓ = mes fuerte' : '✓ = strong month'}</p>
                   <p>{language === 'es' ? '• = en construcción' : '• = building'}</p>
                   <p>{language === 'es' ? '✕ = mes débil' : '✕ = weak month'}</p>

--- a/apps/web/src/components/dashboard-v3/RadarChartCard.tsx
+++ b/apps/web/src/components/dashboard-v3/RadarChartCard.tsx
@@ -316,7 +316,7 @@ export function RadarChartCard({ userId }: RadarChartCardProps) {
         </InfoDotTarget>
       }
     >
-      {status === 'loading' && <div className="h-[260px] w-full animate-pulse rounded-ib-md bg-[color:var(--color-overlay-2)]" />}
+      {status === 'loading' && <div className="h-[260px] w-full animate-pulse rounded-ib-md bg-[color:var(--ib-surface-card-active)]" />}
 
       {status === 'error' && (
         <p className="text-sm text-rose-300">{t('dashboard.radar.loadError')}</p>

--- a/apps/web/src/components/dashboard-v3/RewardsSection.tsx
+++ b/apps/web/src/components/dashboard-v3/RewardsSection.tsx
@@ -391,7 +391,7 @@ function GrowthCalibrationShelf({
         <button
           type="button"
           onClick={onOpenResults}
-          className="mt-3 w-full rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 text-left transition hover:border-[color:var(--color-border-soft)] hover:bg-[color:var(--color-overlay-2)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
+          className="mt-3 w-full rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 text-left transition hover:border-[color:var(--color-border-soft)] hover:bg-[color:var(--ib-surface-card-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300"
         >
           <p className="text-lg font-bold tracking-[0.02em] text-[color:var(--color-text)] sm:text-xl">
             <span className="text-rose-300">
@@ -411,7 +411,7 @@ function GrowthCalibrationShelf({
           ) : null}
         </button>
       ) : (
-        <div className="mt-3 rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4 text-sm text-[color:var(--color-text-muted)]">
+        <div className="mt-3 rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-4 text-sm text-[color:var(--color-text-muted)]">
           {language === "es"
             ? "Todavía no hay resultados de Growth Calibration. Tus próximos ajustes aparecerán aquí."
             : "There are no Growth Calibration results yet. Your next adjustments will appear here."}
@@ -450,7 +450,7 @@ function MonthlyWrapupShelf({
       </div>
       {latest ? (
         <div className="mt-3 space-y-2">
-          <div className="w-full rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 text-left">
+          <div className="w-full rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 text-left">
             <p className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">
               {latest.periodKey}
             </p>
@@ -466,7 +466,7 @@ function MonthlyWrapupShelf({
             />
           </div>
           {previous ? (
-            <div className="w-full rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]/70 p-3 text-left">
+            <div className="w-full rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 text-left">
               <p className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">
                 {previous.periodKey}
               </p>
@@ -477,7 +477,7 @@ function MonthlyWrapupShelf({
           ) : null}
         </div>
       ) : (
-        <div className="mt-3 rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4 text-sm text-[color:var(--color-text-muted)]">
+        <div className="mt-3 rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-4 text-sm text-[color:var(--color-text-muted)]">
           {language === "es"
             ? "Aún no tienes Wrap-Ups mensuales. Tus próximos resúmenes aparecerán aquí."
             : "You don't have monthly wrap-ups yet. Your next summaries will appear here."}
@@ -524,7 +524,7 @@ function WeeklyWrapupShelf({
                 key={item.id}
                 type="button"
                 onClick={() => onOpen?.(item)}
-                className="rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 text-left"
+                className="rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 text-left"
               >
                 <p className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">
                   {item.weekStart} → {item.weekEnd}
@@ -553,7 +553,7 @@ function WeeklyWrapupShelf({
           })}
         </div>
       ) : (
-        <div className="mt-3 rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4 text-sm text-[color:var(--color-text-muted)]">
+        <div className="mt-3 rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-4 text-sm text-[color:var(--color-text-muted)]">
           {language === "es"
             ? "Aún no tienes Weekly Wrap-Ups. Tus próximos resúmenes semanales aparecerán aquí."
             : "You don't have weekly wrap-ups yet. Your next weekly summaries will appear here."}
@@ -652,7 +652,7 @@ function GrowthCalibrationResultsModal({
 
         <div className="max-h-[70vh] overflow-auto p-3 sm:p-4">
           {growthCalibration.latestResults.length === 0 ? (
-            <p className="rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4 text-sm text-[color:var(--color-text-muted)]">
+            <p className="rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-4 text-sm text-[color:var(--color-text-muted)]">
               {language === "es"
                 ? "Todavía no hay resultados de Growth Calibration. Tus próximos ajustes aparecerán aquí."
                 : "There are no Growth Calibration results yet. Your next adjustments will appear here."}
@@ -792,7 +792,7 @@ function CompletionDots({
             className={`flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-semibold ${
               isDone
                 ? "border-[#d8b4fe] bg-[#e9d5ff] text-[#7c3aed] shadow-sm dark:border-violet-300/50 dark:bg-violet-500/45 dark:text-violet-100"
-                : "border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] text-[color:var(--color-text-muted)]"
+                : "border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] text-[color:var(--color-text-muted)]"
             }`}
           >
             {dayLabels[index]}
@@ -1403,13 +1403,13 @@ function AchievedShelf({
       {!isCarouselView && isShelfFocusStep ? (
         <div
           data-demo-anchor="logros-shelves-pillars"
-          className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]/95 p-3 shadow-[0_16px_32px_rgba(0,0,0,0.2)] ring-1 ring-[color:var(--color-accent-primary)]/35"
+          className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 shadow-[0_16px_32px_rgba(0,0,0,0.2)] ring-1 ring-[color:var(--color-accent-primary)]/35"
         >
           <div className="grid grid-cols-3 gap-2">
             {normalizedGroups.map((group) => (
               <div
                 key={`${group.pillar.code}-demo-column`}
-                className="rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-2 py-3 text-center"
+                className="rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-2 py-3 text-center"
               >
                 <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--color-text)]">
                   {resolvePillarHeader(group.pillar, language)}
@@ -1512,7 +1512,7 @@ function AchievedShelf({
                               ? activeCarouselIndex === index
                                 ? "border-amber-400/80 bg-[color:var(--color-surface-elevated)] shadow-[0_0_0_1px_rgba(251,191,36,0.16),0_20px_42px_rgba(2,8,23,0.16)] dark:bg-[rgba(7,13,16,0.78)] dark:shadow-[0_0_0_1px_rgba(251,191,36,0.16),0_22px_44px_rgba(0,0,0,0.26)]"
                                 : "border-[color:var(--color-border-soft)] bg-[color:var(--color-surface-elevated)] shadow-[0_16px_30px_rgba(2,8,23,0.12)] dark:bg-[rgba(7,13,16,0.62)] dark:shadow-[0_16px_30px_rgba(2,8,23,0.32)]"
-                              : "border-dashed border-[color:var(--color-border-strong)] bg-[color:var(--color-overlay-1)]/82 shadow-[0_12px_24px_rgba(2,8,23,0.1)] dark:border-[color:var(--color-border-subtle)] dark:bg-[rgba(7,13,16,0.58)] dark:shadow-[0_12px_24px_rgba(2,8,23,0.22)]"
+                              : "border-dashed border-[color:var(--color-border-strong)] bg-[color:var(--ib-surface-card)] shadow-[0_12px_24px_rgba(2,8,23,0.1)] dark:border-[color:var(--color-border-subtle)] dark:bg-[rgba(7,13,16,0.58)] dark:shadow-[0_12px_24px_rgba(2,8,23,0.22)]"
                           }`}
                           data-demo-anchor={
                             demoAnchors?.achievedCardTaskId === habit.taskId
@@ -1523,7 +1523,7 @@ function AchievedShelf({
                           }
                         >
                           {!isAchieved ? (
-                            <span className="absolute right-0 top-0 z-20 rounded-full border border-amber-300/65 bg-amber-200/90 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-900 shadow-[0_8px_18px_rgba(180,83,9,0.24)] dark:border-amber-300/35 dark:bg-[color:var(--color-overlay-1)] dark:text-[color:var(--color-text-dim)]">
+                            <span className="absolute right-0 top-0 z-20 rounded-full border border-amber-300/65 bg-amber-200/90 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-900 shadow-[0_8px_18px_rgba(180,83,9,0.24)] dark:border-amber-300/35 dark:bg-[color:var(--ib-surface-card)] dark:text-[color:var(--color-text-dim)]">
                               {language === "es" ? "Bloqueado" : "Locked"}
                             </span>
                           ) : null}
@@ -1644,7 +1644,7 @@ function AchievedShelf({
                   type="button"
                   onClick={() => scrollCarouselToIndex(activeCarouselIndex - 1)}
                   disabled={activeCarouselIndex <= 0}
-                  className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-1 text-xs font-semibold text-[color:var(--color-text)] shadow-[0_6px_14px_rgba(15,23,42,0.08)] transition hover:bg-[color:var(--color-overlay-2)] disabled:opacity-50"
+                  className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] px-3 py-1 text-xs font-semibold text-[color:var(--color-text)] shadow-[0_6px_14px_rgba(15,23,42,0.08)] transition hover:bg-[color:var(--ib-surface-card-hover)] disabled:opacity-50"
                 >
                   {language === "es" ? "Anterior" : "Previous"}
                 </button>
@@ -1658,14 +1658,14 @@ function AchievedShelf({
                   disabled={
                     activeCarouselIndex >= activePillarHabits.length - 1
                   }
-                  className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-1 text-xs font-semibold text-[color:var(--color-text)] shadow-[0_6px_14px_rgba(15,23,42,0.08)] transition hover:bg-[color:var(--color-overlay-2)] disabled:opacity-50"
+                  className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] px-3 py-1 text-xs font-semibold text-[color:var(--color-text)] shadow-[0_6px_14px_rgba(15,23,42,0.08)] transition hover:bg-[color:var(--ib-surface-card-hover)] disabled:opacity-50"
                 >
                   {language === "es" ? "Siguiente" : "Next"}
                 </button>
               </div>
             </>
           ) : (
-            <p className="rounded-2xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4 text-sm text-[color:var(--color-text-muted)]">
+            <p className="rounded-2xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-4 text-sm text-[color:var(--color-text-muted)]">
               {language === "es"
                 ? "Sin tareas seguidas en este pilar todavía."
                 : "No tracked tasks in this pillar yet."}
@@ -1702,7 +1702,7 @@ function AchievedShelf({
                       type="button"
                       data-demo-anchor={blockedAnchor}
                       onClick={() => setPreviewHabit(habit)}
-                      className={`flex shrink-0 flex-col items-center justify-center rounded-2xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]/55 px-3 text-center opacity-80 transition hover:border-[color:var(--color-border-strong)] hover:opacity-100 ${isShelfFocusStep ? "h-32 w-24 py-3" : "h-40 w-32 py-4"}`}
+                      className={`flex shrink-0 flex-col items-center justify-center rounded-2xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-3 text-center opacity-80 transition hover:border-[color:var(--color-border-strong)] hover:opacity-100 ${isShelfFocusStep ? "h-32 w-24 py-3" : "h-40 w-32 py-4"}`}
                     >
                       <HabitAchievementSeal
                         pillar={habit.pillar ?? group.pillar.code}
@@ -1740,14 +1740,14 @@ function AchievedShelf({
                       setActiveHabitId(habit.id);
                       setShowBackFace(false);
                     }}
-                    className={`flex shrink-0 flex-col items-center justify-center rounded-2xl border px-3 text-center transition ${isShelfFocusStep ? "h-32 w-24 py-3" : "h-40 w-32 py-4"} ${active ? "border-violet-300/60 bg-violet-500/10" : "border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:border-[color:var(--color-border-strong)]"}`}
+                    className={`flex shrink-0 flex-col items-center justify-center rounded-2xl border px-3 text-center transition ${isShelfFocusStep ? "h-32 w-24 py-3" : "h-40 w-32 py-4"} ${active ? "border-violet-300/60 bg-violet-500/10" : "border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] hover:border-[color:var(--color-border-strong)]"}`}
                   >
                     <HabitAchievementSeal
                       pillar={habit.pillar ?? group.pillar.code}
                       traitCode={habit.trait?.code}
                       traitName={habit.trait?.name}
                       alt={`${habit.taskName} seal`}
-                      className={`flex items-center justify-center overflow-hidden rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] shadow-[0_10px_30px_rgba(0,0,0,0.22)] ${isShelfFocusStep ? "h-16 min-h-16 w-16 min-w-16 max-h-16 max-w-16" : "h-20 min-h-20 w-20 min-w-20 max-h-20 max-w-20"}`}
+                      className={`flex items-center justify-center overflow-hidden rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] shadow-[0_10px_30px_rgba(0,0,0,0.22)] ${isShelfFocusStep ? "h-16 min-h-16 w-16 min-w-16 max-h-16 max-w-16" : "h-20 min-h-20 w-20 min-w-20 max-h-20 max-w-20"}`}
                       imgClassName="h-full w-full object-cover"
                       fallback={
                         <span className="text-3xl leading-none">
@@ -1844,7 +1844,7 @@ function LockedAchievementHabitDevelopment({
     loadOnVisible && !showLoading && !showError && !previewAchievement;
   if (showLoading) {
     return (
-      <p className="rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-2.5 text-xs text-[color:var(--color-text-muted)]">
+      <p className="rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-2.5 text-xs text-[color:var(--color-text-muted)]">
         {language === "es"
           ? "Cargando desarrollo del hábito…"
           : "Loading habit development…"}
@@ -1880,7 +1880,7 @@ function LockedAchievementHabitDevelopment({
 
   if (showEmpty) {
     return (
-      <p className="rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-2.5 text-xs text-[color:var(--color-text-muted)]">
+      <p className="rounded-xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-2.5 text-xs text-[color:var(--color-text-muted)]">
         {language === "es"
           ? "Aún no hay datos suficientes de desarrollo del hábito para esta tarea."
           : "There is not enough habit development data for this task yet."}
@@ -1977,7 +1977,7 @@ function NotAchievedPreviewOverlay({
 
         <div className="mt-4">
           {status === "loading" && !isLocalPreview ? (
-            <div className="rounded-2xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4 text-sm text-[color:var(--color-text-muted)]">
+            <div className="rounded-2xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-4 text-sm text-[color:var(--color-text-muted)]">
               {language === "es"
                 ? "Cargando vista previa del logro…"
                 : "Loading achievement preview…"}
@@ -2000,7 +2000,7 @@ function NotAchievedPreviewOverlay({
             />
           ) : null}
           {(status === "success" || isLocalPreview) && !previewAchievement ? (
-            <div className="rounded-2xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4 text-sm text-[color:var(--color-text-muted)]">
+            <div className="rounded-2xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-4 text-sm text-[color:var(--color-text-muted)]">
               {language === "es"
                 ? "Sigue registrando esta tarea para desbloquear el sello."
                 : "Keep logging this task to unlock the seal."}
@@ -2091,7 +2091,7 @@ function AchievementFocusOverlay({
               className="flex h-full flex-col items-center justify-center gap-4 text-center"
               data-demo-anchor={demoAnchors?.achievementFront}
             >
-              <div className="flex h-[min(60vw,18rem)] min-h-44 w-[min(60vw,18rem)] min-w-44 items-center justify-center rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] text-7xl shadow-[0_20px_50px_rgba(0,0,0,0.24)] sm:h-[75%] sm:max-h-72 sm:min-h-56 sm:w-[75%] sm:max-w-72 sm:min-w-56 sm:text-8xl">
+              <div className="flex h-[min(60vw,18rem)] min-h-44 w-[min(60vw,18rem)] min-w-44 items-center justify-center rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] text-7xl shadow-[0_20px_50px_rgba(0,0,0,0.24)] sm:h-[75%] sm:max-h-72 sm:min-h-56 sm:w-[75%] sm:max-w-72 sm:min-w-56 sm:text-8xl">
                 <HabitAchievementSeal
                   pillar={habit.pillar}
                   traitCode={habit.trait?.code}
@@ -2250,7 +2250,7 @@ function AchievedHabitBackContent({
         : {habit.gpSinceMaintain}
       </p>
       <div
-        className={`mt-0.5 rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 ${centerAligned ? "w-full max-w-sm" : ""}`}
+        className={`mt-0.5 rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-2.5 py-1.5 ${centerAligned ? "w-full max-w-sm" : ""}`}
       >
         <MaintainToggleRow
           language={language}

--- a/apps/web/src/components/dashboard-v3/StreakTaskInsightsModal.tsx
+++ b/apps/web/src/components/dashboard-v3/StreakTaskInsightsModal.tsx
@@ -189,7 +189,7 @@ function RecalibrationTrendIndicator({
           'inline-flex h-7 shrink-0 items-center overflow-hidden rounded-full border text-xs font-bold leading-none transition-[width,max-width,box-shadow,filter] duration-300 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/50',
           isExpanded ? 'w-[9.5rem] max-w-[9.5rem] pr-3' : 'w-7 max-w-7 justify-start pr-0',
           fallback
-            ? 'border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] text-[color:var(--color-slate-300)] shadow-[0_0_0_3px_rgba(148,163,184,0.10)]'
+            ? 'border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card-active)] text-[color:var(--color-slate-300)] shadow-[0_0_0_3px_rgba(148,163,184,0.10)]'
             : `${config[action].tone} ${config[action].glow}`,
         )}
         aria-label={tooltipLabel}
@@ -367,7 +367,7 @@ function MonthMiniChart({ days, t }: { days: Array<{ date: string; count: number
           const height = 12 + ratio * 48;
           return (
             <div key={day.date} className="flex flex-col items-center justify-end gap-1 text-[10px] text-[color:var(--color-slate-400)]">
-              <div className="flex w-4 items-end justify-center rounded-full bg-[color:var(--color-overlay-1)]">
+              <div className="flex w-4 items-end justify-center rounded-full bg-[color:var(--ib-surface-card)]">
                 <div
                   className={cx(
                     'w-[10px] rounded-full bg-gradient-to-b from-violet-200 via-fuchsia-200 to-sky-200 transition-all',
@@ -432,13 +432,13 @@ function WeekMiniChart({
 
   return (
     <div className="mt-3 space-y-1.5">
-      <div className="flex items-end justify-between gap-2 rounded-2xl bg-[color:var(--color-overlay-1)] px-3 py-2">
+      <div className="flex items-end justify-between gap-2 rounded-2xl bg-[color:var(--ib-surface-card)] px-3 py-2">
         {timeline.map((day) => {
           const ratio = Math.min(1, Math.max(0, day.count / maxCount));
           const height = 10 + ratio * 48;
           return (
             <div key={day.label} className="flex flex-1 flex-col items-center justify-end gap-1 text-[11px] text-[color:var(--color-slate-300)]">
-              <div className="flex w-full items-end justify-center rounded-full bg-[color:var(--color-overlay-1)]">
+              <div className="flex w-full items-end justify-center rounded-full bg-[color:var(--ib-surface-card)]">
                 <div
                   className={cx(
                     'w-[14px] rounded-full bg-gradient-to-b from-violet-200 via-fuchsia-200 to-sky-200 transition-all',
@@ -500,7 +500,7 @@ function QuarterMiniChart({
               key={`${week.weekStart}-${week.weekEnd}-${index}`}
               className="flex flex-col items-center justify-end gap-1 text-[10px] text-[color:var(--color-slate-400)]"
             >
-              <div className="flex w-6 items-end justify-center rounded-full bg-[color:var(--color-overlay-1)]">
+              <div className="flex w-6 items-end justify-center rounded-full bg-[color:var(--ib-surface-card)]">
                 <div
                   className={cx(
                     'w-[14px] rounded-full transition-all',
@@ -703,7 +703,7 @@ export function TaskInsightsModal({
           <button
             type="button"
             onClick={onClose}
-            className="shrink-0 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-1 text-sm text-[color:var(--color-slate-200)] transition hover:border-white/25 hover:bg-[color:var(--color-overlay-2)]"
+            className="shrink-0 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] px-3 py-1 text-sm text-[color:var(--color-slate-200)] transition hover:border-white/25 hover:bg-[color:var(--ib-surface-card-hover)]"
             aria-label={t('dashboard.streakTaskInsights.closeAria')}
           >
             ✕
@@ -712,13 +712,13 @@ export function TaskInsightsModal({
 
         <div className="flex-1 overflow-y-auto px-4 pb-5 pt-2">
           <div className="mt-2 space-y-3">
-            <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3">
+            <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3">
               <div className="space-y-3">
                 <div className="flex flex-wrap items-start justify-between gap-2">
                   <div className="space-y-1">
                     <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--color-text-muted)] dark:text-slate-300">{t('dashboard.streakTaskInsights.activity')}</p>
                     <div className="flex justify-center">
-                      <div className="inline-flex w-full max-w-[240px] items-center justify-between gap-1 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-0.5 text-[11px] font-semibold text-[color:var(--color-slate-100)]">
+                      <div className="inline-flex w-full max-w-[240px] items-center justify-between gap-1 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] px-2 py-0.5 text-[11px] font-semibold text-[color:var(--color-slate-100)]">
                         {[
                           { value: 'week', label: 'W' },
                           { value: 'month', label: 'M' },
@@ -734,7 +734,7 @@ export function TaskInsightsModal({
                                 'flex-1 rounded-full px-3 py-0.5 text-[11px] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-surface)]',
                                 isActive
                                   ? 'bg-white text-slate-900 shadow-inner shadow-white/30'
-                                  : 'text-[color:var(--color-slate-200)] hover:bg-[color:var(--color-overlay-2)]',
+                                  : 'text-[color:var(--color-slate-200)] hover:bg-[color:var(--ib-surface-card-hover)]',
                               )}
                               aria-pressed={isActive}
                             >
@@ -747,7 +747,7 @@ export function TaskInsightsModal({
                   </div>
 
                   <div className="flex flex-wrap items-center gap-1.5 text-[11px] font-semibold text-[color:var(--color-slate-100)]">
-                    <span className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] px-2 py-0.5">
+                    <span className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card-active)] px-2 py-0.5">
                       {numberFormatter.format(activityTotals.count)}d
                     </span>
                     <span className="inline-flex items-center gap-1 rounded-full border border-violet-400/40 bg-violet-400/10 px-2 py-0.5">
@@ -756,7 +756,7 @@ export function TaskInsightsModal({
                   </div>
                 </div>
               </div>
-              {status === 'loading' && <div className="mt-3 h-24 animate-pulse rounded-xl bg-[color:var(--color-overlay-2)]" aria-hidden />}
+              {status === 'loading' && <div className="mt-3 h-24 animate-pulse rounded-xl bg-[color:var(--ib-surface-card-active)]" aria-hidden />}
               {status === 'success' && activityScope === 'week' && (
                 <WeekMiniChart days={monthDays} referenceDate={referenceDate} t={t} language={language} />
               )}
@@ -767,10 +767,10 @@ export function TaskInsightsModal({
             </div>
 
             {status === 'loading' && (
-              <div className="h-36 animate-pulse rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-2)]" aria-hidden />
+              <div className="h-36 animate-pulse rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card-active)]" aria-hidden />
             )}
             {status === 'error' && (
-              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 shadow-inner">
+              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 shadow-inner">
                 <p className="text-sm text-rose-300">{t('dashboard.streakTaskInsights.weeklyProgress.error', { message: error?.message ?? '—' })}</p>
               </div>
             )}
@@ -778,7 +778,7 @@ export function TaskInsightsModal({
               <PreviewAchievementCard previewAchievement={previewAchievement} language={language} variant="landing" />
             )}
             {status === 'success' && !previewAchievement && (
-              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 shadow-inner">
+              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 shadow-inner">
                 <div className="flex items-center justify-between gap-2">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--color-text-muted)] dark:text-slate-300">{t('dashboard.streakTaskInsights.weeklyProgress')}</p>
                   <span className="text-xs text-[color:var(--color-slate-400)]">{t('dashboard.streakTaskInsights.goal', { goal: weeklyGoal })}</span>
@@ -799,7 +799,7 @@ export function TaskInsightsModal({
             )}
 
 
-            <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 shadow-inner">
+            <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 shadow-inner">
               <div className="flex items-center justify-between gap-2">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--color-text-muted)] dark:text-slate-300">{t('dashboard.streakTaskInsights.recalibration.title')}</p>
                 {recalibrationLatest?.recalibratedAt && (
@@ -808,7 +808,7 @@ export function TaskInsightsModal({
                   </span>
                 )}
               </div>
-              {status === 'loading' && <div className="mt-2 h-16 animate-pulse rounded-xl bg-[color:var(--color-overlay-2)]" aria-hidden />}
+              {status === 'loading' && <div className="mt-2 h-16 animate-pulse rounded-xl bg-[color:var(--ib-surface-card-active)]" aria-hidden />}
               {status === 'success' && recalibrationHistory.length > 0 && (
                 <ul className="mt-2 space-y-1.5">
                   {recalibrationHistory.map((record, index) => {
@@ -833,7 +833,7 @@ export function TaskInsightsModal({
                     return (
                       <li
                         key={`${record.periodStart ?? 'period'}-${index}`}
-                        className="flex flex-col items-start gap-1.5 rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] px-2.5 py-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3"
+                        className="flex flex-col items-start gap-1.5 rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card-active)] px-2.5 py-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3"
                       >
                         <div className="min-w-0">
                           <p className="text-[11px] font-semibold leading-tight text-[color:var(--color-slate-100)]">{formatPeriodLabel(record, language, t)}</p>
@@ -854,12 +854,12 @@ export function TaskInsightsModal({
             </div>
 
             <div className="grid grid-cols-2 gap-3">
-              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 shadow-inner">
+              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 shadow-inner">
                 <p className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">{t('dashboard.streakTaskInsights.currentStreak')}</p>
                 <p className="mt-1 text-3xl font-semibold text-[color:var(--color-text)]">🔥 {stats.currentStreak}</p>
                 <p className="text-xs text-[color:var(--color-slate-400)]">{t('dashboard.streakTaskInsights.streak.weeksInRow')}</p>
               </div>
-              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3 shadow-inner">
+              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3 shadow-inner">
                 <p className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">{t('dashboard.streakTaskInsights.bestStreak')}</p>
                 <p className="mt-1 text-3xl font-semibold text-[color:var(--color-text)]">{stats.bestStreak}</p>
                 <p className="text-xs text-[color:var(--color-slate-400)]">{t('dashboard.streakTaskInsights.streak.bestLabel')}</p>

--- a/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
+++ b/apps/web/src/components/dashboard-v3/StreaksPanel.tsx
@@ -139,7 +139,7 @@ export function LegacyStreaksPanel({ userId }: LegacyStreaksPanelProps) {
       subtitle="Vista read-only"
       rightSlot={
         <span className="inline-flex items-center gap-2 text-xs text-[color:var(--color-slate-400)]">
-          <span className="hidden rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-2.5 py-1 text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-slate-300)] md:inline-flex">
+          <span className="hidden rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-2.5 py-1 text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-slate-300)] md:inline-flex">
             Beta
           </span>
           <span aria-hidden>⚡</span>
@@ -157,7 +157,7 @@ export function LegacyStreaksPanel({ userId }: LegacyStreaksPanelProps) {
               className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60 ${
                 isActive
                   ? 'border-indigo-300/60 bg-indigo-300/15 text-indigo-100'
-                  : 'border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] text-[color:var(--color-slate-300)] hover:border-[color:var(--color-border-soft)] hover:bg-[color:var(--color-overlay-2)]'
+                  : 'border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] text-[color:var(--color-slate-300)] hover:border-[color:var(--color-border-soft)] hover:bg-[color:var(--ib-surface-card-hover)]'
               }`}
             >
               {filter.label}
@@ -177,7 +177,7 @@ export function LegacyStreaksPanel({ userId }: LegacyStreaksPanelProps) {
               className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60 ${
                 isActive
                   ? 'border-amber-300/60 bg-amber-300/15 text-amber-100'
-                  : 'border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] text-[color:var(--color-slate-300)] hover:border-[color:var(--color-border-soft)] hover:bg-[color:var(--color-overlay-2)]'
+                  : 'border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] text-[color:var(--color-slate-300)] hover:border-[color:var(--color-border-soft)] hover:bg-[color:var(--ib-surface-card-hover)]'
               }`}
             >
               {filter.label}
@@ -186,7 +186,7 @@ export function LegacyStreaksPanel({ userId }: LegacyStreaksPanelProps) {
         })}
       </div>
 
-      {status === 'loading' && <div className="h-56 w-full animate-pulse rounded-ib-md bg-[color:var(--color-overlay-2)]" />}
+      {status === 'loading' && <div className="h-56 w-full animate-pulse rounded-ib-md bg-[color:var(--ib-surface-card-active)]" />}
 
       {status === 'error' && (
         <p className="text-sm text-rose-300">No pudimos cargar tus tareas activas.</p>
@@ -195,10 +195,10 @@ export function LegacyStreaksPanel({ userId }: LegacyStreaksPanelProps) {
       {status === 'success' && data && (
         <div className="flex flex-col gap-4">
           <p className="text-xs text-[color:var(--color-slate-400)]">
-            La API actual aún no expone <code className="rounded bg-[color:var(--color-overlay-2)] px-1 py-px text-[10px]">daily_log_raw</code>. Listamos tus tareas activas y calculamos el GP semanal total como referencia.
+            La API actual aún no expone <code className="rounded bg-[color:var(--ib-surface-card-active)] px-1 py-px text-[10px]">daily_log_raw</code>. Listamos tus tareas activas y calculamos el GP semanal total como referencia.
           </p>
 
-          <div className="rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4">
+          <div className="rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-panel)] p-4">
             <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">GP total últimos 7 días</p>
             <p className="mt-2 text-2xl font-semibold text-[color:var(--color-slate-100)]">{weeklyXp.toLocaleString('es-AR')} GP</p>
             <p className="mt-1 text-xs text-[color:var(--color-slate-400)]">Filtro: {pillarFilter} · Alcance: {scopeFilter === 'week' ? 'Semana' : scopeFilter === 'month' ? 'Mes' : '3 meses'}</p>
@@ -206,15 +206,15 @@ export function LegacyStreaksPanel({ userId }: LegacyStreaksPanelProps) {
 
           <div className="space-y-3">
             {filteredTasks.slice(0, 8).map((task) => (
-              <article key={task.id} className="rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4">
+              <article key={task.id} className="rounded-ib-md border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] p-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
                     <p className="font-semibold text-[color:var(--color-slate-100)]">{task.title}</p>
                     <p className="text-xs text-[color:var(--color-slate-400)]">Pilar: {task.pillarId ?? '—'}</p>
                   </div>
                   <div className="flex items-center gap-2 text-xs text-[color:var(--color-slate-300)]">
-                    <span className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-[color:var(--color-slate-100)]">+{task.xp ?? 0} GP</span>
-                    <span className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-2 py-1">✓×—</span>
+                    <span className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-2 py-1 text-[color:var(--color-slate-100)]">+{task.xp ?? 0} GP</span>
+                    <span className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-2 py-1">✓×—</span>
                   </div>
                 </div>
               </article>
@@ -524,7 +524,7 @@ function TaskItem({
   return (
     <article
       className={cx(
-        'ib-card-contour-shadow flex flex-col gap-1.5 rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-2.5 text-[color:var(--color-slate-200)] transition hover:border-violet-300/50 hover:bg-[color:var(--color-overlay-2)] md:gap-2 md:p-3',
+        'ib-card-contour-shadow flex flex-col gap-1.5 rounded-ib-md border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] p-2.5 text-[color:var(--color-slate-200)] transition hover:border-violet-300/50 hover:bg-[color:var(--ib-surface-card-hover)] md:gap-2 md:p-3',
         item.highlight && 'border-violet-400/60 bg-violet-400/10 shadow-[0_8px_26px_rgba(99,102,241,0.3)]',
       )}
       aria-label={`Streak ${item.name}, ${item.weeklyDone} of ${item.weeklyGoal} this week, ${streakDays} consecutive days`}
@@ -938,7 +938,7 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, avatarProfile, fo
           {isLoading ? (
             <div className="grid grid-cols-1 gap-3">
               {Array.from({ length: 3 }).map((_, index) => (
-                <div key={`top-skeleton-${index}`} className="h-24 animate-pulse rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]" />
+                <div key={`top-skeleton-${index}`} className="h-24 animate-pulse rounded-ib-md border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)]" />
               ))}
             </div>
           ) : (
@@ -1004,7 +1004,7 @@ export function StreaksPanel({ userId, gameMode, weeklyTarget, avatarProfile, fo
             {showTasksSkeleton ? (
               <div className="grid grid-cols-1 gap-3">
                 {Array.from({ length: 4 }).map((_, index) => (
-                  <div key={`task-skeleton-${index}`} className="h-24 animate-pulse rounded-ib-md border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]" />
+                  <div key={`task-skeleton-${index}`} className="h-24 animate-pulse rounded-ib-md border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)]" />
                 ))}
               </div>
             ) : (

--- a/apps/web/src/components/dashboard-v3/ThemeSwitcher.tsx
+++ b/apps/web/src/components/dashboard-v3/ThemeSwitcher.tsx
@@ -42,7 +42,7 @@ export function ThemeSwitcher() {
   }));
 
   return (
-    <section className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-3 py-3">
+    <section className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-3 py-3">
       <p className="text-[0.65rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--color-text-muted)]">
         {t('dashboard.theme.appearance')}
       </p>

--- a/apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx
+++ b/apps/web/src/components/dashboard-v3/UpgradeRecommendationModal.tsx
@@ -262,7 +262,7 @@ export function UpgradeRecommendationModal({
               <button
                 type="button"
                 onClick={onClose}
-                className="inline-flex items-center rounded-full border border-[color:var(--color-border-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--color-text)] transition hover:bg-[color:var(--color-overlay-1)]"
+                className="inline-flex items-center rounded-full border border-[color:var(--color-border-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--color-text)] transition hover:bg-[color:var(--ib-surface-card-hover)]"
               >
                 {t('dashboard.upgradeCta.close')}
               </button>

--- a/apps/web/src/components/dashboard-v3/segmentedControlStyles.ts
+++ b/apps/web/src/components/dashboard-v3/segmentedControlStyles.ts
@@ -1,5 +1,5 @@
 export const DASHBOARD_SEGMENTED_GROUP_BASE =
-  'inline-flex w-full items-center justify-between gap-1 rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-1 shadow-[var(--shadow-elev-1)]';
+  'inline-flex w-full items-center justify-between gap-1 rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-1 shadow-[var(--shadow-elev-1)]';
 
 export const DASHBOARD_SEGMENTED_BUTTON_BASE =
   'flex-1 inline-flex items-center justify-center gap-1 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300 md:text-xs';

--- a/apps/web/src/components/moderation/ModerationWidget.tsx
+++ b/apps/web/src/components/moderation/ModerationWidget.tsx
@@ -113,7 +113,7 @@ function Chip({
     <button
       type="button"
       onClick={() => onCycle(tracker.type, nextStatus(tracker.statusToday))}
-      className={`relative w-full overflow-hidden rounded-ib-lg border px-3 pb-6 pt-[0.3125rem] text-left transition-all duration-200 hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)] sm:px-3.5 sm:pb-6 sm:pt-1.5 ${chipStateClass(tracker.statusToday)}`}
+      className={`relative w-full overflow-hidden rounded-ib-lg border px-3 pb-6 pt-[0.3125rem] text-left transition-all duration-200 hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--ib-surface-card-hover)] sm:px-3.5 sm:pb-6 sm:pt-1.5 ${chipStateClass(tracker.statusToday)}`}
       title={hint}
       {...longPressBind}
     >
@@ -189,7 +189,7 @@ export function ModerationWidget({
         className={`grid gap-2.5 sm:gap-3 ${activeCount === 1 ? "grid-cols-1" : ""} ${activeCount === 2 ? "grid-cols-2" : ""} ${activeCount === 3 ? "grid-cols-3 max-[360px]:grid-cols-2" : ""}`}
       >
         {loading && (
-          <div className="h-20 animate-pulse rounded-ib-lg border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]" />
+          <div className="h-20 animate-pulse rounded-ib-lg border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)]" />
         )}
         {!loading &&
           enabled.map((tracker) => (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -34,23 +34,39 @@
     --onboarding-premium-overlay-soft: rgba(255, 255, 255, 0.06);
     --onboarding-premium-overlay-base: rgba(255, 255, 255, 0.1);
 
-    --color-surface: #010409;
-    --color-surface-muted: #05070b;
-    --color-surface-elevated: #0b0f14;
-    --color-surface-highlight: #11161d;
+    --ib-dark-surface-app: #010409;
+    --ib-dark-surface-section: #05080d;
+    --ib-dark-surface-panel: #0a0f16;
+    --ib-dark-surface-card: #121820;
+    --ib-dark-surface-card-hover: #171f2a;
+    --ib-dark-surface-card-active: #1b2532;
+    --ib-surface-app: var(--ib-dark-surface-app);
+    --ib-surface-section: var(--ib-dark-surface-section);
+    --ib-surface-panel: var(--ib-dark-surface-panel);
+    --ib-surface-card: var(--ib-dark-surface-card);
+    --ib-surface-card-hover: var(--ib-dark-surface-card-hover);
+    --ib-surface-card-active: var(--ib-dark-surface-card-active);
+    --surface-app: var(--ib-surface-app);
+    --surface-section: var(--ib-surface-section);
+    --surface-card: var(--ib-surface-card);
+    --surface-elevated: var(--ib-surface-panel);
+    --color-surface: var(--ib-surface-app);
+    --color-surface-muted: var(--ib-surface-section);
+    --color-surface-elevated: var(--ib-surface-panel);
+    --color-surface-highlight: var(--ib-surface-card);
     --color-text: #f8fafc;
     --color-text-muted: #cbd5f5;
     --color-text-subtle: #94a3b8;
     --color-accent-primary: #38bdf8;
     --color-accent-secondary: #8b5cf6;
-    --color-overlay-1: rgba(255, 255, 255, 0.04);
-    --color-overlay-2: rgba(255, 255, 255, 0.08);
-    --color-overlay-3: rgba(255, 255, 255, 0.12);
+    --color-overlay-1: rgba(255, 255, 255, 0.055);
+    --color-overlay-2: rgba(255, 255, 255, 0.09);
+    --color-overlay-3: rgba(255, 255, 255, 0.13);
     --color-overlay-4: rgba(255, 255, 255, 0.16);
     --color-overlay-5: rgba(255, 255, 255, 0.22);
-    --color-border-subtle: rgba(255, 255, 255, 0.075);
-    --color-border-soft: rgba(255, 255, 255, 0.115);
-    --color-border-strong: rgba(255, 255, 255, 0.18);
+    --color-border-subtle: rgba(255, 255, 255, 0.09);
+    --color-border-soft: rgba(255, 255, 255, 0.13);
+    --color-border-strong: rgba(255, 255, 255, 0.19);
     --color-text-strong: #ffffff;
     --color-text-dim: rgba(255, 255, 255, 0.7);
     --color-text-faint: rgba(255, 255, 255, 0.6);
@@ -115,8 +131,8 @@
     --color-quickaccess-cta-disabled-text: rgba(224, 231, 255, 0.62);
     --color-card-gradient: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.96),
-      rgba(5, 7, 11, 0.98)
+      color-mix(in srgb, var(--ib-surface-panel) 96%, white 4%),
+      color-mix(in srgb, var(--ib-surface-section) 98%, black 2%)
     );
     --color-card-highlight-gradient: radial-gradient(
       ellipse at top,
@@ -128,16 +144,16 @@
     --color-card-border: var(--color-border-subtle);
     --color-glass-surface: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.88),
-      rgba(5, 7, 11, 0.82)
+      color-mix(in srgb, var(--ib-surface-panel) 88%, transparent),
+      color-mix(in srgb, var(--ib-surface-section) 82%, transparent)
     );
     --color-glow-soft: rgba(139, 154, 180, 0.09);
     --shadow-elev-1: 0 8px 20px rgba(0, 0, 0, 0.28);
     --shadow-elev-2: 0 14px 36px rgba(2, 6, 23, 0.34);
     --glass-bg: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.88),
-      rgba(5, 7, 11, 0.82)
+      color-mix(in srgb, var(--ib-surface-panel) 88%, transparent),
+      color-mix(in srgb, var(--ib-surface-section) 82%, transparent)
     );
     --glass-border: rgba(255, 255, 255, 0.085);
     --ib-premium-divider: color-mix(
@@ -161,23 +177,39 @@
 
   :root[data-theme="dark"] {
     color-scheme: dark;
-    --color-surface: #010409;
-    --color-surface-muted: #05070b;
-    --color-surface-elevated: #0b0f14;
-    --color-surface-highlight: #11161d;
+    --ib-dark-surface-app: #010409;
+    --ib-dark-surface-section: #05080d;
+    --ib-dark-surface-panel: #0a0f16;
+    --ib-dark-surface-card: #121820;
+    --ib-dark-surface-card-hover: #171f2a;
+    --ib-dark-surface-card-active: #1b2532;
+    --ib-surface-app: var(--ib-dark-surface-app);
+    --ib-surface-section: var(--ib-dark-surface-section);
+    --ib-surface-panel: var(--ib-dark-surface-panel);
+    --ib-surface-card: var(--ib-dark-surface-card);
+    --ib-surface-card-hover: var(--ib-dark-surface-card-hover);
+    --ib-surface-card-active: var(--ib-dark-surface-card-active);
+    --surface-app: var(--ib-surface-app);
+    --surface-section: var(--ib-surface-section);
+    --surface-card: var(--ib-surface-card);
+    --surface-elevated: var(--ib-surface-panel);
+    --color-surface: var(--ib-surface-app);
+    --color-surface-muted: var(--ib-surface-section);
+    --color-surface-elevated: var(--ib-surface-panel);
+    --color-surface-highlight: var(--ib-surface-card);
     --color-text: #f8fafc;
     --color-text-muted: #cbd5f5;
     --color-text-subtle: #94a3b8;
     --color-accent-primary: #38bdf8;
     --color-accent-secondary: #8b5cf6;
-    --color-overlay-1: rgba(255, 255, 255, 0.04);
-    --color-overlay-2: rgba(255, 255, 255, 0.08);
-    --color-overlay-3: rgba(255, 255, 255, 0.12);
+    --color-overlay-1: rgba(255, 255, 255, 0.055);
+    --color-overlay-2: rgba(255, 255, 255, 0.09);
+    --color-overlay-3: rgba(255, 255, 255, 0.13);
     --color-overlay-4: rgba(255, 255, 255, 0.16);
     --color-overlay-5: rgba(255, 255, 255, 0.22);
-    --color-border-subtle: rgba(255, 255, 255, 0.075);
-    --color-border-soft: rgba(255, 255, 255, 0.115);
-    --color-border-strong: rgba(255, 255, 255, 0.18);
+    --color-border-subtle: rgba(255, 255, 255, 0.09);
+    --color-border-soft: rgba(255, 255, 255, 0.13);
+    --color-border-strong: rgba(255, 255, 255, 0.19);
     --color-text-strong: #ffffff;
     --color-text-dim: rgba(255, 255, 255, 0.7);
     --color-text-faint: rgba(255, 255, 255, 0.6);
@@ -219,8 +251,8 @@
     --color-quickaccess-cta-disabled-text: rgba(224, 231, 255, 0.62);
     --color-card-gradient: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.96),
-      rgba(5, 7, 11, 0.98)
+      color-mix(in srgb, var(--ib-surface-panel) 96%, white 4%),
+      color-mix(in srgb, var(--ib-surface-section) 98%, black 2%)
     );
     --color-card-highlight-gradient: radial-gradient(
       ellipse at top,
@@ -232,16 +264,16 @@
     --color-card-border: var(--color-border-subtle);
     --color-glass-surface: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.88),
-      rgba(5, 7, 11, 0.82)
+      color-mix(in srgb, var(--ib-surface-panel) 88%, transparent),
+      color-mix(in srgb, var(--ib-surface-section) 82%, transparent)
     );
     --color-glow-soft: rgba(139, 154, 180, 0.09);
     --shadow-elev-1: 0 8px 20px rgba(0, 0, 0, 0.28);
     --shadow-elev-2: 0 14px 36px rgba(2, 6, 23, 0.34);
     --glass-bg: linear-gradient(
       180deg,
-      rgba(11, 15, 20, 0.88),
-      rgba(5, 7, 11, 0.82)
+      color-mix(in srgb, var(--ib-surface-panel) 88%, transparent),
+      color-mix(in srgb, var(--ib-surface-section) 82%, transparent)
     );
     --glass-border: rgba(255, 255, 255, 0.085);
   }
@@ -255,10 +287,20 @@
         rgba(148, 163, 184, 0) 62%
       ),
       linear-gradient(180deg, #f8fafc 0%, #f4f6f8 52%, #eef2f6 100%);
-    --color-surface: #f7f8fa;
-    --color-surface-muted: #f1f3f6;
-    --color-surface-elevated: #ffffff;
-    --color-surface-highlight: #fafbfc;
+    --ib-surface-app: #f7f8fa;
+    --ib-surface-section: #f1f3f6;
+    --ib-surface-panel: #ffffff;
+    --ib-surface-card: #fafbfc;
+    --ib-surface-card-hover: #f3f6fb;
+    --ib-surface-card-active: #edf2f8;
+    --surface-app: var(--ib-surface-app);
+    --surface-section: var(--ib-surface-section);
+    --surface-card: var(--ib-surface-card);
+    --surface-elevated: var(--ib-surface-panel);
+    --color-surface: var(--ib-surface-app);
+    --color-surface-muted: var(--ib-surface-section);
+    --color-surface-elevated: var(--ib-surface-panel);
+    --color-surface-highlight: var(--ib-surface-card);
     --color-text: #0f172a;
     --color-text-muted: #334155;
     --color-text-subtle: #64748b;
@@ -1487,7 +1529,7 @@
   }
 
   .ib-light-elevated-surface {
-    background: var(--color-overlay-1);
+    background: var(--ib-surface-card);
     border: 1px solid var(--color-border-subtle);
     box-shadow: var(--IB_SURFACE_CARD_LIGHT);
   }
@@ -6322,7 +6364,7 @@
 
   :root[data-theme="dark"] [data-light-scope="editor"] .editor-pillar-chip {
     border-color: var(--color-border-subtle);
-    background: var(--color-overlay-1);
+    background: var(--ib-surface-card);
     color: var(--color-slate-200);
   }
 
@@ -6330,7 +6372,7 @@
     [data-light-scope="editor"]
     .editor-pillar-chip:hover {
     border-color: var(--color-border-soft);
-    background: var(--color-overlay-2);
+    background: var(--ib-surface-card-hover);
   }
 
   :root[data-theme="dark"]
@@ -6497,7 +6539,7 @@
   .create-task-ai-modal__close {
     border-color: var(--color-border-subtle);
     color: var(--color-slate-200);
-    background: var(--color-overlay-1);
+    background: var(--ib-surface-card);
   }
 
   .create-task-ai-modal__close:hover {
@@ -6626,7 +6668,7 @@
 
   .edit-task-modal__status-checkbox {
     border: 1px solid var(--color-border-soft);
-    background: var(--color-overlay-2);
+    background: var(--ib-surface-card-active);
     color: var(--color-accent-primary);
   }
 
@@ -7310,12 +7352,8 @@
   }
   [data-light-scope="daily-quest"].ib-daily-quest-shell {
     color: var(--color-text);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    background-image: linear-gradient(
-      180deg,
-      rgba(11, 15, 20, 0.97),
-      rgba(5, 7, 11, 0.98)
-    );
+    border: 1px solid var(--color-border-subtle);
+    background-image: var(--color-card-gradient);
     box-shadow:
       0 34px 82px rgba(0, 0, 0, 0.56),
       inset 0 1px 0 rgba(255, 255, 255, 0.05);
@@ -7323,11 +7361,11 @@
 
   [data-light-scope="daily-quest"] .ib-daily-quest-header,
   [data-light-scope="daily-quest"] .ib-daily-quest-footer {
-    border-color: rgba(255, 255, 255, 0.07);
+    border-color: var(--color-border-subtle);
     background-image: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.03),
-      rgba(255, 255, 255, 0.015)
+      color-mix(in srgb, var(--ib-surface-panel) 90%, transparent),
+      color-mix(in srgb, var(--ib-surface-section) 86%, transparent)
     );
   }
 
@@ -7336,11 +7374,11 @@
   [data-light-scope="daily-quest"] .ib-daily-quest-secondary-btn,
   [data-light-scope="daily-quest"] .ib-daily-quest-close-btn,
   [data-light-scope="daily-quest"] .ib-daily-quest-emotion-chip--inactive {
-    border-color: rgba(255, 255, 255, 0.08);
+    border-color: var(--color-border-soft);
     background-image: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.03),
-      rgba(255, 255, 255, 0.015)
+      color-mix(in srgb, var(--ib-surface-card) 96%, white 4%),
+      color-mix(in srgb, var(--ib-surface-card) 92%, black 8%)
     );
   }
 
@@ -7350,16 +7388,16 @@
   [data-light-scope="daily-quest"] .ib-daily-quest-emotion-chip--inactive:hover {
     background-image: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.09),
-      rgba(255, 255, 255, 0.04)
+      color-mix(in srgb, var(--ib-surface-card-hover) 96%, white 4%),
+      color-mix(in srgb, var(--ib-surface-card-hover) 92%, black 8%)
     );
   }
 
   [data-light-scope="daily-quest"] .ib-daily-quest-task-row--selected {
     background-image: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.12),
-      rgba(255, 255, 255, 0.05)
+      color-mix(in srgb, var(--ib-surface-card-active) 96%, white 4%),
+      color-mix(in srgb, var(--ib-surface-card-active) 92%, black 8%)
     );
   }
 

--- a/apps/web/src/pages/DashboardV3.tsx
+++ b/apps/web/src/pages/DashboardV3.tsx
@@ -1644,25 +1644,25 @@ function deriveGameModeFromProfile(mode?: string | null): GameMode | null {
 function ProfileSkeleton() {
   return (
     <div className="space-y-4">
-      <div className="h-6 w-48 animate-pulse rounded bg-[color:var(--color-overlay-2)]" />
+      <div className="h-6 w-48 animate-pulse rounded bg-[color:var(--ib-surface-card-active)]" />
       <div className="grid grid-cols-1 gap-4 md:gap-5 lg:grid-cols-12 lg:gap-6">
         <div className="lg:col-span-12">
-          <div className="h-32 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />
+          <div className="h-32 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />
         </div>
         <div className="space-y-4 md:space-y-5 lg:col-span-4">
-          <div className="h-36 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />
-          <div className="h-64 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />
-          <div className="h-56 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />
-          <div className="h-48 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />
+          <div className="h-36 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />
+          <div className="h-64 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />
+          <div className="h-56 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />
+          <div className="h-48 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />
         </div>
         <div className="space-y-4 md:space-y-5 lg:col-span-4">
-          <div className="h-64 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />
-          <div className="h-64 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />
+          <div className="h-64 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />
+          <div className="h-64 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />
         </div>
         <div className="space-y-4 md:space-y-5 lg:col-span-4">
-          <div className="h-72 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />
-          <div className="h-72 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />
-          <div className="h-48 w-full animate-pulse rounded-2xl bg-[color:var(--color-overlay-2)]" />
+          <div className="h-72 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />
+          <div className="h-72 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />
+          <div className="h-48 w-full animate-pulse rounded-2xl bg-[color:var(--ib-surface-card-active)]" />
         </div>
       </div>
     </div>
@@ -1705,7 +1705,7 @@ function ProfileErrorState({ onRetry, error }: ProfileErrorStateProps) {
 function DashboardFallback() {
   return (
     <div className="mt-8 space-y-6">
-      <section className="rounded-3xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-6 text-[color:var(--color-slate-200)] shadow-glow">
+      <section className="rounded-3xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-panel)] p-6 text-[color:var(--color-slate-200)] shadow-glow">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-slate-400)]">
           Vista previa sin conexión
         </p>
@@ -1741,10 +1741,10 @@ function DashboardFallback() {
             className="min-h-[180px]"
           >
             <div className="flex items-center gap-3">
-              <div className="h-12 w-12 rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-2)]" />
+              <div className="h-12 w-12 rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card-active)]" />
               <div className="space-y-2 text-xs text-[color:var(--color-slate-300)]">
-                <div className="h-3 w-24 rounded bg-[color:var(--color-overlay-2)]" />
-                <div className="h-3 w-16 rounded bg-[color:var(--color-overlay-2)]" />
+                <div className="h-3 w-24 rounded bg-[color:var(--ib-surface-card-active)]" />
+                <div className="h-3 w-16 rounded bg-[color:var(--ib-surface-card-active)]" />
               </div>
             </div>
             <p className="mt-4 text-xs text-[color:var(--color-slate-400)]">
@@ -1789,7 +1789,7 @@ function DashboardFallback() {
             className="min-h-[180px]"
           >
             <div className="space-y-2 text-xs text-[color:var(--color-slate-200)]">
-              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3">
+              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">
                   Siguiente badge
                 </p>
@@ -1797,7 +1797,7 @@ function DashboardFallback() {
                   Disponible al reconectar
                 </p>
               </div>
-              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-3">
+              <div className="rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-3">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--color-slate-400)]">
                   Último logro
                 </p>
@@ -1813,7 +1813,7 @@ function DashboardFallback() {
 
 function FallbackMetric({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-center justify-between rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-3 py-2">
+    <div className="flex items-center justify-between rounded-xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-3 py-2">
       <span className="text-[11px] font-medium uppercase tracking-[0.22em] text-[color:var(--color-slate-400)]">
         {label}
       </span>

--- a/apps/web/src/pages/DemoDashboard.tsx
+++ b/apps/web/src/pages/DemoDashboard.tsx
@@ -133,7 +133,7 @@ export default function DemoDashboardPage() {
         title="Dashboard"
         menuSlot={
           <div className="flex items-center gap-2">
-            <div className="flex items-center gap-1 rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-1">
+            <div className="flex items-center gap-1 rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-1">
               <button
                 type="button"
                 onClick={() => setManualLanguage('es')}
@@ -156,14 +156,14 @@ export default function DemoDashboardPage() {
             <button
               type="button"
               onClick={() => setPreference(theme === 'dark' ? 'light' : 'dark')}
-              className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-3 py-1.5 text-xs font-semibold text-[color:var(--color-text)]"
+              className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-3 py-1.5 text-xs font-semibold text-[color:var(--color-text)]"
             >
               {theme === 'dark' ? '☀️' : '🌙'}
             </button>
             <button
               type="button"
               onClick={() => dailyQuestModalRef.current?.open()}
-              className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-3 py-1.5 text-xs font-semibold text-[color:var(--color-text)]"
+              className="rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-3 py-1.5 text-xs font-semibold text-[color:var(--color-text)]"
             >
               Daily Quest
             </button>
@@ -176,7 +176,7 @@ export default function DemoDashboardPage() {
                 handleDemoExit();
               }}
               aria-label={language === 'es' ? 'Cerrar demo del Dashboard y volver al hub público' : 'Close Dashboard demo and return to the public hub'}
-              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] text-lg font-semibold leading-none text-[color:var(--color-text)] transition-colors hover:bg-[color:var(--color-overlay-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/45 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-bg)]"
+              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] text-lg font-semibold leading-none text-[color:var(--color-text)] transition-colors hover:bg-[color:var(--ib-surface-card-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent-primary)]/45 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-bg)]"
             >
               <span aria-hidden>×</span>
             </Link>

--- a/apps/web/src/pages/Subscription.tsx
+++ b/apps/web/src/pages/Subscription.tsx
@@ -101,7 +101,7 @@ export default function SubscriptionPage() {
     'w-full max-w-3xl rounded-[2rem] border border-[color:var(--color-border-soft)] bg-[linear-gradient(145deg,color-mix(in_srgb,var(--color-surface-elevated)_92%,transparent),color-mix(in_srgb,var(--color-overlay-2)_68%,transparent))] p-6 shadow-[0_24px_64px_color-mix(in_srgb,var(--color-text)_12%,transparent),0_10px_26px_color-mix(in_srgb,var(--color-accent-primary)_12%,transparent)] dark:shadow-[var(--shadow-elev-2)]';
 
   const secondaryButtonClassName =
-    'rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-sm font-semibold text-[color:var(--color-text)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)]';
+    'rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] px-4 py-2 text-sm font-semibold text-[color:var(--color-text)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--ib-surface-card-hover)]';
 
   const primaryActionClassName =
     'rounded-full border border-violet-400/45 bg-violet-500 px-7 py-3 font-semibold text-white shadow-[0_14px_35px_rgba(124,58,237,0.3)] transition hover:-translate-y-0.5 hover:bg-violet-400 hover:shadow-[0_18px_40px_rgba(124,58,237,0.35)]';
@@ -154,13 +154,13 @@ export default function SubscriptionPage() {
             type="button"
             onClick={() => navigate(-1)}
             aria-label={tx('actions.close')}
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] text-xl font-semibold leading-none text-[color:var(--color-text)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)]"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] text-xl font-semibold leading-none text-[color:var(--color-text)] transition hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--ib-surface-card-hover)]"
           >
             ×
           </button>
         </div>
 
-        <div className="mt-6 space-y-4 rounded-3xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-6 shadow-[0_20px_46px_color-mix(in_srgb,var(--color-text)_9%,transparent),0_8px_20px_color-mix(in_srgb,var(--color-accent-primary)_10%,transparent),inset_0_1px_0_color-mix(in_srgb,white_72%,transparent)] dark:shadow-none">
+        <div className="mt-6 space-y-4 rounded-3xl border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card)] p-6 shadow-[0_20px_46px_color-mix(in_srgb,var(--color-text)_9%,transparent),0_8px_20px_color-mix(in_srgb,var(--color-accent-primary)_10%,transparent),inset_0_1px_0_color-mix(in_srgb,white_72%,transparent)] dark:shadow-none">
           <p className="flex items-center gap-2">
             <span className="text-[color:var(--color-text-dim)]">{tx('label.currentPlan')}:</span>
             <span className="rounded-full border border-emerald-400/60 bg-emerald-400 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-emerald-950 shadow-[0_8px_22px_rgba(16,185,129,0.24)] dark:border-emerald-300/45 dark:bg-emerald-400 dark:text-emerald-950">

--- a/apps/web/src/pages/editor/index.tsx
+++ b/apps/web/src/pages/editor/index.tsx
@@ -138,8 +138,8 @@ function ModalPickerField({
             }}
             className={`flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition ${
               value === ""
-                ? "bg-[color:var(--color-overlay-2)] text-[color:var(--color-text)]"
-                : "text-[color:var(--color-text)] hover:bg-[color:var(--color-overlay-1)]"
+                ? "bg-[color:var(--ib-surface-card-active)] text-[color:var(--color-text)]"
+                : "text-[color:var(--color-text)] hover:bg-[color:var(--ib-surface-card-hover)]"
             }`}
           >
             <span>{placeholder}</span>
@@ -156,8 +156,8 @@ function ModalPickerField({
               }}
               className={`flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition ${
                 option.value === value
-                  ? "bg-[color:var(--color-overlay-2)] text-[color:var(--color-text)]"
-                  : "text-[color:var(--color-text)] hover:bg-[color:var(--color-overlay-1)]"
+                  ? "bg-[color:var(--ib-surface-card-active)] text-[color:var(--color-text)]"
+                  : "text-[color:var(--color-text)] hover:bg-[color:var(--ib-surface-card-hover)]"
               }`}
             >
               <span>{option.label}</span>
@@ -975,7 +975,7 @@ export default function TaskEditorPage({ publicDemo = false }: TaskEditorPagePro
               <Link
                 to={demoHubPath}
                 aria-label={language === "es" ? "Cerrar demo de Tareas y volver al hub público" : "Close Tasks demo and return to the public hub"}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] text-lg leading-none text-[color:var(--color-text)]"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] text-lg leading-none text-[color:var(--color-text)]"
               >
                 <span aria-hidden>×</span>
               </Link>
@@ -1275,7 +1275,7 @@ function TaskFilters({
               value={searchTerm}
               onChange={(event) => onSearchChange(event.target.value)}
               placeholder={t("editor.filters.search.placeholder")}
-              className="w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2.5 text-sm ios-touch-input text-[color:var(--color-slate-100)] placeholder:text-[color:var(--color-slate-400)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
+              className="w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-4 py-2.5 text-sm ios-touch-input text-[color:var(--color-slate-100)] placeholder:text-[color:var(--color-slate-400)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
             />
           </div>
         </label>
@@ -1286,7 +1286,7 @@ function TaskFilters({
           <select
             value={selectedPillar}
             onChange={(event) => onPillarChange(event.target.value)}
-            className="w-full appearance-none rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2.5 text-sm ios-touch-input text-[color:var(--color-slate-100)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
+            className="w-full appearance-none rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-4 py-2.5 text-sm ios-touch-input text-[color:var(--color-slate-100)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
           >
             {pillars.map((pillar) => (
               <option
@@ -1373,7 +1373,7 @@ function TaskFilters({
                 value={searchTerm}
                 onChange={(event) => onSearchChange(event.target.value)}
                 placeholder={t("editor.filters.search.placeholder")}
-                className="w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-sm ios-touch-input text-[color:var(--color-slate-100)] placeholder:text-[color:var(--color-slate-400)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
+                className="w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-4 py-2 text-sm ios-touch-input text-[color:var(--color-slate-100)] placeholder:text-[color:var(--color-slate-400)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
               />
             </label>
             <div className="flex gap-2 overflow-x-auto pb-1 [mask-image:linear-gradient(to_right,transparent,black_12%,black_88%,transparent)]">
@@ -1424,7 +1424,7 @@ function TaskFilters({
               value={searchTerm}
               onChange={(event) => onSearchChange(event.target.value)}
               placeholder={t("editor.filters.search.placeholder")}
-              className="w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2.5 text-sm ios-touch-input text-[color:var(--color-slate-100)] placeholder:text-[color:var(--color-slate-400)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
+              className="w-full rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-4 py-2.5 text-sm ios-touch-input text-[color:var(--color-slate-100)] placeholder:text-[color:var(--color-slate-400)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
             />
           </div>
         </label>
@@ -1435,7 +1435,7 @@ function TaskFilters({
           <select
             value={selectedPillar}
             onChange={(event) => onPillarChange(event.target.value)}
-            className="w-full appearance-none rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] px-4 py-2.5 text-sm ios-touch-input text-[color:var(--color-slate-100)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
+            className="w-full appearance-none rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-4 py-2.5 text-sm ios-touch-input text-[color:var(--color-slate-100)] focus:border-[color:var(--color-border-soft)] focus:outline-none focus:ring-2 focus:ring-white/20"
           >
             {pillars.map((pillar) => (
               <option
@@ -1612,7 +1612,7 @@ function TaskListMobile({
 
   // TODO: incorporar gestos de swipe cuando exista infraestructura compartida en el proyecto.
   return (
-    <ul className="divide-y divide-white/5 overflow-visible rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]">
+    <ul className="divide-y divide-white/5 overflow-visible rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)]">
       {tasks.map((task) => {
         const isMenuOpen = openMenuTaskId === task.id;
         const isDuplicating = duplicatingTaskId === task.id;
@@ -1623,7 +1623,7 @@ function TaskListMobile({
             <button
               type="button"
               onClick={() => onEditTask(task)}
-              className="flex w-full flex-col gap-2 px-3 py-2.5 text-left transition hover:bg-[color:var(--color-overlay-2)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+              className="flex w-full flex-col gap-2 px-3 py-2.5 text-left transition hover:bg-[color:var(--ib-surface-card-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
             >
               <div className="flex items-start justify-between gap-3">
                 <p className="line-clamp-1 pr-8 text-sm font-semibold text-white">
@@ -1656,7 +1656,7 @@ function TaskListMobile({
                     current === task.id ? null : task.id,
                   );
                 }}
-                className="flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] text-base text-[color:var(--color-slate-200)] transition hover:border-white/30 hover:bg-[color:var(--color-overlay-2)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+                className="flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] text-base text-[color:var(--color-slate-200)] transition hover:border-white/30 hover:bg-[color:var(--ib-surface-card-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
               >
                 <span aria-hidden>⋯</span>
                 <span className="sr-only">{t("editor.task.actions.more")}</span>
@@ -1670,7 +1670,7 @@ function TaskListMobile({
                       setOpenMenuTaskId(null);
                       onEditTask(task);
                     }}
-                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-[color:var(--color-slate-100)] transition hover:bg-[color:var(--color-overlay-2)]"
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-[color:var(--color-slate-100)] transition hover:bg-[color:var(--ib-surface-card-hover)]"
                   >
                     {t("editor.button.edit")}
                   </button>
@@ -1687,7 +1687,7 @@ function TaskListMobile({
                     className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition ${
                       !onDuplicateTask
                         ? "cursor-not-allowed text-slate-500"
-                        : "text-[color:var(--color-slate-100)] hover:bg-[color:var(--color-overlay-2)]"
+                        : "text-[color:var(--color-slate-100)] hover:bg-[color:var(--ib-surface-card-hover)]"
                     } ${isDuplicating ? "opacity-70" : ""}`.trim()}
                   >
                     {isDuplicating
@@ -1735,7 +1735,7 @@ function TaskCard({
   const { language, t } = usePostLoginLanguage();
 
   return (
-    <article className="group relative flex flex-col gap-3 rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4 shadow-[0_8px_24px_rgba(15,23,42,0.35)] transition hover:border-[color:var(--color-border-soft)]">
+    <article className="group relative flex flex-col gap-3 rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-4 shadow-[0_8px_24px_rgba(15,23,42,0.35)] transition hover:border-[color:var(--color-border-soft)]">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <h3 className="font-semibold text-[color:var(--color-slate-100)]">
           {task.title}
@@ -1906,7 +1906,7 @@ function TaskBoard({
         return (
           <section
             key={group.key}
-            className="flex min-h-[260px] flex-col rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] p-4"
+            className="flex min-h-[260px] flex-col rounded-2xl border border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] p-4"
           >
             <header className="flex items-center justify-between border-b border-white/5 pb-3">
               <div className="space-y-1">
@@ -1927,7 +1927,7 @@ function TaskBoard({
             </header>
             <div className="mt-3 flex-1 space-y-2">
               {group.tasks.length === 0 ? (
-                <p className="rounded-xl border border-white/5 bg-[color:var(--color-overlay-1)] px-3 py-6 text-center text-xs text-slate-500">
+                <p className="rounded-xl border border-white/5 bg-[color:var(--ib-surface-card)] px-3 py-6 text-center text-xs text-slate-500">
                   {t("editor.board.emptyPillar")}
                 </p>
               ) : (
@@ -2178,7 +2178,7 @@ function TaskListSkeleton() {
       {Array.from({ length: 6 }).map((_, index) => (
         <div
           key={index}
-          className="h-40 animate-pulse rounded-2xl border border-white/5 bg-[color:var(--color-overlay-1)]"
+          className="h-40 animate-pulse rounded-2xl border border-white/5 bg-[color:var(--ib-surface-card)]"
         />
       ))}
     </div>
@@ -2187,7 +2187,7 @@ function TaskListSkeleton() {
 
 function TaskListEmpty({ message }: { message: string }) {
   return (
-    <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)]/40 px-6 py-12 text-center text-sm text-[color:var(--color-slate-300)]">
+    <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] px-6 py-12 text-center text-sm text-[color:var(--color-slate-300)]">
       <span className="text-2xl" aria-hidden>
         🌱
       </span>
@@ -2212,7 +2212,7 @@ function TaskListError({
       <button
         type="button"
         onClick={onRetry}
-        className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-2)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-white transition hover:border-[color:var(--color-border-strong)]"
+        className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--ib-surface-card-active)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-white transition hover:border-[color:var(--color-border-strong)]"
       >
         {t("editor.button.retry")}
       </button>
@@ -3651,7 +3651,7 @@ function SuggestionsLabModal({
                         )
                       }
                       aria-pressed={checked}
-                      className={`editor-suggestions-card group flex items-start gap-3 rounded-2xl border px-3 py-3 text-left transition ${checked ? "border-violet-300/60 bg-[linear-gradient(155deg,rgba(167,139,250,0.25),rgba(129,140,248,0.12))] shadow-[0_10px_24px_rgba(139,92,246,0.24)]" : "border-[color:var(--color-border-subtle)] bg-[color:var(--color-overlay-1)] hover:border-white/25"}`}
+                      className={`editor-suggestions-card group flex items-start gap-3 rounded-2xl border px-3 py-3 text-left transition ${checked ? "border-violet-300/60 bg-[linear-gradient(155deg,rgba(167,139,250,0.25),rgba(129,140,248,0.12))] shadow-[0_10px_24px_rgba(139,92,246,0.24)]" : "border-[color:var(--color-border-subtle)] bg-[color:var(--ib-surface-card)] hover:border-white/25"}`}
                     >
                       <span
                         className={`editor-suggestions-card-selector mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] transition ${checked ? "border-violet-100 bg-violet-200/90 text-violet-700" : "border-white/25 text-transparent group-hover:border-white/40"}`}

--- a/styles/theme-tokens.css
+++ b/styles/theme-tokens.css
@@ -16,10 +16,16 @@
   /* Light mode tokens extracted from Dashboard-v3 visual system */
 
   /* SURFACES */
-  --surface-app: #f8fafc;
-  --surface-section: #f1f5f9;
-  --surface-card: #ffffff;
-  --surface-elevated: #f8faff;
+  --ib-surface-app: #f8fafc;
+  --ib-surface-section: #f1f5f9;
+  --ib-surface-panel: #ffffff;
+  --ib-surface-card: #f8faff;
+  --ib-surface-card-hover: #f3f6fb;
+  --ib-surface-card-active: #edf2f8;
+  --surface-app: var(--ib-surface-app);
+  --surface-section: var(--ib-surface-section);
+  --surface-card: var(--ib-surface-card);
+  --surface-elevated: var(--ib-surface-panel);
 
   /* TEXT */
   --text-primary: #0f172a;
@@ -57,10 +63,22 @@
   /* Dark mode overrides extracted from Dashboard-v3 visual system */
 
   /* SURFACES */
-  --surface-app: #0f172a;
-  --surface-section: #111c33;
-  --surface-card: rgba(255, 255, 255, 0.05);
-  --surface-elevated: #182640;
+  --ib-dark-surface-app: #010409;
+  --ib-dark-surface-section: #05080d;
+  --ib-dark-surface-panel: #0a0f16;
+  --ib-dark-surface-card: #121820;
+  --ib-dark-surface-card-hover: #171f2a;
+  --ib-dark-surface-card-active: #1b2532;
+  --ib-surface-app: var(--ib-dark-surface-app);
+  --ib-surface-section: var(--ib-dark-surface-section);
+  --ib-surface-panel: var(--ib-dark-surface-panel);
+  --ib-surface-card: var(--ib-dark-surface-card);
+  --ib-surface-card-hover: var(--ib-dark-surface-card-hover);
+  --ib-surface-card-active: var(--ib-dark-surface-card-active);
+  --surface-app: var(--ib-surface-app);
+  --surface-section: var(--ib-surface-section);
+  --surface-card: var(--ib-surface-card);
+  --surface-elevated: var(--ib-surface-panel);
 
   /* TEXT */
   --text-primary: #f8fafc;
@@ -69,8 +87,8 @@
   --text-disabled: rgba(255, 255, 255, 0.6);
 
   /* BORDERS */
-  --border-subtle: rgba(255, 255, 255, 0.1);
-  --border-default: rgba(255, 255, 255, 0.2);
+  --border-subtle: rgba(255, 255, 255, 0.09);
+  --border-default: rgba(255, 255, 255, 0.13);
 
   /* ACCENTS */
   --accent-primary: #38bdf8;


### PR DESCRIPTION
### Motivation
- Unify and modernize surface/color tokens across the app to provide consistent card/panel/skeleton/hover/active treatments for the Dashboard and related pages.
- Replace ad-hoc overlay variables (`--color-overlay-*`) with explicit `--ib-surface-*` tokens to make surface semantic roles easier to reason about and theme.
- Apply the new surface tokens across dashboard components, modals and editor screens to harmonize look and hover/active states.

### Description
- Add new semantic surface variables (`--ib-surface-*`, `--ib-dark-surface-*`, and aliases) in `apps/web/src/index.css` and centralize tokens in `styles/theme-tokens.css` to support app/panel/card/hover/active roles.
- Replace many usages of `bg-[color:var(--color-overlay-1|2|3)]`, `bg-[color:var(--color-surface-elevated)]`, and similar ad-hoc overlays with the new `var(--ib-surface-card)`, `var(--ib-surface-card-hover)`, `var(--ib-surface-card-active)`, and `var(--ib-surface-panel)` tokens across numerous components (dashboard-v3, DailyQuest modal, Emotion cards/timeline, Rewards/Preview/Achievement components, Moderation widgets/sheets, Missions modals, StreaksPanel, ThemeSwitcher, Subscription, Editor pages, Demo dashboard, etc.).
- Update hover/selected/active styles to use the new hover/active tokens, and switch multiple skeleton/placeholder backgrounds to the `--ib-surface-card-active` value for consistent pulsing UI.
- Adjust some border and overlay mappings (`--color-border-soft`, `--color-border-subtle`, overlay opacities and card gradients) to align with the new tokens and ensure consistent contrast across light/dark themes.

### Testing
- Ran project build with `yarn build` and the app compiled successfully without errors.
- Executed the unit test suite with `yarn test` and all tests passed.
- Ran linting via `yarn lint` and fixed/validated styles; lint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b47aa39c83329c51ed37b54c93bd)