### PR TITLE
[codex] Polish InnerBloom 2 wrapped and reminder layouts

### DIFF
--- a/apps/web/src/pages/labs/mobile-premium/PremiumHabitDevelopment.tsx
+++ b/apps/web/src/pages/labs/mobile-premium/PremiumHabitDevelopment.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from 'react';
+import { usePostLoginLanguage } from '../../../i18n/postLoginLanguage';
 
 type HabitTone = 'fragile' | 'building' | 'strong';
 
@@ -24,8 +25,13 @@ export function habitDevelopmentTone(score: number) {
   return TONE_STYLES[resolveTone(score)];
 }
 
-export function habitDevelopmentStatusLabel(score: number) {
+export function habitDevelopmentStatusLabel(score: number, language: 'es' | 'en' = 'es') {
   const tone = resolveTone(clampScore(score));
+  if (language === 'en') {
+    if (tone === 'fragile') return 'Fragile habit';
+    if (tone === 'building') return 'Building habit';
+    return 'Strong habit';
+  }
   if (tone === 'fragile') return 'Hábito frágil';
   if (tone === 'building') return 'Hábito en construcción';
   return 'Hábito fuerte';
@@ -40,7 +46,9 @@ export function HabitStatusChip({
   score: number;
   compact?: boolean;
 }) {
+  const { language } = usePostLoginLanguage();
   const tone = habitDevelopmentTone(score);
+  const displayLabel = translateHabitStatusLabel(label, score, language);
 
   return (
     <span
@@ -49,9 +57,24 @@ export function HabitStatusChip({
       }`}
       style={{ backgroundColor: tone.soft, color: tone.color }}
     >
-      {label}
+      {displayLabel}
     </span>
   );
+}
+
+function translateHabitStatusLabel(label: string, score: number, language: 'es' | 'en') {
+  if (language === 'es') return label;
+  const normalized = label
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
+  if (normalized === 'habito fragil') return 'Fragile habit';
+  if (normalized === 'habito en construccion') return 'Building habit';
+  if (normalized === 'habito fuerte') return 'Strong habit';
+  if (normalized === 'habito logrado') return 'Achieved habit';
+  if (normalized === 'habito guardado') return 'Saved habit';
+  return habitDevelopmentStatusLabel(score, language);
 }
 
 export function PremiumScoreRing({

--- a/apps/web/src/pages/labs/mobile-premium/variants/PremiumInteractionOverlays.tsx
+++ b/apps/web/src/pages/labs/mobile-premium/variants/PremiumInteractionOverlays.tsx
@@ -861,15 +861,17 @@ function ReminderSheet({
   return (
     <PremiumSheet eyebrow={t('mobilePremium.reminder.eyebrow')} onClose={onClose} title={t('mobilePremium.reminder.title')}>
       <div className="space-y-6">
-        <label className="block">
+        <label className="block min-w-0">
           <span className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--mp-text-muted)]">{t('mobilePremium.reminder.localTime')}</span>
-          <input
-            aria-label={t('mobilePremium.reminder.timeA11y')}
-            className="mp-time-input mt-3 h-12 w-full rounded-full border border-[color:var(--mp-violet)] bg-[color:var(--mp-surface-strong)] px-5 text-center text-base font-semibold text-[color:var(--mp-violet-strong)] outline-none"
-            onChange={(event) => setTime(event.target.value)}
-            type="time"
-            value={time}
-          />
+          <span className="mt-3 block max-w-full overflow-hidden rounded-full border border-[color:var(--mp-violet)] bg-[color:var(--mp-surface-strong)]">
+            <input
+              aria-label={t('mobilePremium.reminder.timeA11y')}
+              className="mp-time-input block h-12 w-full min-w-0 max-w-full appearance-none border-0 bg-transparent px-5 text-center text-base font-semibold text-[color:var(--mp-violet-strong)] outline-none"
+              onChange={(event) => setTime(event.target.value)}
+              type="time"
+              value={time}
+            />
+          </span>
         </label>
         <div className="flex items-center gap-3 rounded-[1rem] border border-[color:var(--mp-border)] bg-[color:var(--mp-surface)] p-3">
           <span className="grid h-9 w-9 place-items-center rounded-full bg-violet-400/12 text-[color:var(--mp-violet)]">

--- a/apps/web/src/pages/labs/mobile-premium/variants/PremiumRewardsSection.tsx
+++ b/apps/web/src/pages/labs/mobile-premium/variants/PremiumRewardsSection.tsx
@@ -19,7 +19,7 @@ type WrappedShareTarget<T extends string> = { key: T; label: string; slideIndex:
 type WrappedShareImageCache = Map<string, string>;
 
 const WEEKLY_PILLAR_ORDER: RewardsPillarCode[] = ['BODY', 'MIND', 'SOUL'];
-const STORY_MODAL_LAYER_CLASS = 'fixed bottom-0 left-0 right-0 top-0 isolate z-[9999] h-[100svh] min-h-[100svh] w-screen overflow-hidden bg-black';
+const STORY_MODAL_LAYER_CLASS = 'fixed bottom-0 left-0 right-0 top-0 isolate z-[9999] h-[100dvh] min-h-[100dvh] w-screen overflow-hidden bg-black';
 
 const FALLBACK_REWARDS_HISTORY: RewardsHistorySummary = {
   weeklyWrapups: [
@@ -1328,6 +1328,7 @@ function AchievementDetailRow({ label, value }: { label: string; value: string }
 }
 
 function MonthHealthDot({ active = true, month, percent, projected }: { active?: boolean; month: string; percent: number; projected?: boolean }) {
+  const { language, t } = usePostLoginLanguage();
   const tone = getScoreTone(percent);
   return (
     <div className={`text-center ${active ? '' : 'opacity-55'}`}>
@@ -1344,10 +1345,45 @@ function MonthHealthDot({ active = true, month, percent, projected }: { active?:
         ) : null}
         {percent}%
       </div>
-      <p className="mt-1 text-[11px] text-[color:var(--mp-text-secondary)]">{month}</p>
-      {projected ? <p className="-mt-0.5 text-[8px] text-[color:var(--mp-text-muted)]">proy.</p> : null}
+      <p className="mt-1 text-[11px] text-[color:var(--mp-text-secondary)]">{formatHabitMonthLabel(month, language)}</p>
+      {projected ? <p className="-mt-0.5 text-[8px] text-[color:var(--mp-text-muted)]">{t('mobilePremium.taskDetail.projectedShort')}</p> : null}
     </div>
   );
+}
+
+function formatHabitMonthLabel(month: string, language: 'es' | 'en') {
+  if (language === 'es') return month;
+  const normalized = month.trim().toLowerCase().replace('.', '');
+  const monthIndexByLabel: Record<string, number> = {
+    ene: 0,
+    enero: 0,
+    feb: 1,
+    febrero: 1,
+    mar: 2,
+    marzo: 2,
+    abr: 3,
+    abril: 3,
+    may: 4,
+    mayo: 4,
+    jun: 5,
+    junio: 5,
+    jul: 6,
+    julio: 6,
+    ago: 7,
+    agosto: 7,
+    sep: 8,
+    sept: 8,
+    septiembre: 8,
+    oct: 9,
+    octubre: 9,
+    nov: 10,
+    noviembre: 10,
+    dic: 11,
+    diciembre: 11,
+  };
+  const monthIndex = monthIndexByLabel[normalized];
+  if (monthIndex == null) return month;
+  return new Intl.DateTimeFormat('en', { month: 'short' }).format(new Date(2026, monthIndex, 1)).replace('.', '').toLowerCase();
 }
 
 function resolveHabitDevelopmentMonths(months: Array<{ month: string; percent: number; projected?: boolean; periodKey?: string | null }>) {
@@ -2402,7 +2438,7 @@ export function PremiumWeeklyWrappedStory({
         `}
       </style>
       <div
-        className="mp-weekly-story-root relative h-[100svh] min-h-[100svh] w-screen overflow-hidden [--weekly-safe-bottom:max(env(safe-area-inset-bottom),1rem)] [--weekly-safe-top:max(env(safe-area-inset-top),1rem)] [--weekly-share-safe-bottom:max(env(safe-area-inset-bottom),clamp(4.75rem,9dvh,6rem))]"
+        className="mp-weekly-story-root relative h-[100dvh] min-h-[100dvh] w-screen overflow-hidden [--weekly-safe-bottom:max(env(safe-area-inset-bottom),1rem)] [--weekly-safe-top:max(env(safe-area-inset-top),1rem)] [--weekly-share-safe-bottom:max(env(safe-area-inset-bottom),clamp(4.75rem,9dvh,6rem))]"
         data-weekly-mode={storyVisualMode}
       >
         <button
@@ -2415,7 +2451,7 @@ export function PremiumWeeklyWrappedStory({
           ×
         </button>
 
-        <div className={`h-full snap-y snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${showSharePicker ? 'overflow-hidden' : 'overflow-y-auto'}`} ref={storyScrollRef}>
+        <div className={`h-full snap-y snap-mandatory overscroll-contain [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [touch-action:pan-y] [&::-webkit-scrollbar]:hidden ${showSharePicker ? 'overflow-hidden' : 'overflow-y-scroll'}`} ref={storyScrollRef}>
           <WeeklyStorySlide
             accent={dominantColor}
             active={showSharePicker || activeStorySlide === 0}
@@ -2756,7 +2792,7 @@ function PremiumMonthlyWrappedStory({
     >
       <MonthlyStoryStyles />
       <div
-        className="mp-weekly-story-root relative h-[100svh] min-h-[100svh] w-screen overflow-hidden [--weekly-safe-bottom:max(env(safe-area-inset-bottom),1rem)] [--weekly-safe-top:max(env(safe-area-inset-top),1rem)] [--weekly-share-safe-bottom:max(env(safe-area-inset-bottom),clamp(4.75rem,9dvh,6rem))]"
+        className="mp-weekly-story-root relative h-[100dvh] min-h-[100dvh] w-screen overflow-hidden [--weekly-safe-bottom:max(env(safe-area-inset-bottom),1rem)] [--weekly-safe-top:max(env(safe-area-inset-top),1rem)] [--weekly-share-safe-bottom:max(env(safe-area-inset-bottom),clamp(4.75rem,9dvh,6rem))]"
         data-weekly-mode={storyVisualMode}
       >
         <button
@@ -2769,7 +2805,7 @@ function PremiumMonthlyWrappedStory({
           ×
         </button>
 
-        <div className={`h-full snap-y snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${showSharePicker ? 'overflow-hidden' : 'overflow-y-auto'}`} ref={storyScrollRef}>
+        <div className={`h-full snap-y snap-mandatory overscroll-contain [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [touch-action:pan-y] [&::-webkit-scrollbar]:hidden ${showSharePicker ? 'overflow-hidden' : 'overflow-y-scroll'}`} ref={storyScrollRef}>
           <WeeklyStorySlide
             accent="#A78BFA"
             active={showSharePicker || activeStorySlide === 0}
@@ -3496,7 +3532,7 @@ function WeeklyStorySlide({
 }) {
   return (
     <section
-      className={`mp-weekly-slide-shell relative flex h-[100svh] min-h-[100svh] snap-start justify-center overflow-hidden px-7 ${active ? 'mp-weekly-slide-active' : ''}`}
+      className={`mp-weekly-slide-shell relative flex h-[100dvh] min-h-[100dvh] snap-start justify-center overflow-hidden px-7 ${active ? 'mp-weekly-slide-active' : ''}`}
       data-weekly-slide={index}
       ref={registerSlide}
       style={{


### PR DESCRIPTION
## Summary
- Fixes Weekly/Monthly Wrapped modal scrolling on mobile by using dynamic viewport height and explicit touch scrolling on the internal story scroller.
- Keeps Wrapped slides snap-scrolling while avoiding the iOS Safari locked-screen behavior reported in English mode.
- Localizes habit development status chips and projected/month labels inside flipped achievement cards.
- Constrains the native reminder time input so it stays inside the sheet on narrow mobile viewports without changing the visual style.

## Validation
- `pnpm --dir apps/web exec vitest --run src/i18n/postLoginLanguage.integration.test.tsx` passed.
- `pnpm --dir apps/web exec tsc --noEmit` still fails on existing unrelated repo type errors (Clerk typings, demo/test fixtures, CSS variable typing, existing PremiumTaskDetail fixture typing, Landing union typing).

## Notes
- Unrelated local changes in `apps/web/public/ai.json` and `apps/web/public/ai/index.html` were not included.