### PR TITLE
Fix marketing R2 upload API route

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -23,3 +23,10 @@ STRIPE_PRICE_ID_YEAR=price_xxx_year
 STRIPE_CHECKOUT_SUCCESS_URL=https://innerbloomjourney.org/subscription?checkout=success
 STRIPE_CHECKOUT_CANCEL_URL=https://innerbloomjourney.org/pricing?checkout=cancel
 STRIPE_PORTAL_RETURN_URL=https://innerbloomjourney.org/subscription
+
+# Marketing asset CDN. Server-only values for /api/admin/marketing/r2/*.
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=innerbloom-marketing-assets
+R2_PUBLIC_BASE_URL=https://assets.innerbloomjourney.org

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
     "backfill:task-difficulty": "tsx scripts/task-difficulty-backfill.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "3.1075.0",
     "@fastify/express": "^4.0.2",
     "@innerbloom/missions-v2-contracts": "file:../../packages/missions-v2-contracts",
     "ajv": "^8.17.1",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -97,7 +97,7 @@ app.use('/api', stripeWebhookRouter);
 if (apiLoggingEnabled) {
   console.info('[boot] registering express.json() after Clerk webhook router');
 }
-app.use(express.json({ limit: '2mb' }));
+app.use(express.json({ limit: '25mb' }));
 
 app.get('/_debug/db', (_req, res, next) => {
   if (process.env.NODE_ENV === 'production') {

--- a/apps/api/src/modules/admin/admin.handlers.ts
+++ b/apps/api/src/modules/admin/admin.handlers.ts
@@ -19,6 +19,7 @@ import {
   feedbackUserNotificationUpdateSchema,
   subscriptionNotificationsTriggerBodySchema,
   adminSubscriptionUpdateBodySchema,
+  marketingR2AssetUploadBodySchema,
   taskDifficultyCalibrationRunBodySchema,
   modeUpgradeAggregationRunBodySchema,
   habitAchievementRetroactiveRunBodySchema,
@@ -69,6 +70,7 @@ import {
 import { runUserMonthlyModeUpgradeAggregation } from '../../services/modeUpgradeMonthlyAggregationService.js';
 import { runRetroactiveHabitAchievementDetection } from '../../services/habitAchievementService.js';
 import { getMonthlyPipelineStatus, runMonthlyPipelineForPeriod } from '../../services/monthlyPipelineService.js';
+import { getMarketingR2Status, uploadMarketingR2Assets } from '../../services/marketingR2AssetService.js';
 import { pool } from '../../db.js';
 
 const taskgenForceRunRequestSchema = z
@@ -120,6 +122,23 @@ export const getAdminUsers = asyncHandler(async (req: Request, res: Response) =>
   const query = listUsersQuerySchema.parse(req.query);
   const result = await listUsers(query);
   res.json(result);
+});
+
+export const getAdminMarketingR2Status = asyncHandler(async (_req: Request, res: Response) => {
+  res.json({
+    ok: true,
+    ...getMarketingR2Status(),
+  });
+});
+
+export const postAdminMarketingR2Assets = asyncHandler(async (req: Request, res: Response) => {
+  const body = marketingR2AssetUploadBodySchema.parse(req.body);
+  const assets = await uploadMarketingR2Assets(body.assets);
+
+  res.json({
+    ok: true,
+    assets,
+  });
 });
 
 export const getAdminUserInsights = asyncHandler(async (req: Request, res: Response) => {

--- a/apps/api/src/modules/admin/admin.routes.ts
+++ b/apps/api/src/modules/admin/admin.routes.ts
@@ -40,7 +40,9 @@ import {
   putAdminUserModeUpgradeCtaOverride,
   deleteAdminUserModeUpgradeCtaOverride,
   getAdminMonthlyPipelineStatus,
+  getAdminMarketingR2Status,
   postAdminMonthlyPipelineRun,
+  postAdminMarketingR2Assets,
 } from './admin.handlers.js';
 import { requireAdmin } from './admin.middleware.js';
 
@@ -49,6 +51,8 @@ const adminRouter = Router();
 
 adminRouter.get('/me', getAdminMe);
 adminRouter.get('/users', getAdminUsers);
+adminRouter.get('/marketing/r2/status', getAdminMarketingR2Status);
+adminRouter.post('/marketing/r2/assets', postAdminMarketingR2Assets);
 adminRouter.get('/taskgen/jobs', getTaskgenJobs);
 adminRouter.get('/taskgen/jobs/:jobId/logs', getTaskgenJobLogsHandler);
 adminRouter.post('/taskgen/jobs/:jobId/retry', retryTaskgenJobHandler);

--- a/apps/api/src/modules/admin/admin.schemas.ts
+++ b/apps/api/src/modules/admin/admin.schemas.ts
@@ -193,6 +193,18 @@ export const adminSubscriptionUpdateBodySchema = z.object({
   status: subscriptionStatusSchema.optional().default('active'),
 });
 
+export const marketingR2AssetUploadBodySchema = z.object({
+  assets: z
+    .array(
+      z.object({
+        key: z.string().trim().min(1).max(240),
+        contentBase64: z.string().trim().min(1),
+        contentType: z.string().trim().min(1).max(100).optional(),
+      }),
+    )
+    .min(1)
+    .max(10),
+});
 
 export const subscriptionNotificationsTriggerBodySchema = z.object({
   runAt: z.string().datetime().optional(),

--- a/apps/api/src/services/marketingR2AssetService.ts
+++ b/apps/api/src/services/marketingR2AssetService.ts
@@ -1,0 +1,168 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { HttpError } from '../lib/http-error.js';
+
+export type MarketingR2AssetUpload = {
+  key: string;
+  contentBase64: string;
+  contentType?: string;
+};
+
+export type MarketingR2UploadedAsset = {
+  key: string;
+  size: number;
+  url: string;
+};
+
+type R2Config = {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+  publicBaseUrl: string;
+  configured: boolean;
+  missing: string[];
+};
+
+let r2Client: S3Client | null = null;
+
+export function getMarketingR2Status() {
+  const config = getR2Config();
+
+  return {
+    configured: config.configured,
+    missing: config.missing,
+    bucket: config.bucket || null,
+    publicBaseUrl: config.publicBaseUrl || null,
+  };
+}
+
+export async function uploadMarketingR2Assets(assets: MarketingR2AssetUpload[]) {
+  if (assets.length === 0 || assets.length > 10) {
+    throw new HttpError(400, 'invalid_assets', 'Expected 1-10 assets.');
+  }
+
+  const config = getR2Config();
+  if (!config.configured) {
+    throw new HttpError(503, 'r2_not_configured', 'R2 is not configured.', {
+      missing: config.missing,
+    });
+  }
+
+  const client = getR2Client(config);
+  const uploaded: MarketingR2UploadedAsset[] = [];
+
+  for (const asset of assets) {
+    const key = sanitizeAssetKey(asset.key);
+    const bytes = parseBase64Asset(asset.contentBase64);
+
+    if (bytes.length === 0 || bytes.length > 10 * 1024 * 1024) {
+      throw new HttpError(400, 'invalid_asset_size', `Invalid asset size for ${key}.`);
+    }
+
+    await client.send(new PutObjectCommand({
+      Bucket: config.bucket,
+      Key: key,
+      Body: bytes,
+      ContentType: normalizeContentType(asset.contentType),
+      CacheControl: 'public, max-age=31536000, immutable',
+    }));
+
+    uploaded.push({
+      key,
+      size: bytes.length,
+      url: `${config.publicBaseUrl}/${key}`,
+    });
+  }
+
+  return uploaded;
+}
+
+function getR2Config(): R2Config {
+  const config = {
+    accountId: readEnv('R2_ACCOUNT_ID'),
+    accessKeyId: readEnv('R2_ACCESS_KEY_ID'),
+    secretAccessKey: readEnv('R2_SECRET_ACCESS_KEY'),
+    bucket: readEnv('R2_BUCKET'),
+    publicBaseUrl: normalizeBaseUrl(readEnv('R2_PUBLIC_BASE_URL')),
+  };
+
+  const missing = Object.entries(config)
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  return {
+    ...config,
+    configured: missing.length === 0,
+    missing,
+  };
+}
+
+function getR2Client(config: R2Config) {
+  if (!r2Client) {
+    r2Client = new S3Client({
+      credentials: {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+      },
+      endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
+      forcePathStyle: true,
+      region: 'auto',
+    });
+  }
+
+  return r2Client;
+}
+
+function readEnv(key: string) {
+  return String(process.env[key] || '').trim();
+}
+
+function normalizeBaseUrl(value: string) {
+  const trimmed = value.trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return '';
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `https://${trimmed}`;
+}
+
+function sanitizeAssetKey(value: string) {
+  const key = String(value || '').trim().replace(/^\/+/, '');
+
+  if (
+    !key
+    || key.includes('..')
+    || key.length > 240
+    || !/^[a-zA-Z0-9][a-zA-Z0-9._/-]*$/.test(key)
+  ) {
+    throw new HttpError(400, 'invalid_asset_key', `Invalid asset key: ${value}`);
+  }
+
+  return key;
+}
+
+function parseBase64Asset(value: string) {
+  const text = String(value || '').trim();
+  const match = text.match(/^data:([^;,]+);base64,(.+)$/);
+  const base64 = match ? match[2] : text;
+
+  try {
+    return Buffer.from(base64, 'base64');
+  } catch {
+    throw new HttpError(400, 'invalid_asset_content', 'Invalid base64 asset content.');
+  }
+}
+
+function normalizeContentType(value: string | undefined) {
+  const contentType = String(value || 'application/octet-stream').trim().toLowerCase();
+
+  if (!/^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/i.test(contentType)) {
+    return 'application/octet-stream';
+  }
+
+  return contentType;
+}

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -6,10 +6,3 @@ VITE_DASHBOARD_PATH=/dashboard
 VITE_SHOW_STREAKS_PANEL=true
 VITE_WEB_BASE_URL=https://your-web.example.com
 VITE_GA4_MEASUREMENT_ID=G-XXXXXXXXXX
-
-# Server-only marketing asset CDN variables. Do not prefix secrets with VITE_.
-R2_ACCOUNT_ID=
-R2_ACCESS_KEY_ID=
-R2_SECRET_ACCESS_KEY=
-R2_BUCKET=innerbloom-marketing-assets
-R2_PUBLIC_BASE_URL=https://assets.innerbloomjourney.org

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1075.0",
     "@clerk/clerk-react": "^5.8.1",
     "@clerk/types": "^4.27.0",
     "@innerbloom/missions-v2-contracts": "file:../../packages/missions-v2-contracts",

--- a/apps/web/server.mjs
+++ b/apps/web/server.mjs
@@ -3,14 +3,11 @@ import { access, stat } from 'node:fs/promises';
 import http from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const distDir = path.join(__dirname, 'dist');
 const port = Number(process.env.PORT || 3000);
-const JSON_BODY_LIMIT_BYTES = 25 * 1024 * 1024;
-const MARKETING_R2_ROUTE_PREFIX = '/api/admin/marketing/r2';
 
 const EXACT_PAGE_ROUTES = new Map([
   ['/intro-journey', 'onboarding/index.html'],
@@ -34,217 +31,6 @@ const CONTENT_TYPES = new Map([
 
 function getContentType(filePath) {
   return CONTENT_TYPES.get(path.extname(filePath).toLowerCase()) || 'application/octet-stream';
-}
-
-function sendJson(res, status, payload) {
-  const body = JSON.stringify(payload);
-  res.writeHead(status, {
-    'Content-Length': Buffer.byteLength(body),
-    'Content-Type': 'application/json; charset=utf-8',
-  });
-  res.end(body);
-}
-
-function readJsonBody(req, limitBytes = JSON_BODY_LIMIT_BYTES) {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    let totalBytes = 0;
-
-    req.on('data', (chunk) => {
-      totalBytes += chunk.length;
-      if (totalBytes > limitBytes) {
-        reject(Object.assign(new Error('Payload too large'), { statusCode: 413 }));
-        req.destroy();
-        return;
-      }
-      chunks.push(chunk);
-    });
-
-    req.on('end', () => {
-      try {
-        const text = Buffer.concat(chunks).toString('utf8');
-        resolve(text ? JSON.parse(text) : {});
-      } catch {
-        reject(Object.assign(new Error('Invalid JSON body'), { statusCode: 400 }));
-      }
-    });
-
-    req.on('error', reject);
-  });
-}
-
-function normalizeBaseUrl(value) {
-  const trimmed = String(value || '').trim().replace(/\/+$/, '');
-  if (!trimmed) {
-    return '';
-  }
-
-  if (/^https?:\/\//i.test(trimmed)) {
-    return trimmed;
-  }
-
-  return `https://${trimmed}`;
-}
-
-function getApiBaseUrl() {
-  return normalizeBaseUrl(process.env.VITE_API_BASE_URL || process.env.VITE_API_URL || process.env.API_BASE_URL);
-}
-
-async function verifyAdminRequest(req) {
-  const authorization = req.headers.authorization;
-  if (!authorization) {
-    return false;
-  }
-
-  const apiBaseUrl = getApiBaseUrl();
-  if (!apiBaseUrl) {
-    console.error('[marketing-r2] Missing VITE_API_BASE_URL/VITE_API_URL/API_BASE_URL for admin verification.');
-    return false;
-  }
-
-  const response = await fetch(`${apiBaseUrl}/api/admin/me`, {
-    headers: {
-      Accept: 'application/json',
-      Authorization: authorization,
-    },
-  });
-
-  return response.ok;
-}
-
-function getR2Config() {
-  const config = {
-    accountId: String(process.env.R2_ACCOUNT_ID || '').trim(),
-    accessKeyId: String(process.env.R2_ACCESS_KEY_ID || '').trim(),
-    secretAccessKey: String(process.env.R2_SECRET_ACCESS_KEY || '').trim(),
-    bucket: String(process.env.R2_BUCKET || '').trim(),
-    publicBaseUrl: normalizeBaseUrl(process.env.R2_PUBLIC_BASE_URL),
-  };
-
-  const missing = Object.entries(config)
-    .filter(([, value]) => !value)
-    .map(([key]) => key);
-
-  return { ...config, configured: missing.length === 0, missing };
-}
-
-let r2Client;
-
-function getR2Client(config) {
-  if (!r2Client) {
-    r2Client = new S3Client({
-      credentials: {
-        accessKeyId: config.accessKeyId,
-        secretAccessKey: config.secretAccessKey,
-      },
-      endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
-      forcePathStyle: true,
-      region: 'auto',
-    });
-  }
-
-  return r2Client;
-}
-
-function sanitizeAssetKey(value) {
-  const key = String(value || '').trim().replace(/^\/+/, '');
-
-  if (
-    !key
-    || key.includes('..')
-    || key.length > 240
-    || !/^[a-zA-Z0-9][a-zA-Z0-9._/-]*$/.test(key)
-  ) {
-    return null;
-  }
-
-  return key;
-}
-
-function parseBase64Asset(value) {
-  const text = String(value || '').trim();
-  const match = text.match(/^data:([^;,]+);base64,(.+)$/);
-  const base64 = match ? match[2] : text;
-  return Buffer.from(base64, 'base64');
-}
-
-async function handleMarketingR2Request(req, res, requestUrl) {
-  if (requestUrl.pathname === `${MARKETING_R2_ROUTE_PREFIX}/status` && req.method === 'GET') {
-    const allowed = await verifyAdminRequest(req);
-    if (!allowed) {
-      sendJson(res, 401, { ok: false, message: 'Unauthorized' });
-      return true;
-    }
-
-    const config = getR2Config();
-    sendJson(res, 200, {
-      ok: true,
-      configured: config.configured,
-      missing: config.missing,
-      bucket: config.bucket || null,
-      publicBaseUrl: config.publicBaseUrl || null,
-    });
-    return true;
-  }
-
-  if (requestUrl.pathname === `${MARKETING_R2_ROUTE_PREFIX}/assets` && req.method === 'POST') {
-    const allowed = await verifyAdminRequest(req);
-    if (!allowed) {
-      sendJson(res, 401, { ok: false, message: 'Unauthorized' });
-      return true;
-    }
-
-    const config = getR2Config();
-    if (!config.configured) {
-      sendJson(res, 503, { ok: false, message: 'R2 is not configured', missing: config.missing });
-      return true;
-    }
-
-    const body = await readJsonBody(req);
-    const assets = Array.isArray(body?.assets) ? body.assets : [];
-    if (assets.length === 0 || assets.length > 10) {
-      sendJson(res, 400, { ok: false, message: 'Expected 1-10 assets.' });
-      return true;
-    }
-
-    const client = getR2Client(config);
-    const uploaded = [];
-
-    for (const asset of assets) {
-      const key = sanitizeAssetKey(asset?.key);
-      if (!key) {
-        sendJson(res, 400, { ok: false, message: `Invalid asset key: ${asset?.key ?? ''}` });
-        return true;
-      }
-
-      const bytes = parseBase64Asset(asset?.contentBase64);
-      if (bytes.length === 0 || bytes.length > 10 * 1024 * 1024) {
-        sendJson(res, 400, { ok: false, message: `Invalid asset size for ${key}.` });
-        return true;
-      }
-
-      const contentType = String(asset?.contentType || 'application/octet-stream').trim();
-
-      await client.send(new PutObjectCommand({
-        Bucket: config.bucket,
-        Key: key,
-        Body: bytes,
-        ContentType: contentType,
-        CacheControl: 'public, max-age=31536000, immutable',
-      }));
-
-      uploaded.push({
-        key,
-        size: bytes.length,
-        url: `${config.publicBaseUrl}/${key}`,
-      });
-    }
-
-    sendJson(res, 200, { ok: true, assets: uploaded });
-    return true;
-  }
-
-  return false;
 }
 
 async function exists(filePath) {
@@ -288,13 +74,6 @@ async function resolveRequestPath(urlPath) {
 const server = http.createServer(async (req, res) => {
   try {
     const requestUrl = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
-    if (requestUrl.pathname.startsWith(MARKETING_R2_ROUTE_PREFIX)) {
-      const handled = await handleMarketingR2Request(req, res, requestUrl);
-      if (handled) {
-        return;
-      }
-    }
-
     const filePath = await resolveRequestPath(requestUrl.pathname);
     const fileStats = await stat(filePath);
 
@@ -310,16 +89,8 @@ const server = http.createServer(async (req, res) => {
 
     createReadStream(filePath).pipe(res);
   } catch (error) {
-    const statusCode = Number(error?.statusCode || 500);
-    const message = statusCode >= 500 ? 'Internal Server Error' : error.message;
-
-    if (req.url?.startsWith(MARKETING_R2_ROUTE_PREFIX)) {
-      sendJson(res, statusCode, { ok: false, message });
-      return;
-    }
-
-    res.writeHead(statusCode, { 'Content-Type': 'text/plain; charset=utf-8' });
-    res.end(message);
+    res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Internal Server Error');
     console.error(error);
   }
 });

--- a/apps/web/src/lib/marketingR2Assets.ts
+++ b/apps/web/src/lib/marketingR2Assets.ts
@@ -43,7 +43,7 @@ export function buildMarketingAssetKey({
 }
 
 export async function fetchMarketingR2Status() {
-  const response = await apiAuthorizedFetch(`${getR2RoutePrefix()}/status`, {
+  const response = await apiAuthorizedFetch('/admin/marketing/r2/status', {
     headers: {
       Accept: 'application/json',
     },
@@ -72,7 +72,7 @@ export async function uploadMarketingAssetsToR2(inputs: UploadAssetInput[]) {
     }),
   );
 
-  const response = await apiAuthorizedFetch(`${getR2RoutePrefix()}/assets`, {
+  const response = await apiAuthorizedFetch('/admin/marketing/r2/assets', {
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -120,12 +120,4 @@ function toSafeSegment(value: string) {
     .toLowerCase()
     .replace(/[^a-z0-9_-]+/g, '-')
     .replace(/^-+|-+$/g, '') || 'default';
-}
-
-function getR2RoutePrefix() {
-  const origin = typeof window !== 'undefined' && window.location?.origin
-    ? window.location.origin
-    : '';
-
-  return `${origin}/api/admin/marketing/r2`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: 3.1075.0
+        version: 3.1075.0
       '@fastify/express':
         specifier: ^4.0.2
         version: 4.0.2
@@ -167,9 +170,6 @@ importers:
 
   apps/web:
     dependencies:
-      '@aws-sdk/client-s3':
-        specifier: ^3.1075.0
-        version: 3.1075.0
       '@clerk/clerk-react':
         specifier: ^5.8.1
         version: 5.59.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
## Summary

- Moves the marketing R2 status/upload endpoints from the Web static server into the API service.
- Updates the marketing admin frontend to call the authenticated API client for R2 status and uploads.
- Moves the S3/R2 SDK dependency and R2 environment documentation to `apps/api`.

## Why

The marketing admin was calling `/api/admin/marketing/r2/status` on the web domain, which returned the web app instead of an API route in production. That made the Cloudflare R2 status fail with HTTP 404 and kept the upload button disabled.

The API domain already responds correctly for protected admin routes. This change puts the R2 routes behind the existing API admin auth middleware.

## Validation

- `pnpm install --frozen-lockfile`
- `npm --workspace apps/api run build`
- `npm --workspace apps/web run test -- src/lib/__tests__/marketingR2Assets.test.ts src/lib/__tests__/marketingMetricoolCsv.test.ts --run`

## Deploy note

The R2 variables must be configured on the Railway API service, not only the Web service:

```env
R2_ACCOUNT_ID=...
R2_ACCESS_KEY_ID=...
R2_SECRET_ACCESS_KEY=...
R2_BUCKET=innerbloom-marketing-assets
R2_PUBLIC_BASE_URL=https://assets.innerbloomjourney.org
```