### PR TITLE
Improve marketing analytics hygiene

### DIFF
--- a/Docs/marketing/strategy-memory.md
+++ b/Docs/marketing/strategy-memory.md
@@ -1,6 +1,6 @@
 # Innerbloom Marketing Strategy Memory
 
-Last updated: 2026-06-27
+Last updated: 2026-06-29
 
 ## Purpose
 
@@ -64,22 +64,78 @@ Every post must include:
 - Current MVP campaign code: `ib20_mvp`
 - Current tested format: square static + square carousel
 
-## What Worked So Far
+## Baseline: 2026-06 MVP
 
-The first two-post MVP proved that:
+The first operational MVP proved that:
 
 - Metricool CSV import works.
-- Metricool can ingest image URLs from GitHub raw URLs.
+- Metricool can ingest image URLs from Cloudflare R2 URLs.
 - Instagram posts published successfully from the generated CSV.
-- The creative format is acceptable for the first acquisition experiment.
+- Cloudflare R2 is now the publishing asset store for CSV exports.
+- Google Drive remains the human-readable marketing library.
+- GA4 and Search Console snapshots can be synced into Neon and shown in `/admin/marketing`.
+
+The first content batch was only a technical proof. Its performance should not be treated as a strategic signal yet.
+
+## Data Interpretation Rules
+
+GA4 active users are anonymous, cookie/device-based users. They are not the same as registered users in Neon.
+
+For marketing decisions:
+
+- Treat landing page views as acquisition signal.
+- Treat `/innerbloom2/...` pages as product usage signal.
+- Exclude auth redirects such as `accounts.google.com`.
+- Exclude internal/admin emails before reading registered-user growth.
+- Search Console is sparse until Google has more impressions.
+
+## First 20-Post Strategy Proposal
+
+This is the first real monthly plan once draft generation is wired.
+
+Planned mix:
+
+- 8 pain/friction posts: streak pressure, perfect-day planning, restarting from zero, habits collapsing during messy weeks.
+- 5 product mechanism/demo posts: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum.
+- 4 belief/differentiation posts: real weeks over perfect calendars, progress without shame, sustainable habit design, anti-all-or-nothing routines.
+- 3 early-adopter CTA posts: try the early version, help shape the product, give feedback after using the dashboard.
+
+Creative rules:
+
+- Prefer real Innerbloom 2.0 screenshots over generic lifestyle imagery.
+- Use both dark-mode and light-mode product assets when available.
+- Keep carousel slides readable on mobile.
+- Use R2 URLs in Metricool CSV output.
+- Store source assets and planning context in Google Drive for browsing.
+
+Measurement:
+
+- Primary acquisition: landing views and CTA events from UTM-tagged links.
+- Primary activation: `auth_started -> auth_completed -> dashboard_view`.
+- Product-interest proxy: views of `/innerbloom2/dashboard`, `/innerbloom2/tareas`, `/innerbloom2/task-detail`, and `/innerbloom2/logros`.
 
 ## Known Gaps
 
-- Google Drive should replace GitHub raw URLs for marketing asset storage if Metricool accepts Drive-hosted links reliably.
-- GA4 and Search Console data are not connected to the admin yet.
+- Monthly draft generation is not automated yet.
+- The scheduled Codex prompt still needs to be created and tested.
 - Metricool performance data is manual export for now.
-- The admin marketing approval board is still MVP/static until backend persistence is added.
+- The admin marketing approval board is still seeded/local-storage based until backend post persistence is added.
 - Image generation is template-based; new visual assets should be generated only when needed.
+
+## Scheduled Codex Prompt Draft
+
+When the monthly scheduled task runs, use this operating prompt:
+
+1. Read `Docs/marketing/strategy-memory.md`.
+2. Read the latest Neon marketing analytics snapshot and the `/admin/marketing` campaign state.
+3. Separate acquisition evidence from product-usage evidence.
+4. Ignore internal/admin users and auth/referral noise already configured in analytics settings.
+5. Update this file with what changed, what was learned, and what will be attempted next.
+6. Generate the configured number of post drafts for the next month.
+7. For every post, include platform, format, scheduled date/time, hypothesis, metric, UTM tracking URL, caption, and required visual assets.
+8. Reuse existing assets when they are sufficient. Generate new assets only when the current library does not support the post.
+9. Save the drafts so `/admin/marketing` can render them for approval.
+10. Do not export the Metricool CSV until posts are approved.
 
 ## Next Run Instructions
 

--- a/apps/api/src/db/migrations/202606290002_marketing_analytics_hygiene.sql
+++ b/apps/api/src/db/migrations/202606290002_marketing_analytics_hygiene.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS marketing_analytics_settings (
+  id BOOLEAN PRIMARY KEY DEFAULT true CHECK (id),
+  excluded_sources TEXT[] NOT NULL DEFAULT ARRAY['accounts.google.com'],
+  excluded_page_prefixes TEXT[] NOT NULL DEFAULT ARRAY[
+    '/login',
+    '/login2',
+    '/sign-up',
+    '/sign-up2',
+    '/onboarding',
+    '/onboarding2',
+    '/sso-callback'
+  ],
+  product_page_prefixes TEXT[] NOT NULL DEFAULT ARRAY[
+    '/innerbloom2',
+    '/dashboard',
+    '/dashboard-v3',
+    '/editor'
+  ],
+  marketing_page_paths TEXT[] NOT NULL DEFAULT ARRAY[
+    '/',
+    '/v2',
+    '/v3'
+  ],
+  internal_user_emails TEXT[] NOT NULL DEFAULT ARRAY[
+    'ramagpt23@gmail.com',
+    'rfullivarri22@gmail.com'
+  ],
+  internal_user_ids UUID[] NOT NULL DEFAULT ARRAY[]::UUID[],
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO marketing_analytics_settings (id)
+VALUES (true)
+ON CONFLICT (id) DO NOTHING;

--- a/apps/api/src/modules/admin/admin.handlers.ts
+++ b/apps/api/src/modules/admin/admin.handlers.ts
@@ -20,6 +20,7 @@ import {
   subscriptionNotificationsTriggerBodySchema,
   adminSubscriptionUpdateBodySchema,
   marketingAnalyticsSyncBodySchema,
+  marketingAnalyticsSettingsBodySchema,
   marketingR2AssetUploadBodySchema,
   taskDifficultyCalibrationRunBodySchema,
   modeUpgradeAggregationRunBodySchema,
@@ -76,6 +77,7 @@ import {
   getMarketingAnalyticsInsights,
   getMarketingAnalyticsStatus,
   runMarketingAnalyticsSync,
+  updateMarketingAnalyticsSettings,
 } from '../../services/marketingAnalyticsService.js';
 import { pool } from '../../db.js';
 
@@ -161,6 +163,12 @@ export const postAdminMarketingAnalyticsSync = asyncHandler(async (req: Request,
   const body = marketingAnalyticsSyncBodySchema.parse(req.body ?? {});
   const result = await runMarketingAnalyticsSync(body);
   res.json(result);
+});
+
+export const putAdminMarketingAnalyticsSettings = asyncHandler(async (req: Request, res: Response) => {
+  const body = marketingAnalyticsSettingsBodySchema.parse(req.body ?? {});
+  const settings = await updateMarketingAnalyticsSettings(body);
+  res.json({ ok: true, settings });
 });
 
 export const getAdminUserInsights = asyncHandler(async (req: Request, res: Response) => {

--- a/apps/api/src/modules/admin/admin.routes.ts
+++ b/apps/api/src/modules/admin/admin.routes.ts
@@ -46,6 +46,7 @@ import {
   postAdminMonthlyPipelineRun,
   postAdminMarketingAnalyticsSync,
   postAdminMarketingR2Assets,
+  putAdminMarketingAnalyticsSettings,
 } from './admin.handlers.js';
 import { requireAdmin } from './admin.middleware.js';
 
@@ -57,6 +58,7 @@ adminRouter.get('/users', getAdminUsers);
 adminRouter.get('/marketing/analytics/status', getAdminMarketingAnalyticsStatus);
 adminRouter.get('/marketing/analytics/insights', getAdminMarketingAnalyticsInsights);
 adminRouter.post('/marketing/analytics/sync', postAdminMarketingAnalyticsSync);
+adminRouter.put('/marketing/analytics/settings', putAdminMarketingAnalyticsSettings);
 adminRouter.get('/marketing/r2/status', getAdminMarketingR2Status);
 adminRouter.post('/marketing/r2/assets', postAdminMarketingR2Assets);
 adminRouter.get('/taskgen/jobs', getTaskgenJobs);

--- a/apps/api/src/modules/admin/admin.schemas.ts
+++ b/apps/api/src/modules/admin/admin.schemas.ts
@@ -220,6 +220,19 @@ export const marketingAnalyticsSyncBodySchema = z.object({
   force: z.coerce.boolean().default(false),
 });
 
+const marketingAnalyticsStringListSchema = z
+  .array(z.string().trim().min(1).max(240))
+  .max(100);
+
+export const marketingAnalyticsSettingsBodySchema = z.object({
+  excludedSources: marketingAnalyticsStringListSchema.optional(),
+  excludedPagePrefixes: marketingAnalyticsStringListSchema.optional(),
+  productPagePrefixes: marketingAnalyticsStringListSchema.optional(),
+  marketingPagePaths: marketingAnalyticsStringListSchema.optional(),
+  internalUserEmails: marketingAnalyticsStringListSchema.optional(),
+  internalUserIds: z.array(z.string().uuid()).max(50).optional(),
+});
+
 export const subscriptionNotificationsTriggerBodySchema = z.object({
   runAt: z.string().datetime().optional(),
 });

--- a/apps/api/src/services/marketingAnalyticsService.ts
+++ b/apps/api/src/services/marketingAnalyticsService.ts
@@ -64,6 +64,66 @@ type GscApiResponse = {
   rows?: GscApiRow[];
 };
 
+export type MarketingAnalyticsSettings = {
+  excludedSources: string[];
+  excludedPagePrefixes: string[];
+  productPagePrefixes: string[];
+  marketingPagePaths: string[];
+  internalUserEmails: string[];
+  internalUserIds: string[];
+};
+
+type MarketingAnalyticsSettingsRow = {
+  excluded_sources: string[] | null;
+  excluded_page_prefixes: string[] | null;
+  product_page_prefixes: string[] | null;
+  marketing_page_paths: string[] | null;
+  internal_user_emails: string[] | null;
+  internal_user_ids: string[] | null;
+};
+
+type PageMetricRecord = {
+  page_path: string;
+  page_title: string;
+  active_users: number;
+  sessions: number;
+  screen_page_views: number;
+  event_count: number;
+};
+
+type SourceMetricRecord = {
+  source: string;
+  medium: string;
+  campaign: string;
+  active_users: number;
+  sessions: number;
+  screen_page_views: number;
+};
+
+type QueryMetricRecord = {
+  query: string;
+  page: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+};
+
+type RegisteredUserStats = {
+  total: number;
+  newInPeriod: number;
+  excludedInternal: number;
+};
+
+const DEFAULT_MARKETING_ANALYTICS_SETTINGS: MarketingAnalyticsSettings = {
+  excludedSources: ['accounts.google.com'],
+  excludedPagePrefixes: ['/login', '/login2', '/sign-up', '/sign-up2', '/onboarding', '/onboarding2', '/sso-callback'],
+  productPagePrefixes: ['/innerbloom2', '/dashboard', '/dashboard-v3', '/editor'],
+  marketingPagePaths: ['/', '/v2', '/v3'],
+  internalUserEmails: ['ramagpt23@gmail.com', 'rfullivarri22@gmail.com'],
+  internalUserIds: [],
+};
+
 let cachedGoogleToken: GoogleAccessToken | null = null;
 let schemaReady: Promise<void> | null = null;
 
@@ -75,6 +135,7 @@ export async function getMarketingAnalyticsStatus() {
   await ensureMarketingAnalyticsSchema();
   const config = getMarketingAnalyticsConfig();
   const latestRun = await getLatestRun();
+  const settings = await getMarketingAnalyticsSettings();
 
   return {
     configured: config.configured,
@@ -82,6 +143,7 @@ export async function getMarketingAnalyticsStatus() {
     ga4PropertyId: config.ga4PropertyId || null,
     gscSiteUrl: config.gscSiteUrl || null,
     latestRun,
+    settings,
   };
 }
 
@@ -89,39 +151,45 @@ export async function getMarketingAnalyticsInsights() {
   await ensureMarketingAnalyticsSchema();
   const config = getMarketingAnalyticsConfig();
   const latestRun = await getLatestRun();
+  const settings = await getMarketingAnalyticsSettings();
 
   if (!latestRun || latestRun.status !== 'completed') {
     return {
       configured: config.configured,
       missing: config.missing,
       latestRun,
+      settings,
       summary: null,
       topPages: [],
       topSources: [],
+      marketingPages: [],
+      productPages: [],
+      cleanSources: [],
       topEvents: [],
       topQueries: [],
+      registeredUsers: null,
     };
   }
 
   const [insightResult, pageResult, sourceResult, eventResult, queryResult] = await Promise.all([
     pool.query<{ summary: unknown }>('SELECT summary FROM marketing_insights WHERE run_id = $1 LIMIT 1', [latestRun.runId]),
-    pool.query(
+    pool.query<PageMetricRecord>(
       `SELECT page_path, page_title, active_users, sessions, screen_page_views, event_count
        FROM marketing_ga4_page_metrics
        WHERE run_id = $1
        ORDER BY screen_page_views DESC, active_users DESC
-       LIMIT 10`,
+       LIMIT 100`,
       [latestRun.runId],
     ),
-    pool.query(
+    pool.query<SourceMetricRecord>(
       `SELECT source, medium, campaign, active_users, sessions, screen_page_views
        FROM marketing_ga4_source_metrics
        WHERE run_id = $1
        ORDER BY sessions DESC, active_users DESC
-       LIMIT 10`,
+       LIMIT 100`,
       [latestRun.runId],
     ),
-    pool.query(
+    pool.query<{ event_name: string; event_count: number }>(
       `SELECT event_name, event_count
        FROM marketing_ga4_event_metrics
        WHERE run_id = $1
@@ -129,7 +197,7 @@ export async function getMarketingAnalyticsInsights() {
        LIMIT 10`,
       [latestRun.runId],
     ),
-    pool.query(
+    pool.query<QueryMetricRecord>(
       `SELECT query, page, clicks, impressions, ctr::float AS ctr, position::float AS position
        FROM marketing_gsc_query_page_metrics
        WHERE run_id = $1
@@ -138,17 +206,84 @@ export async function getMarketingAnalyticsInsights() {
       [latestRun.runId],
     ),
   ]);
+  const registeredUsers = await getRegisteredUserStats(latestRun.periodStart, latestRun.periodEnd, settings);
+  const topPages = pageResult.rows.map(normalizePageMetricRecord);
+  const topSources = sourceResult.rows.map(normalizeSourceMetricRecord);
+  const topQueries = queryResult.rows.map(normalizeQueryMetricRecord);
+  const visiblePages = topPages.filter((row) => !isExcludedPage(row.page_path, settings));
+  const marketingPages = visiblePages.filter((row) => isMarketingPage(row.page_path, settings));
+  const productPages = visiblePages.filter((row) => isProductPage(row.page_path, settings));
+  const cleanSources = topSources.filter((row) => !isExcludedSource(row.source, settings));
+  const rawSummary = readSummaryRecord(insightResult.rows[0]?.summary);
+  const summary = rawSummary
+    ? decorateMarketingSummary(rawSummary, {
+        marketingPages,
+        productPages,
+        cleanSources,
+        topQueries,
+        registeredUsers,
+      })
+    : null;
 
   return {
     configured: config.configured,
     missing: config.missing,
     latestRun,
-    summary: insightResult.rows[0]?.summary ?? null,
-    topPages: pageResult.rows,
-    topSources: sourceResult.rows,
+    settings,
+    summary,
+    topPages,
+    topSources,
+    marketingPages,
+    productPages,
+    cleanSources,
     topEvents: eventResult.rows,
-    topQueries: queryResult.rows,
+    topQueries,
+    registeredUsers,
   };
+}
+
+export async function updateMarketingAnalyticsSettings(input: Partial<MarketingAnalyticsSettings>) {
+  await ensureMarketingAnalyticsSchema();
+  const current = await getMarketingAnalyticsSettings();
+  const next: MarketingAnalyticsSettings = {
+    excludedSources: normalizeStringList(input.excludedSources, current.excludedSources),
+    excludedPagePrefixes: normalizePathList(input.excludedPagePrefixes, current.excludedPagePrefixes),
+    productPagePrefixes: normalizePathList(input.productPagePrefixes, current.productPagePrefixes),
+    marketingPagePaths: normalizePathList(input.marketingPagePaths, current.marketingPagePaths),
+    internalUserEmails: normalizeStringList(input.internalUserEmails, current.internalUserEmails).map((email) => email.toLowerCase()),
+    internalUserIds: normalizeUuidList(input.internalUserIds, current.internalUserIds),
+  };
+
+  await pool.query(
+    `INSERT INTO marketing_analytics_settings (
+      id,
+      excluded_sources,
+      excluded_page_prefixes,
+      product_page_prefixes,
+      marketing_page_paths,
+      internal_user_emails,
+      internal_user_ids,
+      updated_at
+    ) VALUES (true, $1, $2, $3, $4, $5, $6::uuid[], now())
+    ON CONFLICT (id) DO UPDATE SET
+      excluded_sources = EXCLUDED.excluded_sources,
+      excluded_page_prefixes = EXCLUDED.excluded_page_prefixes,
+      product_page_prefixes = EXCLUDED.product_page_prefixes,
+      marketing_page_paths = EXCLUDED.marketing_page_paths,
+      internal_user_emails = EXCLUDED.internal_user_emails,
+      internal_user_ids = EXCLUDED.internal_user_ids,
+      updated_at = now()`,
+    [
+      next.excludedSources,
+      next.excludedPagePrefixes,
+      next.productPagePrefixes,
+      next.marketingPagePaths,
+      next.internalUserEmails,
+      next.internalUserIds,
+    ],
+  );
+
+  return next;
 }
 
 export async function runMarketingAnalyticsSync(options: MarketingAnalyticsSyncOptions = {}) {
@@ -178,7 +313,13 @@ export async function runMarketingAnalyticsSync(options: MarketingAnalyticsSyncO
 
   try {
     const token = await getGoogleAccessToken(config.serviceAccount);
-    const [ga4Pages, ga4Sources, ga4Events, gscQueries] = await Promise.all([
+    const [ga4Totals, ga4Pages, ga4Sources, ga4Events, gscQueries] = await Promise.all([
+      fetchGa4Rows(config.ga4PropertyId, token, dateRange, [], [
+        'activeUsers',
+        'sessions',
+        'screenPageViews',
+        'eventCount',
+      ]),
       fetchGa4Rows(config.ga4PropertyId, token, dateRange, ['pagePath', 'pageTitle'], [
         'activeUsers',
         'sessions',
@@ -197,9 +338,9 @@ export async function runMarketingAnalyticsSync(options: MarketingAnalyticsSyncO
     const summary = buildMarketingInsightSummary({
       runId,
       dateRange,
+      ga4Totals,
       ga4Pages,
       ga4Sources,
-      ga4Events,
       gscQueries,
     });
 
@@ -331,23 +472,24 @@ export async function runMarketingAnalyticsSync(options: MarketingAnalyticsSyncO
 function buildMarketingInsightSummary({
   runId,
   dateRange,
+  ga4Totals,
   ga4Pages,
   ga4Sources,
-  ga4Events,
   gscQueries,
 }: {
   runId: string;
   dateRange: DateRange;
+  ga4Totals: Ga4MetricRow[];
   ga4Pages: Ga4MetricRow[];
   ga4Sources: Ga4MetricRow[];
-  ga4Events: Ga4MetricRow[];
   gscQueries: GscMetricRow[];
 }) {
+  const aggregateTotals = ga4Totals[0]?.metrics ?? [];
   const totals = {
-    activeUsers: sumMetric(ga4Pages, 0),
-    sessions: sumMetric(ga4Pages, 1),
-    pageViews: sumMetric(ga4Pages, 2),
-    events: sumMetric(ga4Events, 0),
+    activeUsers: toInteger(aggregateTotals[0]),
+    sessions: toInteger(aggregateTotals[1]),
+    pageViews: toInteger(aggregateTotals[2]),
+    events: toInteger(aggregateTotals[3]),
     searchClicks: gscQueries.reduce((total, row) => total + toInteger(row.clicks), 0),
     searchImpressions: gscQueries.reduce((total, row) => total + toInteger(row.impressions), 0),
   };
@@ -375,6 +517,281 @@ function buildMarketingInsightSummary({
   };
 }
 
+function decorateMarketingSummary(
+  summary: Record<string, unknown>,
+  {
+    marketingPages,
+    productPages,
+    cleanSources,
+    topQueries,
+    registeredUsers,
+  }: {
+    marketingPages: PageMetricRecord[];
+    productPages: PageMetricRecord[];
+    cleanSources: SourceMetricRecord[];
+    topQueries: QueryMetricRecord[];
+    registeredUsers: RegisteredUserStats;
+  },
+) {
+  const rawTotals = readTotals(summary.totals);
+  const marketingTotals = sumPageRecords(marketingPages);
+  const productTotals = sumPageRecords(productPages);
+  const topMarketingPage = [...marketingPages].sort(byPageViews)[0] ?? null;
+  const topProductPage = [...productPages].sort(byPageViews)[0] ?? null;
+  const topSource = [...cleanSources].sort((left, right) => right.sessions - left.sessions)[0] ?? null;
+  const topQuery = [...topQueries].sort((left, right) => right.impressions - left.impressions)[0] ?? null;
+  const highlights = [
+    topMarketingPage
+      ? `Top marketing landing: ${topMarketingPage.page_path} with ${topMarketingPage.screen_page_views} views.`
+      : 'No clean marketing landing page data returned yet.',
+    topProductPage
+      ? `Top product page: ${topProductPage.page_path} with ${topProductPage.screen_page_views} views.`
+      : 'No product usage page data returned yet.',
+    topSource
+      ? `Top acquisition source after filters: ${formatSourceLabel(topSource)} with ${topSource.sessions} sessions.`
+      : 'No clean acquisition source data returned yet.',
+    topQuery
+      ? `Top search query: "${topQuery.query}" with ${toInteger(topQuery.impressions)} impressions.`
+      : 'No Search Console query data returned yet.',
+  ];
+
+  return {
+    ...summary,
+    totals: rawTotals,
+    rawTotals,
+    marketingTotals,
+    productTotals,
+    registeredUsers,
+    highlights,
+    notes: [
+      'GA active users are anonymous, cookie/device-based visitors. They are not the same number as registered Neon users.',
+      'Landing and product page rows are directional rankings. Aggregate GA totals come from a no-dimension GA4 report.',
+      'Configured auth/internal sources and internal users are filtered from the clean dashboard views.',
+    ],
+  };
+}
+
+function readSummaryRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function readTotals(value: unknown) {
+  const record = value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+
+  return {
+    activeUsers: toInteger(record.activeUsers),
+    sessions: toInteger(record.sessions),
+    pageViews: toInteger(record.pageViews),
+    events: toInteger(record.events),
+    searchClicks: toInteger(record.searchClicks),
+    searchImpressions: toInteger(record.searchImpressions),
+  };
+}
+
+function sumPageRecords(rows: PageMetricRecord[]) {
+  return rows.reduce(
+    (totals, row) => ({
+      activeUsers: totals.activeUsers + toInteger(row.active_users),
+      sessions: totals.sessions + toInteger(row.sessions),
+      pageViews: totals.pageViews + toInteger(row.screen_page_views),
+      events: totals.events + toInteger(row.event_count),
+    }),
+    { activeUsers: 0, sessions: 0, pageViews: 0, events: 0 },
+  );
+}
+
+function byPageViews(left: PageMetricRecord, right: PageMetricRecord) {
+  return right.screen_page_views - left.screen_page_views;
+}
+
+function normalizePageMetricRecord(row: PageMetricRecord): PageMetricRecord {
+  return {
+    page_path: normalizePagePath(String(row.page_path ?? '')),
+    page_title: String(row.page_title ?? ''),
+    active_users: toInteger(row.active_users),
+    sessions: toInteger(row.sessions),
+    screen_page_views: toInteger(row.screen_page_views),
+    event_count: toInteger(row.event_count),
+  };
+}
+
+function normalizeSourceMetricRecord(row: SourceMetricRecord): SourceMetricRecord {
+  return {
+    source: String(row.source ?? ''),
+    medium: String(row.medium ?? ''),
+    campaign: String(row.campaign ?? ''),
+    active_users: toInteger(row.active_users),
+    sessions: toInteger(row.sessions),
+    screen_page_views: toInteger(row.screen_page_views),
+  };
+}
+
+function normalizeQueryMetricRecord(row: QueryMetricRecord): QueryMetricRecord {
+  return {
+    query: String(row.query ?? ''),
+    page: String(row.page ?? ''),
+    clicks: toInteger(row.clicks),
+    impressions: toInteger(row.impressions),
+    ctr: Number(row.ctr ?? 0),
+    position: Number(row.position ?? 0),
+  };
+}
+
+function normalizePagePath(path: string) {
+  const trimmed = path.trim() || '/';
+  const withoutQuery = trimmed.split('?')[0]?.split('#')[0] || '/';
+  if (withoutQuery === '/') {
+    return '/';
+  }
+
+  return withoutQuery.endsWith('/') ? withoutQuery.slice(0, -1) : withoutQuery;
+}
+
+function isMarketingPage(path: string, settings: MarketingAnalyticsSettings) {
+  const normalized = normalizePagePath(path);
+  return settings.marketingPagePaths.some((marketingPath) => normalizePagePath(marketingPath) === normalized);
+}
+
+function isProductPage(path: string, settings: MarketingAnalyticsSettings) {
+  const normalized = normalizePagePath(path);
+  return settings.productPagePrefixes.some((prefix) => normalized.startsWith(normalizePagePath(prefix)));
+}
+
+function isExcludedPage(path: string, settings: MarketingAnalyticsSettings) {
+  const normalized = normalizePagePath(path);
+  return settings.excludedPagePrefixes.some((prefix) => normalized.startsWith(normalizePagePath(prefix)));
+}
+
+function isExcludedSource(source: string, settings: MarketingAnalyticsSettings) {
+  const normalized = source.trim().toLowerCase();
+  return settings.excludedSources.some((excludedSource) => {
+    const normalizedExcludedSource = excludedSource.trim().toLowerCase();
+    return normalizedExcludedSource.length > 0 && normalized.includes(normalizedExcludedSource);
+  });
+}
+
+function formatSourceLabel(row: SourceMetricRecord) {
+  return [row.source || '(direct)', row.medium || '(none)'].join(' / ');
+}
+
+async function getMarketingAnalyticsSettings(): Promise<MarketingAnalyticsSettings> {
+  const result = await pool.query<MarketingAnalyticsSettingsRow>(
+    `SELECT
+      excluded_sources,
+      excluded_page_prefixes,
+      product_page_prefixes,
+      marketing_page_paths,
+      internal_user_emails,
+      internal_user_ids
+     FROM marketing_analytics_settings
+     WHERE id = true
+     LIMIT 1`,
+  );
+
+  if (!result.rows[0]) {
+    await pool.query('INSERT INTO marketing_analytics_settings (id) VALUES (true) ON CONFLICT (id) DO NOTHING');
+    return DEFAULT_MARKETING_ANALYTICS_SETTINGS;
+  }
+
+  return normalizeSettingsRow(result.rows[0]);
+}
+
+function normalizeSettingsRow(row: MarketingAnalyticsSettingsRow): MarketingAnalyticsSettings {
+  return {
+    excludedSources: normalizeStringList(row.excluded_sources, DEFAULT_MARKETING_ANALYTICS_SETTINGS.excludedSources),
+    excludedPagePrefixes: normalizePathList(
+      row.excluded_page_prefixes,
+      DEFAULT_MARKETING_ANALYTICS_SETTINGS.excludedPagePrefixes,
+    ),
+    productPagePrefixes: normalizePathList(
+      row.product_page_prefixes,
+      DEFAULT_MARKETING_ANALYTICS_SETTINGS.productPagePrefixes,
+    ),
+    marketingPagePaths: normalizePathList(row.marketing_page_paths, DEFAULT_MARKETING_ANALYTICS_SETTINGS.marketingPagePaths),
+    internalUserEmails: normalizeStringList(
+      row.internal_user_emails,
+      DEFAULT_MARKETING_ANALYTICS_SETTINGS.internalUserEmails,
+    ).map((email) => email.toLowerCase()),
+    internalUserIds: normalizeUuidList(row.internal_user_ids, DEFAULT_MARKETING_ANALYTICS_SETTINGS.internalUserIds),
+  };
+}
+
+function normalizeStringList(value: unknown, fallback: string[]) {
+  const source = Array.isArray(value) ? value : fallback;
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const item of source) {
+    const text = String(item ?? '').trim();
+    const key = text.toLowerCase();
+    if (!text || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(text);
+  }
+
+  return result;
+}
+
+function normalizePathList(value: unknown, fallback: string[]) {
+  return normalizeStringList(value, fallback).map(normalizePagePath);
+}
+
+function normalizeUuidList(value: unknown, fallback: string[]) {
+  const source = Array.isArray(value) ? value : fallback;
+  return source
+    .map((item) => String(item ?? '').trim())
+    .filter((item) => /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(item));
+}
+
+async function getRegisteredUserStats(periodStart: string, periodEnd: string, settings: MarketingAnalyticsSettings) {
+  const emails = settings.internalUserEmails.map((email) => email.toLowerCase());
+  const ids = settings.internalUserIds;
+  const result = await pool.query<{
+    total: string | number;
+    new_in_period: string | number;
+    excluded_internal: string | number;
+  }>(
+    `SELECT
+      COUNT(*) FILTER (
+        WHERE deleted_at IS NULL
+          AND NOT (
+            user_id = ANY($1::uuid[])
+            OR lower(coalesce(email_primary, email, '')) = ANY($2::text[])
+          )
+      ) AS total,
+      COUNT(*) FILTER (
+        WHERE deleted_at IS NULL
+          AND created_at::date BETWEEN $3::date AND $4::date
+          AND NOT (
+            user_id = ANY($1::uuid[])
+            OR lower(coalesce(email_primary, email, '')) = ANY($2::text[])
+          )
+      ) AS new_in_period,
+      COUNT(*) FILTER (
+        WHERE deleted_at IS NULL
+          AND (
+            user_id = ANY($1::uuid[])
+            OR lower(coalesce(email_primary, email, '')) = ANY($2::text[])
+          )
+      ) AS excluded_internal
+     FROM users`,
+    [ids, emails, periodStart, periodEnd],
+  );
+  const row = result.rows[0];
+
+  return {
+    total: toInteger(row?.total),
+    newInPeriod: toInteger(row?.new_in_period),
+    excludedInternal: toInteger(row?.excluded_internal),
+  };
+}
+
 async function fetchGa4Rows(
   propertyId: string,
   accessToken: string,
@@ -390,7 +807,7 @@ async function fetchGa4Rows(
     },
     body: JSON.stringify({
       dateRanges: [dateRange],
-      dimensions: dimensions.map((name) => ({ name })),
+      ...(dimensions.length > 0 ? { dimensions: dimensions.map((name) => ({ name })) } : {}),
       metrics: metrics.map((name) => ({ name })),
       limit: '100',
     }),
@@ -611,10 +1028,6 @@ function toInteger(value: unknown) {
   return Number.isFinite(numberValue) ? Math.round(numberValue) : 0;
 }
 
-function sumMetric(rows: Ga4MetricRow[], metricIndex: number) {
-  return rows.reduce((total, row) => total + toInteger(row.metrics[metricIndex]), 0);
-}
-
 function sortGa4RowsByMetric(rows: Ga4MetricRow[], metricIndex: number) {
   return [...rows].sort((left, right) => toInteger(right.metrics[metricIndex]) - toInteger(left.metrics[metricIndex]));
 }
@@ -687,6 +1100,43 @@ function ensureMarketingAnalyticsSchema() {
             summary JSONB NOT NULL,
             created_at TIMESTAMPTZ NOT NULL DEFAULT now()
           )
+        `);
+        await client.query(`
+          CREATE TABLE IF NOT EXISTS marketing_analytics_settings (
+            id BOOLEAN PRIMARY KEY DEFAULT true CHECK (id),
+            excluded_sources TEXT[] NOT NULL DEFAULT ARRAY['accounts.google.com'],
+            excluded_page_prefixes TEXT[] NOT NULL DEFAULT ARRAY[
+              '/login',
+              '/login2',
+              '/sign-up',
+              '/sign-up2',
+              '/onboarding',
+              '/onboarding2',
+              '/sso-callback'
+            ],
+            product_page_prefixes TEXT[] NOT NULL DEFAULT ARRAY[
+              '/innerbloom2',
+              '/dashboard',
+              '/dashboard-v3',
+              '/editor'
+            ],
+            marketing_page_paths TEXT[] NOT NULL DEFAULT ARRAY[
+              '/',
+              '/v2',
+              '/v3'
+            ],
+            internal_user_emails TEXT[] NOT NULL DEFAULT ARRAY[
+              'ramagpt23@gmail.com',
+              'rfullivarri22@gmail.com'
+            ],
+            internal_user_ids UUID[] NOT NULL DEFAULT ARRAY[]::UUID[],
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+          )
+        `);
+        await client.query(`
+          INSERT INTO marketing_analytics_settings (id)
+          VALUES (true)
+          ON CONFLICT (id) DO NOTHING
         `);
         await client.query(`
           CREATE INDEX IF NOT EXISTS marketing_analytics_sync_runs_completed_idx

--- a/apps/web/src/lib/marketingAnalytics.ts
+++ b/apps/web/src/lib/marketingAnalytics.ts
@@ -12,19 +12,66 @@ export type MarketingAnalyticsRun = {
   errorMessage: string | null;
 };
 
+export type MarketingAnalyticsTotals = {
+  activeUsers: number;
+  sessions: number;
+  pageViews: number;
+  events: number;
+  searchClicks: number;
+  searchImpressions: number;
+};
+
+export type MarketingPageTotals = {
+  activeUsers: number;
+  sessions: number;
+  pageViews: number;
+  events: number;
+};
+
 export type MarketingAnalyticsSummary = {
   runId: string;
   periodStart: string;
   periodEnd: string;
-  totals: {
-    activeUsers: number;
-    sessions: number;
-    pageViews: number;
-    events: number;
-    searchClicks: number;
-    searchImpressions: number;
-  };
+  totals: MarketingAnalyticsTotals;
+  rawTotals?: MarketingAnalyticsTotals;
+  marketingTotals?: MarketingPageTotals;
+  productTotals?: MarketingPageTotals;
+  registeredUsers?: MarketingRegisteredUserStats;
   highlights: string[];
+  notes?: string[];
+};
+
+export type MarketingAnalyticsSettings = {
+  excludedSources: string[];
+  excludedPagePrefixes: string[];
+  productPagePrefixes: string[];
+  marketingPagePaths: string[];
+  internalUserEmails: string[];
+  internalUserIds: string[];
+};
+
+export type MarketingRegisteredUserStats = {
+  total: number;
+  newInPeriod: number;
+  excludedInternal: number;
+};
+
+export type MarketingPageMetric = {
+  page_path: string;
+  page_title: string;
+  active_users: number;
+  sessions: number;
+  screen_page_views: number;
+  event_count: number;
+};
+
+export type MarketingSourceMetric = {
+  source: string;
+  medium: string;
+  campaign: string;
+  active_users: number;
+  sessions: number;
+  screen_page_views: number;
 };
 
 export type MarketingAnalyticsInsights = {
@@ -32,23 +79,14 @@ export type MarketingAnalyticsInsights = {
   configured: boolean;
   missing: string[];
   latestRun: MarketingAnalyticsRun | null;
+  settings: MarketingAnalyticsSettings;
   summary: MarketingAnalyticsSummary | null;
-  topPages: Array<{
-    page_path: string;
-    page_title: string;
-    active_users: number;
-    sessions: number;
-    screen_page_views: number;
-    event_count: number;
-  }>;
-  topSources: Array<{
-    source: string;
-    medium: string;
-    campaign: string;
-    active_users: number;
-    sessions: number;
-    screen_page_views: number;
-  }>;
+  registeredUsers: MarketingRegisteredUserStats | null;
+  topPages: MarketingPageMetric[];
+  topSources: MarketingSourceMetric[];
+  marketingPages: MarketingPageMetric[];
+  productPages: MarketingPageMetric[];
+  cleanSources: MarketingSourceMetric[];
   topEvents: Array<{
     event_name: string;
     event_count: number;
@@ -107,4 +145,22 @@ export async function syncMarketingAnalytics() {
   }
 
   return response.json() as Promise<MarketingAnalyticsSyncResult>;
+}
+
+export async function updateMarketingAnalyticsSettings(settings: Partial<MarketingAnalyticsSettings>) {
+  const response = await apiAuthorizedFetch('/admin/marketing/analytics/settings', {
+    method: 'PUT',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(settings),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Marketing analytics settings failed with HTTP ${response.status}: ${body}`);
+  }
+
+  return response.json() as Promise<{ ok: boolean; settings: MarketingAnalyticsSettings }>;
 }

--- a/apps/web/src/pages/admin2/MarketingPage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPage.tsx
@@ -32,7 +32,9 @@ import {
 import {
   fetchMarketingAnalyticsInsights,
   syncMarketingAnalytics,
+  updateMarketingAnalyticsSettings,
   type MarketingAnalyticsInsights,
+  type MarketingAnalyticsSettings,
 } from '../../lib/marketingAnalytics';
 
 const STATUS_LABELS: Record<MarketingPostStatus, string> = {
@@ -55,6 +57,13 @@ const iconButtonVariants = {
 } as const;
 
 type IconButtonVariant = keyof typeof iconButtonVariants;
+
+const DEFAULT_PAGE_TOTALS = {
+  activeUsers: 0,
+  sessions: 0,
+  pageViews: 0,
+  events: 0,
+};
 
 function statusClass(status: MarketingPostStatus) {
   if (status === 'approved') {
@@ -433,9 +442,14 @@ export function MarketingPage() {
   const [analyticsError, setAnalyticsError] = useState<string | null>(null);
   const [analyticsMessage, setAnalyticsMessage] = useState<string | null>(null);
   const [isSyncingAnalytics, setIsSyncingAnalytics] = useState(false);
+  const [settingsDraft, setSettingsDraft] = useState<MarketingAnalyticsSettings | null>(null);
+  const [isSavingSettings, setIsSavingSettings] = useState(false);
   const approvedPosts = useMemo(() => posts.filter((post) => post.status === 'approved'), [posts]);
   const needsReviewCount = posts.filter((post) => post.status === 'needs_review').length;
   const analyticsTotals = getAnalyticsTotals(analyticsInsights);
+  const analyticsMarketingTotals = analyticsInsights?.summary?.marketingTotals ?? DEFAULT_PAGE_TOTALS;
+  const analyticsProductTotals = analyticsInsights?.summary?.productTotals ?? DEFAULT_PAGE_TOTALS;
+  const registeredUsers = analyticsInsights?.registeredUsers ?? analyticsInsights?.summary?.registeredUsers ?? null;
   const approvedAssetCount = approvedPosts.reduce((total, post) => total + post.assets.length, 0);
   const r2ReadyAssetCount = approvedPosts.reduce(
     (total, post) =>
@@ -481,6 +495,7 @@ export function MarketingPage() {
     try {
       const nextInsights = await fetchMarketingAnalyticsInsights();
       setAnalyticsInsights(nextInsights);
+      setSettingsDraft(nextInsights.settings);
       setAnalyticsError(null);
     } catch (error) {
       setAnalyticsInsights(null);
@@ -596,6 +611,25 @@ export function MarketingPage() {
       setAnalyticsMessage(error instanceof Error ? error.message : 'Marketing analytics sync failed.');
     } finally {
       setIsSyncingAnalytics(false);
+    }
+  }
+
+  async function saveAnalyticsSettings() {
+    if (!settingsDraft) {
+      return;
+    }
+
+    setIsSavingSettings(true);
+    setAnalyticsMessage(null);
+
+    try {
+      await updateMarketingAnalyticsSettings(settingsDraft);
+      setAnalyticsMessage('Saved analytics filters.');
+      await loadAnalyticsInsights();
+    } catch (error) {
+      setAnalyticsMessage(error instanceof Error ? error.message : 'Analytics filter save failed.');
+    } finally {
+      setIsSavingSettings(false);
     }
   }
 
@@ -740,6 +774,49 @@ export function MarketingPage() {
               ) : null}
             </div>
           </div>
+          {settingsDraft ? (
+            <div className="mt-5 rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 text-sm">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="font-semibold">Analytics hygiene filters</p>
+                  <p className="mt-1 text-xs text-[color:var(--admin-muted)]">
+                    Exclude internal users and auth noise before generating marketing insights.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="admin2-btn admin2-btn--secondary inline-flex items-center gap-2"
+                  onClick={saveAnalyticsSettings}
+                  disabled={isSavingSettings}
+                >
+                  <Check size={16} />
+                  <span>{isSavingSettings ? 'Saving' : 'Save'}</span>
+                </button>
+              </div>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                <SettingsListField
+                  label="Internal user emails"
+                  value={settingsDraft.internalUserEmails}
+                  onChange={(internalUserEmails) => setSettingsDraft((current) => current ? { ...current, internalUserEmails } : current)}
+                />
+                <SettingsListField
+                  label="Excluded sources"
+                  value={settingsDraft.excludedSources}
+                  onChange={(excludedSources) => setSettingsDraft((current) => current ? { ...current, excludedSources } : current)}
+                />
+                <SettingsListField
+                  label="Marketing landing paths"
+                  value={settingsDraft.marketingPagePaths}
+                  onChange={(marketingPagePaths) => setSettingsDraft((current) => current ? { ...current, marketingPagePaths } : current)}
+                />
+                <SettingsListField
+                  label="Product page prefixes"
+                  value={settingsDraft.productPagePrefixes}
+                  onChange={(productPagePrefixes) => setSettingsDraft((current) => current ? { ...current, productPagePrefixes } : current)}
+                />
+              </div>
+            </div>
+          ) : null}
           <div className="mt-5 rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 text-sm">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
@@ -817,12 +894,12 @@ export function MarketingPage() {
 
         {analyticsInsights?.summary ? (
           <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-6">
-            <InsightStat label="Users" value={formatNumber(analyticsTotals.activeUsers)} />
-            <InsightStat label="Sessions" value={formatNumber(analyticsTotals.sessions)} />
-            <InsightStat label="Views" value={formatNumber(analyticsTotals.pageViews)} />
-            <InsightStat label="Events" value={formatNumber(analyticsTotals.events)} />
-            <InsightStat label="Clicks" value={formatNumber(analyticsTotals.searchClicks)} />
-            <InsightStat label="Impressions" value={formatNumber(analyticsTotals.searchImpressions)} />
+            <InsightStat label="GA active users" value={formatNumber(analyticsTotals.activeUsers)} />
+            <InsightStat label="Registered users" value={formatNumber(registeredUsers?.total)} />
+            <InsightStat label="Landing views" value={formatNumber(analyticsMarketingTotals.pageViews)} />
+            <InsightStat label="Product views" value={formatNumber(analyticsProductTotals.pageViews)} />
+            <InsightStat label="Search clicks" value={formatNumber(analyticsTotals.searchClicks)} />
+            <InsightStat label="Search impressions" value={formatNumber(analyticsTotals.searchImpressions)} />
           </div>
         ) : (
           <p className="mt-5 rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-4 text-sm text-[color:var(--admin-muted)]">
@@ -841,18 +918,26 @@ export function MarketingPage() {
         ) : null}
 
         {analyticsInsights?.summary ? (
-          <div className="mt-5 grid gap-4 lg:grid-cols-3">
+          <div className="mt-5 grid gap-4 lg:grid-cols-4">
             <InsightTable
-              title="Top pages"
-              rows={analyticsInsights.topPages.slice(0, 5).map((row) => ({
+              title="Landing pages"
+              rows={analyticsInsights.marketingPages.slice(0, 5).map((row) => ({
                 label: row.page_path || '/',
                 detail: row.page_title,
                 value: formatNumber(row.screen_page_views),
               }))}
             />
             <InsightTable
-              title="Top sources"
-              rows={analyticsInsights.topSources.slice(0, 5).map((row) => ({
+              title="Product pages"
+              rows={analyticsInsights.productPages.slice(0, 5).map((row) => ({
+                label: row.page_path || '/',
+                detail: row.page_title,
+                value: formatNumber(row.screen_page_views),
+              }))}
+            />
+            <InsightTable
+              title="Acquisition sources"
+              rows={analyticsInsights.cleanSources.slice(0, 5).map((row) => ({
                 label: [row.source || '(direct)', row.medium || '(none)'].join(' / '),
                 detail: row.campaign || 'No campaign',
                 value: formatNumber(row.sessions),
@@ -866,6 +951,16 @@ export function MarketingPage() {
                 value: `${formatNumber(row.impressions)} imp. / ${formatNumber(row.clicks)} clicks`,
               }))}
             />
+          </div>
+        ) : null}
+
+        {analyticsInsights?.summary?.notes?.length ? (
+          <div className="mt-5 grid gap-2">
+            {analyticsInsights.summary.notes.map((note) => (
+              <p key={note} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-xs text-[color:var(--admin-muted)]">
+                {note}
+              </p>
+            ))}
           </div>
         ) : null}
       </section>
@@ -931,6 +1026,45 @@ function InsightTable({
       </div>
     </div>
   );
+}
+
+function SettingsListField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string[];
+  onChange: (value: string[]) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">{label}</span>
+      <textarea
+        value={value.join('\n')}
+        rows={4}
+        onChange={(event) => onChange(parseSettingsList(event.target.value))}
+        className="mt-2 w-full resize-y rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] px-3 py-2 font-mono text-xs leading-relaxed text-[color:var(--admin-text)]"
+      />
+    </label>
+  );
+}
+
+function parseSettingsList(value: string) {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const item of value.split(/[\n,]/)) {
+    const text = item.trim();
+    const key = text.toLowerCase();
+    if (!text || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(text);
+  }
+
+  return result;
 }
 
 function getAnalyticsTotals(insights: MarketingAnalyticsInsights | null) {


### PR DESCRIPTION
## Summary
- add persisted marketing analytics hygiene settings for excluded sources, page groups, and internal/admin users
- separate landing-page, product-page, and cleaned acquisition insights in the admin marketing dashboard
- compute GA4 totals from aggregate API rows instead of summing page rows, and show registered-user counts from Neon
- update the marketing strategy memory with the first 20-post proposal and scheduled Codex prompt draft

## Validation
- pnpm run lint
- npm --workspace apps/api run typecheck
- npm --workspace apps/api run build
- npm --workspace apps/web run build

## Notes
- npm --workspace apps/web run typecheck still fails on existing unrelated Clerk/demo/labs/test type errors in main.