### PR TITLE
Add admin marketing approval MVP

### DIFF
--- a/Docs/marketing/strategy-memory.md
+++ b/Docs/marketing/strategy-memory.md
@@ -1,0 +1,92 @@
+# Innerbloom Marketing Strategy Memory
+
+Last updated: 2026-06-27
+
+## Purpose
+
+This file is the first read for every monthly marketing generation run. The run should update this file before generating new posts, so future agents can see the latest positioning, experiments, results, and operating rules.
+
+## Current Objective
+
+Acquire early adopter users for Innerbloom 2.0 with lightweight, measurable social content. The system should minimize manual marketing operations while keeping final approval under human control.
+
+## Current Positioning
+
+Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.
+
+Core message:
+
+- adaptive habits
+- real-life rhythm
+- recalibration instead of restart
+- visible progress without perfection pressure
+- early product, feedback welcome
+
+## Current Funnel
+
+Primary destination:
+
+`https://innerbloomjourney.org/`
+
+Tracked app path:
+
+`/innerbloom2/dashboard`
+
+Minimum funnel to monitor:
+
+`page_view -> landing_cta_clicked -> auth_started -> auth_completed -> dashboard_view`
+
+Every post must include:
+
+- `utm_source`
+- `utm_medium`
+- `utm_campaign`
+- `utm_content`
+- `ib_post`
+
+## Current Operating Flow
+
+1. Read this strategy memory.
+2. Read the latest GA4/Search Console/Metricool data available.
+3. Summarize what changed since the last run.
+4. Update this strategy memory with the new learning.
+5. Generate campaign drafts.
+6. Save draft copy, assets, tracking URLs, and scheduling metadata.
+7. Show drafts in `/admin/marketing`.
+8. Wait for human approval or regeneration requests.
+9. Export a Metricool CSV only for approved posts.
+
+## Campaign Defaults
+
+- Default platform: Instagram
+- Default language: English
+- Default monthly post count: 20
+- Current MVP campaign code: `ib20_mvp`
+- Current tested format: square static + square carousel
+
+## What Worked So Far
+
+The first two-post MVP proved that:
+
+- Metricool CSV import works.
+- Metricool can ingest image URLs from GitHub raw URLs.
+- Instagram posts published successfully from the generated CSV.
+- The creative format is acceptable for the first acquisition experiment.
+
+## Known Gaps
+
+- Google Drive should replace GitHub raw URLs for marketing asset storage if Metricool accepts Drive-hosted links reliably.
+- GA4 and Search Console data are not connected to the admin yet.
+- Metricool performance data is manual export for now.
+- The admin marketing approval board is still MVP/static until backend persistence is added.
+- Image generation is template-based; new visual assets should be generated only when needed.
+
+## Next Run Instructions
+
+For the next monthly run:
+
+1. Keep the number of configurable knobs small.
+2. Prefer strong hooks and measurable hypotheses over generic motivational posts.
+3. Reuse visual patterns that remain readable on mobile.
+4. Generate only new visuals when the existing asset library cannot support the post.
+5. Preserve every decision and result in this strategy memory.

--- a/apps/web/src/components/admin2/Admin2Shell.tsx
+++ b/apps/web/src/components/admin2/Admin2Shell.tsx
@@ -5,6 +5,7 @@ import { UserOpsPage } from '../../pages/admin2/UserOpsPage';
 import { NotificationsPage } from '../../pages/admin2/NotificationsPage';
 import { AiTaskgenPage } from '../../pages/admin2/AiTaskgenPage';
 import { AdvancedPage } from '../../pages/admin2/AdvancedPage';
+import { MarketingPage } from '../../pages/admin2/MarketingPage';
 import { TaskgenUserPage } from '../../pages/admin/TaskgenUserPage';
 import { useAdmin2Theme } from './Admin2ThemeProvider';
 
@@ -13,6 +14,7 @@ const NAV_ITEMS = [
   { to: '/admin/core-engine', label: 'Core Engine' },
   { to: '/admin/user-ops', label: 'User Ops' },
   { to: '/admin/notifications', label: 'Notifications' },
+  { to: '/admin/marketing', label: 'Marketing' },
   { to: '/admin/ai-taskgen', label: 'AI TaskGen' },
   { to: '/admin/advanced', label: 'Advanced' },
 ];
@@ -108,6 +110,7 @@ export function Admin2Shell() {
             <Route path="core-engine" element={<CoreEnginePage />} />
             <Route path="user-ops" element={<UserOpsPage />} />
             <Route path="notifications" element={<NotificationsPage />} />
+            <Route path="marketing" element={<MarketingPage />} />
             <Route path="ai-taskgen" element={<AiTaskgenPage />} />
             <Route path="advanced" element={<AdvancedPage />} />
             <Route

--- a/apps/web/src/content/marketingAdminSeed.ts
+++ b/apps/web/src/content/marketingAdminSeed.ts
@@ -1,0 +1,148 @@
+export type MarketingAsset = {
+  file: string;
+  title: string;
+  url: string;
+};
+
+export type MarketingPostStatus = 'draft' | 'needs_review' | 'approved';
+
+export type MarketingPostSeed = {
+  id: string;
+  number: string;
+  platform: 'instagram';
+  format: 'carousel' | 'static';
+  status: MarketingPostStatus;
+  scheduledDate: string;
+  scheduledTime: string;
+  hypothesis: string;
+  metric: string;
+  caption: string;
+  trackingUrl: string;
+  assets: MarketingAsset[];
+};
+
+export type MarketingCampaignSeed = {
+  title: string;
+  campaignCode: string;
+  primaryUrl: string;
+  postCount: number;
+  language: 'English' | 'Spanish';
+  driveRootUrl: string;
+  strategyMemoryUrl: string;
+  assetsFolderUrl: string;
+  campaignsFolderUrl: string;
+  posts: MarketingPostSeed[];
+};
+
+const assetBaseUrl =
+  'https://raw.githubusercontent.com/rfullivarri/innerbloomv3/main/Docs/marketing/campaigns/2026-06-mvp/assets';
+
+export const marketingCampaignSeed: MarketingCampaignSeed = {
+  title: 'Innerbloom 2.0 Marketing MVP - English Test',
+  campaignCode: 'ib20_mvp',
+  primaryUrl: 'https://innerbloomjourney.org/',
+  postCount: 20,
+  language: 'English',
+  driveRootUrl: 'https://drive.google.com/drive/folders/1OMs5zzPQcx9Db9RjpA7J-xL5h1b5V9cZ',
+  strategyMemoryUrl: 'https://drive.google.com/file/d/1FGQPOJ1Gp0A7--yNbPDMKhgdOP89Gres/view?usp=drivesdk',
+  assetsFolderUrl: 'https://drive.google.com/drive/folders/1FplCAOvdgLA9p73fA7-piQH16d0nSuEg',
+  campaignsFolderUrl: 'https://drive.google.com/drive/folders/1S3J3aFgtd1np7mjBKGBpN1w5xuyuGyuH',
+  posts: [
+    {
+      id: 'post_001',
+      number: '001',
+      platform: 'instagram',
+      format: 'carousel',
+      status: 'needs_review',
+      scheduledDate: '2026-06-30',
+      scheduledTime: '19:30:00',
+      hypothesis:
+        'People who have failed with streak-based apps will respond to adaptive rhythm and real weeks.',
+      metric: 'page_view -> landing_cta_clicked -> auth_started -> auth_completed -> dashboard_view',
+      trackingUrl:
+        'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_001&ib_post=001',
+      caption: [
+        'Your habits should adapt to your real life.',
+        '',
+        'Most habit apps assume every day is the same.',
+        '',
+        'Then a busy week hits, your streak breaks, and the whole plan starts feeling useless.',
+        '',
+        'Innerbloom is built around adaptive rhythm:',
+        '',
+        '- lower the intensity when life gets heavy',
+        '- keep visible progress',
+        '- recalibrate instead of starting over',
+        '- build a Journey that can survive real weeks',
+        '',
+        'Early version is live.',
+        '',
+        'Try it here:',
+        'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_001&ib_post=001',
+        '',
+        '#habits #habitbuilding #selfimprovement #productivity #personalgrowth #wellbeing #buildinpublic',
+      ].join('\n'),
+      assets: [
+        {
+          file: 'post-001-carousel-01.png',
+          title: 'Your habits should adapt to your real life.',
+          url: `${assetBaseUrl}/post-001-carousel-01.png`,
+        },
+        {
+          file: 'post-001-carousel-02.png',
+          title: 'Most habit apps assume every day is the same.',
+          url: `${assetBaseUrl}/post-001-carousel-02.png`,
+        },
+        {
+          file: 'post-001-carousel-03.png',
+          title: 'Lower the intensity. Keep the direction.',
+          url: `${assetBaseUrl}/post-001-carousel-03.png`,
+        },
+        {
+          file: 'post-001-carousel-04.png',
+          title: 'Build a Journey that can survive real weeks.',
+          url: `${assetBaseUrl}/post-001-carousel-04.png`,
+        },
+      ],
+    },
+    {
+      id: 'post_002',
+      number: '002',
+      platform: 'instagram',
+      format: 'static',
+      status: 'needs_review',
+      scheduledDate: '2026-07-03',
+      scheduledTime: '19:30:00',
+      hypothesis:
+        'A direct anti-perfect-days message will perform better for people tired of rigid productivity systems.',
+      metric: 'page_view, scroll depth, landing_cta_clicked, and dashboard_view',
+      trackingUrl:
+        'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_002&ib_post=002',
+      caption: [
+        'If your plan only works on perfect days, it is not a plan.',
+        '',
+        'Most people do not fail habits because they are lazy.',
+        '',
+        'They fail because the system expects the same output from them every day, even when their energy, stress, sleep, and schedule change.',
+        '',
+        'Innerbloom is an adaptive habit app.',
+        '',
+        'It helps you keep direction without forcing the same rhythm all the time.',
+        '',
+        'Start small. Recalibrate. Keep moving.',
+        '',
+        'Try it here:',
+        'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_002&ib_post=002',
+        '',
+        '#habits #selfimprovement #wellbeing #productivity #mentalclarity #habittracker #buildinpublic',
+      ].join('\n'),
+      assets: [
+        {
+          file: 'post-002-static-pain-proposal.png',
+          title: 'If your plan only works on perfect days, it is not a plan.',
+          url: `${assetBaseUrl}/post-002-static-pain-proposal.png`,
+        },
+      ],
+    },
+  ],
+};

--- a/apps/web/src/lib/__tests__/marketingMetricoolCsv.test.ts
+++ b/apps/web/src/lib/__tests__/marketingMetricoolCsv.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { marketingCampaignSeed } from '../../content/marketingAdminSeed';
+import { buildMetricoolCalendarCsv } from '../marketingMetricoolCsv';
+
+describe('buildMetricoolCalendarCsv', () => {
+  it('exports only the approved posts passed to it in Metricool import format', () => {
+    const post = {
+      ...marketingCampaignSeed.posts[0],
+      status: 'approved' as const,
+    };
+    const csv = buildMetricoolCalendarCsv([post]);
+
+    expect(csv).toContain('Text,Date,Time,Draft');
+    expect(csv).toContain('Instagram');
+    expect(csv).toContain(post.scheduledDate);
+    expect(csv).toContain(post.scheduledTime);
+    expect(csv).toContain(post.assets[0].url);
+    expect(csv).toContain('TRUE');
+    expect(csv).not.toContain(marketingCampaignSeed.posts[1].trackingUrl);
+  });
+});

--- a/apps/web/src/lib/marketingMetricoolCsv.ts
+++ b/apps/web/src/lib/marketingMetricoolCsv.ts
@@ -1,0 +1,76 @@
+import type { MarketingPostSeed } from '../content/marketingAdminSeed';
+
+const PICTURE_LIMIT = 10;
+
+function csvEscape(value: string | number | boolean | null | undefined) {
+  const text = String(value ?? '');
+  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+export function buildMetricoolCalendarCsv(posts: MarketingPostSeed[]) {
+  const pictureColumns = Array.from({ length: PICTURE_LIMIT }, (_, index) => `Picture Url ${index + 1}`);
+  const altTextColumns = Array.from({ length: PICTURE_LIMIT }, (_, index) => `Alt text picture ${index + 1}`);
+  const columns = [
+    'Text',
+    'Date',
+    'Time',
+    'Draft',
+    'Facebook',
+    'Twitter/X',
+    'LinkedIn',
+    'GBP',
+    'Instagram',
+    'Pinterest',
+    'TikTok',
+    'YouTube',
+    'Threads',
+    'Bluesky',
+    ...pictureColumns,
+    ...altTextColumns,
+    'Shortener',
+    'Instagram Post Type',
+    'Brand name',
+  ];
+
+  const rows = posts.map((post) => {
+    const row = Object.fromEntries(columns.map((column) => [column, '']));
+    row.Text = post.caption;
+    row.Date = post.scheduledDate;
+    row.Time = post.scheduledTime;
+    row.Draft = 'FALSE';
+    row.Facebook = 'FALSE';
+    row['Twitter/X'] = 'FALSE';
+    row.LinkedIn = 'FALSE';
+    row.GBP = 'FALSE';
+    row.Instagram = 'TRUE';
+    row.Pinterest = 'FALSE';
+    row.TikTok = 'FALSE';
+    row.YouTube = 'FALSE';
+    row.Threads = 'FALSE';
+    row.Bluesky = 'FALSE';
+    row.Shortener = 'FALSE';
+    row['Instagram Post Type'] = 'POST';
+
+    post.assets.slice(0, PICTURE_LIMIT).forEach((asset, index) => {
+      row[`Picture Url ${index + 1}`] = asset.url;
+      row[`Alt text picture ${index + 1}`] = asset.title;
+    });
+
+    return columns.map((column) => row[column]);
+  });
+
+  return `${[columns, ...rows].map((row) => row.map(csvEscape).join(',')).join('\n')}\n`;
+}
+
+export function downloadMetricoolCalendarCsv(posts: MarketingPostSeed[]) {
+  const csv = buildMetricoolCalendarCsv(posts);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = 'metricool-calendar-import.csv';
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}

--- a/apps/web/src/pages/admin2/MarketingPage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPage.tsx
@@ -1,0 +1,217 @@
+import { useMemo, useState } from 'react';
+import { marketingCampaignSeed, type MarketingPostSeed, type MarketingPostStatus } from '../../content/marketingAdminSeed';
+import { downloadMetricoolCalendarCsv } from '../../lib/marketingMetricoolCsv';
+
+const STATUS_LABELS: Record<MarketingPostStatus, string> = {
+  draft: 'Draft',
+  needs_review: 'Needs review',
+  approved: 'Approved',
+};
+
+function statusClass(status: MarketingPostStatus) {
+  if (status === 'approved') {
+    return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200';
+  }
+
+  if (status === 'needs_review') {
+    return 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-200';
+  }
+
+  return 'border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] text-[color:var(--admin-muted)]';
+}
+
+function PostCard({
+  post,
+  onStatusChange,
+}: {
+  post: MarketingPostSeed;
+  onStatusChange: (postId: string, status: MarketingPostStatus) => void;
+}) {
+  return (
+    <article className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">
+            {post.platform} / {post.format} / {post.id}
+          </p>
+          <h3 className="mt-1 text-lg font-semibold tracking-tight">{post.assets[0]?.title ?? post.id}</h3>
+        </div>
+        <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${statusClass(post.status)}`}>
+          {STATUS_LABELS[post.status]}
+        </span>
+      </div>
+
+      <div className="mt-4 flex gap-2 overflow-x-auto pb-1">
+        {post.assets.map((asset) => (
+          <img
+            key={asset.file}
+            src={asset.url}
+            alt={asset.title}
+            className="h-32 w-32 shrink-0 rounded-xl border border-[color:var(--admin-border)] object-cover"
+            loading="lazy"
+          />
+        ))}
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-[1.15fr_0.85fr]">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Caption</p>
+          <pre className="mt-2 max-h-56 overflow-auto whitespace-pre-wrap rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 text-xs leading-relaxed text-[color:var(--admin-text)]">
+            {post.caption}
+          </pre>
+        </div>
+        <div className="space-y-3 text-sm">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Schedule</p>
+            <p className="mt-1 font-medium">{post.scheduledDate} / {post.scheduledTime}</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Hypothesis</p>
+            <p className="mt-1 text-[color:var(--admin-muted)]">{post.hypothesis}</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Metric</p>
+            <p className="mt-1 text-[color:var(--admin-muted)]">{post.metric}</p>
+          </div>
+          <a
+            href={post.trackingUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="block break-all text-xs font-semibold text-[color:var(--admin-accent)]"
+          >
+            {post.trackingUrl}
+          </a>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button type="button" className="admin2-btn admin2-btn--success" onClick={() => onStatusChange(post.id, 'approved')}>
+          Approve
+        </button>
+        <button type="button" className="admin2-btn admin2-btn--secondary" onClick={() => onStatusChange(post.id, 'needs_review')}>
+          Needs review
+        </button>
+        <button type="button" className="admin2-btn admin2-btn--ghost" onClick={() => onStatusChange(post.id, 'draft')}>
+          Draft
+        </button>
+        <button type="button" className="admin2-btn admin2-btn--ghost" disabled title="Next step: wire generation service">
+          Regenerate copy
+        </button>
+        <button type="button" className="admin2-btn admin2-btn--ghost" disabled title="Next step: wire image generation">
+          Regenerate image
+        </button>
+      </div>
+    </article>
+  );
+}
+
+export function MarketingPage() {
+  const [postCount, setPostCount] = useState(marketingCampaignSeed.postCount);
+  const [posts, setPosts] = useState(marketingCampaignSeed.posts);
+  const approvedPosts = useMemo(() => posts.filter((post) => post.status === 'approved'), [posts]);
+  const needsReviewCount = posts.filter((post) => post.status === 'needs_review').length;
+
+  function updateStatus(postId: string, status: MarketingPostStatus) {
+    setPosts((currentPosts) =>
+      currentPosts.map((post) => (post.id === postId ? { ...post, status } : post)),
+    );
+  }
+
+  function downloadApprovedCsv() {
+    downloadMetricoolCalendarCsv(approvedPosts);
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6">
+      <header className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--admin-muted)]">Marketing</p>
+        <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h2 className="text-3xl font-semibold tracking-tight">Monthly content approval board</h2>
+            <p className="mt-3 max-w-3xl text-sm text-[color:var(--admin-muted)]">
+              Review generated posts, approve the ones that are ready, and export a Metricool CSV for the approved queue.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="admin2-btn admin2-btn--primary"
+            onClick={downloadApprovedCsv}
+            disabled={approvedPosts.length === 0}
+          >
+            Download Metricool CSV
+          </button>
+        </div>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-4">
+        <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Configured posts</p>
+          <label className="mt-3 block">
+            <span className="sr-only">Monthly post count</span>
+            <input
+              type="number"
+              min={1}
+              max={100}
+              value={postCount}
+              onChange={(event) => setPostCount(Number(event.target.value))}
+              className="w-full rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-2xl font-semibold text-[color:var(--admin-text)]"
+            />
+          </label>
+        </div>
+        <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Approved</p>
+          <p className="mt-3 text-3xl font-semibold">{approvedPosts.length}</p>
+        </div>
+        <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Needs review</p>
+          <p className="mt-3 text-3xl font-semibold">{needsReviewCount}</p>
+        </div>
+        <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Campaign</p>
+          <p className="mt-3 text-lg font-semibold">{marketingCampaignSeed.campaignCode}</p>
+          <p className="mt-1 text-xs text-[color:var(--admin-muted)]">{marketingCampaignSeed.language}</p>
+        </div>
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-[0.8fr_1.2fr]">
+        <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5">
+          <h3 className="text-lg font-semibold tracking-tight">Data & storage</h3>
+          <p className="mt-2 text-sm text-[color:var(--admin-muted)]">
+            This is prepared for GA4, Search Console and manual Metricool exports. Live integrations are intentionally not wired yet.
+          </p>
+          <div className="mt-4 grid gap-3 text-sm">
+            <a className="font-semibold text-[color:var(--admin-accent)]" href={marketingCampaignSeed.driveRootUrl} target="_blank" rel="noreferrer">
+              Google Drive marketing root
+            </a>
+            <a className="font-semibold text-[color:var(--admin-accent)]" href={marketingCampaignSeed.strategyMemoryUrl} target="_blank" rel="noreferrer">
+              Strategy memory file
+            </a>
+            <a className="font-semibold text-[color:var(--admin-accent)]" href={marketingCampaignSeed.assetsFolderUrl} target="_blank" rel="noreferrer">
+              Assets folder
+            </a>
+            <a className="font-semibold text-[color:var(--admin-accent)]" href={marketingCampaignSeed.campaignsFolderUrl} target="_blank" rel="noreferrer">
+              Campaigns folder
+            </a>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5">
+          <h3 className="text-lg font-semibold tracking-tight">Monthly generation protocol</h3>
+          <ol className="mt-3 space-y-2 text-sm text-[color:var(--admin-muted)]">
+            <li>1. Read and update the latest strategy memory Markdown.</li>
+            <li>2. Read new GA4, Search Console and Metricool data when available.</li>
+            <li>3. Generate drafts and save copy, assets, schedule and tracking URLs.</li>
+            <li>4. Review drafts here, approve or request regeneration.</li>
+            <li>5. Export a Metricool CSV only after approval.</li>
+          </ol>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        {posts.map((post) => (
+          <PostCard key={post.id} post={post} onStatusChange={updateStatus} />
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/pages/admin2/OverviewPage.tsx
+++ b/apps/web/src/pages/admin2/OverviewPage.tsx
@@ -17,6 +17,11 @@ const SECTIONS = [
     to: '/admin/notifications',
   },
   {
+    title: 'Marketing',
+    description: 'Revisión de posts generados, aprobación mensual y export CSV para Metricool.',
+    to: '/admin/marketing',
+  },
+  {
     title: 'AI TaskGen',
     description: 'Monitorea jobs, KPIs y reintentos desde un único panel operativo.',
     to: '/admin/ai-taskgen',


### PR DESCRIPTION
## Summary
- Adds a new `/admin/marketing` page to the current Admin2 shell.
- Seeds the page with the two MVP Instagram posts, assets, captions, tracking URLs, hypotheses, and approval states.
- Adds a configurable monthly post count field, Drive/storage links, a monthly generation protocol panel, and a Metricool CSV download for approved posts only.
- Adds `Docs/marketing/strategy-memory.md` as the first-read monthly strategy memory for future generation runs.
- Adds a focused unit test for the Metricool CSV builder.

## Google Drive setup
Created a minimal Drive structure:
- `Innerbloom Marketing`
- `01 Strategy Memory`
- `02 Assets`
- `03 Campaigns`
- `03 Campaigns / 2026-06 MVP Test`

Uploaded `strategy-memory.md` to the Strategy Memory folder and linked it from the admin seed.

## Current limitations
- This is an MVP/static admin surface; approval state is local UI state and not persisted yet.
- Regenerate copy/image buttons are disabled placeholders until we wire generation.
- GA4, Search Console, Google Drive asset upload, and Metricool exports are not integrated live yet.
- Visual smoke testing of `/admin/marketing` was blocked locally by the admin access gate without a running admin API; the route compiles far enough to hit the existing gate.

## Validation
- `npm --workspace apps/web run test -- src/lib/__tests__/marketingMetricoolCsv.test.ts --run`
- `git diff --check`

Note: full `npm --workspace apps/web run typecheck` still fails on pre-existing repo errors in auth/tests/mobile premium files; no errors from the new marketing files were reported after fixing the CSV helper.