### PR TITLE
[codex] Refine mobile landing snap and cards

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -8827,6 +8827,20 @@
   }
 }
 
+@keyframes v3-adjustment-difficulty-mobile {
+  0%, 20%, 82%, 100% {
+    max-width: 54px;
+    opacity: 1;
+    padding-inline: 0.56rem;
+  }
+
+  34%, 66% {
+    max-width: 0;
+    opacity: 0;
+    padding-inline: 0;
+  }
+}
+
 @keyframes v3-adjustment-arrow-rotate {
   0%, 18%, 84%, 100% { transform: rotate(0deg); }
   34%, 66% { transform: rotate(-90deg); }
@@ -10083,13 +10097,33 @@
 /* Final mobile overrides must stay at the end of this file because the landing
    has several repeated conversion blocks above. */
 @media (max-width: 768px) {
+  html {
+    scroll-padding-top: 0;
+    scroll-snap-type: y proximity;
+  }
+
+  .landing > main {
+    padding-top: calc(72px + env(safe-area-inset-top, 0px));
+  }
+
+  .landing .nav {
+    position: fixed;
+    inset: 0 0 auto;
+    min-height: 72px;
+    padding-top: max(10px, env(safe-area-inset-top, 0px));
+  }
+
+  .landing .brand-text {
+    display: none;
+  }
+
   .landing,
   .landing.landing--v3-conversion {
     height: auto !important;
     min-height: 100svh;
     overflow-y: visible !important;
     overscroll-behavior-y: auto;
-    scroll-snap-type: none !important;
+    scroll-snap-type: y proximity !important;
   }
 
   .landing :is(section, .v3-method-snap-panel) {
@@ -10098,23 +10132,38 @@
     scroll-margin-top: calc(92px + env(safe-area-inset-top, 0px));
   }
 
+  .landing.landing--v3-conversion :is(.hero, .truth-problem, .feature-showcase, .why, .modes, .testimonials, .faq, .pricing, .next) {
+    scroll-snap-align: none !important;
+  }
+
+  .landing.landing--v3-conversion .v3-method-card {
+    scroll-snap-align: start !important;
+    scroll-snap-stop: always !important;
+    scroll-margin-top: 0;
+  }
+
   .landing.landing--v3-conversion .hero {
     padding-top: clamp(22px, 6vw, 38px);
   }
 
-  .landing.landing--v3-conversion .v3-method-card-copy .v2-method-step-badge,
-  .landing.landing--v3-conversion .ib20-detail-nav,
-  .landing.landing--v3-conversion .ib20-detail-chip--difficulty {
+  .landing.landing--v3-conversion .v3-method-card-copy .v2-method-step-badge {
+    display: inline-flex !important;
+    opacity: 0.92;
+  }
+
+  .landing.landing--v3-conversion .ib20-detail-nav {
     display: none !important;
   }
 
   .landing.landing--v3-conversion .ib20-detail-chips {
-    display: grid;
-    grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+    display: flex;
+    align-items: center;
     gap: 6px;
+    overflow: hidden;
   }
 
   .landing.landing--v3-conversion .ib20-detail-chip--trait {
+    flex: 0 1 auto;
     min-width: 0;
     overflow: hidden;
     font-size: 0.78rem;
@@ -10122,18 +10171,27 @@
     white-space: nowrap;
   }
 
+  .landing.landing--v3-conversion .ib20-detail-chip--difficulty {
+    display: inline-flex !important;
+    flex: 0 0 auto;
+    max-width: 54px;
+    overflow: hidden;
+    animation: v3-adjustment-difficulty-mobile 3.4s ease-in-out infinite;
+    white-space: nowrap;
+  }
+
   .landing.landing--v3-conversion .ib20-detail-chip--down {
-    width: 100% !important;
-    max-width: 176px;
+    flex: 1 1 28px;
+    width: auto !important;
+    max-width: 184px;
     min-width: 0;
-    animation: none !important;
+    animation: v3-adjustment-chip-open 3.4s ease-in-out infinite !important;
   }
 
   .landing.landing--v3-conversion .ib20-detail-chip--down i,
   .landing.landing--v3-conversion .ib20-detail-chip--down b {
-    animation: none !important;
-    opacity: 1 !important;
-    transform: none !important;
+    animation-duration: 3.4s !important;
+    animation-iteration-count: infinite !important;
   }
 
   .landing.landing--v3-conversion .ib20-detail-chip--down b {
@@ -10153,9 +10211,16 @@
     width: 92px;
   }
 
+  .landing.landing--v3-conversion .ib20-habit-ring strong {
+    transform: translateY(-8px);
+  }
+
   .landing.landing--v3-conversion .ib20-habit-ring span {
-    margin-top: 38px;
+    top: 50%;
+    left: 50%;
+    margin-top: 0;
     font-size: 0.62rem;
+    transform: translate(-50%, 13px);
   }
 
   .landing.landing--v3-conversion .ib20-habit-status {
@@ -10187,9 +10252,34 @@
     width: 92px;
   }
 
+  .landing.landing--v3-conversion .v3-logros-dev-ring strong {
+    font-size: 2rem !important;
+    transform: translateY(-8px);
+  }
+
+  .landing.landing--v3-conversion .v3-logros-dev-ring span {
+    top: 50%;
+    left: 50%;
+    margin-top: 0 !important;
+    font-size: 0.56rem;
+    transform: translate(-50%, 13px);
+  }
+
   .landing.landing--v3-conversion .v3-logros-dev-ranges {
     gap: 4px;
     font-size: 0.48rem;
+  }
+
+  .landing.landing--v3-conversion .ib20-habit-window-title {
+    display: grid;
+    grid-template-columns: minmax(22px, 1fr) auto minmax(64px, 1.6fr);
+    margin-left: 108px;
+    width: calc(100% - 108px);
+    gap: 7px;
+  }
+
+  .landing.landing--v3-conversion .ib20-habit-window-title span {
+    white-space: nowrap;
   }
 
   .landing.landing--v3-conversion .v3-logros-dev-window i {
@@ -10210,7 +10300,7 @@
 
 @media (max-width: 430px) {
   .landing .nav {
-    grid-template-columns: auto auto 1fr;
+    grid-template-columns: auto 1fr;
     padding-inline: 12px;
   }
 
@@ -10218,9 +10308,15 @@
     display: none;
   }
 
+  .landing .nav-actions {
+    grid-column: 2;
+    justify-self: end;
+    gap: 7px;
+  }
+
   .landing .landing-theme-toggle {
-    width: 42px;
-    height: 42px;
+    width: 38px;
+    height: 38px;
   }
 
   .landing .logo-mark {
@@ -10228,13 +10324,9 @@
     height: 36px;
   }
 
-  .landing .nav-actions {
-    gap: 7px;
-  }
-
   .landing .nav-actions .nav-auth-button {
-    padding: 0.62rem 0.9rem;
-    font-size: 0.72rem;
+    padding: 0.58rem 0.78rem;
+    font-size: 0.68rem;
   }
 
   .landing.landing--v3-conversion .ib20-habit-body {


### PR DESCRIPTION
## What changed
- Kept mobile scroll flexible across the landing while enabling proximity snap only for method steps 1-4.
- Restored the PASO chips on those steps and aligned snap so the fixed header can cover that chip area instead of wasting vertical animation space.
- Made the mobile nav fixed/persistent and pushed theme/language/auth actions to the right, leaving the flower logo alone on the left.
- Fixed the step 3 difficulty-lowered chip animation: closed state is a circular down-arrow button, expanded state becomes the green pill with the arrow rotated horizontally and the label visible.
- Synced the `Fácil` chip so it stays visible while the green chip is closed and collapses while the green chip is expanded.
- Re-contained the step 3 habit-development card so insight text, ranges, `Ventana activa`, months, and projected June stay inside the card.
- Centered score labels inside the step 3 and habit-shelf score rings, with larger score numbers on locked habit development backs.

## Validation
- `npm --workspace apps/web run build` passes.
- `npm run typecheck:web` was not rerun in this pass; it failed earlier on existing unrelated TypeScript issues in Clerk/runtime auth, tests, and mobile-premium labs.

Note: `apps/web/public/ai.json` and `apps/web/public/ai/index.html` have unrelated version/timestamp changes in the local worktree and are not included.