### PR TITLE
Add marketing analytics sync

### DIFF
--- a/apps/api/src/db/migrations/202606290001_marketing_analytics.sql
+++ b/apps/api/src/db/migrations/202606290001_marketing_analytics.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS marketing_analytics_sync_runs (
+  run_id TEXT PRIMARY KEY,
+  status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'failed')),
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  ga4_property_id TEXT,
+  gsc_site_url TEXT,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ,
+  error_message TEXT
+);
+
+CREATE TABLE IF NOT EXISTS marketing_ga4_page_metrics (
+  run_id TEXT NOT NULL REFERENCES marketing_analytics_sync_runs(run_id) ON DELETE CASCADE,
+  page_path TEXT NOT NULL,
+  page_title TEXT NOT NULL DEFAULT '',
+  active_users INTEGER NOT NULL DEFAULT 0,
+  sessions INTEGER NOT NULL DEFAULT 0,
+  screen_page_views INTEGER NOT NULL DEFAULT 0,
+  event_count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (run_id, page_path, page_title)
+);
+
+CREATE TABLE IF NOT EXISTS marketing_ga4_source_metrics (
+  run_id TEXT NOT NULL REFERENCES marketing_analytics_sync_runs(run_id) ON DELETE CASCADE,
+  source TEXT NOT NULL DEFAULT '',
+  medium TEXT NOT NULL DEFAULT '',
+  campaign TEXT NOT NULL DEFAULT '',
+  active_users INTEGER NOT NULL DEFAULT 0,
+  sessions INTEGER NOT NULL DEFAULT 0,
+  screen_page_views INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (run_id, source, medium, campaign)
+);
+
+CREATE TABLE IF NOT EXISTS marketing_ga4_event_metrics (
+  run_id TEXT NOT NULL REFERENCES marketing_analytics_sync_runs(run_id) ON DELETE CASCADE,
+  event_name TEXT NOT NULL,
+  event_count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (run_id, event_name)
+);
+
+CREATE TABLE IF NOT EXISTS marketing_gsc_query_page_metrics (
+  run_id TEXT NOT NULL REFERENCES marketing_analytics_sync_runs(run_id) ON DELETE CASCADE,
+  query TEXT NOT NULL DEFAULT '',
+  page TEXT NOT NULL DEFAULT '',
+  clicks INTEGER NOT NULL DEFAULT 0,
+  impressions INTEGER NOT NULL DEFAULT 0,
+  ctr NUMERIC NOT NULL DEFAULT 0,
+  position NUMERIC NOT NULL DEFAULT 0,
+  PRIMARY KEY (run_id, query, page)
+);
+
+CREATE TABLE IF NOT EXISTS marketing_insights (
+  run_id TEXT PRIMARY KEY REFERENCES marketing_analytics_sync_runs(run_id) ON DELETE CASCADE,
+  summary JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS marketing_analytics_sync_runs_completed_idx
+  ON marketing_analytics_sync_runs (completed_at DESC)
+  WHERE status = 'completed';
+
+CREATE INDEX IF NOT EXISTS marketing_ga4_page_metrics_views_idx
+  ON marketing_ga4_page_metrics (run_id, screen_page_views DESC);
+
+CREATE INDEX IF NOT EXISTS marketing_gsc_query_page_metrics_impressions_idx
+  ON marketing_gsc_query_page_metrics (run_id, impressions DESC);

--- a/apps/api/src/modules/admin/admin.handlers.ts
+++ b/apps/api/src/modules/admin/admin.handlers.ts
@@ -19,6 +19,7 @@ import {
   feedbackUserNotificationUpdateSchema,
   subscriptionNotificationsTriggerBodySchema,
   adminSubscriptionUpdateBodySchema,
+  marketingAnalyticsSyncBodySchema,
   marketingR2AssetUploadBodySchema,
   taskDifficultyCalibrationRunBodySchema,
   modeUpgradeAggregationRunBodySchema,
@@ -71,6 +72,11 @@ import { runUserMonthlyModeUpgradeAggregation } from '../../services/modeUpgrade
 import { runRetroactiveHabitAchievementDetection } from '../../services/habitAchievementService.js';
 import { getMonthlyPipelineStatus, runMonthlyPipelineForPeriod } from '../../services/monthlyPipelineService.js';
 import { getMarketingR2Status, uploadMarketingR2Assets } from '../../services/marketingR2AssetService.js';
+import {
+  getMarketingAnalyticsInsights,
+  getMarketingAnalyticsStatus,
+  runMarketingAnalyticsSync,
+} from '../../services/marketingAnalyticsService.js';
 import { pool } from '../../db.js';
 
 const taskgenForceRunRequestSchema = z
@@ -139,6 +145,22 @@ export const postAdminMarketingR2Assets = asyncHandler(async (req: Request, res:
     ok: true,
     assets,
   });
+});
+
+export const getAdminMarketingAnalyticsStatus = asyncHandler(async (_req: Request, res: Response) => {
+  const status = await getMarketingAnalyticsStatus();
+  res.json({ ok: true, ...status });
+});
+
+export const getAdminMarketingAnalyticsInsights = asyncHandler(async (_req: Request, res: Response) => {
+  const insights = await getMarketingAnalyticsInsights();
+  res.json({ ok: true, ...insights });
+});
+
+export const postAdminMarketingAnalyticsSync = asyncHandler(async (req: Request, res: Response) => {
+  const body = marketingAnalyticsSyncBodySchema.parse(req.body ?? {});
+  const result = await runMarketingAnalyticsSync(body);
+  res.json(result);
 });
 
 export const getAdminUserInsights = asyncHandler(async (req: Request, res: Response) => {

--- a/apps/api/src/modules/admin/admin.routes.ts
+++ b/apps/api/src/modules/admin/admin.routes.ts
@@ -40,8 +40,11 @@ import {
   putAdminUserModeUpgradeCtaOverride,
   deleteAdminUserModeUpgradeCtaOverride,
   getAdminMonthlyPipelineStatus,
+  getAdminMarketingAnalyticsInsights,
+  getAdminMarketingAnalyticsStatus,
   getAdminMarketingR2Status,
   postAdminMonthlyPipelineRun,
+  postAdminMarketingAnalyticsSync,
   postAdminMarketingR2Assets,
 } from './admin.handlers.js';
 import { requireAdmin } from './admin.middleware.js';
@@ -51,6 +54,9 @@ const adminRouter = Router();
 
 adminRouter.get('/me', getAdminMe);
 adminRouter.get('/users', getAdminUsers);
+adminRouter.get('/marketing/analytics/status', getAdminMarketingAnalyticsStatus);
+adminRouter.get('/marketing/analytics/insights', getAdminMarketingAnalyticsInsights);
+adminRouter.post('/marketing/analytics/sync', postAdminMarketingAnalyticsSync);
 adminRouter.get('/marketing/r2/status', getAdminMarketingR2Status);
 adminRouter.post('/marketing/r2/assets', postAdminMarketingR2Assets);
 adminRouter.get('/taskgen/jobs', getTaskgenJobs);

--- a/apps/api/src/modules/admin/admin.schemas.ts
+++ b/apps/api/src/modules/admin/admin.schemas.ts
@@ -206,6 +206,20 @@ export const marketingR2AssetUploadBodySchema = z.object({
     .max(10),
 });
 
+export const marketingAnalyticsSyncBodySchema = z.object({
+  startDate: z
+    .string()
+    .trim()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, { message: 'startDate must be YYYY-MM-DD' })
+    .optional(),
+  endDate: z
+    .string()
+    .trim()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, { message: 'endDate must be YYYY-MM-DD' })
+    .optional(),
+  force: z.coerce.boolean().default(false),
+});
+
 export const subscriptionNotificationsTriggerBodySchema = z.object({
   runAt: z.string().datetime().optional(),
 });

--- a/apps/api/src/services/marketingAnalyticsService.ts
+++ b/apps/api/src/services/marketingAnalyticsService.ts
@@ -39,6 +39,31 @@ type GscMetricRow = {
   position: number;
 };
 
+type GoogleMetricValue = {
+  value?: unknown;
+};
+
+type Ga4ApiRow = {
+  dimensionValues?: GoogleMetricValue[];
+  metricValues?: GoogleMetricValue[];
+};
+
+type Ga4ApiResponse = {
+  rows?: Ga4ApiRow[];
+};
+
+type GscApiRow = {
+  keys?: unknown[];
+  clicks?: unknown;
+  impressions?: unknown;
+  ctr?: unknown;
+  position?: unknown;
+};
+
+type GscApiResponse = {
+  rows?: GscApiRow[];
+};
+
 let cachedGoogleToken: GoogleAccessToken | null = null;
 let schemaReady: Promise<void> | null = null;
 
@@ -371,18 +396,14 @@ async function fetchGa4Rows(
     }),
   });
 
-  const body = await response.json().catch(() => null);
+  const body = await response.json().catch(() => null) as Ga4ApiResponse | null;
   if (!response.ok) {
     throw new HttpError(response.status, 'ga4_request_failed', 'GA4 Data API request failed.', body);
   }
 
-  return (Array.isArray(body?.rows) ? body.rows : []).map((row: any) => ({
-    dimensions: Array.isArray(row.dimensionValues)
-      ? row.dimensionValues.map((value: any) => String(value?.value ?? ''))
-      : [],
-    metrics: Array.isArray(row.metricValues)
-      ? row.metricValues.map((value: any) => Number(value?.value ?? 0))
-      : [],
+  return (Array.isArray(body?.rows) ? body.rows : []).map((row) => ({
+    dimensions: readGoogleMetricValues(row.dimensionValues).map((value) => String(value ?? '')),
+    metrics: readGoogleMetricValues(row.metricValues).map((value) => Number(value ?? 0)),
   }));
 }
 
@@ -404,18 +425,22 @@ async function fetchGscRows(siteUrl: string, accessToken: string, dateRange: Dat
     },
   );
 
-  const body = await response.json().catch(() => null);
+  const body = await response.json().catch(() => null) as GscApiResponse | null;
   if (!response.ok) {
     throw new HttpError(response.status, 'gsc_request_failed', 'Search Console API request failed.', body);
   }
 
-  return (Array.isArray(body?.rows) ? body.rows : []).map((row: any) => ({
+  return (Array.isArray(body?.rows) ? body.rows : []).map((row) => ({
     keys: Array.isArray(row.keys) ? row.keys.map((value: unknown) => String(value ?? '')) : [],
     clicks: Number(row.clicks ?? 0),
     impressions: Number(row.impressions ?? 0),
     ctr: Number(row.ctr ?? 0),
     position: Number(row.position ?? 0),
   }));
+}
+
+function readGoogleMetricValues(values: GoogleMetricValue[] | undefined) {
+  return Array.isArray(values) ? values.map((value) => value.value) : [];
 }
 
 async function getGoogleAccessToken(serviceAccount: GoogleServiceAccount) {

--- a/apps/api/src/services/marketingAnalyticsService.ts
+++ b/apps/api/src/services/marketingAnalyticsService.ts
@@ -1,0 +1,689 @@
+import { randomUUID } from 'node:crypto';
+import { importPKCS8, SignJWT } from 'jose';
+import { HttpError } from '../lib/http-error.js';
+import { pool, withClient } from '../db.js';
+
+const GOOGLE_TOKEN_SCOPE = [
+  'https://www.googleapis.com/auth/analytics.readonly',
+  'https://www.googleapis.com/auth/webmasters.readonly',
+].join(' ');
+
+const DEFAULT_WINDOW_DAYS = 28;
+
+type GoogleServiceAccount = {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+};
+
+type GoogleAccessToken = {
+  token: string;
+  expiresAtMs: number;
+};
+
+type DateRange = {
+  startDate: string;
+  endDate: string;
+};
+
+type Ga4MetricRow = {
+  dimensions: string[];
+  metrics: number[];
+};
+
+type GscMetricRow = {
+  keys: string[];
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+};
+
+let cachedGoogleToken: GoogleAccessToken | null = null;
+let schemaReady: Promise<void> | null = null;
+
+export type MarketingAnalyticsSyncOptions = Partial<DateRange> & {
+  force?: boolean;
+};
+
+export async function getMarketingAnalyticsStatus() {
+  await ensureMarketingAnalyticsSchema();
+  const config = getMarketingAnalyticsConfig();
+  const latestRun = await getLatestRun();
+
+  return {
+    configured: config.configured,
+    missing: config.missing,
+    ga4PropertyId: config.ga4PropertyId || null,
+    gscSiteUrl: config.gscSiteUrl || null,
+    latestRun,
+  };
+}
+
+export async function getMarketingAnalyticsInsights() {
+  await ensureMarketingAnalyticsSchema();
+  const config = getMarketingAnalyticsConfig();
+  const latestRun = await getLatestRun();
+
+  if (!latestRun || latestRun.status !== 'completed') {
+    return {
+      configured: config.configured,
+      missing: config.missing,
+      latestRun,
+      summary: null,
+      topPages: [],
+      topSources: [],
+      topEvents: [],
+      topQueries: [],
+    };
+  }
+
+  const [insightResult, pageResult, sourceResult, eventResult, queryResult] = await Promise.all([
+    pool.query<{ summary: unknown }>('SELECT summary FROM marketing_insights WHERE run_id = $1 LIMIT 1', [latestRun.runId]),
+    pool.query(
+      `SELECT page_path, page_title, active_users, sessions, screen_page_views, event_count
+       FROM marketing_ga4_page_metrics
+       WHERE run_id = $1
+       ORDER BY screen_page_views DESC, active_users DESC
+       LIMIT 10`,
+      [latestRun.runId],
+    ),
+    pool.query(
+      `SELECT source, medium, campaign, active_users, sessions, screen_page_views
+       FROM marketing_ga4_source_metrics
+       WHERE run_id = $1
+       ORDER BY sessions DESC, active_users DESC
+       LIMIT 10`,
+      [latestRun.runId],
+    ),
+    pool.query(
+      `SELECT event_name, event_count
+       FROM marketing_ga4_event_metrics
+       WHERE run_id = $1
+       ORDER BY event_count DESC
+       LIMIT 10`,
+      [latestRun.runId],
+    ),
+    pool.query(
+      `SELECT query, page, clicks, impressions, ctr::float AS ctr, position::float AS position
+       FROM marketing_gsc_query_page_metrics
+       WHERE run_id = $1
+       ORDER BY impressions DESC, clicks DESC
+       LIMIT 10`,
+      [latestRun.runId],
+    ),
+  ]);
+
+  return {
+    configured: config.configured,
+    missing: config.missing,
+    latestRun,
+    summary: insightResult.rows[0]?.summary ?? null,
+    topPages: pageResult.rows,
+    topSources: sourceResult.rows,
+    topEvents: eventResult.rows,
+    topQueries: queryResult.rows,
+  };
+}
+
+export async function runMarketingAnalyticsSync(options: MarketingAnalyticsSyncOptions = {}) {
+  await ensureMarketingAnalyticsSchema();
+  const config = getMarketingAnalyticsConfig();
+
+  if (!config.configured) {
+    throw new HttpError(503, 'marketing_analytics_not_configured', 'Marketing analytics is not configured.', {
+      missing: config.missing,
+    });
+  }
+
+  const dateRange = normalizeDateRange(options);
+  const runId = `marketing-${dateRange.startDate}-${dateRange.endDate}-${randomUUID()}`;
+
+  await pool.query(
+    `INSERT INTO marketing_analytics_sync_runs (
+      run_id,
+      status,
+      period_start,
+      period_end,
+      ga4_property_id,
+      gsc_site_url
+    ) VALUES ($1, 'running', $2, $3, $4, $5)`,
+    [runId, dateRange.startDate, dateRange.endDate, config.ga4PropertyId, config.gscSiteUrl],
+  );
+
+  try {
+    const token = await getGoogleAccessToken(config.serviceAccount);
+    const [ga4Pages, ga4Sources, ga4Events, gscQueries] = await Promise.all([
+      fetchGa4Rows(config.ga4PropertyId, token, dateRange, ['pagePath', 'pageTitle'], [
+        'activeUsers',
+        'sessions',
+        'screenPageViews',
+        'eventCount',
+      ]),
+      fetchGa4Rows(config.ga4PropertyId, token, dateRange, ['sessionSource', 'sessionMedium', 'sessionCampaignName'], [
+        'activeUsers',
+        'sessions',
+        'screenPageViews',
+      ]),
+      fetchGa4Rows(config.ga4PropertyId, token, dateRange, ['eventName'], ['eventCount']),
+      fetchGscRows(config.gscSiteUrl, token, dateRange),
+    ]);
+
+    const summary = buildMarketingInsightSummary({
+      runId,
+      dateRange,
+      ga4Pages,
+      ga4Sources,
+      ga4Events,
+      gscQueries,
+    });
+
+    await withClient(async (client) => {
+      await client.query('BEGIN');
+      try {
+        for (const row of ga4Pages) {
+          await client.query(
+            `INSERT INTO marketing_ga4_page_metrics (
+              run_id,
+              page_path,
+              page_title,
+              active_users,
+              sessions,
+              screen_page_views,
+              event_count
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+            [
+              runId,
+              row.dimensions[0] ?? '',
+              row.dimensions[1] ?? '',
+              toInteger(row.metrics[0]),
+              toInteger(row.metrics[1]),
+              toInteger(row.metrics[2]),
+              toInteger(row.metrics[3]),
+            ],
+          );
+        }
+
+        for (const row of ga4Sources) {
+          await client.query(
+            `INSERT INTO marketing_ga4_source_metrics (
+              run_id,
+              source,
+              medium,
+              campaign,
+              active_users,
+              sessions,
+              screen_page_views
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+            [
+              runId,
+              row.dimensions[0] ?? '',
+              row.dimensions[1] ?? '',
+              row.dimensions[2] ?? '',
+              toInteger(row.metrics[0]),
+              toInteger(row.metrics[1]),
+              toInteger(row.metrics[2]),
+            ],
+          );
+        }
+
+        for (const row of ga4Events) {
+          await client.query(
+            `INSERT INTO marketing_ga4_event_metrics (run_id, event_name, event_count)
+             VALUES ($1, $2, $3)`,
+            [runId, row.dimensions[0] ?? '', toInteger(row.metrics[0])],
+          );
+        }
+
+        for (const row of gscQueries) {
+          await client.query(
+            `INSERT INTO marketing_gsc_query_page_metrics (
+              run_id,
+              query,
+              page,
+              clicks,
+              impressions,
+              ctr,
+              position
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+            [
+              runId,
+              row.keys[0] ?? '',
+              row.keys[1] ?? '',
+              toInteger(row.clicks),
+              toInteger(row.impressions),
+              row.ctr,
+              row.position,
+            ],
+          );
+        }
+
+        await client.query(
+          `INSERT INTO marketing_insights (run_id, summary)
+           VALUES ($1, $2::jsonb)`,
+          [runId, JSON.stringify(summary)],
+        );
+
+        await client.query(
+          `UPDATE marketing_analytics_sync_runs
+           SET status = 'completed', completed_at = now()
+           WHERE run_id = $1`,
+          [runId],
+        );
+
+        await client.query('COMMIT');
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      }
+    });
+
+    return {
+      ok: true,
+      runId,
+      periodStart: dateRange.startDate,
+      periodEnd: dateRange.endDate,
+      rows: {
+        ga4Pages: ga4Pages.length,
+        ga4Sources: ga4Sources.length,
+        ga4Events: ga4Events.length,
+        gscQueries: gscQueries.length,
+      },
+      summary,
+    };
+  } catch (error) {
+    await pool.query(
+      `UPDATE marketing_analytics_sync_runs
+       SET status = 'failed', completed_at = now(), error_message = $2
+       WHERE run_id = $1`,
+      [runId, error instanceof Error ? error.message : 'Unknown marketing analytics sync error'],
+    );
+
+    throw error;
+  }
+}
+
+function buildMarketingInsightSummary({
+  runId,
+  dateRange,
+  ga4Pages,
+  ga4Sources,
+  ga4Events,
+  gscQueries,
+}: {
+  runId: string;
+  dateRange: DateRange;
+  ga4Pages: Ga4MetricRow[];
+  ga4Sources: Ga4MetricRow[];
+  ga4Events: Ga4MetricRow[];
+  gscQueries: GscMetricRow[];
+}) {
+  const totals = {
+    activeUsers: sumMetric(ga4Pages, 0),
+    sessions: sumMetric(ga4Pages, 1),
+    pageViews: sumMetric(ga4Pages, 2),
+    events: sumMetric(ga4Events, 0),
+    searchClicks: gscQueries.reduce((total, row) => total + toInteger(row.clicks), 0),
+    searchImpressions: gscQueries.reduce((total, row) => total + toInteger(row.impressions), 0),
+  };
+
+  const topLandingPage = sortGa4RowsByMetric(ga4Pages, 2)[0] ?? null;
+  const topSource = sortGa4RowsByMetric(ga4Sources, 1)[0] ?? null;
+  const topQuery = [...gscQueries].sort((left, right) => right.impressions - left.impressions)[0] ?? null;
+
+  return {
+    runId,
+    periodStart: dateRange.startDate,
+    periodEnd: dateRange.endDate,
+    totals,
+    highlights: [
+      topLandingPage
+        ? `Top landing page: ${topLandingPage.dimensions[0]} with ${toInteger(topLandingPage.metrics[2])} views.`
+        : 'No GA4 landing page data returned.',
+      topSource
+        ? `Top acquisition source: ${[topSource.dimensions[0], topSource.dimensions[1]].filter(Boolean).join(' / ')}.`
+        : 'No GA4 acquisition source data returned.',
+      topQuery
+        ? `Top search query: "${topQuery.keys[0]}" with ${toInteger(topQuery.impressions)} impressions.`
+        : 'No Search Console query data returned.',
+    ],
+  };
+}
+
+async function fetchGa4Rows(
+  propertyId: string,
+  accessToken: string,
+  dateRange: DateRange,
+  dimensions: string[],
+  metrics: string[],
+): Promise<Ga4MetricRow[]> {
+  const response = await fetch(`https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      dateRanges: [dateRange],
+      dimensions: dimensions.map((name) => ({ name })),
+      metrics: metrics.map((name) => ({ name })),
+      limit: '100',
+    }),
+  });
+
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new HttpError(response.status, 'ga4_request_failed', 'GA4 Data API request failed.', body);
+  }
+
+  return (Array.isArray(body?.rows) ? body.rows : []).map((row: any) => ({
+    dimensions: Array.isArray(row.dimensionValues)
+      ? row.dimensionValues.map((value: any) => String(value?.value ?? ''))
+      : [],
+    metrics: Array.isArray(row.metricValues)
+      ? row.metricValues.map((value: any) => Number(value?.value ?? 0))
+      : [],
+  }));
+}
+
+async function fetchGscRows(siteUrl: string, accessToken: string, dateRange: DateRange): Promise<GscMetricRow[]> {
+  const response = await fetch(
+    `https://searchconsole.googleapis.com/webmasters/v3/sites/${encodeURIComponent(siteUrl)}/searchAnalytics/query`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        startDate: dateRange.startDate,
+        endDate: dateRange.endDate,
+        dimensions: ['query', 'page'],
+        rowLimit: 100,
+      }),
+    },
+  );
+
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new HttpError(response.status, 'gsc_request_failed', 'Search Console API request failed.', body);
+  }
+
+  return (Array.isArray(body?.rows) ? body.rows : []).map((row: any) => ({
+    keys: Array.isArray(row.keys) ? row.keys.map((value: unknown) => String(value ?? '')) : [],
+    clicks: Number(row.clicks ?? 0),
+    impressions: Number(row.impressions ?? 0),
+    ctr: Number(row.ctr ?? 0),
+    position: Number(row.position ?? 0),
+  }));
+}
+
+async function getGoogleAccessToken(serviceAccount: GoogleServiceAccount) {
+  const now = Date.now();
+  if (cachedGoogleToken && cachedGoogleToken.expiresAtMs - now > 60_000) {
+    return cachedGoogleToken.token;
+  }
+
+  const iat = Math.floor(now / 1000);
+  const exp = iat + 3600;
+  const tokenUri = serviceAccount.token_uri || 'https://oauth2.googleapis.com/token';
+  const privateKey = await importPKCS8(serviceAccount.private_key, 'RS256');
+  const assertion = await new SignJWT({ scope: GOOGLE_TOKEN_SCOPE })
+    .setProtectedHeader({ alg: 'RS256', typ: 'JWT' })
+    .setIssuer(serviceAccount.client_email)
+    .setSubject(serviceAccount.client_email)
+    .setAudience(tokenUri)
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .sign(privateKey);
+
+  const response = await fetch(tokenUri, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    }),
+  });
+
+  const body = await response.json().catch(() => null);
+  if (!response.ok || typeof body?.access_token !== 'string') {
+    throw new HttpError(response.status, 'google_auth_failed', 'Google service account authentication failed.', body);
+  }
+
+  cachedGoogleToken = {
+    token: body.access_token,
+    expiresAtMs: now + Number(body.expires_in ?? 3600) * 1000,
+  };
+
+  return cachedGoogleToken.token;
+}
+
+function getMarketingAnalyticsConfig() {
+  const ga4PropertyId = readEnv('GA4_PROPERTY_ID');
+  const gscSiteUrl = readEnv('GSC_SITE_URL');
+  const serviceAccountRaw = readEnv('GOOGLE_SERVICE_ACCOUNT_JSON_BASE64');
+  const missing = [
+    ['GA4_PROPERTY_ID', ga4PropertyId],
+    ['GSC_SITE_URL', gscSiteUrl],
+    ['GOOGLE_SERVICE_ACCOUNT_JSON_BASE64', serviceAccountRaw],
+  ]
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  let serviceAccount: GoogleServiceAccount | null = null;
+  if (serviceAccountRaw) {
+    try {
+      serviceAccount = JSON.parse(Buffer.from(serviceAccountRaw, 'base64').toString('utf8')) as GoogleServiceAccount;
+      if (!serviceAccount.client_email) {
+        missing.push('GOOGLE_SERVICE_ACCOUNT_JSON_BASE64.client_email');
+      }
+      if (!serviceAccount.private_key) {
+        missing.push('GOOGLE_SERVICE_ACCOUNT_JSON_BASE64.private_key');
+      }
+    } catch {
+      missing.push('GOOGLE_SERVICE_ACCOUNT_JSON_BASE64.valid_json');
+    }
+  }
+
+  return {
+    configured: missing.length === 0,
+    missing,
+    ga4PropertyId,
+    gscSiteUrl,
+    serviceAccount: serviceAccount as GoogleServiceAccount,
+  };
+}
+
+async function getLatestRun() {
+  const result = await pool.query<{
+    run_id: string;
+    status: string;
+    period_start: string;
+    period_end: string;
+    ga4_property_id: string | null;
+    gsc_site_url: string | null;
+    started_at: string;
+    completed_at: string | null;
+    error_message: string | null;
+  }>(
+    `SELECT run_id, status, period_start, period_end, ga4_property_id, gsc_site_url, started_at, completed_at, error_message
+     FROM marketing_analytics_sync_runs
+     ORDER BY started_at DESC
+     LIMIT 1`,
+  );
+
+  const row = result.rows[0];
+  if (!row) {
+    return null;
+  }
+
+  return {
+    runId: row.run_id,
+    status: row.status,
+    periodStart: toDateString(row.period_start),
+    periodEnd: toDateString(row.period_end),
+    ga4PropertyId: row.ga4_property_id,
+    gscSiteUrl: row.gsc_site_url,
+    startedAt: toIsoString(row.started_at),
+    completedAt: row.completed_at ? toIsoString(row.completed_at) : null,
+    errorMessage: row.error_message,
+  };
+}
+
+function normalizeDateRange(options: MarketingAnalyticsSyncOptions): DateRange {
+  if (options.startDate && options.endDate) {
+    return {
+      startDate: assertDateOnly(options.startDate, 'startDate'),
+      endDate: assertDateOnly(options.endDate, 'endDate'),
+    };
+  }
+
+  const end = new Date();
+  end.setUTCDate(end.getUTCDate() - 1);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - DEFAULT_WINDOW_DAYS + 1);
+
+  return {
+    startDate: toDateOnly(start),
+    endDate: toDateOnly(end),
+  };
+}
+
+function assertDateOnly(value: string, field: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new HttpError(400, 'invalid_date_range', `${field} must be YYYY-MM-DD.`);
+  }
+  return value;
+}
+
+function toDateOnly(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function toDateString(value: unknown) {
+  if (value instanceof Date) {
+    return toDateOnly(value);
+  }
+
+  return String(value ?? '').slice(0, 10);
+}
+
+function toIsoString(value: unknown) {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return String(value ?? '');
+}
+
+function readEnv(key: string) {
+  return String(process.env[key] || '').trim();
+}
+
+function toInteger(value: unknown) {
+  const numberValue = Number(value ?? 0);
+  return Number.isFinite(numberValue) ? Math.round(numberValue) : 0;
+}
+
+function sumMetric(rows: Ga4MetricRow[], metricIndex: number) {
+  return rows.reduce((total, row) => total + toInteger(row.metrics[metricIndex]), 0);
+}
+
+function sortGa4RowsByMetric(rows: Ga4MetricRow[], metricIndex: number) {
+  return [...rows].sort((left, right) => toInteger(right.metrics[metricIndex]) - toInteger(left.metrics[metricIndex]));
+}
+
+function ensureMarketingAnalyticsSchema() {
+  if (!schemaReady) {
+    schemaReady = withClient(async (client) => {
+      await client.query('BEGIN');
+      try {
+        await client.query(`
+          CREATE TABLE IF NOT EXISTS marketing_analytics_sync_runs (
+            run_id TEXT PRIMARY KEY,
+            status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'failed')),
+            period_start DATE NOT NULL,
+            period_end DATE NOT NULL,
+            ga4_property_id TEXT,
+            gsc_site_url TEXT,
+            started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            completed_at TIMESTAMPTZ,
+            error_message TEXT
+          )
+        `);
+        await client.query(`
+          CREATE TABLE IF NOT EXISTS marketing_ga4_page_metrics (
+            run_id TEXT NOT NULL REFERENCES marketing_analytics_sync_runs(run_id) ON DELETE CASCADE,
+            page_path TEXT NOT NULL,
+            page_title TEXT NOT NULL DEFAULT '',
+            active_users INTEGER NOT NULL DEFAULT 0,
+            sessions INTEGER NOT NULL DEFAULT 0,
+            screen_page_views INTEGER NOT NULL DEFAULT 0,
+            event_count INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (run_id, page_path, page_title)
+          )
+        `);
+        await client.query(`
+          CREATE TABLE IF NOT EXISTS marketing_ga4_source_metrics (
+            run_id TEXT NOT NULL REFERENCES marketing_analytics_sync_runs(run_id) ON DELETE CASCADE,
+            source TEXT NOT NULL DEFAULT '',
+            medium TEXT NOT NULL DEFAULT '',
+            campaign TEXT NOT NULL DEFAULT '',
+            active_users INTEGER NOT NULL DEFAULT 0,
+            sessions INTEGER NOT NULL DEFAULT 0,
+            screen_page_views INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (run_id, source, medium, campaign)
+          )
+        `);
+        await client.query(`
+          CREATE TABLE IF NOT EXISTS marketing_ga4_event_metrics (
+            run_id TEXT NOT NULL REFERENCES marketing_analytics_sync_runs(run_id) ON DELETE CASCADE,
+            event_name TEXT NOT NULL,
+            event_count INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (run_id, event_name)
+          )
+        `);
+        await client.query(`
+          CREATE TABLE IF NOT EXISTS marketing_gsc_query_page_metrics (
+            run_id TEXT NOT NULL REFERENCES marketing_analytics_sync_runs(run_id) ON DELETE CASCADE,
+            query TEXT NOT NULL DEFAULT '',
+            page TEXT NOT NULL DEFAULT '',
+            clicks INTEGER NOT NULL DEFAULT 0,
+            impressions INTEGER NOT NULL DEFAULT 0,
+            ctr NUMERIC NOT NULL DEFAULT 0,
+            position NUMERIC NOT NULL DEFAULT 0,
+            PRIMARY KEY (run_id, query, page)
+          )
+        `);
+        await client.query(`
+          CREATE TABLE IF NOT EXISTS marketing_insights (
+            run_id TEXT PRIMARY KEY REFERENCES marketing_analytics_sync_runs(run_id) ON DELETE CASCADE,
+            summary JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+          )
+        `);
+        await client.query(`
+          CREATE INDEX IF NOT EXISTS marketing_analytics_sync_runs_completed_idx
+          ON marketing_analytics_sync_runs (completed_at DESC)
+          WHERE status = 'completed'
+        `);
+        await client.query(`
+          CREATE INDEX IF NOT EXISTS marketing_ga4_page_metrics_views_idx
+          ON marketing_ga4_page_metrics (run_id, screen_page_views DESC)
+        `);
+        await client.query(`
+          CREATE INDEX IF NOT EXISTS marketing_gsc_query_page_metrics_impressions_idx
+          ON marketing_gsc_query_page_metrics (run_id, impressions DESC)
+        `);
+        await client.query('COMMIT');
+      } catch (error) {
+        await client.query('ROLLBACK');
+        schemaReady = null;
+        throw error;
+      }
+    });
+  }
+
+  return schemaReady;
+}

--- a/apps/web/src/lib/marketingAnalytics.ts
+++ b/apps/web/src/lib/marketingAnalytics.ts
@@ -1,0 +1,110 @@
+import { apiAuthorizedFetch } from './api';
+
+export type MarketingAnalyticsRun = {
+  runId: string;
+  status: string;
+  periodStart: string;
+  periodEnd: string;
+  ga4PropertyId: string | null;
+  gscSiteUrl: string | null;
+  startedAt: string;
+  completedAt: string | null;
+  errorMessage: string | null;
+};
+
+export type MarketingAnalyticsSummary = {
+  runId: string;
+  periodStart: string;
+  periodEnd: string;
+  totals: {
+    activeUsers: number;
+    sessions: number;
+    pageViews: number;
+    events: number;
+    searchClicks: number;
+    searchImpressions: number;
+  };
+  highlights: string[];
+};
+
+export type MarketingAnalyticsInsights = {
+  ok: boolean;
+  configured: boolean;
+  missing: string[];
+  latestRun: MarketingAnalyticsRun | null;
+  summary: MarketingAnalyticsSummary | null;
+  topPages: Array<{
+    page_path: string;
+    page_title: string;
+    active_users: number;
+    sessions: number;
+    screen_page_views: number;
+    event_count: number;
+  }>;
+  topSources: Array<{
+    source: string;
+    medium: string;
+    campaign: string;
+    active_users: number;
+    sessions: number;
+    screen_page_views: number;
+  }>;
+  topEvents: Array<{
+    event_name: string;
+    event_count: number;
+  }>;
+  topQueries: Array<{
+    query: string;
+    page: string;
+    clicks: number;
+    impressions: number;
+    ctr: number;
+    position: number;
+  }>;
+};
+
+export type MarketingAnalyticsSyncResult = {
+  ok: boolean;
+  runId: string;
+  periodStart: string;
+  periodEnd: string;
+  rows: {
+    ga4Pages: number;
+    ga4Sources: number;
+    ga4Events: number;
+    gscQueries: number;
+  };
+  summary: MarketingAnalyticsSummary;
+};
+
+export async function fetchMarketingAnalyticsInsights() {
+  const response = await apiAuthorizedFetch('/admin/marketing/analytics/insights', {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Marketing analytics request failed with HTTP ${response.status}`);
+  }
+
+  return response.json() as Promise<MarketingAnalyticsInsights>;
+}
+
+export async function syncMarketingAnalytics() {
+  const response = await apiAuthorizedFetch('/admin/marketing/analytics/sync', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({}),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Marketing analytics sync failed with HTTP ${response.status}: ${body}`);
+  }
+
+  return response.json() as Promise<MarketingAnalyticsSyncResult>;
+}

--- a/apps/web/src/pages/admin2/MarketingPage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPage.tsx
@@ -8,6 +8,7 @@ import {
   ImagePlus,
   Pencil,
   RotateCcw,
+  RefreshCcwDot,
   Trash2,
   UploadCloud,
   WandSparkles,
@@ -28,6 +29,11 @@ import {
   uploadMarketingAssetsToR2,
   type MarketingR2Status,
 } from '../../lib/marketingR2Assets';
+import {
+  fetchMarketingAnalyticsInsights,
+  syncMarketingAnalytics,
+  type MarketingAnalyticsInsights,
+} from '../../lib/marketingAnalytics';
 
 const STATUS_LABELS: Record<MarketingPostStatus, string> = {
   draft: 'Draft',
@@ -423,8 +429,13 @@ export function MarketingPage() {
   const [r2StatusError, setR2StatusError] = useState<string | null>(null);
   const [isUploadingAssets, setIsUploadingAssets] = useState(false);
   const [uploadMessage, setUploadMessage] = useState<string | null>(null);
+  const [analyticsInsights, setAnalyticsInsights] = useState<MarketingAnalyticsInsights | null>(null);
+  const [analyticsError, setAnalyticsError] = useState<string | null>(null);
+  const [analyticsMessage, setAnalyticsMessage] = useState<string | null>(null);
+  const [isSyncingAnalytics, setIsSyncingAnalytics] = useState(false);
   const approvedPosts = useMemo(() => posts.filter((post) => post.status === 'approved'), [posts]);
   const needsReviewCount = posts.filter((post) => post.status === 'needs_review').length;
+  const analyticsTotals = getAnalyticsTotals(analyticsInsights);
   const approvedAssetCount = approvedPosts.reduce((total, post) => total + post.assets.length, 0);
   const r2ReadyAssetCount = approvedPosts.reduce(
     (total, post) =>
@@ -461,6 +472,21 @@ export function MarketingPage() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    void loadAnalyticsInsights();
+  }, []);
+
+  async function loadAnalyticsInsights() {
+    try {
+      const nextInsights = await fetchMarketingAnalyticsInsights();
+      setAnalyticsInsights(nextInsights);
+      setAnalyticsError(null);
+    } catch (error) {
+      setAnalyticsInsights(null);
+      setAnalyticsError(error instanceof Error ? error.message : 'Unable to load marketing analytics.');
+    }
+  }
 
   function updateStatus(postId: string, status: MarketingPostStatus) {
     updatePost(postId, (post) => ({ ...post, status }));
@@ -558,6 +584,21 @@ export function MarketingPage() {
     }
   }
 
+  async function runAnalyticsSync() {
+    setIsSyncingAnalytics(true);
+    setAnalyticsMessage(null);
+
+    try {
+      const result = await syncMarketingAnalytics();
+      setAnalyticsMessage(`Synced ${result.periodStart} to ${result.periodEnd}.`);
+      await loadAnalyticsInsights();
+    } catch (error) {
+      setAnalyticsMessage(error instanceof Error ? error.message : 'Marketing analytics sync failed.');
+    } finally {
+      setIsSyncingAnalytics(false);
+    }
+  }
+
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-6">
       <header className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-6">
@@ -638,7 +679,7 @@ export function MarketingPage() {
         <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5">
           <h3 className="text-lg font-semibold tracking-tight">Data & storage</h3>
           <p className="mt-2 text-sm text-[color:var(--admin-muted)]">
-            This is prepared for GA4, Search Console and manual Metricool exports. Live integrations are intentionally not wired yet.
+            GA4 and Search Console snapshots are stored in Neon. Metricool stays manual through approved CSV exports.
           </p>
           <div className="mt-4 grid gap-3 text-sm">
             <a className="font-semibold text-[color:var(--admin-accent)]" href={selectedCampaign.driveRootUrl} target="_blank" rel="noreferrer">
@@ -653,6 +694,51 @@ export function MarketingPage() {
             <a className="font-semibold text-[color:var(--admin-accent)]" href={selectedCampaign.campaignsFolderUrl} target="_blank" rel="noreferrer">
               Campaigns folder
             </a>
+          </div>
+          <div className="mt-5 rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 text-sm">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="font-semibold">GA4 + Search Console</p>
+                <p className="mt-1 text-xs text-[color:var(--admin-muted)]">
+                  {analyticsError
+                    ? analyticsError
+                    : analyticsInsights?.latestRun
+                      ? `Last sync ${analyticsInsights.latestRun.periodStart} -> ${analyticsInsights.latestRun.periodEnd}`
+                      : 'No Neon analytics snapshot yet.'}
+                </p>
+              </div>
+              <span className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${
+                analyticsInsights?.configured
+                  ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
+                  : 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-200'
+              }`}>
+                {analyticsInsights?.configured ? 'Ready' : 'Pending'}
+              </span>
+            </div>
+            {analyticsInsights && !analyticsInsights.configured ? (
+              <p className="mt-2 text-xs text-[color:var(--admin-muted)]">
+                Missing: {analyticsInsights.missing.join(', ')}
+              </p>
+            ) : null}
+            {analyticsInsights?.latestRun?.errorMessage ? (
+              <p className="mt-2 text-xs text-amber-700 dark:text-amber-200">
+                {analyticsInsights.latestRun.errorMessage}
+              </p>
+            ) : null}
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                className="admin2-btn admin2-btn--secondary inline-flex items-center gap-2"
+                onClick={runAnalyticsSync}
+                disabled={!analyticsInsights?.configured || isSyncingAnalytics}
+              >
+                <RefreshCcwDot size={16} />
+                <span>{isSyncingAnalytics ? 'Syncing' : 'Sync data'}</span>
+              </button>
+              {analyticsMessage ? (
+                <p className="text-xs text-[color:var(--admin-muted)]">{analyticsMessage}</p>
+              ) : null}
+            </div>
           </div>
           <div className="mt-5 rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 text-sm">
             <div className="flex flex-wrap items-start justify-between gap-3">
@@ -708,6 +794,82 @@ export function MarketingPage() {
         </div>
       </section>
 
+      <section className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="text-lg font-semibold tracking-tight">Marketing insights</h3>
+            <p className="mt-2 text-sm text-[color:var(--admin-muted)]">
+              Latest GA4 and Search Console snapshot saved in Neon.
+            </p>
+          </div>
+          {analyticsInsights?.latestRun ? (
+            <span className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${
+              analyticsInsights.latestRun.status === 'completed'
+                ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
+                : analyticsInsights.latestRun.status === 'failed'
+                  ? 'border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-200'
+                  : 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-200'
+            }`}>
+              {analyticsInsights.latestRun.status}
+            </span>
+          ) : null}
+        </div>
+
+        {analyticsInsights?.summary ? (
+          <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-6">
+            <InsightStat label="Users" value={formatNumber(analyticsTotals.activeUsers)} />
+            <InsightStat label="Sessions" value={formatNumber(analyticsTotals.sessions)} />
+            <InsightStat label="Views" value={formatNumber(analyticsTotals.pageViews)} />
+            <InsightStat label="Events" value={formatNumber(analyticsTotals.events)} />
+            <InsightStat label="Clicks" value={formatNumber(analyticsTotals.searchClicks)} />
+            <InsightStat label="Impressions" value={formatNumber(analyticsTotals.searchImpressions)} />
+          </div>
+        ) : (
+          <p className="mt-5 rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-4 text-sm text-[color:var(--admin-muted)]">
+            Run the first sync to populate this dashboard.
+          </p>
+        )}
+
+        {analyticsInsights?.summary?.highlights.length ? (
+          <div className="mt-5 grid gap-2">
+            {analyticsInsights.summary.highlights.map((highlight) => (
+              <p key={highlight} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-sm text-[color:var(--admin-text)]">
+                {highlight}
+              </p>
+            ))}
+          </div>
+        ) : null}
+
+        {analyticsInsights?.summary ? (
+          <div className="mt-5 grid gap-4 lg:grid-cols-3">
+            <InsightTable
+              title="Top pages"
+              rows={analyticsInsights.topPages.slice(0, 5).map((row) => ({
+                label: row.page_path || '/',
+                detail: row.page_title,
+                value: formatNumber(row.screen_page_views),
+              }))}
+            />
+            <InsightTable
+              title="Top sources"
+              rows={analyticsInsights.topSources.slice(0, 5).map((row) => ({
+                label: [row.source || '(direct)', row.medium || '(none)'].join(' / '),
+                detail: row.campaign || 'No campaign',
+                value: formatNumber(row.sessions),
+              }))}
+            />
+            <InsightTable
+              title="Search queries"
+              rows={analyticsInsights.topQueries.slice(0, 5).map((row) => ({
+                label: row.query || '(not provided)',
+                detail: row.page,
+                value: `${formatNumber(row.impressions)} imp. / ${formatNumber(row.clicks)} clicks`,
+              }))}
+            />
+          </div>
+        ) : null}
+      </section>
+
       <section className="flex flex-col gap-4">
         {posts.map((post) => (
           <PostCard
@@ -731,6 +893,64 @@ function cloneCampaignPosts(campaign: MarketingCampaignSeed) {
     ...post,
     assets: post.assets.map((asset) => ({ ...asset })),
   }));
+}
+
+function InsightStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">{label}</p>
+      <p className="mt-2 text-2xl font-semibold text-[color:var(--admin-text)]">{value}</p>
+    </div>
+  );
+}
+
+function InsightTable({
+  title,
+  rows,
+}: {
+  title: string;
+  rows: Array<{ label: string; detail?: string; value: string }>;
+}) {
+  return (
+    <div className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3">
+      <p className="text-sm font-semibold text-[color:var(--admin-text)]">{title}</p>
+      <div className="mt-3 divide-y divide-[color:var(--admin-border)]">
+        {rows.length ? rows.map((row) => (
+          <div key={`${row.label}-${row.value}`} className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 py-2 text-sm">
+            <div className="min-w-0">
+              <p className="truncate font-medium text-[color:var(--admin-text)]">{row.label}</p>
+              {row.detail ? (
+                <p className="mt-1 truncate text-xs text-[color:var(--admin-muted)]">{row.detail}</p>
+              ) : null}
+            </div>
+            <p className="whitespace-nowrap font-semibold text-[color:var(--admin-text)]">{row.value}</p>
+          </div>
+        )) : (
+          <p className="py-2 text-sm text-[color:var(--admin-muted)]">No data yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function getAnalyticsTotals(insights: MarketingAnalyticsInsights | null) {
+  return insights?.summary?.totals ?? {
+    activeUsers: 0,
+    sessions: 0,
+    pageViews: 0,
+    events: 0,
+    searchClicks: 0,
+    searchImpressions: 0,
+  };
+}
+
+function formatNumber(value: number | string | null | undefined) {
+  const numberValue = Number(value ?? 0);
+  if (!Number.isFinite(numberValue)) {
+    return '0';
+  }
+
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(numberValue);
 }
 
 function storageKeyForCampaign(campaignCode: string) {


### PR DESCRIPTION
## Summary

- Adds Neon-backed tables for monthly marketing analytics sync runs, GA4 page/source/event metrics, Search Console query/page metrics, and generated insight summaries.
- Adds admin endpoints to check analytics configuration, fetch latest insights, and trigger a manual GA4 + Search Console sync.
- Adds `/admin/marketing` UI for GA4/Search Console status, manual sync, and a basic insights dashboard next to the existing R2/Metricool flow.

## Notes

This PR implements the first operational step only: manual sync + persisted snapshots + dashboard. The monthly cron/scheduled Codex brain flow and automatic draft generation should come after this is verified in production.

## Validation

- `npm --workspace apps/api run typecheck`
- `npm --workspace apps/api run build`
- `npm --workspace apps/web run build`

`npm --workspace apps/web run typecheck` still fails on existing unrelated Clerk/demo/labs/test type errors in main.