### PR TITLE
Share real weekly and monthly story slides

### DIFF
--- a/apps/web/src/pages/labs/mobile-premium/variants/PremiumRewardsSection.tsx
+++ b/apps/web/src/pages/labs/mobile-premium/variants/PremiumRewardsSection.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ReactNode, useEffect, useId, useRef, useState } from 'react';
+import { forwardRef, type MutableRefObject, type ReactNode, useEffect, useId, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { decideTaskHabitAchievement, getRewardsHistory, getTaskInsights, getUserXpByTrait, toggleTaskHabitAchievementMaintained, type HabitAchievementPillarGroup, type HabitAchievementShelfItem, type MonthlyWrappedRecord, type RewardsGrowthCalibrationRow, type RewardsHistorySummary, type TaskInsightsResponse, type TraitXpEntry, type WeeklyWrappedRecord } from '../../../../lib/api';
 import { useRequest } from '../../../../hooks/useRequest';
@@ -12,6 +12,9 @@ import type { LocalOnboardingSnapshot } from '../localOnboardingBridge';
 type RewardsPillarCode = 'BODY' | 'MIND' | 'SOUL';
 type WeeklyStoryVisualMode = 'dark' | 'light';
 type CalibrationFilter = RewardsGrowthCalibrationRow['finalAction'];
+type WeeklyShareOption = 'tasks' | 'balance' | 'habits' | 'emotion';
+type MonthlyShareOption = 'month' | 'tasks' | 'habits' | 'emotion';
+type WrappedShareTarget<T extends string> = { key: T; label: string; slideIndex: number };
 
 const WEEKLY_PILLAR_ORDER: RewardsPillarCode[] = ['BODY', 'MIND', 'SOUL'];
 const STORY_MODAL_LAYER_CLASS = 'fixed bottom-0 left-0 right-0 top-0 isolate z-[9999] h-screen h-[100dvh] w-screen overflow-hidden bg-black';
@@ -2051,6 +2054,12 @@ export function PremiumWeeklyWrappedStory({
   const energySlideIndex = pillarSlideIndex + 1;
   const emotionSlideIndex = energySlideIndex + 1;
   const closingSlideIndex = emotionSlideIndex + 1;
+  const weeklyShareTargets: Array<WrappedShareTarget<WeeklyShareOption>> = [
+    { key: 'tasks', label: 'Tareas', slideIndex: 1 },
+    { key: 'balance', label: 'Balance', slideIndex: pillarSlideIndex },
+    { key: 'habits', label: 'Hábitos', slideIndex: habitsSlideIndex },
+    { key: 'emotion', label: emotion?.label ?? 'Emoción', slideIndex: emotionSlideIndex },
+  ];
 
   useBodyScrollLock();
 
@@ -2389,7 +2398,7 @@ export function PremiumWeeklyWrappedStory({
         <div className={`h-full snap-y snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${showSharePicker ? 'overflow-hidden' : 'overflow-y-auto'}`} ref={storyScrollRef}>
           <WeeklyStorySlide
             accent={dominantColor}
-            active={activeStorySlide === 0}
+            active={showSharePicker || activeStorySlide === 0}
             eyebrow="WEEKLY WRAPPED"
             index={0}
             registerSlide={(el) => (storySlideRefs.current[0] = el)}
@@ -2406,7 +2415,7 @@ export function PremiumWeeklyWrappedStory({
                 />
                 <div className="relative text-center">
                   <p className="mp-weekly-gradient-text text-[clamp(6.6rem,30vw,9.5rem)] font-semibold leading-none tracking-[-0.08em]">
-                    <AnimatedWeeklyNumber active={activeStorySlide === 0} value={completedCount} />/7
+                    <AnimatedWeeklyNumber active={showSharePicker || activeStorySlide === 0} value={completedCount} />/7
                   </p>
                   <p className="mt-4 text-sm uppercase tracking-[0.34em] text-[color:var(--weekly-muted)]">días activos</p>
                 </div>
@@ -2431,7 +2440,7 @@ export function PremiumWeeklyWrappedStory({
 
           <WeeklyStorySlide
             accent="#A78BFA"
-            active={activeStorySlide === 1}
+            active={showSharePicker || activeStorySlide === 1}
             eyebrow={sectionsByKey.get('achievements')?.accent ?? 'RESUMEN 7 DÍAS'}
             index={1}
             registerSlide={(el) => (storySlideRefs.current[1] = el)}
@@ -2444,12 +2453,12 @@ export function PremiumWeeklyWrappedStory({
               <div className="space-y-[clamp(1.6rem,4dvh,2.2rem)]">
                 <div className="mp-weekly-fragment text-center" style={{ transitionDelay: '210ms' }}>
                   <p className="mp-weekly-gradient-text text-[clamp(7rem,34vw,10rem)] font-semibold leading-none tracking-[-0.08em]">
-                    <AnimatedWeeklyNumber active={activeStorySlide === 1} value={completions} />
+                    <AnimatedWeeklyNumber active={showSharePicker || activeStorySlide === 1} value={completions} />
                   </p>
                   <p className="mt-2 text-sm uppercase tracking-[0.34em] text-[color:var(--weekly-muted)]">tareas completadas</p>
                 </div>
                 <WeeklyDifficultyConstellation
-                  active={activeStorySlide === 1}
+                  active={showSharePicker || activeStorySlide === 1}
                   easyCount={easyCount}
                   easyPct={easyPct}
                   hardCount={hardCount}
@@ -2461,7 +2470,7 @@ export function PremiumWeeklyWrappedStory({
                 <div className="mp-weekly-fragment flex items-center justify-center gap-2 pt-1 text-[color:var(--weekly-muted)]" style={{ transitionDelay: '860ms' }}>
                   <span className="h-px w-8 bg-[color:var(--weekly-line)]" />
                   <p className="text-xs uppercase tracking-[0.22em]">
-                    <AnimatedWeeklyNumber active={activeStorySlide === 1} duration={900} value={xpTotal} />
+                    <AnimatedWeeklyNumber active={showSharePicker || activeStorySlide === 1} duration={900} value={xpTotal} />
                     {' '}GP generados
                   </p>
                   <span className="h-px w-8 bg-[color:var(--weekly-line)]" />
@@ -2473,7 +2482,7 @@ export function PremiumWeeklyWrappedStory({
           {payload.levelUp?.happened ? (
             <WeeklyStorySlide
               accent="#F7C86A"
-              active={activeStorySlide === 2}
+              active={showSharePicker || activeStorySlide === 2}
               eyebrow="LEVEL UP"
               index={2}
               registerSlide={(el) => (storySlideRefs.current[2] = el)}
@@ -2486,7 +2495,7 @@ export function PremiumWeeklyWrappedStory({
                 <div className="mp-weekly-fragment relative" style={{ transitionDelay: '210ms' }}>
                   <span className="mp-weekly-story-glow absolute inset-0 rounded-full bg-amber-300/30 blur-3xl" />
                   <p className="relative text-[clamp(5.6rem,25vw,8rem)] font-semibold leading-none text-[color:var(--weekly-title)]">
-                    <AnimatedWeeklyNumber active={activeStorySlide === 2} value={payload.levelUp.currentLevel ?? 0} />
+                    <AnimatedWeeklyNumber active={showSharePicker || activeStorySlide === 2} value={payload.levelUp.currentLevel ?? 0} />
                   </p>
                   <p className="relative mt-3 text-sm uppercase tracking-[0.3em] text-[#F7C86A]">+{payload.levelUp.xpGained} GP</p>
                 </div>
@@ -2496,7 +2505,7 @@ export function PremiumWeeklyWrappedStory({
 
           <WeeklyStorySlide
             accent={dominantColor}
-            active={activeStorySlide === habitsSlideIndex}
+            active={showSharePicker || activeStorySlide === habitsSlideIndex}
             eyebrow="HÁBITOS"
             index={habitsSlideIndex}
             registerSlide={(el) => (storySlideRefs.current[habitsSlideIndex] = el)}
@@ -2542,7 +2551,7 @@ export function PremiumWeeklyWrappedStory({
 
           <WeeklyStorySlide
             accent={dominantColor}
-            active={activeStorySlide === pillarSlideIndex}
+            active={showSharePicker || activeStorySlide === pillarSlideIndex}
             eyebrow="PILAR DOMINANTE"
             index={pillarSlideIndex}
             registerSlide={(el) => (storySlideRefs.current[pillarSlideIndex] = el)}
@@ -2550,7 +2559,7 @@ export function PremiumWeeklyWrappedStory({
           >
             <div className="flex flex-1 flex-col justify-between gap-8">
               <WeeklyRadarAnalysisChart
-                active={activeStorySlide === pillarSlideIndex}
+                active={showSharePicker || activeStorySlide === pillarSlideIndex}
                 dominant={dominantPillar}
                 dominantPct={dominantPct}
                 message={sectionsByKey.get('pillar')?.body ?? `${dominantLabel} lideró tu energía estos días.`}
@@ -2563,7 +2572,7 @@ export function PremiumWeeklyWrappedStory({
 
           <WeeklyStorySlide
             accent="#56DDF5"
-            active={activeStorySlide === energySlideIndex}
+            active={showSharePicker || activeStorySlide === energySlideIndex}
             eyebrow="DAILY ENERGY"
             index={energySlideIndex}
             registerSlide={(el) => (storySlideRefs.current[energySlideIndex] = el)}
@@ -2576,7 +2585,7 @@ export function PremiumWeeklyWrappedStory({
                   : `${formatSignedPct(energy.deltaPct)} frente a la semana anterior.`}
               </p>
               <WeeklyEnergyRaceChart
-                active={activeStorySlide === energySlideIndex}
+                active={showSharePicker || activeStorySlide === energySlideIndex}
                 energy={energy}
               />
             </div>
@@ -2584,7 +2593,7 @@ export function PremiumWeeklyWrappedStory({
 
           <WeeklyStorySlide
             accent={emotion?.color ?? dominantColor}
-            active={activeStorySlide === emotionSlideIndex}
+            active={showSharePicker || activeStorySlide === emotionSlideIndex}
             eyebrow="EMOCIÓN"
             index={emotionSlideIndex}
             registerSlide={(el) => (storySlideRefs.current[emotionSlideIndex] = el)}
@@ -2621,22 +2630,23 @@ export function PremiumWeeklyWrappedStory({
 
           <WeeklyStorySlide
             accent="#F7C86A"
-            active={activeStorySlide === closingSlideIndex}
+            active={showSharePicker || activeStorySlide === closingSlideIndex}
             eyebrow="CIERRE"
             index={closingSlideIndex}
             registerSlide={(el) => (storySlideRefs.current[closingSlideIndex] = el)}
             title={sectionsByKey.get('closing')?.accent ?? 'Seguimos'}
+            titleClassName="text-[clamp(2.05rem,8.4vw,2.8rem)]"
           >
             <div className="flex flex-1 flex-col justify-between gap-[clamp(2rem,7dvh,2.5rem)]">
               <div className="space-y-[clamp(1.5rem,5dvh,2rem)]">
-                <p className="mp-weekly-fragment text-3xl font-semibold leading-tight text-[color:var(--weekly-text)]" style={{ transitionDelay: '120ms' }}>
+                <p className="mp-weekly-fragment text-[clamp(1.65rem,6.8vw,2.35rem)] font-semibold leading-tight text-[color:var(--weekly-text)]" style={{ transitionDelay: '120ms' }}>
                   {sectionsByKey.get('closing')?.body ?? 'Seguimos. Mañana vuelve el Daily Quest para sumar otro paso.'}
                 </p>
                 <div className="mp-weekly-fragment h-1.5 w-24 rounded-full bg-gradient-to-r from-[#F7C86A] to-[color:var(--mp-violet)] shadow-[0_0_28px_rgba(247,200,106,0.28)]" style={{ transitionDelay: '260ms' }} />
               </div>
               <div className="space-y-7 pb-[max(env(safe-area-inset-bottom),0px)]">
                 <button
-                  className="mp-weekly-fragment w-full rounded-full bg-[color:var(--mp-violet)] px-6 py-4 text-base font-semibold text-white shadow-[0_0_32px_rgba(167,139,250,0.22)]"
+                  className="mp-weekly-fragment w-full rounded-full bg-[color:var(--weekly-brand)] px-6 py-4 text-base font-semibold text-white shadow-[0_0_32px_rgba(167,139,250,0.22)]"
                   onClick={() => setShowSharePicker(true)}
                   style={{ transitionDelay: '420ms' }}
                   type="button"
@@ -2649,14 +2659,11 @@ export function PremiumWeeklyWrappedStory({
         </div>
         {showSharePicker ? (
           <WeeklySharePicker
-            dominantColor={dominantColor}
-            dominantLabel={dominantLabel}
-            energy={energy}
-            emotion={emotion}
             mode={storyVisualMode}
             onClose={() => setShowSharePicker(false)}
             onModeChange={setStoryVisualMode}
-            storyHabits={storyHabits}
+            slideRefs={storySlideRefs}
+            targets={weeklyShareTargets}
           />
         ) : null}
       </div>
@@ -2679,6 +2686,12 @@ function PremiumMonthlyWrappedStory({
   const [activeStorySlide, setActiveStorySlide] = useState(0);
   const [showSharePicker, setShowSharePicker] = useState(false);
   const [storyVisualMode, setStoryVisualMode] = useState<WeeklyStoryVisualMode>('dark');
+  const monthlyShareTargets: Array<WrappedShareTarget<MonthlyShareOption>> = [
+    { key: 'month', label: 'Mes', slideIndex: 0 },
+    { key: 'tasks', label: 'Tareas', slideIndex: 1 },
+    { key: 'habits', label: 'Hábitos', slideIndex: 3 },
+    { key: 'emotion', label: monthlyData.emotion.label, slideIndex: 5 },
+  ];
 
   useBodyScrollLock();
 
@@ -2736,7 +2749,7 @@ function PremiumMonthlyWrappedStory({
         <div className={`h-full snap-y snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${showSharePicker ? 'overflow-hidden' : 'overflow-y-auto'}`} ref={storyScrollRef}>
           <WeeklyStorySlide
             accent="#A78BFA"
-            active={activeStorySlide === 0}
+            active={showSharePicker || activeStorySlide === 0}
             eyebrow="MONTHLY WRAPPED"
             index={0}
             registerSlide={(el) => (storySlideRefs.current[0] = el)}
@@ -2750,20 +2763,20 @@ function PremiumMonthlyWrappedStory({
                 <span className="mp-weekly-story-glow absolute h-72 w-72 rounded-full bg-violet-400/20 blur-3xl" />
                 <div className="relative text-center">
                   <p className="mp-weekly-gradient-text text-[clamp(6.4rem,29vw,9rem)] font-semibold leading-none tracking-[-0.08em]">
-                    <AnimatedWeeklyNumber active={activeStorySlide === 0} value={monthlyData.trackedDays} />/{monthlyData.totalDays}
+                    <AnimatedWeeklyNumber active={showSharePicker || activeStorySlide === 0} value={monthlyData.trackedDays} />/{monthlyData.totalDays}
                   </p>
                   <p className="mt-4 text-sm uppercase tracking-[0.34em] text-[color:var(--weekly-muted)]">días trackeados</p>
                 </div>
               </div>
               <div className="pb-[clamp(.75rem,3dvh,1.6rem)]">
-                <MonthlyCalendarStrip active={activeStorySlide === 0} days={monthlyData.calendarDays} />
+                <MonthlyCalendarStrip active={showSharePicker || activeStorySlide === 0} days={monthlyData.calendarDays} />
               </div>
             </div>
           </WeeklyStorySlide>
 
           <WeeklyStorySlide
             accent="#A78BFA"
-            active={activeStorySlide === 1}
+            active={showSharePicker || activeStorySlide === 1}
             eyebrow="DATOS REALES"
             index={1}
             registerSlide={(el) => (storySlideRefs.current[1] = el)}
@@ -2776,12 +2789,12 @@ function PremiumMonthlyWrappedStory({
               <div className="space-y-[clamp(1.8rem,4.5dvh,2.8rem)]">
                 <div className="mp-weekly-fragment text-center" style={{ transitionDelay: '210ms' }}>
                   <p className="mp-weekly-gradient-text text-[clamp(7rem,34vw,10rem)] font-semibold leading-none tracking-[-0.08em]">
-                    <AnimatedWeeklyNumber active={activeStorySlide === 1} value={monthlyData.completedTasks} />
+                    <AnimatedWeeklyNumber active={showSharePicker || activeStorySlide === 1} value={monthlyData.completedTasks} />
                   </p>
                   <p className="mt-2 text-sm uppercase tracking-[0.34em] text-[color:var(--weekly-muted)]">tareas completadas</p>
                 </div>
                 <WeeklyDifficultyConstellation
-                  active={activeStorySlide === 1}
+                  active={showSharePicker || activeStorySlide === 1}
                   easyCount={monthlyData.difficulty.easy}
                   easyPct={monthlyData.difficulty.easyPct}
                   hardCount={monthlyData.difficulty.hard}
@@ -2791,7 +2804,7 @@ function PremiumMonthlyWrappedStory({
                   total={monthlyData.completedTasks}
                 />
                 <p className="mp-weekly-fragment text-center text-xs uppercase tracking-[0.24em] text-[color:var(--weekly-muted)]" style={{ transitionDelay: '900ms' }}>
-                  <AnimatedWeeklyNumber active={activeStorySlide === 1} duration={900} value={monthlyData.gpTotal} /> GP generados
+                  <AnimatedWeeklyNumber active={showSharePicker || activeStorySlide === 1} duration={900} value={monthlyData.gpTotal} /> GP generados
                 </p>
               </div>
             </div>
@@ -2799,14 +2812,14 @@ function PremiumMonthlyWrappedStory({
 
           <WeeklyStorySlide
             accent="#F7C86A"
-            active={activeStorySlide === 2}
+            active={showSharePicker || activeStorySlide === 2}
             eyebrow="CALIBRACIÓN"
             index={2}
             registerSlide={(el) => (storySlideRefs.current[2] = el)}
             title="Ajustes del mes"
           >
             <MonthlyCalibrationStory
-              active={activeStorySlide === 2}
+              active={showSharePicker || activeStorySlide === 2}
               downTasks={monthlyData.calibration.downTasks}
               keep={monthlyData.calibration.keep}
               upTasks={monthlyData.calibration.upTasks}
@@ -2815,14 +2828,14 @@ function PremiumMonthlyWrappedStory({
 
           <WeeklyStorySlide
             accent="#A78BFA"
-            active={activeStorySlide === 3}
+            active={showSharePicker || activeStorySlide === 3}
             eyebrow="HÁBITOS"
             index={3}
             registerSlide={(el) => (storySlideRefs.current[3] = el)}
             title="Más cerca de lograrlo"
           >
             <MonthlyNearHabitsStory
-              active={activeStorySlide === 3}
+              active={showSharePicker || activeStorySlide === 3}
               habits={monthlyData.nearHabits}
               unlockedHabits={monthlyData.unlockedHabits}
             />
@@ -2830,14 +2843,14 @@ function PremiumMonthlyWrappedStory({
 
           <WeeklyStorySlide
             accent="#5BE282"
-            active={activeStorySlide === 4}
+            active={showSharePicker || activeStorySlide === 4}
             eyebrow="RITMO"
             index={4}
             registerSlide={(el) => (storySlideRefs.current[4] = el)}
             title="Cerca del próximo ritmo"
           >
             <MonthlyRhythmReadinessStory
-              active={activeStorySlide === 4}
+              active={showSharePicker || activeStorySlide === 4}
               currentMode={monthlyData.rhythm.currentMode}
               nextMode={monthlyData.rhythm.nextMode}
               readiness={monthlyData.rhythm.readiness}
@@ -2849,26 +2862,27 @@ function PremiumMonthlyWrappedStory({
 
           <WeeklyStorySlide
             accent={monthlyData.emotion.color}
-            active={activeStorySlide === 5}
+            active={showSharePicker || activeStorySlide === 5}
             eyebrow="EMOCIÓN"
             index={5}
             registerSlide={(el) => (storySlideRefs.current[5] = el)}
             title={monthlyData.emotion.label}
           >
-            <MonthlyEmotionJourneyStory active={activeStorySlide === 5} emotion={monthlyData.emotion} />
+            <MonthlyEmotionJourneyStory active={showSharePicker || activeStorySlide === 5} emotion={monthlyData.emotion} />
           </WeeklyStorySlide>
 
           <WeeklyStorySlide
             accent="#A78BFA"
-            active={activeStorySlide === 6}
+            active={showSharePicker || activeStorySlide === 6}
             eyebrow="CIERRE"
             index={6}
             registerSlide={(el) => (storySlideRefs.current[6] = el)}
             title="Seguimos"
+            titleClassName="text-[clamp(2.05rem,8.4vw,2.8rem)]"
           >
             <div className="flex flex-1 flex-col justify-between gap-[clamp(2rem,7dvh,3rem)]">
               <div className="space-y-8">
-                <p className="mp-weekly-fragment text-[clamp(2.25rem,10vw,3.7rem)] font-semibold leading-tight text-[color:var(--weekly-title)]" style={{ transitionDelay: '140ms' }}>
+                <p className="mp-weekly-fragment text-[clamp(1.75rem,7.4vw,2.65rem)] font-semibold leading-tight text-[color:var(--weekly-title)]" style={{ transitionDelay: '140ms' }}>
                   Un mes de señales claras para ajustar tu Journey.
                 </p>
                 <p className="mp-weekly-fragment text-xl leading-relaxed text-[color:var(--weekly-muted)]" style={{ transitionDelay: '280ms' }}>
@@ -2876,7 +2890,7 @@ function PremiumMonthlyWrappedStory({
                 </p>
               </div>
               <button
-                className="mp-weekly-fragment w-full rounded-full bg-[color:var(--mp-violet)] px-6 py-4 text-lg font-semibold text-white shadow-[0_18px_70px_rgba(167,139,250,0.34)]"
+                className="mp-weekly-fragment w-full rounded-full bg-[color:var(--weekly-brand)] px-6 py-4 text-lg font-semibold text-white shadow-[0_18px_70px_rgba(167,139,250,0.34)]"
                 onClick={() => setShowSharePicker(true)}
                 style={{ transitionDelay: '520ms' }}
                 type="button"
@@ -2889,10 +2903,11 @@ function PremiumMonthlyWrappedStory({
 
         {showSharePicker ? (
           <MonthlySharePicker
-            data={monthlyData}
             mode={storyVisualMode}
             onClose={() => setShowSharePicker(false)}
             onModeChange={setStoryVisualMode}
+            slideRefs={storySlideRefs}
+            targets={monthlyShareTargets}
           />
         ) : null}
       </div>
@@ -3440,6 +3455,7 @@ function WeeklyStorySlide({
   index,
   registerSlide,
   title,
+  titleClassName = 'text-[clamp(2.45rem,10.5vw,3.35rem)]',
   titleDelay = '95ms',
 }: {
   accent: string;
@@ -3449,6 +3465,7 @@ function WeeklyStorySlide({
   index: number;
   registerSlide: (el: HTMLElement | null) => void;
   title: string;
+  titleClassName?: string;
   titleDelay?: string;
 }) {
   return (
@@ -3478,7 +3495,7 @@ function WeeklyStorySlide({
             style={{ color: 'var(--weekly-brand)', transitionDelay: '0ms' }}
           />
           <p className="mp-weekly-fragment mt-[clamp(.9rem,2.4dvh,1.25rem)] text-xs font-semibold uppercase tracking-[0.34em]" style={{ color: accent, transitionDelay: '40ms' }}>{eyebrow}</p>
-          <h2 className="mp-weekly-fragment mt-3 text-[clamp(2.45rem,10.5vw,3.35rem)] font-semibold leading-[0.96] tracking-[-0.035em] text-[color:var(--weekly-title)]" style={{ transitionDelay: titleDelay }}>{title}</h2>
+          <h2 className={`mp-weekly-fragment mt-3 ${titleClassName} font-semibold leading-[0.96] tracking-[-0.035em] text-[color:var(--weekly-title)]`} style={{ transitionDelay: titleDelay }}>{title}</h2>
         </div>
         <div className="flex min-h-0 flex-1 flex-col">{children}</div>
       </div>
@@ -3920,36 +3937,166 @@ function WeeklyRadarAnalysisChart({
 }
 
 function WeeklySharePicker({
-  dominantColor,
-  dominantLabel,
-  energy,
-  emotion,
   mode,
   onClose,
   onModeChange,
-  storyHabits,
+  slideRefs,
+  targets,
 }: {
-  dominantColor: string;
-  dominantLabel: string;
-  energy: WeeklyWrappedRecord['payload']['summary']['energyHighlight'] | undefined;
-  emotion: WeeklyWrappedRecord['payload']['emotions']['weekly'] | WeeklyWrappedRecord['payload']['emotions']['biweekly'] | undefined;
   mode: WeeklyStoryVisualMode;
   onClose: () => void;
   onModeChange: (mode: WeeklyStoryVisualMode) => void;
-  storyHabits: Array<{ title: string; body?: string; daysActive?: number; completionRate?: number | string | null }>;
+  slideRefs: MutableRefObject<(HTMLElement | null)[]>;
+  targets: Array<WrappedShareTarget<WeeklyShareOption>>;
 }) {
-  const [selected, setSelected] = useState<'tasks' | 'balance' | 'habits' | 'emotion'>('tasks');
+  return (
+    <WrappedStorySharePicker
+      eyebrow="Compartir story"
+      filePrefix="innerbloom-weekly"
+      mode={mode}
+      onClose={onClose}
+      onModeChange={onModeChange}
+      shareText="Mi Weekly Wrapped en Innerbloom"
+      shareTitle="Weekly Wrapped en Innerbloom"
+      slideRefs={slideRefs}
+      targets={targets}
+      title="Elegí una versión"
+    />
+  );
+}
+
+function WrappedStorySharePicker<T extends string>({
+  eyebrow,
+  filePrefix,
+  mode,
+  onClose,
+  onModeChange,
+  shareText,
+  shareTitle,
+  slideRefs,
+  targets,
+  title,
+}: {
+  eyebrow: string;
+  filePrefix: string;
+  mode: WeeklyStoryVisualMode;
+  onClose: () => void;
+  onModeChange: (mode: WeeklyStoryVisualMode) => void;
+  shareText: string;
+  shareTitle: string;
+  slideRefs: MutableRefObject<(HTMLElement | null)[]>;
+  targets: Array<WrappedShareTarget<T>>;
+  title: string;
+}) {
+  const [selected, setSelected] = useState<T>((targets[0]?.key ?? '') as T);
   const [previewing, setPreviewing] = useState(false);
-  const options: Array<{ key: typeof selected; label: string }> = [
-    { key: 'tasks', label: 'Tareas' },
-    { key: 'balance', label: 'Balance' },
-    { key: 'habits', label: 'Hábitos' },
-    { key: 'emotion', label: emotion?.label ?? 'Calma' },
-  ];
+  const [isSharing, setIsSharing] = useState(false);
+  const [shareError, setShareError] = useState<string | null>(null);
+  const [thumbnails, setThumbnails] = useState<Record<string, string>>({});
+  const [previewDataUrl, setPreviewDataUrl] = useState<string | null>(null);
+  const selectedTarget = targets.find((target) => target.key === selected) ?? targets[0];
+  const targetSignature = targets.map((target) => `${target.key}:${target.slideIndex}`).join('|');
+
+  useEffect(() => {
+    if (targets[0] && !targets.some((target) => target.key === selected)) {
+      setSelected(targets[0].key);
+    }
+  }, [selected, targetSignature]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setThumbnails({});
+    void (async () => {
+      await waitForNextFrame();
+      await waitForNextFrame();
+      const next: Record<string, string> = {};
+      for (const target of targets) {
+        const slide = slideRefs.current[target.slideIndex];
+        if (!slide) continue;
+        try {
+          next[target.key] = await exportWrappedStorySlideToPng(slide, {
+            mode,
+            pixelRatio: 0.38,
+          });
+          if (!cancelled) setThumbnails({ ...next });
+        } catch (error) {
+          if (import.meta.env.DEV) {
+            console.warn('Wrapped story thumbnail generation failed', { error, slideIndex: target.slideIndex });
+          }
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, slideRefs, targetSignature]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPreviewDataUrl(null);
+    if (!previewing || !selectedTarget) return () => {
+      cancelled = true;
+    };
+    void (async () => {
+      const slide = slideRefs.current[selectedTarget.slideIndex];
+      if (!slide) return;
+      try {
+        const dataUrl = await exportWrappedStorySlideToPng(slide, {
+          mode,
+          pixelRatio: 0.9,
+        });
+        if (!cancelled) setPreviewDataUrl(dataUrl);
+      } catch (error) {
+        if (import.meta.env.DEV) {
+          console.warn('Wrapped story preview generation failed', { error, slideIndex: selectedTarget.slideIndex });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, previewing, selectedTarget?.key, selectedTarget?.slideIndex, slideRefs]);
+
+  const handleShare = async () => {
+    if (!selectedTarget) return;
+    const slide = slideRefs.current[selectedTarget.slideIndex];
+    if (!slide) return;
+    setIsSharing(true);
+    setShareError(null);
+    try {
+      const dataUrl = await exportWrappedStorySlideToPng(slide, {
+        mode,
+        pixelRatio: 3,
+      });
+      const filename = `${filePrefix}-${slugifyShareFilename(selectedTarget.label)}.png`;
+      const blob = await dataUrlToBlob(dataUrl);
+      const file = new File([blob], filename, { type: 'image/png' });
+      const browserNavigator = typeof navigator === 'undefined' ? null : navigator as Navigator & {
+        canShare?: (data: { files?: File[] }) => boolean;
+        share?: (data: { files?: File[]; title?: string; text?: string }) => Promise<void>;
+      };
+
+      if (browserNavigator?.share && browserNavigator.canShare?.({ files: [file] })) {
+        await browserNavigator.share({
+          files: [file],
+          title: shareTitle,
+          text: shareText,
+        });
+      } else {
+        downloadShareImage(dataUrl, filename);
+      }
+    } catch (error) {
+      console.error('Wrapped story share failed', error);
+      setShareError('No pudimos generar la imagen. Intentá otra vez.');
+    } finally {
+      setIsSharing(false);
+    }
+  };
 
   return (
     <div
       className="absolute inset-0 z-30 flex items-end bg-black/46 px-4 pb-[calc(var(--weekly-safe-bottom)+0.75rem)] backdrop-blur-md"
+      data-wrapped-share-picker="true"
       onClick={onClose}
       onTouchMove={(event) => event.stopPropagation()}
       onWheel={(event) => event.stopPropagation()}
@@ -3972,8 +4119,8 @@ function WeeklySharePicker({
             </button>
           ) : (
             <div>
-              <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[color:var(--weekly-brand)]">Compartir story</p>
-              <h3 className="mt-1 text-lg font-semibold text-[color:var(--weekly-title)]">Elegí una versión</h3>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[color:var(--weekly-brand)]">{eyebrow}</p>
+              <h3 className="mt-1 text-lg font-semibold text-[color:var(--weekly-title)]">{title}</h3>
             </div>
           )}
           <button
@@ -4000,49 +4147,45 @@ function WeeklySharePicker({
         {previewing ? (
           <div className="mt-3 flex min-h-0 flex-1 flex-col">
             <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-              <div className="mx-auto w-full max-w-[min(72vw,19.5rem)]">
-                <WeeklySharePreview
-                  dominantColor={dominantColor}
-                  dominantLabel={dominantLabel}
-                  energy={energy}
-                  emotion={emotion}
-                  full
-                  mode={mode}
-                  storyHabits={storyHabits}
-                  type={selected}
-                />
+              <div className="mx-auto aspect-[9/16] w-full max-w-[min(72vw,19.5rem)] overflow-hidden rounded-[1.25rem] border border-[color:var(--weekly-line)] bg-black/20">
+                {previewDataUrl ? (
+                  <img alt={`${selectedTarget?.label ?? 'Story'} preview`} className="h-full w-full object-cover" src={previewDataUrl} />
+                ) : (
+                  <div className="grid h-full place-items-center text-sm font-semibold text-[color:var(--weekly-muted)]">Preparando preview...</div>
+                )}
               </div>
             </div>
+            {shareError ? <p className="mt-2 text-sm text-[color:var(--mp-red)]">{shareError}</p> : null}
             <button
-              className="mt-3 w-full shrink-0 rounded-full bg-[color:var(--mp-violet)] px-5 py-3 text-base font-semibold text-white"
+              className="mt-3 w-full shrink-0 rounded-full bg-[color:var(--weekly-brand)] px-5 py-3 text-base font-semibold text-white shadow-[0_14px_34px_rgba(139,92,246,0.28)] disabled:opacity-60"
+              disabled={isSharing}
+              onClick={() => void handleShare()}
               type="button"
             >
-              Compartir
+              {isSharing ? 'Generando...' : 'Compartir'}
             </button>
           </div>
         ) : (
           <div className="mt-3 grid min-h-0 flex-1 grid-cols-2 gap-2 overflow-y-auto overscroll-contain pr-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            {options.map((option) => (
+            {targets.map((target) => (
               <button
-                aria-pressed={selected === option.key}
-                className={`group overflow-hidden rounded-[0.85rem] border p-1.5 text-left transition ${selected === option.key ? 'border-[color:var(--weekly-brand)] bg-white/[0.08] shadow-[0_0_22px_rgba(167,139,250,0.18)]' : 'border-[color:var(--weekly-line)] bg-white/[0.035]'}`}
-                key={option.key}
+                aria-pressed={selected === target.key}
+                className={`group overflow-hidden rounded-[0.85rem] border p-1.5 text-left transition ${selected === target.key ? 'border-[color:var(--weekly-brand)] bg-white/[0.08] shadow-[0_0_22px_rgba(167,139,250,0.18)]' : 'border-[color:var(--weekly-line)] bg-white/[0.035]'}`}
+                key={target.key}
                 onClick={() => {
-                  setSelected(option.key);
+                  setSelected(target.key);
                   setPreviewing(true);
                 }}
                 type="button"
               >
-                <WeeklySharePreview
-                  dominantColor={dominantColor}
-                  dominantLabel={dominantLabel}
-                  energy={energy}
-                  emotion={emotion}
-                  mode={mode}
-                  storyHabits={storyHabits}
-                  type={option.key}
-                />
-                <span className="mt-1 block px-1 pb-0.5 text-[11px] font-semibold text-[color:var(--weekly-title)]">{option.label}</span>
+                <div className="aspect-[9/16] overflow-hidden rounded-[0.75rem] bg-black/20">
+                  {thumbnails[target.key] ? (
+                    <img alt={`${target.label} preview`} className="h-full w-full object-cover" src={thumbnails[target.key]} />
+                  ) : (
+                    <div className="grid h-full place-items-center text-[9px] font-semibold text-[color:var(--weekly-muted)]">Preparando</div>
+                  )}
+                </div>
+                <span className="mt-1 block px-1 pb-0.5 text-[11px] font-semibold text-[color:var(--weekly-title)]">{target.label}</span>
               </button>
             ))}
           </div>
@@ -4171,110 +4314,32 @@ function WeeklySharePreview({
   );
 }
 
-type MonthlyShareOption = 'month' | 'tasks' | 'habits' | 'emotion';
-
 function MonthlySharePicker({
-  data,
   mode,
   onClose,
   onModeChange,
+  slideRefs,
+  targets,
 }: {
-  data: MonthlyStoryData;
   mode: WeeklyStoryVisualMode;
   onClose: () => void;
   onModeChange: (mode: WeeklyStoryVisualMode) => void;
+  slideRefs: MutableRefObject<(HTMLElement | null)[]>;
+  targets: Array<WrappedShareTarget<MonthlyShareOption>>;
 }) {
-  const [selected, setSelected] = useState<MonthlyShareOption>('month');
-  const [previewing, setPreviewing] = useState(false);
-  const options: Array<{ key: MonthlyShareOption; label: string }> = [
-    { key: 'month', label: 'Mes' },
-    { key: 'tasks', label: 'Tareas' },
-    { key: 'habits', label: 'Hábitos' },
-    { key: 'emotion', label: data.emotion.label },
-  ];
-
   return (
-    <div
-      className="absolute inset-0 z-30 flex items-end bg-black/46 px-4 pb-[calc(var(--weekly-safe-bottom)+0.75rem)] backdrop-blur-md"
-      onClick={onClose}
-      onTouchMove={(event) => event.stopPropagation()}
-      onWheel={(event) => event.stopPropagation()}
-    >
-      <div
-        className="mp-weekly-panel flex max-h-[min(90dvh,45rem)] w-full flex-col overflow-hidden rounded-[1.65rem] p-3.5"
-        onClick={(event) => event.stopPropagation()}
-        onTouchMove={(event) => event.stopPropagation()}
-        onWheel={(event) => event.stopPropagation()}
-      >
-        <div className="flex items-start justify-between gap-4">
-          {previewing ? (
-            <button
-              className="-ml-1 inline-flex items-center gap-2 rounded-full px-2 py-1 text-sm font-semibold text-[color:var(--weekly-title)]"
-              onClick={() => setPreviewing(false)}
-              type="button"
-            >
-              <span className="text-xl leading-none">‹</span>
-              Cambiar story
-            </button>
-          ) : (
-            <div>
-              <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[color:var(--weekly-brand)]">Compartir mes</p>
-              <h3 className="mt-1 text-lg font-semibold text-[color:var(--weekly-title)]">Elegí una story</h3>
-            </div>
-          )}
-          <button
-            aria-label="Cerrar selector"
-            className="grid h-9 w-9 place-items-center rounded-full bg-black/10 text-xl text-[color:var(--weekly-muted)]"
-            onClick={onClose}
-            type="button"
-          >
-            ×
-          </button>
-        </div>
-        <div className="mt-3 grid grid-cols-2 gap-2 rounded-full bg-black/10 p-1">
-          {(['dark', 'light'] as WeeklyStoryVisualMode[]).map((item) => (
-            <button
-              className={`rounded-full px-4 py-1.5 text-sm font-semibold transition ${mode === item ? 'bg-[color:var(--weekly-brand)] text-white' : 'text-[color:var(--weekly-muted)]'}`}
-              key={item}
-              onClick={() => onModeChange(item)}
-              type="button"
-            >
-              {item === 'dark' ? 'Dark' : 'Light'}
-            </button>
-          ))}
-        </div>
-        {previewing ? (
-          <div className="mt-3 flex min-h-0 flex-1 flex-col">
-            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-              <div className="mx-auto w-full max-w-[min(72vw,19.5rem)]">
-                <MonthlySharePreview data={data} full mode={mode} type={selected} />
-              </div>
-            </div>
-            <button className="mt-3 w-full shrink-0 rounded-full bg-[color:var(--mp-violet)] px-5 py-3 text-base font-semibold text-white" type="button">
-              Compartir
-            </button>
-          </div>
-        ) : (
-          <div className="mt-3 grid min-h-0 flex-1 grid-cols-2 gap-2 overflow-y-auto overscroll-contain pr-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            {options.map((option) => (
-              <button
-                aria-pressed={selected === option.key}
-                className={`group overflow-hidden rounded-[0.85rem] border p-1.5 text-left transition ${selected === option.key ? 'border-[color:var(--weekly-brand)] bg-white/[0.08] shadow-[0_0_22px_rgba(167,139,250,0.18)]' : 'border-[color:var(--weekly-line)] bg-white/[0.035]'}`}
-                key={option.key}
-                onClick={() => {
-                  setSelected(option.key);
-                  setPreviewing(true);
-                }}
-                type="button"
-              >
-                <MonthlySharePreview data={data} mode={mode} type={option.key} />
-                <span className="mt-1 block px-1 pb-0.5 text-[11px] font-semibold text-[color:var(--weekly-title)]">{option.label}</span>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
+    <WrappedStorySharePicker
+      eyebrow="Compartir mes"
+      filePrefix="innerbloom-monthly"
+      mode={mode}
+      onClose={onClose}
+      onModeChange={onModeChange}
+      shareText="Mi Monthly Wrapped en Innerbloom"
+      shareTitle="Monthly Wrapped en Innerbloom"
+      slideRefs={slideRefs}
+      targets={targets}
+      title="Elegí una story"
+    />
   );
 }
 
@@ -4427,6 +4492,10 @@ function AnimatedWeeklyNumber({
   useEffect(() => {
     if (!active) {
       setDisplayValue(0);
+      return;
+    }
+    if (typeof document !== 'undefined' && document.querySelector('[data-wrapped-share-picker="true"]')) {
+      setDisplayValue(Math.max(0, value));
       return;
     }
 
@@ -5410,6 +5479,80 @@ async function waitForSharePreviewImages(node: HTMLElement) {
       image.addEventListener('error', finish, { once: true });
     });
   }));
+}
+
+async function exportWrappedStorySlideToPng(
+  slide: HTMLElement,
+  {
+    mode,
+    pixelRatio,
+  }: {
+    mode: WeeklyStoryVisualMode;
+    pixelRatio: number;
+  },
+) {
+  const restore = prepareWrappedStorySlideForExport(slide);
+  try {
+    await waitForNextFrame();
+    await waitForNextFrame();
+    await waitForSharePreviewImages(slide);
+    const { toPng } = await import('html-to-image');
+    return await toPng(slide, {
+      pixelRatio,
+      cacheBust: true,
+      backgroundColor: mode === 'light' ? '#FFF8EF' : '#05050A',
+    });
+  } finally {
+    restore();
+  }
+}
+
+function prepareWrappedStorySlideForExport(slide: HTMLElement) {
+  const hadActiveClass = slide.classList.contains('mp-weekly-slide-active');
+  slide.classList.add('mp-weekly-slide-active');
+  const style = document.createElement('style');
+  style.textContent = `
+    [data-wrapped-exporting="true"] .mp-weekly-fragment,
+    [data-wrapped-exporting="true"] .mp-weekly-race-late,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-reveal,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-stage,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-final,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-label,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-dominant-fill,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-glow,
+    [data-wrapped-exporting="true"] .mp-weekly-late-text,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-percent,
+    [data-wrapped-exporting="true"] .mp-weekly-emotion-orb,
+    [data-wrapped-exporting="true"] .mp-weekly-arc-svg {
+      opacity: 1 !important;
+      transform: none !important;
+      transition: none !important;
+      animation: none !important;
+    }
+    [data-wrapped-exporting="true"] .mp-weekly-bar,
+    [data-wrapped-exporting="true"] .mp-weekly-race-line,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-polygon,
+    [data-wrapped-exporting="true"] .mp-weekly-arc-path {
+      transition: none !important;
+      stroke-dashoffset: 0 !important;
+    }
+    [data-wrapped-exporting="true"] .mp-weekly-radar-area,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-grid,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-axis,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-ring,
+    [data-wrapped-exporting="true"] .mp-weekly-radar-center {
+      opacity: 1 !important;
+      transition: none !important;
+      transform: none !important;
+    }
+  `;
+  slide.setAttribute('data-wrapped-exporting', 'true');
+  document.head.appendChild(style);
+  return () => {
+    if (!hadActiveClass) slide.classList.remove('mp-weekly-slide-active');
+    slide.removeAttribute('data-wrapped-exporting');
+    style.remove();
+  };
 }
 
 function waitForNextFrame() {


### PR DESCRIPTION
## Summary

- Makes Weekly and Monthly share pickers generate previews from the actual story slide DOM instead of separate preview-only components.
- Implements PNG export with `html-to-image`, native Web Share files support, and download fallback for Weekly/Monthly story slides.
- Forces story slides into their final visual state while sharing so animated fragments and counters are captured correctly.
- Fixes the closing slide share button color to use the story violet brand token.
- Tightens closing slide typography so the closing story fits better on mobile screens.

## Validation

- Ran a focused TypeScript check for `PremiumRewardsSection.tsx`; no errors were reported for this file.
- Ran `git diff --check`.