### PR TITLE
Fix Weekly Wrapped popup real data

### DIFF
--- a/apps/api/src/__tests__/users.weekly-wrapped.test.ts
+++ b/apps/api/src/__tests__/users.weekly-wrapped.test.ts
@@ -298,7 +298,12 @@ describe('GET /api/users/:id/weekly-wrapped/pending and POST /seen', () => {
 
   it('returns unseen weekly wrapup as pending with unseen count', async () => {
     mockVerifyToken.mockResolvedValue({ id: userId, clerkId: 'user_123', email: 'test@example.com', isNew: false });
-    mockQuery.mockResolvedValue({ rows: [{ user_id: userId }] });
+    mockQuery.mockImplementation((sql: string) => {
+      if (sql.includes('FROM daily_log')) {
+        return Promise.resolve({ rows: [{ day_key: '2024-10-07' }, { day_key: '2024-10-09' }] });
+      }
+      return Promise.resolve({ rows: [{ user_id: userId }] });
+    });
     mockGetRecentWrapped.mockResolvedValue([{ id: 'wrap-pending', userId, weekStart: '2024-10-07', weekEnd: '2024-10-13', payload: { mode: 'final' } }]);
     mockFindPendingWeeklyWrappedId.mockResolvedValue('wrap-pending');
     mockCountUnseenWeeklyWrapped.mockResolvedValue(2);
@@ -310,6 +315,7 @@ describe('GET /api/users/:id/weekly-wrapped/pending and POST /seen', () => {
     expect(response.status).toBe(200);
     expect(response.body.item?.id).toBe('wrap-pending');
     expect(response.body.item?.seen).toBe(false);
+    expect(response.body.item?.completionDays).toEqual(['2024-10-07', '2024-10-09']);
     expect(response.body.unseen_count).toBe(2);
   });
 

--- a/apps/api/src/controllers/users/weekly-wrapped.ts
+++ b/apps/api/src/controllers/users/weekly-wrapped.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { AsyncHandler } from '../../lib/async-handler.js';
+import { pool } from '../../db.js';
 import { ensureUserExists } from './shared.js';
 import { getRecentWeeklyWrapped } from '../../services/weeklyWrappedService.js';
 import {
@@ -11,6 +12,21 @@ import {
 
 const paramsSchema = z.object({ id: z.string().uuid() });
 const seenParamsSchema = z.object({ id: z.string().uuid(), weeklyWrappedId: z.string().uuid() });
+
+async function listCompletionDays(userId: string, start: string, end: string): Promise<string[]> {
+  const result = await pool.query<{ day_key: string }>(
+    `SELECT DISTINCT date::text AS day_key
+       FROM daily_log
+      WHERE user_id = $1::uuid
+        AND date >= $2::date
+        AND date <= $3::date
+        AND COALESCE(quantity, 0) > 0
+   ORDER BY day_key ASC`,
+    [userId, start, end],
+  );
+
+  return result.rows.map((row) => row.day_key).filter(Boolean);
+}
 
 export const getUserWeeklyWrappedLatest: AsyncHandler = async (req, res) => {
   const { id } = paramsSchema.parse(req.params);
@@ -47,8 +63,11 @@ export const getUserWeeklyWrappedPending: AsyncHandler = async (req, res) => {
   ]);
 
   const pending = pendingId ? items.find((entry) => entry.id === pendingId) ?? null : null;
+  const completionDays = pending
+    ? await listCompletionDays(id, pending.weekStart, pending.weekEnd)
+    : [];
 
-  res.json({ item: pending ? { ...pending, seen: false } : null, unseen_count: unseenCount });
+  res.json({ item: pending ? { ...pending, seen: false, completionDays } : null, unseen_count: unseenCount });
 };
 
 export const markUserWeeklyWrappedSeen: AsyncHandler = async (req, res) => {

--- a/apps/web/src/pages/labs/MobilePremiumLabPage.tsx
+++ b/apps/web/src/pages/labs/MobilePremiumLabPage.tsx
@@ -16,6 +16,7 @@ import {
   getRewardsHistory,
   getTaskInsights,
   getUserStreakPanel,
+  getUserXpByTrait,
   acceptGameModeUpgradeSuggestion,
   dismissGameModeUpgradeSuggestion,
   submitDailyQuest,
@@ -528,6 +529,11 @@ function MobilePremiumLabPageInner() {
     enabled: Boolean(effectiveBackendUserId),
   });
   const weeklyWrapped = useWeeklyWrapped(effectiveBackendUserId);
+  const weeklyWrappedRadarRequest = useRequest(
+    () => getUserXpByTrait(effectiveBackendUserId ?? ''),
+    [effectiveBackendUserId],
+    { enabled: Boolean(effectiveBackendUserId) },
+  );
 
   useEffect(() => {
     const selector = 'meta[name="robots"][data-innerbloom-labs="mobile-premium"]';
@@ -1085,6 +1091,7 @@ function MobilePremiumLabPageInner() {
       {weeklyWrapped.isModalOpen && weeklyWrapped.activeRecord && !activeOverlay ? (
         <PremiumWeeklyWrappedStory
           onClose={handleWeeklyWrappedClose}
+          radarTraits={weeklyWrappedRadarRequest.data?.traits ?? []}
           weekly={weeklyWrapped.activeRecord}
         />
       ) : null}


### PR DESCRIPTION
## Summary
- Add `completionDays` to `/weekly-wrapped/pending` so the auto-open Weekly Wrapped story uses the same active-day data shown in Logros.
- Pass real `getUserXpByTrait` radar traits into the auto-open premium Weekly Wrapped story, matching the Logros story behavior.
- Cover the pending endpoint response with a focused API test.

## Root cause
The auto popup used the pending weekly endpoint directly. That endpoint returned the wrapped payload but not the enriched `completionDays` that `/rewards/history` adds for Logros. The popup also opened the story without `radarTraits`, causing the fallback/demo radar to render.

## Validation
- `pnpm -C apps/api test src/__tests__/users.weekly-wrapped.test.ts`
- `pnpm --filter web test src/hooks/__tests__/useWeeklyWrapped.test.tsx --run`