### PR TITLE
Skip already uploaded marketing R2 assets

### DIFF
--- a/apps/web/src/lib/__tests__/marketingR2Assets.test.ts
+++ b/apps/web/src/lib/__tests__/marketingR2Assets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildMarketingAssetKey } from '../marketingR2Assets';
+import { buildMarketingAssetKey, isMarketingAssetStoredOnR2 } from '../marketingR2Assets';
 
 describe('buildMarketingAssetKey', () => {
   it('builds stable public R2 object keys for campaign assets', () => {
@@ -20,5 +20,21 @@ describe('buildMarketingAssetKey', () => {
         file: 'Docs/marketing/assets/post-002.png',
       }),
     ).toBe('campaigns/2026-07-launch/post-002/post-002.png');
+  });
+
+  it('detects assets that already point at the R2 public base URL', () => {
+    expect(
+      isMarketingAssetStoredOnR2(
+        'https://assets.innerbloomjourney.org/campaigns/ib20_mvp/post_001/post-001-carousel-01.png',
+        'https://assets.innerbloomjourney.org/',
+      ),
+    ).toBe(true);
+
+    expect(
+      isMarketingAssetStoredOnR2(
+        'https://raw.githubusercontent.com/rfullivarri/innerbloomv3/main/Docs/marketing/post.png',
+        'https://assets.innerbloomjourney.org',
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/marketingR2Assets.ts
+++ b/apps/web/src/lib/marketingR2Assets.ts
@@ -89,6 +89,15 @@ export async function uploadMarketingAssetsToR2(inputs: UploadAssetInput[]) {
   return response.json() as Promise<UploadMarketingAssetsResponse>;
 }
 
+export function isMarketingAssetStoredOnR2(assetUrl: string, publicBaseUrl: string | null | undefined) {
+  const normalizedBaseUrl = String(publicBaseUrl ?? '').trim().replace(/\/+$/, '');
+  if (!normalizedBaseUrl) {
+    return false;
+  }
+
+  return assetUrl.trim().startsWith(`${normalizedBaseUrl}/`);
+}
+
 async function fetchAssetAsBase64(url: string) {
   const response = await fetch(url);
   if (!response.ok) {

--- a/apps/web/src/pages/admin2/MarketingPage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPage.tsx
@@ -10,6 +10,7 @@ import { downloadMetricoolCalendarCsv } from '../../lib/marketingMetricoolCsv';
 import {
   buildMarketingAssetKey,
   fetchMarketingR2Status,
+  isMarketingAssetStoredOnR2,
   uploadMarketingAssetsToR2,
   type MarketingR2Status,
 } from '../../lib/marketingR2Assets';
@@ -351,7 +352,8 @@ export function MarketingPage() {
   const needsReviewCount = posts.filter((post) => post.status === 'needs_review').length;
   const approvedAssetCount = approvedPosts.reduce((total, post) => total + post.assets.length, 0);
   const r2ReadyAssetCount = approvedPosts.reduce(
-    (total, post) => total + post.assets.filter((asset) => r2Status?.publicBaseUrl && asset.url.startsWith(r2Status.publicBaseUrl)).length,
+    (total, post) =>
+      total + post.assets.filter((asset) => isMarketingAssetStoredOnR2(asset.url, r2Status?.publicBaseUrl)).length,
     0,
   );
 
@@ -431,17 +433,25 @@ export function MarketingPage() {
       return;
     }
 
-    setIsUploadingAssets(true);
     setUploadMessage(null);
 
     try {
       const uploadInputs = approvedPosts.flatMap((post) =>
-        post.assets.map((asset) => ({
-          asset,
-          campaignCode: selectedCampaign.campaignCode,
-          postId: post.id,
-        })),
+        post.assets
+          .filter((asset) => !isMarketingAssetStoredOnR2(asset.url, r2Status?.publicBaseUrl))
+          .map((asset) => ({
+            asset,
+            campaignCode: selectedCampaign.campaignCode,
+            postId: post.id,
+          })),
       );
+
+      if (uploadInputs.length === 0) {
+        setUploadMessage('All approved assets are already on R2.');
+        return;
+      }
+
+      setIsUploadingAssets(true);
 
       const result = await uploadMarketingAssetsToR2(uploadInputs);
       const uploadedByKey = new Map(result.assets.map((asset) => [asset.key, asset]));


### PR DESCRIPTION
## Summary

- Skips approved marketing assets that already point to the configured R2 public base URL before uploading.
- Prevents the admin browser from trying to fetch existing `assets.innerbloomjourney.org` files, which was causing CORS failures after a second upload.
- Keeps the R2 ready asset counter aligned with the same detection logic.

## Validation

- `npm --workspace apps/web run test -- src/lib/__tests__/marketingR2Assets.test.ts src/lib/__tests__/marketingMetricoolCsv.test.ts --run`
- `npm --workspace apps/web run build`
- `git diff --check`