### PR TITLE
Add Metricool tracking for public landings

### DIFF
--- a/apps/web/src/components/landing/useMetricoolTracking.test.tsx
+++ b/apps/web/src/components/landing/useMetricoolTracking.test.tsx
@@ -1,0 +1,94 @@
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type AnalyticsConsentStatus } from '../../lib/cookieConsent';
+import { isMetricoolLandingPath, resetMetricoolTrackingForTests, useMetricoolTracking } from './useMetricoolTracking';
+
+function MetricoolHarness({ consent, pathname }: { consent: AnalyticsConsentStatus; pathname: string }) {
+  useMetricoolTracking({ consent, pathname });
+  return null;
+}
+
+describe('useMetricoolTracking', () => {
+  beforeEach(() => {
+    resetMetricoolTrackingForTests();
+    document.head.innerHTML = '';
+    window.beTracker = { t: vi.fn() };
+  });
+
+  afterEach(() => {
+    resetMetricoolTrackingForTests();
+    document.head.innerHTML = '';
+    delete window.beTracker;
+    vi.restoreAllMocks();
+  });
+
+  it('only allows the three public landing paths', () => {
+    expect(isMetricoolLandingPath('/')).toBe(true);
+    expect(isMetricoolLandingPath('/v2')).toBe(true);
+    expect(isMetricoolLandingPath('/v3')).toBe(true);
+    expect(isMetricoolLandingPath('/v2/')).toBe(true);
+    expect(isMetricoolLandingPath('/login')).toBe(false);
+    expect(isMetricoolLandingPath('/sign-up')).toBe(false);
+    expect(isMetricoolLandingPath('/onboarding')).toBe(false);
+    expect(isMetricoolLandingPath('/dashboard')).toBe(false);
+    expect(isMetricoolLandingPath('/pricing')).toBe(false);
+  });
+
+  it.each(['/', '/v2', '/v3'])('loads and tracks on %s with analytics consent', async (pathname) => {
+    render(<MetricoolHarness consent="accepted" pathname={pathname} />);
+
+    const script = await findMetricoolScript();
+    script.dispatchEvent(new Event('load'));
+
+    await vi.waitFor(() => {
+      expect(window.beTracker?.t).toHaveBeenCalledWith({ hash: 'a88da44ed483bed8d8615d3f9ca928bc' });
+    });
+  });
+
+  it.each(['/login', '/sign-up', '/onboarding', '/dashboard', '/innerbloom2/dashboard', '/pricing'])('does not load or track on %s', async (pathname) => {
+    render(<MetricoolHarness consent="accepted" pathname={pathname} />);
+
+    expect(getMetricoolScripts()).toHaveLength(0);
+    expect(window.beTracker?.t).not.toHaveBeenCalled();
+  });
+
+  it('does not load without analytics consent', () => {
+    render(<MetricoolHarness consent="rejected" pathname="/" />);
+    render(<MetricoolHarness consent="unset" pathname="/v2" />);
+
+    expect(getMetricoolScripts()).toHaveLength(0);
+    expect(window.beTracker?.t).not.toHaveBeenCalled();
+  });
+
+  it('does not insert the script more than once or duplicate tracking for the same landing path', async () => {
+    const { rerender } = render(<MetricoolHarness consent="accepted" pathname="/" />);
+
+    const script = await findMetricoolScript();
+    script.dispatchEvent(new Event('load'));
+
+    await vi.waitFor(() => {
+      expect(window.beTracker?.t).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(<MetricoolHarness consent="accepted" pathname="/v2" />);
+    await vi.waitFor(() => {
+      expect(window.beTracker?.t).toHaveBeenCalledTimes(2);
+    });
+
+    rerender(<MetricoolHarness consent="accepted" pathname="/" />);
+
+    expect(getMetricoolScripts()).toHaveLength(1);
+    expect(window.beTracker?.t).toHaveBeenCalledTimes(2);
+  });
+});
+
+function getMetricoolScripts(): HTMLScriptElement[] {
+  return Array.from(document.querySelectorAll<HTMLScriptElement>('script[src="https://tracker.metricool.com/resources/be.js"]'));
+}
+
+async function findMetricoolScript(): Promise<HTMLScriptElement> {
+  await vi.waitFor(() => {
+    expect(getMetricoolScripts()).toHaveLength(1);
+  });
+  return getMetricoolScripts()[0];
+}

--- a/apps/web/src/components/landing/useMetricoolTracking.ts
+++ b/apps/web/src/components/landing/useMetricoolTracking.ts
@@ -1,0 +1,154 @@
+import { useEffect } from 'react';
+import { type AnalyticsConsentStatus } from '../../lib/cookieConsent';
+
+const METRICOOL_SCRIPT_ID = 'innerbloom-metricool-script';
+const METRICOOL_SCRIPT_SRC = 'https://tracker.metricool.com/resources/be.js';
+const METRICOOL_HASH = 'a88da44ed483bed8d8615d3f9ca928bc';
+const METRICOOL_ALLOWED_PATHS = new Set(['/', '/v2', '/v3']);
+const METRICOOL_TRACKER_TIMEOUT_MS = 5000;
+const METRICOOL_TRACKER_POLL_MS = 50;
+
+type MetricoolTracker = {
+  t: (params: { hash: string }) => void;
+};
+
+declare global {
+  interface Window {
+    beTracker?: MetricoolTracker;
+  }
+}
+
+let metricoolScriptLoadPromise: Promise<void> | null = null;
+const trackedMetricoolPageViews = new Set<string>();
+
+export function isMetricoolLandingPath(pathname: string): boolean {
+  const normalizedPathname = normalizePathname(pathname);
+  return METRICOOL_ALLOWED_PATHS.has(normalizedPathname);
+}
+
+export function useMetricoolTracking({
+  consent,
+  pathname,
+}: {
+  consent: AnalyticsConsentStatus;
+  pathname: string;
+}) {
+  useEffect(() => {
+    const normalizedPathname = normalizePathname(pathname);
+
+    if (consent !== 'accepted' || !METRICOOL_ALLOWED_PATHS.has(normalizedPathname)) {
+      return;
+    }
+
+    if (trackedMetricoolPageViews.has(normalizedPathname)) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void ensureMetricoolScriptLoaded()
+      .then(() => waitForMetricoolTracker())
+      .then((tracker) => {
+        if (cancelled || trackedMetricoolPageViews.has(normalizedPathname)) {
+          return;
+        }
+
+        tracker.t({ hash: METRICOOL_HASH });
+        trackedMetricoolPageViews.add(normalizedPathname);
+      })
+      .catch((error) => {
+        console.error('[landing] Metricool initialization failed.', error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [consent, pathname]);
+}
+
+function normalizePathname(pathname: string): string {
+  if (!pathname || pathname === '/') {
+    return '/';
+  }
+
+  return pathname.replace(/\/+$/, '');
+}
+
+function ensureMetricoolScriptLoaded(): Promise<void> {
+  if (typeof window === 'undefined') {
+    return Promise.resolve();
+  }
+
+  if (metricoolScriptLoadPromise) {
+    return metricoolScriptLoadPromise;
+  }
+
+  metricoolScriptLoadPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.getElementById(METRICOOL_SCRIPT_ID) as HTMLScriptElement | null;
+
+    if (existing) {
+      if (existing.dataset.loaded === 'true') {
+        resolve();
+        return;
+      }
+
+      existing.addEventListener('load', () => {
+        existing.dataset.loaded = 'true';
+        resolve();
+      }, { once: true });
+      existing.addEventListener('error', () => {
+        metricoolScriptLoadPromise = null;
+        reject(new Error('[metricool] be.js failed to load.'));
+      }, { once: true });
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.id = METRICOOL_SCRIPT_ID;
+    script.type = 'text/javascript';
+    script.async = true;
+    script.src = METRICOOL_SCRIPT_SRC;
+    script.addEventListener('load', () => {
+      script.dataset.loaded = 'true';
+      resolve();
+    }, { once: true });
+    script.addEventListener('error', () => {
+      metricoolScriptLoadPromise = null;
+      reject(new Error('[metricool] be.js failed to load.'));
+    }, { once: true });
+    document.head.appendChild(script);
+  });
+
+  return metricoolScriptLoadPromise;
+}
+
+function waitForMetricoolTracker(): Promise<MetricoolTracker> {
+  if (window.beTracker) {
+    return Promise.resolve(window.beTracker);
+  }
+
+  return new Promise<MetricoolTracker>((resolve, reject) => {
+    const startedAt = Date.now();
+
+    const poll = () => {
+      if (window.beTracker) {
+        resolve(window.beTracker);
+        return;
+      }
+
+      if (Date.now() - startedAt >= METRICOOL_TRACKER_TIMEOUT_MS) {
+        reject(new Error('[metricool] beTracker was not available after script load.'));
+        return;
+      }
+
+      window.setTimeout(poll, METRICOOL_TRACKER_POLL_MS);
+    };
+
+    poll();
+  });
+}
+
+export function resetMetricoolTrackingForTests(): void {
+  metricoolScriptLoadPromise = null;
+  trackedMetricoolPageViews.clear();
+}

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -26,6 +26,7 @@ import PremiumTimeline from "../components/PremiumTimeline";
 import { AdaptiveText } from "../components/landing/AdaptiveText";
 import { CookieConsentBanner } from "../components/landing/CookieConsentBanner";
 import { debugLandingGa4, useLandingAnalytics } from "../components/landing/useLandingAnalytics";
+import { useMetricoolTracking } from "../components/landing/useMetricoolTracking";
 import { HeroPhoneShowcase } from "../components/landing/HeroPhoneShowcase";
 import { HeroProductScene } from "../components/landing/hero/HeroProductScene";
 import { AdaptiveJourneyGraphic } from "../components/landing/problem/AdaptiveJourneyGraphic";
@@ -1188,6 +1189,11 @@ export default function LandingPage({
     consent: analyticsConsent,
     pathname: location.pathname,
     search: location.search,
+  });
+
+  useMetricoolTracking({
+    consent: analyticsConsent,
+    pathname: location.pathname,
   });
 
   const handleLanguageChange = (nextLanguage: Language) => {


### PR DESCRIPTION
### Motivation

- Integrate Metricool tracker only on the three public landing routes (`/`, `/v2`, `/v3`) while respecting the existing cookie analytics consent and avoiding global or duplicated script injection.
- Keep the integration isolated from existing GA4, UTM attribution, Search Console, SEO, canonical tags and the rest of the funnel.

### Description

- Add a reusable hook `useMetricoolTracking` implemented in `apps/web/src/components/landing/useMetricoolTracking.ts` that gates activation on `consent === 'accepted'` and an allowlist of normalized paths (`/`, `/v2`, `/v3`).
- The hook ensures the external script `https://tracker.metricool.com/resources/be.js` is inserted at most once using a stable `id` and a shared load promise, and prevents duplicate tracking using an in-module `Set` of tracked landing paths.
- The implementation types `window.beTracker` and the expected `t({ hash })` call with TypeScript (no `any`) and waits for `beTracker` availability via polling with timeout to avoid errors if the tracker initializes slowly.
- Wire the hook into the shared landing component at `apps/web/src/pages/Landing.tsx` (invoked alongside the existing `useLandingAnalytics`), and export `resetMetricoolTrackingForTests` for unit tests.

### Testing

- Ran the unit tests for the new hook with `npm -w @innerbloom/web run test -- --run useMetricoolTracking.test.tsx`, and the file `apps/web/src/components/landing/useMetricoolTracking.test.tsx` passed (12 tests passed).
- Performed a local build with `npm -w @innerbloom/web run build` which completed successfully (Vite emitted existing warnings but produced a build).
- Ran type checking with `npm -w @innerbloom/web run typecheck`; the run failed due to pre-existing, unrelated TypeScript errors elsewhere in the repo (Clerk/runtime types and other tests), and did not flag issues introduced by the Metricool hook.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4026bee1d8833289af005b6bd5f2c9)