### PR TITLE
[codex] Add GA4 attribution and indexing cleanup

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -6,10 +6,6 @@ Disallow: /login2
 Disallow: /sign-up
 Disallow: /sign-up2
 Disallow: /signup
-Disallow: /onboarding
-Disallow: /onboarding2
-Disallow: /intro-journey
-Disallow: /intro-journey2
 Disallow: /dashboard
 Disallow: /dashboard-v3
 Disallow: /innerbloom2/

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -2,10 +2,17 @@ User-agent: *
 Allow: /
 
 Disallow: /login
+Disallow: /login2
 Disallow: /sign-up
+Disallow: /sign-up2
 Disallow: /signup
+Disallow: /onboarding
+Disallow: /onboarding2
+Disallow: /intro-journey
+Disallow: /intro-journey2
 Disallow: /dashboard
 Disallow: /dashboard-v3
+Disallow: /innerbloom2/
 Disallow: /admin
 Disallow: /api/
 Disallow: /_debug/

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -22,6 +22,10 @@
   </url>
   <url>
     <loc>https://innerbloomjourney.org/support</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://innerbloomjourney.org/account-deletion</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
-import { useEffect, useState, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
 import { useAuth } from './auth/runtimeAuth';
 import DashboardV3Page from './pages/DashboardV3';
 import TaskEditorPage from './pages/editor';
@@ -305,7 +305,11 @@ export default function App() {
   );
   const innerbloom2BasePath = '/innerbloom2';
   const innerbloom2DashboardPath = `${innerbloom2BasePath}/dashboard`;
-  useGa4FunnelTracking({ dashboardBasePath: trimmedDashboardPath });
+  const analyticsDashboardBasePaths = useMemo(
+    () => [trimmedDashboardPath, innerbloom2DashboardPath],
+    [innerbloom2DashboardPath, trimmedDashboardPath],
+  );
+  useGa4FunnelTracking({ dashboardBasePaths: analyticsDashboardBasePaths });
 
   return (
     <div className="min-h-screen bg-transparent">

--- a/apps/web/src/components/landing/useLandingAnalytics.ts
+++ b/apps/web/src/components/landing/useLandingAnalytics.ts
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { type AnalyticsConsentStatus } from '../../lib/cookieConsent';
 import { ensureGa4Initialized, sendGaEvent } from '../../lib/ga4';
+import {
+  buildMarketingAttribution,
+  getMarketingEventParams,
+  persistMarketingAttribution,
+} from '../../lib/marketingAttribution';
 
 const LANDING_GA4_MEASUREMENT_ID = (
   import.meta.env.VITE_GA4_MEASUREMENT_ID
@@ -12,27 +17,40 @@ const LANDING_GA4_MEASUREMENT_ID_SOURCE = import.meta.env.VITE_GA4_MEASUREMENT_I
   : import.meta.env.VITE_GA_MEASUREMENT_ID
     ? 'VITE_GA_MEASUREMENT_ID'
     : 'unset';
+const LANDING_GA4_DEBUG = import.meta.env.DEV
+  || String(import.meta.env.VITE_GA4_DEBUG ?? '').toLowerCase() === 'true';
 let missingMeasurementIdWarningShown = false;
+
+export function debugLandingGa4(message: string, payload?: Record<string, unknown>): void {
+  if (!LANDING_GA4_DEBUG) {
+    return;
+  }
+
+  console.info(message, payload);
+}
 
 export function useLandingAnalytics({
   consent,
   pathname,
+  search,
 }: {
   consent: AnalyticsConsentStatus;
   pathname: string;
+  search: string;
 }) {
   const [isReady, setIsReady] = useState(false);
+  const trackedPageViews = useRef<Set<string>>(new Set());
   const trackedScrollMilestones = useRef<Set<number>>(new Set());
 
   useEffect(() => {
-    console.info('[landing][ga4-debug] analytics init effect', {
+    debugLandingGa4('[landing][ga4-debug] analytics init effect', {
       consent,
       measurementIdSource: LANDING_GA4_MEASUREMENT_ID_SOURCE,
       measurementId: LANDING_GA4_MEASUREMENT_ID,
     });
 
     if (consent !== 'accepted') {
-      console.info('[landing][ga4-debug] analytics init effect blocked: consent is not accepted', { consent });
+      debugLandingGa4('[landing][ga4-debug] analytics init effect blocked: consent is not accepted', { consent });
       setIsReady(false);
       trackedScrollMilestones.current.clear();
       return;
@@ -43,20 +61,29 @@ export function useLandingAnalytics({
         missingMeasurementIdWarningShown = true;
         console.warn('[landing] VITE_GA4_MEASUREMENT_ID is not configured. GA4 will stay disabled.');
       }
-      console.info('[landing][ga4-debug] analytics init effect blocked: empty measurement id');
+      debugLandingGa4('[landing][ga4-debug] analytics init effect blocked: empty measurement id');
       setIsReady(false);
       return;
     }
 
     let cancelled = false;
 
-    console.info('[landing][ga4-debug] calling ensureGa4Initialized', {
+    debugLandingGa4('[landing][ga4-debug] calling ensureGa4Initialized', {
       measurementId: LANDING_GA4_MEASUREMENT_ID,
     });
     void ensureGa4Initialized(LANDING_GA4_MEASUREMENT_ID)
       .then(() => {
         if (!cancelled) {
-          console.info('[landing][ga4-debug] ensureGa4Initialized resolved, setting isReady=true');
+          const attribution = buildMarketingAttribution({
+            pathname,
+            search,
+            referrer: document.referrer,
+            origin: window.location.origin,
+          });
+          if (attribution) {
+            persistMarketingAttribution(attribution);
+          }
+          debugLandingGa4('[landing][ga4-debug] ensureGa4Initialized resolved, setting isReady=true');
           setIsReady(true);
         }
       })
@@ -67,7 +94,30 @@ export function useLandingAnalytics({
     return () => {
       cancelled = true;
     };
-  }, [consent]);
+  }, [consent, pathname, search]);
+
+  useEffect(() => {
+    if (!isReady || consent !== 'accepted') {
+      return;
+    }
+
+    const pageKey = `${pathname}${search}`;
+    if (trackedPageViews.current.has(pageKey)) {
+      return;
+    }
+
+    trackedPageViews.current.add(pageKey);
+    sendGaEvent('page_view', {
+      page_path: pathname,
+      page_location: `${window.location.origin}${pathname}${search}`,
+      ...getMarketingEventParams({
+        pathname,
+        search,
+        allowStoredAttribution: true,
+      }),
+    });
+  }, [consent, isReady, pathname, search]);
+
   useEffect(() => {
     if (!isReady || consent !== 'accepted') {
       return;
@@ -91,6 +141,11 @@ export function useLandingAnalytics({
           sendGaEvent('scroll', {
             percent_scrolled: milestone,
             page_path: pathname,
+            ...getMarketingEventParams({
+              pathname,
+              search,
+              allowStoredAttribution: true,
+            }),
           });
         }
       });
@@ -102,7 +157,7 @@ export function useLandingAnalytics({
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [consent, isReady, pathname]);
+  }, [consent, isReady, pathname, search]);
 
   useEffect(() => {
     if (!isReady || consent !== 'accepted') {
@@ -131,6 +186,11 @@ export function useLandingAnalytics({
         ...(destination ? { destination } : {}),
         outbound: isOutbound,
         page_path: pathname,
+        ...getMarketingEventParams({
+          pathname,
+          search,
+          allowStoredAttribution: true,
+        }),
       });
     };
 
@@ -139,5 +199,37 @@ export function useLandingAnalytics({
     return () => {
       document.removeEventListener('click', clickHandler);
     };
-  }, [consent, isReady, pathname]);
+  }, [consent, isReady, pathname, search]);
+
+  useEffect(() => {
+    if (!isReady || consent !== 'accepted') {
+      return;
+    }
+
+    const handler = (event: Event) => {
+      const element = event.target as HTMLElement | null;
+      const analyticsEvent = element?.closest<HTMLElement>('[data-analytics-event]')?.dataset.analyticsEvent;
+      if (!analyticsEvent) {
+        return;
+      }
+
+      sendGaEvent(analyticsEvent, {
+        page_path: pathname,
+        ...(element?.dataset.analyticsValue ? { event_value: element.dataset.analyticsValue } : {}),
+        ...getMarketingEventParams({
+          pathname,
+          search,
+          allowStoredAttribution: true,
+        }),
+      });
+    };
+
+    document.addEventListener('click', handler);
+    document.addEventListener('change', handler);
+
+    return () => {
+      document.removeEventListener('click', handler);
+      document.removeEventListener('change', handler);
+    };
+  }, [consent, isReady, pathname, search]);
 }

--- a/apps/web/src/hooks/useGa4FunnelTracking.ts
+++ b/apps/web/src/hooks/useGa4FunnelTracking.ts
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 import { useAuth } from '../auth/runtimeAuth';
 import { readCookieConsentState } from '../lib/cookieConsent';
 import { ensureGa4Initialized, sendGaEvent } from '../lib/ga4';
+import { getMarketingEventParams } from '../lib/marketingAttribution';
 
 const GA4_MEASUREMENT_ID = (
   import.meta.env.VITE_GA4_MEASUREMENT_ID
@@ -15,11 +16,17 @@ const AUTH_SURFACE_UNKNOWN = 'unknown';
 type AuthenticatedView = 'dashboard_home' | 'missions' | 'dquest' | 'rewards' | 'editor';
 
 function isAuthLoginPath(pathname: string): boolean {
-  return pathname === '/login' || pathname.startsWith('/login/');
+  return pathname === '/login'
+    || pathname.startsWith('/login/')
+    || pathname === '/login2'
+    || pathname.startsWith('/login2/');
 }
 
 function isAuthSignUpPath(pathname: string): boolean {
-  return pathname === '/sign-up' || pathname.startsWith('/sign-up/');
+  return pathname === '/sign-up'
+    || pathname.startsWith('/sign-up/')
+    || pathname === '/sign-up2'
+    || pathname.startsWith('/sign-up2/');
 }
 
 function getAuthSurfaceFromPath(pathname: string): 'login' | 'sign_up' | null {
@@ -56,46 +63,48 @@ function writeLastAuthSurface(surface: 'login' | 'sign_up'): void {
   window.sessionStorage.setItem(AUTH_SURFACE_STORAGE_KEY, surface);
 }
 
-function resolveAuthenticatedView(pathname: string, dashboardBasePath: string): AuthenticatedView | null {
+function resolveAuthenticatedView(pathname: string, dashboardBasePaths: readonly string[]): AuthenticatedView | null {
   if (pathname === '/editor' || pathname.startsWith('/editor/')) {
     return 'editor';
   }
 
-  if (pathname === dashboardBasePath) {
-    return 'dashboard_home';
-  }
+  for (const dashboardBasePath of dashboardBasePaths) {
+    if (pathname === dashboardBasePath) {
+      return 'dashboard_home';
+    }
 
-  if (!pathname.startsWith(`${dashboardBasePath}/`)) {
-    return null;
-  }
+    if (!pathname.startsWith(`${dashboardBasePath}/`)) {
+      continue;
+    }
 
-  const suffix = pathname.slice(dashboardBasePath.length + 1);
+    const suffix = pathname.slice(dashboardBasePath.length + 1);
 
-  if (suffix === 'rewards' || suffix.startsWith('rewards/')) {
-    return 'rewards';
-  }
+    if (suffix === 'rewards' || suffix.startsWith('rewards/')) {
+      return 'rewards';
+    }
 
-  if (
-    suffix === 'misiones'
-    || suffix.startsWith('misiones/')
-    || suffix === 'missions'
-    || suffix.startsWith('missions/')
-    || suffix === 'missions-v2'
-    || suffix.startsWith('missions-v2/')
-    || suffix === 'missions-v3'
-    || suffix.startsWith('missions-v3/')
-  ) {
-    return 'missions';
-  }
+    if (
+      suffix === 'misiones'
+      || suffix.startsWith('misiones/')
+      || suffix === 'missions'
+      || suffix.startsWith('missions/')
+      || suffix === 'missions-v2'
+      || suffix.startsWith('missions-v2/')
+      || suffix === 'missions-v3'
+      || suffix.startsWith('missions-v3/')
+    ) {
+      return 'missions';
+    }
 
-  if (suffix === 'dquest' || suffix.startsWith('dquest/')) {
-    return 'dquest';
+    if (suffix === 'dquest' || suffix.startsWith('dquest/')) {
+      return 'dquest';
+    }
   }
 
   return null;
 }
 
-export function useGa4FunnelTracking({ dashboardBasePath }: { dashboardBasePath: string }) {
+export function useGa4FunnelTracking({ dashboardBasePaths }: { dashboardBasePaths: readonly string[] }) {
   const location = useLocation();
   const { isLoaded, userId } = useAuth();
   const [isReady, setIsReady] = useState(false);
@@ -146,6 +155,11 @@ export function useGa4FunnelTracking({ dashboardBasePath }: { dashboardBasePath:
       sendGaEvent('page_view', {
         page_path: location.pathname,
         page_type: pageType,
+        ...getMarketingEventParams({
+          pathname: location.pathname,
+          search: location.search,
+          allowStoredAttribution: true,
+        }),
       });
     }
 
@@ -155,11 +169,16 @@ export function useGa4FunnelTracking({ dashboardBasePath }: { dashboardBasePath:
         auth_surface: authSurface,
         auth_method: 'unknown',
         page_path: location.pathname,
+        ...getMarketingEventParams({
+          pathname: location.pathname,
+          search: location.search,
+          allowStoredAttribution: true,
+        }),
       });
     }
 
     writeLastAuthSurface(authSurface);
-  }, [isReady, location.pathname]);
+  }, [isReady, location.pathname, location.search]);
 
   useEffect(() => {
     if (!isReady || !isLoaded) {
@@ -179,17 +198,24 @@ export function useGa4FunnelTracking({ dashboardBasePath }: { dashboardBasePath:
         auth_surface: readLastAuthSurface(),
         auth_method: 'unknown',
         redirect_target: location.pathname,
+        ...getMarketingEventParams({
+          pathname: location.pathname,
+          search: location.search,
+          allowStoredAttribution: true,
+        }),
       });
     }
-  }, [isLoaded, isReady, location.pathname, userId]);
+  }, [isLoaded, isReady, location.pathname, location.search, userId]);
 
   useEffect(() => {
     if (!isReady || trackedDashboardViewRef.current) {
       return;
     }
 
-    const isDashboardPath = location.pathname === dashboardBasePath
-      || location.pathname.startsWith(`${dashboardBasePath}/`);
+    const isDashboardPath = dashboardBasePaths.some((dashboardBasePath) => (
+      location.pathname === dashboardBasePath
+      || location.pathname.startsWith(`${dashboardBasePath}/`)
+    ));
 
     if (!isDashboardPath) {
       return;
@@ -200,15 +226,20 @@ export function useGa4FunnelTracking({ dashboardBasePath }: { dashboardBasePath:
       page_path: location.pathname,
       page_type: 'dashboard',
       is_first_dashboard_view: true,
+      ...getMarketingEventParams({
+        pathname: location.pathname,
+        search: location.search,
+        allowStoredAttribution: true,
+      }),
     });
-  }, [dashboardBasePath, isReady, location.pathname]);
+  }, [dashboardBasePaths, isReady, location.pathname, location.search]);
 
   useEffect(() => {
     if (!isReady || !isLoaded || !userId) {
       return;
     }
 
-    const currentView = resolveAuthenticatedView(location.pathname, dashboardBasePath);
+    const currentView = resolveAuthenticatedView(location.pathname, dashboardBasePaths);
     if (!currentView) {
       return;
     }
@@ -221,6 +252,11 @@ export function useGa4FunnelTracking({ dashboardBasePath }: { dashboardBasePath:
       previous_section: previousView ?? 'none',
       page_path: location.pathname,
       is_authenticated: true,
+      ...getMarketingEventParams({
+        pathname: location.pathname,
+        search: location.search,
+        allowStoredAttribution: true,
+      }),
     });
-  }, [dashboardBasePath, isLoaded, isReady, location.pathname, userId]);
+  }, [dashboardBasePaths, isLoaded, isReady, location.pathname, location.search, userId]);
 }

--- a/apps/web/src/lib/__tests__/ga4.test.ts
+++ b/apps/web/src/lib/__tests__/ga4.test.ts
@@ -25,6 +25,9 @@ describe('ga4 bootstrap', () => {
     expect(window.dataLayer).toContainEqual(expect.objectContaining({
       0: 'config',
       1: 'G-TEST1234',
+      2: expect.objectContaining({
+        send_page_view: false,
+      }),
     }));
     expect(window.dataLayer).toContainEqual(expect.objectContaining({
       0: 'event',

--- a/apps/web/src/lib/__tests__/marketingAttribution.test.ts
+++ b/apps/web/src/lib/__tests__/marketingAttribution.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMarketingAttribution,
+  getMarketingEventParams,
+  resolveLandingVariant,
+} from '../marketingAttribution';
+
+describe('marketing attribution', () => {
+  it('resolves public landing variants', () => {
+    expect(resolveLandingVariant('/')).toBe('root_v3');
+    expect(resolveLandingVariant('/v2')).toBe('v2');
+    expect(resolveLandingVariant('/v3')).toBe('v3_legacy');
+    expect(resolveLandingVariant('/pricing')).toBe('unknown');
+  });
+
+  it('builds attribution from UTM and Innerbloom campaign params', () => {
+    const attribution = buildMarketingAttribution({
+      pathname: '/v2',
+      search: '?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_001&ib_post=001',
+      referrer: 'https://instagram.com/p/example',
+      origin: 'https://innerbloomjourney.org',
+      now: new Date('2026-06-27T10:00:00.000Z'),
+    });
+
+    expect(attribution).toMatchObject({
+      captured_at: '2026-06-27T10:00:00.000Z',
+      entry_path: '/v2?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_001&ib_post=001',
+      landing_variant: 'v2',
+      referrer_domain: 'instagram.com',
+      utm_source: 'instagram',
+      utm_medium: 'social',
+      utm_campaign: 'ib20_mvp',
+      utm_content: 'post_001',
+      ib_post: '001',
+    });
+  });
+
+  it('ignores internal referrers without explicit campaign params', () => {
+    const attribution = buildMarketingAttribution({
+      pathname: '/',
+      search: '',
+      referrer: 'https://innerbloomjourney.org/v2',
+      origin: 'https://innerbloomjourney.org',
+      now: new Date('2026-06-27T10:00:00.000Z'),
+    });
+
+    expect(attribution).toBeNull();
+  });
+
+  it('always includes current landing variant in event params', () => {
+    expect(getMarketingEventParams({
+      pathname: '/v3',
+      search: '',
+      allowStoredAttribution: false,
+    })).toEqual({ landing_variant: 'v3_legacy' });
+  });
+});

--- a/apps/web/src/lib/ga4.ts
+++ b/apps/web/src/lib/ga4.ts
@@ -110,6 +110,7 @@ export async function ensureGa4Initialized(measurementId: string): Promise<void>
 
   gtag('config', normalizedMeasurementId, {
     anonymize_ip: true,
+    send_page_view: false,
   });
 
   gaConfiguredForId = normalizedMeasurementId;

--- a/apps/web/src/lib/marketingAttribution.ts
+++ b/apps/web/src/lib/marketingAttribution.ts
@@ -1,0 +1,194 @@
+export type LandingVariantId = 'root_v3' | 'v2' | 'v3_legacy' | 'unknown';
+
+export type MarketingAttribution = {
+  captured_at: string;
+  entry_path: string;
+  landing_variant: LandingVariantId;
+  referrer: string;
+  referrer_domain: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
+  ib_campaign?: string;
+  ib_post?: string;
+};
+
+const STORAGE_KEY = 'ib:marketing-attribution:v1';
+const UTM_PARAM_KEYS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+  'ib_campaign',
+  'ib_post',
+] as const;
+
+type AttributionParamKey = typeof UTM_PARAM_KEYS[number];
+
+function normalizeParamValue(value: string | null): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized.slice(0, 160) : undefined;
+}
+
+function getReferrerDomain(referrer: string): string {
+  if (!referrer) {
+    return '';
+  }
+
+  try {
+    return new URL(referrer).hostname;
+  } catch {
+    return '';
+  }
+}
+
+function getExternalReferrer(referrer: string, origin: string): string {
+  if (!referrer) {
+    return '';
+  }
+
+  try {
+    const url = new URL(referrer);
+    return url.origin === origin ? '' : referrer.slice(0, 500);
+  } catch {
+    return referrer.slice(0, 500);
+  }
+}
+
+export function resolveLandingVariant(pathname: string): LandingVariantId {
+  const normalizedPathname = pathname.replace(/\/+$/, '') || '/';
+
+  if (normalizedPathname === '/') {
+    return 'root_v3';
+  }
+
+  if (normalizedPathname === '/v2') {
+    return 'v2';
+  }
+
+  if (normalizedPathname === '/v3') {
+    return 'v3_legacy';
+  }
+
+  return 'unknown';
+}
+
+export function buildMarketingAttribution({
+  pathname,
+  search,
+  referrer = '',
+  origin = '',
+  now = new Date(),
+}: {
+  pathname: string;
+  search: string;
+  referrer?: string;
+  origin?: string;
+  now?: Date;
+}): MarketingAttribution | null {
+  const params = new URLSearchParams(search);
+  const attributionParams = UTM_PARAM_KEYS.reduce<Partial<Record<AttributionParamKey, string>>>((acc, key) => {
+    const value = normalizeParamValue(params.get(key));
+    if (value) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+  const externalReferrer = getExternalReferrer(referrer, origin);
+  const hasAttribution = Object.keys(attributionParams).length > 0 || Boolean(externalReferrer);
+
+  if (!hasAttribution) {
+    return null;
+  }
+
+  return {
+    captured_at: now.toISOString(),
+    entry_path: `${pathname}${search}`,
+    landing_variant: resolveLandingVariant(pathname),
+    referrer: externalReferrer,
+    referrer_domain: getReferrerDomain(externalReferrer),
+    ...attributionParams,
+  };
+}
+export function readMarketingAttribution(): MarketingAttribution | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<MarketingAttribution>;
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.captured_at !== 'string') {
+      return null;
+    }
+
+    return {
+      captured_at: parsed.captured_at,
+      entry_path: typeof parsed.entry_path === 'string' ? parsed.entry_path : '',
+      landing_variant: parsed.landing_variant ?? 'unknown',
+      referrer: typeof parsed.referrer === 'string' ? parsed.referrer : '',
+      referrer_domain: typeof parsed.referrer_domain === 'string' ? parsed.referrer_domain : '',
+      ...(typeof parsed.utm_source === 'string' ? { utm_source: parsed.utm_source } : {}),
+      ...(typeof parsed.utm_medium === 'string' ? { utm_medium: parsed.utm_medium } : {}),
+      ...(typeof parsed.utm_campaign === 'string' ? { utm_campaign: parsed.utm_campaign } : {}),
+      ...(typeof parsed.utm_content === 'string' ? { utm_content: parsed.utm_content } : {}),
+      ...(typeof parsed.utm_term === 'string' ? { utm_term: parsed.utm_term } : {}),
+      ...(typeof parsed.ib_campaign === 'string' ? { ib_campaign: parsed.ib_campaign } : {}),
+      ...(typeof parsed.ib_post === 'string' ? { ib_post: parsed.ib_post } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function persistMarketingAttribution(attribution: MarketingAttribution): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(attribution));
+  } catch {
+    // Attribution is helpful for analytics, but it must never block the app.
+  }
+}
+
+export function getMarketingEventParams({
+  pathname,
+  search,
+  allowStoredAttribution,
+}: {
+  pathname: string;
+  search: string;
+  allowStoredAttribution: boolean;
+}): Record<string, string> {
+  const liveAttribution = buildMarketingAttribution({
+    pathname,
+    search,
+    referrer: typeof document !== 'undefined' ? document.referrer : '',
+    origin: typeof window !== 'undefined' ? window.location.origin : '',
+  });
+  const attribution = liveAttribution ?? (allowStoredAttribution ? readMarketingAttribution() : null);
+  const variant = attribution?.landing_variant ?? resolveLandingVariant(pathname);
+
+  return {
+    landing_variant: variant,
+    ...(attribution?.entry_path ? { attribution_entry_path: attribution.entry_path } : {}),
+    ...(attribution?.referrer ? { referrer: attribution.referrer } : {}),
+    ...(attribution?.referrer_domain ? { referrer_domain: attribution.referrer_domain } : {}),
+    ...(attribution?.utm_source ? { utm_source: attribution.utm_source } : {}),
+    ...(attribution?.utm_medium ? { utm_medium: attribution.utm_medium } : {}),
+    ...(attribution?.utm_campaign ? { utm_campaign: attribution.utm_campaign } : {}),
+    ...(attribution?.utm_content ? { utm_content: attribution.utm_content } : {}),
+    ...(attribution?.utm_term ? { utm_term: attribution.utm_term } : {}),
+    ...(attribution?.ib_campaign ? { ib_campaign: attribution.ib_campaign } : {}),
+    ...(attribution?.ib_post ? { ib_post: attribution.ib_post } : {}),
+  };
+}

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -13,6 +13,7 @@ type MetaInput = {
   twitterImage?: string;
   twitterImageAlt?: string;
   url?: string;
+  robots?: string;
   type?: 'website' | 'article';
   siteName?: string;
 };
@@ -76,6 +77,7 @@ export const usePageMeta = ({
   ogImageWidth,
   ogImageHeight,
   url,
+  robots,
   type = 'website',
   siteName = 'Innerbloom'
 }: MetaInput) => {
@@ -117,6 +119,11 @@ export const usePageMeta = ({
     if (twitterImageAlt) {
       upsertMetaTag('twitter:image:alt', twitterImageAlt, 'name');
     }
+    if (robots) {
+      upsertMetaTag('robots', robots, 'name');
+    } else {
+      removeMetaTags('robots', 'name');
+    }
     upsertCanonical(resolvedUrl);
   }, [
     description,
@@ -130,6 +137,7 @@ export const usePageMeta = ({
     title,
     twitterImage,
     twitterImageAlt,
+    robots,
     type,
     url
   ]);

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -25,7 +25,7 @@ import { buildDemoModeSelectUrl } from "../lib/demoEntry";
 import PremiumTimeline from "../components/PremiumTimeline";
 import { AdaptiveText } from "../components/landing/AdaptiveText";
 import { CookieConsentBanner } from "../components/landing/CookieConsentBanner";
-import { useLandingAnalytics } from "../components/landing/useLandingAnalytics";
+import { debugLandingGa4, useLandingAnalytics } from "../components/landing/useLandingAnalytics";
 import { HeroPhoneShowcase } from "../components/landing/HeroPhoneShowcase";
 import { HeroProductScene } from "../components/landing/hero/HeroProductScene";
 import { AdaptiveJourneyGraphic } from "../components/landing/problem/AdaptiveJourneyGraphic";
@@ -449,6 +449,8 @@ function LanguageDropdown({
             role="option"
             aria-selected={value === option.code}
             className={value === option.code ? "active" : ""}
+            data-analytics-event="landing_language_changed"
+            data-analytics-value={option.code}
             onClick={() => handleSelect(option.code)}
           >
             {option.label}
@@ -1170,7 +1172,7 @@ export default function LandingPage({
   const activeMode = copy.modes.items[activeModeIndex] ?? copy.modes.items[0];
   const activeVisual = MODE_VISUALS[language][activeMode.id];
   useEffect(() => {
-    console.info(
+    debugLandingGa4(
       "[landing][ga4-debug] cookie consent read on load",
       initialCookieConsentStateRef.current,
     );
@@ -1185,6 +1187,7 @@ export default function LandingPage({
   useLandingAnalytics({
     consent: analyticsConsent,
     pathname: location.pathname,
+    search: location.search,
   });
 
   const handleLanguageChange = (nextLanguage: Language) => {
@@ -1372,7 +1375,7 @@ export default function LandingPage({
 
   const handleAnalyticsConsent = (nextDecision: "accepted" | "rejected") => {
     const nextState = persistCookieConsentState(nextDecision);
-    console.info("[landing][ga4-debug] cookie consent updated", {
+    debugLandingGa4("[landing][ga4-debug] cookie consent updated", {
       nextDecision,
       persistedState: nextState,
     });
@@ -1423,6 +1426,8 @@ export default function LandingPage({
             type="button"
             onClick={toggleThemeMode}
             className="landing-theme-toggle"
+            data-analytics-event="landing_theme_toggled"
+            data-analytics-value={themeMode === "dark" ? "light" : "dark"}
             aria-label={
               themeMode === "dark"
                 ? language === "es"

--- a/apps/web/src/pages/OnboardingIntro.tsx
+++ b/apps/web/src/pages/OnboardingIntro.tsx
@@ -86,7 +86,8 @@ export default function OnboardingIntroPage({
       language === 'en'
         ? 'Official preview of the Innerbloom onboarding'
         : 'Preview oficial del onboarding de Innerbloom',
-    url: ONBOARDING_CANONICAL_URL
+    url: ONBOARDING_CANONICAL_URL,
+    robots: 'noindex,nofollow',
   });
 
   const handleFinish = useCallback(

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_BUILD_TARGET?: string;
   readonly VITE_CLERK_TOKEN_TEMPLATE?: string;
   readonly VITE_GA4_MEASUREMENT_ID?: string;
+  readonly VITE_GA4_DEBUG?: string;
   readonly VITE_GA_MEASUREMENT_ID?: string;
   readonly VITE_WEB_BASE_URL?: string;
   readonly VITE_SITE_URL?: string;


### PR DESCRIPTION
## Summary

- Add campaign attribution capture for GA4 events, including UTM params, Innerbloom campaign/post ids, landing variant, referrer, and stored attribution handoff into auth/dashboard funnel events.
- Track `/`, `/v2`, `/v3`, `/login2`, `/sign-up2`, and `/innerbloom2/dashboard` with the same attribution context.
- Disable GA4 automatic page views so enriched manual `page_view` events do not double count.
- Fix the public sitemap entry for `support`/`account-deletion`.
- Keep private/auth/app routes blocked in `robots.txt` and mark onboarding routes as `noindex,nofollow` so Google can crawl them and remove old onboarding URLs from the index.
- Gate landing GA4 debug console logs behind dev mode or `VITE_GA4_DEBUG=true`.

## Why

Production already reads `VITE_GA4_MEASUREMENT_ID` correctly and sends data to GA4 after cookie consent, but campaign traffic would not be easy to connect across landing, signup, and Inner Bloom 2.0 dashboard behavior. Search Console also had a malformed sitemap entry and crawlable onboarding URLs that should not remain indexed.

## Validation

- `npm --workspace apps/web run test -- src/lib/__tests__/marketingAttribution.test.ts src/lib/__tests__/ga4.test.ts --run`
- `npm --workspace apps/web run typecheck -- --pretty false 2>&1 | rg "marketingAttribution|useLandingAnalytics|useGa4FunnelTracking|src/App.tsx|src/lib/ga4|vite-env|Landing.tsx|seo.ts|OnboardingIntro" || true`
- `xmllint --noout apps/web/public/sitemap.xml`
- `git diff --check`