### PR TITLE
[codex] Use canonical Quick Start trait codes

### DIFF
--- a/apps/web/src/onboarding/__tests__/payload.test.ts
+++ b/apps/web/src/onboarding/__tests__/payload.test.ts
@@ -96,4 +96,63 @@ describe('buildPayload onboarding_path', () => {
 
     vi.unstubAllGlobals();
   });
+
+  it('uses canonical trait codes for quick_start even when browser language is English', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: vi.fn().mockReturnValue('cid-456'),
+        setItem: vi.fn(),
+      },
+      navigator: {
+        language: 'en-US',
+        userAgent: 'Mozilla/5.0',
+      },
+      crypto: {
+        randomUUID: vi.fn().mockReturnValue('cid-456'),
+      },
+    });
+
+    const payload = buildPayload(
+      {
+        ...initialAnswers,
+        mode: 'EVOLVE',
+        email: 'english@quick.com',
+        user_id: 'user_3',
+        quickStart: {
+          selectedTasksByPillar: {
+            Body: ['SUENO', 'POSTURA'],
+            Mind: ['AUTOCONTROL', 'ORDEN'],
+            Soul: ['GRATITUD', 'AUTOESTIMA'],
+          },
+          editableTaskValues: {
+            'Body-SUENO': '7',
+          },
+          selectedModerations: [],
+        },
+      },
+      { Body: 6, Mind: 6, Soul: 6, total: 18 },
+      'quick_start',
+    );
+
+    const traitCodes = payload.data.quick_start?.manual_task_candidates.map((candidate) => candidate.trait_code);
+
+    expect(traitCodes).toEqual([
+      'SUENO',
+      'POSTURA',
+      'AUTOCONTROL',
+      'ORDEN',
+      'GRATITUD',
+      'AUTOESTIMA',
+    ]);
+    expect(traitCodes).not.toContain('SLEEP');
+    expect(traitCodes).not.toContain('POSTURE');
+    expect(traitCodes).not.toContain('GRATITUDE');
+    expect(payload.data.quick_start?.manual_task_candidates[0]).toEqual(expect.objectContaining({
+      task: 'Sleep at least',
+      trait_code: 'SUENO',
+      input_value: '7',
+    }));
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/apps/web/src/onboarding/quickStart.ts
+++ b/apps/web/src/onboarding/quickStart.ts
@@ -254,7 +254,7 @@ export function buildQuickStartManualCandidates(args: {
       return [{
         task: task.text,
         pillar_code: pillar.toUpperCase(),
-        trait_code: task.trait.toUpperCase(),
+        trait_code: task.id.toUpperCase(),
         input_value: inputValue || undefined,
         metadata: {
           task_id: task.id,


### PR DESCRIPTION
## Summary
- Fix Quick Start payload generation so `trait_code` always uses the canonical task id stored in the database (`POSTURA`, `SUENO`, `GRATITUD`, etc.).
- Preserve localized English task copy while preventing English trait codes like `POSTURE` or `GRATITUDE` from reaching backend validation.
- Add a payload regression test for English browser language producing canonical trait codes.

## Root Cause
Quick Start selected tasks use canonical ids, but `buildQuickStartManualCandidates` serialized `task.trait`. In English UI/browser language, `task.trait` is English (`POSTURE`, `SLEEP`, etc.), while Neon `cat_trait.code` is canonical Spanish. Backend validation then failed with errors like `Invalid trait_code: POSTURE`, leaving users with no tasks.

## Validation
- `git diff --check` passed.
- Attempted `pnpm --filter @innerbloom/web test -- src/onboarding/__tests__/payload.test.ts --run`, but the clean worktree has no `node_modules`/`vitest` installed, so the command could not run there.