### PR TITLE
fix(web): remove stale MarketingPage references after revert

### DIFF
--- a/apps/web/src/components/admin2/Admin2Shell.tsx
+++ b/apps/web/src/components/admin2/Admin2Shell.tsx
@@ -3,10 +3,8 @@ import { OverviewPage } from '../../pages/admin2/OverviewPage';
 import { CoreEnginePage } from '../../pages/admin2/CoreEnginePage';
 import { UserOpsPage } from '../../pages/admin2/UserOpsPage';
 import { NotificationsPage } from '../../pages/admin2/NotificationsPage';
-import { MarketingPage } from '../../pages/admin2/MarketingPage';
 import { AiTaskgenPage } from '../../pages/admin2/AiTaskgenPage';
 import { AdvancedPage } from '../../pages/admin2/AdvancedPage';
-import { MarketingPage } from '../../pages/admin2/MarketingPage';
 import { TaskgenUserPage } from '../../pages/admin/TaskgenUserPage';
 import { useAdmin2Theme } from './Admin2ThemeProvider';
 
@@ -15,7 +13,6 @@ const NAV_ITEMS = [
   { to: '/admin/core-engine', label: 'Core Engine' },
   { to: '/admin/user-ops', label: 'User Ops' },
   { to: '/admin/notifications', label: 'Notifications' },
-  { to: '/admin/marketing', label: 'Marketing' },
   { to: '/admin/ai-taskgen', label: 'AI TaskGen' },
   { to: '/admin/advanced', label: 'Advanced' },
 ];
@@ -111,7 +108,6 @@ export function Admin2Shell() {
             <Route path="core-engine" element={<CoreEnginePage />} />
             <Route path="user-ops" element={<UserOpsPage />} />
             <Route path="notifications" element={<NotificationsPage />} />
-            <Route path="marketing" element={<MarketingPage />} />
             <Route path="ai-taskgen" element={<AiTaskgenPage />} />
             <Route path="advanced" element={<AdvancedPage />} />
             <Route


### PR DESCRIPTION
## Qué corrige

El revert de la PR #2216 eliminó `MarketingPage.tsx`, pero dejó referencias activas en `Admin2Shell.tsx`. Eso hacía fallar el build de Railway con:

`Could not resolve "../../pages/admin2/MarketingPage"`

## Cambios

- Elimina los imports obsoletos y duplicados de `MarketingPage`.
- Elimina la opción `Marketing` del menú admin.
- Elimina la ruta `/admin/marketing` que apuntaba al archivo borrado.

No restaura la UI de marketing revertida; solo corrige las referencias huérfanas para que el build vuelva a compilar.