### PR TITLE
Add R2 uploads for marketing assets

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -6,3 +6,10 @@ VITE_DASHBOARD_PATH=/dashboard
 VITE_SHOW_STREAKS_PANEL=true
 VITE_WEB_BASE_URL=https://your-web.example.com
 VITE_GA4_MEASUREMENT_ID=G-XXXXXXXXXX
+
+# Server-only marketing asset CDN variables. Do not prefix secrets with VITE_.
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=innerbloom-marketing-assets
+R2_PUBLIC_BASE_URL=https://assets.innerbloomjourney.org

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1075.0",
     "@clerk/clerk-react": "^5.8.1",
     "@clerk/types": "^4.27.0",
     "@innerbloom/missions-v2-contracts": "file:../../packages/missions-v2-contracts",

--- a/apps/web/server.mjs
+++ b/apps/web/server.mjs
@@ -3,11 +3,14 @@ import { access, stat } from 'node:fs/promises';
 import http from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const distDir = path.join(__dirname, 'dist');
 const port = Number(process.env.PORT || 3000);
+const JSON_BODY_LIMIT_BYTES = 25 * 1024 * 1024;
+const MARKETING_R2_ROUTE_PREFIX = '/api/admin/marketing/r2';
 
 const EXACT_PAGE_ROUTES = new Map([
   ['/intro-journey', 'onboarding/index.html'],
@@ -31,6 +34,217 @@ const CONTENT_TYPES = new Map([
 
 function getContentType(filePath) {
   return CONTENT_TYPES.get(path.extname(filePath).toLowerCase()) || 'application/octet-stream';
+}
+
+function sendJson(res, status, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    'Content-Length': Buffer.byteLength(body),
+    'Content-Type': 'application/json; charset=utf-8',
+  });
+  res.end(body);
+}
+
+function readJsonBody(req, limitBytes = JSON_BODY_LIMIT_BYTES) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let totalBytes = 0;
+
+    req.on('data', (chunk) => {
+      totalBytes += chunk.length;
+      if (totalBytes > limitBytes) {
+        reject(Object.assign(new Error('Payload too large'), { statusCode: 413 }));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    req.on('end', () => {
+      try {
+        const text = Buffer.concat(chunks).toString('utf8');
+        resolve(text ? JSON.parse(text) : {});
+      } catch {
+        reject(Object.assign(new Error('Invalid JSON body'), { statusCode: 400 }));
+      }
+    });
+
+    req.on('error', reject);
+  });
+}
+
+function normalizeBaseUrl(value) {
+  const trimmed = String(value || '').trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return '';
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `https://${trimmed}`;
+}
+
+function getApiBaseUrl() {
+  return normalizeBaseUrl(process.env.VITE_API_BASE_URL || process.env.VITE_API_URL || process.env.API_BASE_URL);
+}
+
+async function verifyAdminRequest(req) {
+  const authorization = req.headers.authorization;
+  if (!authorization) {
+    return false;
+  }
+
+  const apiBaseUrl = getApiBaseUrl();
+  if (!apiBaseUrl) {
+    console.error('[marketing-r2] Missing VITE_API_BASE_URL/VITE_API_URL/API_BASE_URL for admin verification.');
+    return false;
+  }
+
+  const response = await fetch(`${apiBaseUrl}/api/admin/me`, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: authorization,
+    },
+  });
+
+  return response.ok;
+}
+
+function getR2Config() {
+  const config = {
+    accountId: String(process.env.R2_ACCOUNT_ID || '').trim(),
+    accessKeyId: String(process.env.R2_ACCESS_KEY_ID || '').trim(),
+    secretAccessKey: String(process.env.R2_SECRET_ACCESS_KEY || '').trim(),
+    bucket: String(process.env.R2_BUCKET || '').trim(),
+    publicBaseUrl: normalizeBaseUrl(process.env.R2_PUBLIC_BASE_URL),
+  };
+
+  const missing = Object.entries(config)
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  return { ...config, configured: missing.length === 0, missing };
+}
+
+let r2Client;
+
+function getR2Client(config) {
+  if (!r2Client) {
+    r2Client = new S3Client({
+      credentials: {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+      },
+      endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
+      forcePathStyle: true,
+      region: 'auto',
+    });
+  }
+
+  return r2Client;
+}
+
+function sanitizeAssetKey(value) {
+  const key = String(value || '').trim().replace(/^\/+/, '');
+
+  if (
+    !key
+    || key.includes('..')
+    || key.length > 240
+    || !/^[a-zA-Z0-9][a-zA-Z0-9._/-]*$/.test(key)
+  ) {
+    return null;
+  }
+
+  return key;
+}
+
+function parseBase64Asset(value) {
+  const text = String(value || '').trim();
+  const match = text.match(/^data:([^;,]+);base64,(.+)$/);
+  const base64 = match ? match[2] : text;
+  return Buffer.from(base64, 'base64');
+}
+
+async function handleMarketingR2Request(req, res, requestUrl) {
+  if (requestUrl.pathname === `${MARKETING_R2_ROUTE_PREFIX}/status` && req.method === 'GET') {
+    const allowed = await verifyAdminRequest(req);
+    if (!allowed) {
+      sendJson(res, 401, { ok: false, message: 'Unauthorized' });
+      return true;
+    }
+
+    const config = getR2Config();
+    sendJson(res, 200, {
+      ok: true,
+      configured: config.configured,
+      missing: config.missing,
+      bucket: config.bucket || null,
+      publicBaseUrl: config.publicBaseUrl || null,
+    });
+    return true;
+  }
+
+  if (requestUrl.pathname === `${MARKETING_R2_ROUTE_PREFIX}/assets` && req.method === 'POST') {
+    const allowed = await verifyAdminRequest(req);
+    if (!allowed) {
+      sendJson(res, 401, { ok: false, message: 'Unauthorized' });
+      return true;
+    }
+
+    const config = getR2Config();
+    if (!config.configured) {
+      sendJson(res, 503, { ok: false, message: 'R2 is not configured', missing: config.missing });
+      return true;
+    }
+
+    const body = await readJsonBody(req);
+    const assets = Array.isArray(body?.assets) ? body.assets : [];
+    if (assets.length === 0 || assets.length > 10) {
+      sendJson(res, 400, { ok: false, message: 'Expected 1-10 assets.' });
+      return true;
+    }
+
+    const client = getR2Client(config);
+    const uploaded = [];
+
+    for (const asset of assets) {
+      const key = sanitizeAssetKey(asset?.key);
+      if (!key) {
+        sendJson(res, 400, { ok: false, message: `Invalid asset key: ${asset?.key ?? ''}` });
+        return true;
+      }
+
+      const bytes = parseBase64Asset(asset?.contentBase64);
+      if (bytes.length === 0 || bytes.length > 10 * 1024 * 1024) {
+        sendJson(res, 400, { ok: false, message: `Invalid asset size for ${key}.` });
+        return true;
+      }
+
+      const contentType = String(asset?.contentType || 'application/octet-stream').trim();
+
+      await client.send(new PutObjectCommand({
+        Bucket: config.bucket,
+        Key: key,
+        Body: bytes,
+        ContentType: contentType,
+        CacheControl: 'public, max-age=31536000, immutable',
+      }));
+
+      uploaded.push({
+        key,
+        size: bytes.length,
+        url: `${config.publicBaseUrl}/${key}`,
+      });
+    }
+
+    sendJson(res, 200, { ok: true, assets: uploaded });
+    return true;
+  }
+
+  return false;
 }
 
 async function exists(filePath) {
@@ -74,6 +288,13 @@ async function resolveRequestPath(urlPath) {
 const server = http.createServer(async (req, res) => {
   try {
     const requestUrl = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+    if (requestUrl.pathname.startsWith(MARKETING_R2_ROUTE_PREFIX)) {
+      const handled = await handleMarketingR2Request(req, res, requestUrl);
+      if (handled) {
+        return;
+      }
+    }
+
     const filePath = await resolveRequestPath(requestUrl.pathname);
     const fileStats = await stat(filePath);
 
@@ -89,8 +310,16 @@ const server = http.createServer(async (req, res) => {
 
     createReadStream(filePath).pipe(res);
   } catch (error) {
-    res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
-    res.end('Internal Server Error');
+    const statusCode = Number(error?.statusCode || 500);
+    const message = statusCode >= 500 ? 'Internal Server Error' : error.message;
+
+    if (req.url?.startsWith(MARKETING_R2_ROUTE_PREFIX)) {
+      sendJson(res, statusCode, { ok: false, message });
+      return;
+    }
+
+    res.writeHead(statusCode, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end(message);
     console.error(error);
   }
 });

--- a/apps/web/src/lib/__tests__/marketingR2Assets.test.ts
+++ b/apps/web/src/lib/__tests__/marketingR2Assets.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { buildMarketingAssetKey } from '../marketingR2Assets';
+
+describe('buildMarketingAssetKey', () => {
+  it('builds stable public R2 object keys for campaign assets', () => {
+    expect(
+      buildMarketingAssetKey({
+        campaignCode: 'IB20 MVP',
+        postId: 'post_001',
+        file: 'post-001-carousel-01.png',
+      }),
+    ).toBe('campaigns/ib20-mvp/post_001/post-001-carousel-01.png');
+  });
+
+  it('uses only the file basename when a source path is passed', () => {
+    expect(
+      buildMarketingAssetKey({
+        campaignCode: '2026/07 Launch',
+        postId: 'Post 002',
+        file: 'Docs/marketing/assets/post-002.png',
+      }),
+    ).toBe('campaigns/2026-07-launch/post-002/post-002.png');
+  });
+});

--- a/apps/web/src/lib/marketingR2Assets.ts
+++ b/apps/web/src/lib/marketingR2Assets.ts
@@ -1,0 +1,131 @@
+import { apiAuthorizedFetch } from './api';
+import type { MarketingAsset } from '../content/marketingAdminSeed';
+
+export type MarketingR2Status = {
+  ok: boolean;
+  configured: boolean;
+  missing: string[];
+  bucket: string | null;
+  publicBaseUrl: string | null;
+};
+
+export type UploadedMarketingAsset = {
+  key: string;
+  size: number;
+  url: string;
+};
+
+type UploadAssetInput = {
+  asset: MarketingAsset;
+  campaignCode: string;
+  postId: string;
+};
+
+type UploadMarketingAssetsResponse = {
+  ok: boolean;
+  assets: UploadedMarketingAsset[];
+};
+
+export function buildMarketingAssetKey({
+  campaignCode,
+  postId,
+  file,
+}: {
+  campaignCode: string;
+  postId: string;
+  file: string;
+}) {
+  const safeCampaign = toSafeSegment(campaignCode);
+  const safePost = toSafeSegment(postId);
+  const safeFile = file.split('/').pop() ?? file;
+
+  return `campaigns/${safeCampaign}/${safePost}/${safeFile}`;
+}
+
+export async function fetchMarketingR2Status() {
+  const response = await apiAuthorizedFetch(`${getR2RoutePrefix()}/status`, {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`R2 status request failed with HTTP ${response.status}`);
+  }
+
+  return response.json() as Promise<MarketingR2Status>;
+}
+
+export async function uploadMarketingAssetsToR2(inputs: UploadAssetInput[]) {
+  const assets = await Promise.all(
+    inputs.map(async ({ asset, campaignCode, postId }) => {
+      const fetchedAsset = await fetchAssetAsBase64(asset.url);
+      return {
+        key: buildMarketingAssetKey({
+          campaignCode,
+          postId,
+          file: asset.file,
+        }),
+        contentBase64: fetchedAsset.contentBase64,
+        contentType: fetchedAsset.contentType,
+      };
+    }),
+  );
+
+  const response = await apiAuthorizedFetch(`${getR2RoutePrefix()}/assets`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ assets }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`R2 upload failed with HTTP ${response.status}: ${body}`);
+  }
+
+  return response.json() as Promise<UploadMarketingAssetsResponse>;
+}
+
+async function fetchAssetAsBase64(url: string) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Asset fetch failed with HTTP ${response.status}: ${url}`);
+  }
+
+  const blob = await response.blob();
+  const contentType = blob.type || 'application/octet-stream';
+  const contentBase64 = await blobToBase64(blob);
+
+  return { contentBase64, contentType };
+}
+
+function blobToBase64(blob: Blob) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      resolve(result.includes(',') ? result.split(',')[1] : result);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read asset.'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function toSafeSegment(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'default';
+}
+
+function getR2RoutePrefix() {
+  const origin = typeof window !== 'undefined' && window.location?.origin
+    ? window.location.origin
+    : '';
+
+  return `${origin}/api/admin/marketing/r2`;
+}

--- a/apps/web/src/pages/admin2/MarketingPage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPage.tsx
@@ -1,6 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { marketingCampaignSeed, type MarketingPostSeed, type MarketingPostStatus } from '../../content/marketingAdminSeed';
 import { downloadMetricoolCalendarCsv } from '../../lib/marketingMetricoolCsv';
+import {
+  buildMarketingAssetKey,
+  fetchMarketingR2Status,
+  uploadMarketingAssetsToR2,
+  type MarketingR2Status,
+} from '../../lib/marketingR2Assets';
 
 const STATUS_LABELS: Record<MarketingPostStatus, string> = {
   draft: 'Draft',
@@ -108,8 +114,39 @@ function PostCard({
 export function MarketingPage() {
   const [postCount, setPostCount] = useState(marketingCampaignSeed.postCount);
   const [posts, setPosts] = useState(marketingCampaignSeed.posts);
+  const [r2Status, setR2Status] = useState<MarketingR2Status | null>(null);
+  const [r2StatusError, setR2StatusError] = useState<string | null>(null);
+  const [isUploadingAssets, setIsUploadingAssets] = useState(false);
+  const [uploadMessage, setUploadMessage] = useState<string | null>(null);
   const approvedPosts = useMemo(() => posts.filter((post) => post.status === 'approved'), [posts]);
   const needsReviewCount = posts.filter((post) => post.status === 'needs_review').length;
+  const approvedAssetCount = approvedPosts.reduce((total, post) => total + post.assets.length, 0);
+  const r2ReadyAssetCount = approvedPosts.reduce(
+    (total, post) => total + post.assets.filter((asset) => r2Status?.publicBaseUrl && asset.url.startsWith(r2Status.publicBaseUrl)).length,
+    0,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchMarketingR2Status()
+      .then((status) => {
+        if (!cancelled) {
+          setR2Status(status);
+          setR2StatusError(null);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setR2Status(null);
+          setR2StatusError(error instanceof Error ? error.message : 'Unable to load R2 status.');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   function updateStatus(postId: string, status: MarketingPostStatus) {
     setPosts((currentPosts) =>
@@ -119,6 +156,50 @@ export function MarketingPage() {
 
   function downloadApprovedCsv() {
     downloadMetricoolCalendarCsv(approvedPosts);
+  }
+
+  async function uploadApprovedAssets() {
+    if (approvedPosts.length === 0) {
+      return;
+    }
+
+    setIsUploadingAssets(true);
+    setUploadMessage(null);
+
+    try {
+      const uploadInputs = approvedPosts.flatMap((post) =>
+        post.assets.map((asset) => ({
+          asset,
+          campaignCode: marketingCampaignSeed.campaignCode,
+          postId: post.id,
+        })),
+      );
+
+      const result = await uploadMarketingAssetsToR2(uploadInputs);
+      const uploadedByKey = new Map(result.assets.map((asset) => [asset.key, asset]));
+
+      setPosts((currentPosts) =>
+        currentPosts.map((post) => ({
+          ...post,
+          assets: post.assets.map((asset) => {
+            const key = buildMarketingAssetKey({
+              campaignCode: marketingCampaignSeed.campaignCode,
+              postId: post.id,
+              file: asset.file,
+            });
+            const uploaded = uploadedByKey.get(key);
+
+            return uploaded ? { ...asset, url: uploaded.url } : asset;
+          }),
+        })),
+      );
+
+      setUploadMessage(`Uploaded ${result.assets.length} approved asset${result.assets.length === 1 ? '' : 's'} to R2.`);
+    } catch (error) {
+      setUploadMessage(error instanceof Error ? error.message : 'R2 upload failed.');
+    } finally {
+      setIsUploadingAssets(false);
+    }
   }
 
   return (
@@ -143,7 +224,7 @@ export function MarketingPage() {
         </div>
       </header>
 
-      <section className="grid gap-4 md:grid-cols-4">
+      <section className="grid gap-4 md:grid-cols-5">
         <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4">
           <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Configured posts</p>
           <label className="mt-3 block">
@@ -171,6 +252,11 @@ export function MarketingPage() {
           <p className="mt-3 text-lg font-semibold">{marketingCampaignSeed.campaignCode}</p>
           <p className="mt-1 text-xs text-[color:var(--admin-muted)]">{marketingCampaignSeed.language}</p>
         </div>
+        <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Metricool assets</p>
+          <p className="mt-3 text-3xl font-semibold">{r2ReadyAssetCount}/{approvedAssetCount}</p>
+          <p className="mt-1 text-xs text-[color:var(--admin-muted)]">Approved assets on R2</p>
+        </div>
       </section>
 
       <section className="grid gap-4 xl:grid-cols-[0.8fr_1.2fr]">
@@ -192,6 +278,45 @@ export function MarketingPage() {
             <a className="font-semibold text-[color:var(--admin-accent)]" href={marketingCampaignSeed.campaignsFolderUrl} target="_blank" rel="noreferrer">
               Campaigns folder
             </a>
+          </div>
+          <div className="mt-5 rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 text-sm">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="font-semibold">Cloudflare R2</p>
+                <p className="mt-1 text-xs text-[color:var(--admin-muted)]">
+                  {r2StatusError
+                    ? r2StatusError
+                    : r2Status?.configured
+                      ? `${r2Status.bucket} -> ${r2Status.publicBaseUrl}`
+                      : 'Checking R2 configuration...'}
+                </p>
+              </div>
+              <span className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${
+                r2Status?.configured
+                  ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
+                  : 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-200'
+              }`}>
+                {r2Status?.configured ? 'Ready' : 'Pending'}
+              </span>
+            </div>
+            {r2Status && !r2Status.configured ? (
+              <p className="mt-2 text-xs text-[color:var(--admin-muted)]">
+                Missing: {r2Status.missing.join(', ')}
+              </p>
+            ) : null}
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                className="admin2-btn admin2-btn--secondary"
+                onClick={uploadApprovedAssets}
+                disabled={!r2Status?.configured || approvedPosts.length === 0 || isUploadingAssets}
+              >
+                {isUploadingAssets ? 'Uploading assets...' : 'Upload approved assets to R2'}
+              </button>
+              {uploadMessage ? (
+                <p className="text-xs text-[color:var(--admin-muted)]">{uploadMessage}</p>
+              ) : null}
+            </div>
           </div>
         </div>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1075.0
+        version: 3.1075.0
       '@clerk/clerk-react':
         specifier: ^5.8.1
         version: 5.59.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -264,6 +267,109 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/checksums@3.1000.8':
+    resolution: {integrity: sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1075.0':
+    resolution: {integrity: sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.23':
+    resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.49':
+    resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.58':
+    resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.33':
+    resolution: {integrity: sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.54':
+    resolution: {integrity: sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.23':
+    resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1074.0':
+    resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.13':
+    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.31':
+    resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1046,6 +1152,42 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@smithy/core@3.26.0':
+    resolution: {integrity: sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.2':
+    resolution: {integrity: sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.5.2':
+    resolution: {integrity: sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.8.2':
+    resolution: {integrity: sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.5.2':
+    resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.0':
+    resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -1473,6 +1615,9 @@ packages:
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
@@ -3975,6 +4120,235 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/checksums@3.1000.8':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1075.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-node': 3.972.58
+      '@aws-sdk/middleware-flexible-checksums': 3.974.33
+      '@aws-sdk/middleware-sdk-s3': 3.972.54
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.23':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.31
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.26.0
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-login': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.58':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-ini': 3.972.56
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/token-providers': 3.1074.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.33':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.8
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.23':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1074.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.13':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.31':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -4655,6 +5029,54 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@smithy/core@3.26.0':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.5.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.8.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.5.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@stablelib/base64@1.0.1': {}
 
   '@tanstack/react-virtual@3.13.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
@@ -5165,6 +5587,8 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   boxen@7.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds a Web server endpoint for admin-verified marketing asset uploads to Cloudflare R2.
- Adds a marketing admin action to upload approved post assets to R2 and replace asset URLs before exporting Metricool CSV.
- Documents the server-only R2 env vars and adds tests for stable R2 asset key generation.

## Validation
- `npm --workspace apps/web run test -- src/lib/__tests__/marketingR2Assets.test.ts src/lib/__tests__/marketingMetricoolCsv.test.ts --run`
- `node --check apps/web/server.mjs`
- `npm --workspace apps/web run build`
- `git diff --check`

## Notes
- `npm --workspace apps/web run typecheck` still fails on existing unrelated Clerk/demo/labs type errors in main.