### PR TITLE
[codex] Add marketing campaign persistence

### DIFF
--- a/apps/api/src/db/migrations/202606300001_marketing_campaign_state.sql
+++ b/apps/api/src/db/migrations/202606300001_marketing_campaign_state.sql
@@ -1,0 +1,93 @@
+CREATE TABLE IF NOT EXISTS marketing_campaigns (
+  marketing_campaign_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  period_key text NOT NULL CHECK (period_key ~ '^\d{4}-\d{2}$'),
+  campaign_code text NOT NULL UNIQUE,
+  title text NOT NULL,
+  objective text NOT NULL DEFAULT 'new_users' CHECK (objective IN ('new_users', 'leads', 'activation', 'awareness', 'retention')),
+  status text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'review', 'approved', 'published', 'completed', 'archived')),
+  strategy_summary text NOT NULL DEFAULT '',
+  source_context jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  approved_at timestamptz,
+  published_at timestamptz,
+  completed_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS marketing_posts (
+  marketing_post_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  marketing_campaign_id uuid NOT NULL REFERENCES marketing_campaigns(marketing_campaign_id) ON DELETE CASCADE,
+  post_code text NOT NULL,
+  platform text NOT NULL DEFAULT 'instagram',
+  format text NOT NULL CHECK (format IN ('carousel', 'static', 'reel', 'story', 'thread', 'short_video')),
+  status text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'needs_review', 'approved', 'rejected', 'published', 'measured', 'archived')),
+  hook text NOT NULL DEFAULT '',
+  caption text NOT NULL DEFAULT '',
+  hypothesis text NOT NULL DEFAULT '',
+  target_metric text NOT NULL DEFAULT '',
+  tracking_url text NOT NULL DEFAULT '',
+  asset_urls jsonb NOT NULL DEFAULT '[]'::jsonb,
+  agent_notes text NOT NULL DEFAULT '',
+  decision_note text NOT NULL DEFAULT '',
+  rejection_reason text NOT NULL DEFAULT '',
+  scheduled_at timestamptz,
+  approved_at timestamptz,
+  rejected_at timestamptz,
+  published_at timestamptz,
+  measured_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (marketing_campaign_id, post_code)
+);
+
+CREATE TABLE IF NOT EXISTS marketing_post_metrics (
+  marketing_post_metric_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  marketing_post_id uuid NOT NULL REFERENCES marketing_posts(marketing_post_id) ON DELETE CASCADE,
+  source text NOT NULL CHECK (source IN ('ga4', 'gsc', 'metricool_manual', 'manual')),
+  period_start date NOT NULL,
+  period_end date NOT NULL,
+  impressions integer NOT NULL DEFAULT 0 CHECK (impressions >= 0),
+  reach integer NOT NULL DEFAULT 0 CHECK (reach >= 0),
+  clicks integer NOT NULL DEFAULT 0 CHECK (clicks >= 0),
+  sessions integer NOT NULL DEFAULT 0 CHECK (sessions >= 0),
+  landing_cta_clicks integer NOT NULL DEFAULT 0 CHECK (landing_cta_clicks >= 0),
+  signups integer NOT NULL DEFAULT 0 CHECK (signups >= 0),
+  dashboard_views integer NOT NULL DEFAULT 0 CHECK (dashboard_views >= 0),
+  leads integer NOT NULL DEFAULT 0 CHECK (leads >= 0),
+  raw_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  notes text NOT NULL DEFAULT '',
+  imported_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (marketing_post_id, source, period_start, period_end)
+);
+
+CREATE TABLE IF NOT EXISTS marketing_learnings (
+  marketing_learning_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  marketing_campaign_id uuid REFERENCES marketing_campaigns(marketing_campaign_id) ON DELETE SET NULL,
+  period_key text NOT NULL CHECK (period_key ~ '^\d{4}-\d{2}$'),
+  learning_stage text NOT NULL DEFAULT 'pre_next_generation' CHECK (learning_stage IN ('pre_next_generation', 'monthly_close', 'manual_note')),
+  has_metrics boolean NOT NULL DEFAULT false,
+  summary text NOT NULL DEFAULT '',
+  winning_patterns jsonb NOT NULL DEFAULT '[]'::jsonb,
+  losing_patterns jsonb NOT NULL DEFAULT '[]'::jsonb,
+  next_recommendations jsonb NOT NULL DEFAULT '[]'::jsonb,
+  agent_context_summary text NOT NULL DEFAULT '',
+  source_context jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS marketing_campaigns_period_idx
+  ON marketing_campaigns (period_key DESC, status);
+
+CREATE INDEX IF NOT EXISTS marketing_posts_campaign_status_idx
+  ON marketing_posts (marketing_campaign_id, status);
+
+CREATE INDEX IF NOT EXISTS marketing_posts_tracking_url_idx
+  ON marketing_posts (tracking_url)
+  WHERE tracking_url <> '';
+
+CREATE INDEX IF NOT EXISTS marketing_post_metrics_post_period_idx
+  ON marketing_post_metrics (marketing_post_id, period_start DESC, period_end DESC);
+
+CREATE INDEX IF NOT EXISTS marketing_learnings_period_stage_idx
+  ON marketing_learnings (period_key DESC, learning_stage);

--- a/apps/api/src/modules/admin/admin.handlers.ts
+++ b/apps/api/src/modules/admin/admin.handlers.ts
@@ -28,6 +28,8 @@ import {
   habitAchievementDiagnosticsQuerySchema,
   adminManualGameModeChangeBodySchema,
   adminModeUpgradeCtaOverrideUpsertBodySchema,
+  marketingPostParamsSchema,
+  marketingPostUpdateBodySchema,
 } from './admin.schemas.js';
 import {
   exportUserLogsCsv,
@@ -79,6 +81,7 @@ import {
   runMarketingAnalyticsSync,
   updateMarketingAnalyticsSettings,
 } from '../../services/marketingAnalyticsService.js';
+import { listMarketingCampaigns, updateMarketingPost } from '../../services/marketingCampaignService.js';
 import { pool } from '../../db.js';
 
 const taskgenForceRunRequestSchema = z
@@ -152,6 +155,18 @@ export const postAdminMarketingR2Assets = asyncHandler(async (req: Request, res:
 export const getAdminMarketingAnalyticsStatus = asyncHandler(async (_req: Request, res: Response) => {
   const status = await getMarketingAnalyticsStatus();
   res.json({ ok: true, ...status });
+});
+
+export const getAdminMarketingCampaigns = asyncHandler(async (_req: Request, res: Response) => {
+  const campaigns = await listMarketingCampaigns();
+  res.json({ ok: true, campaigns });
+});
+
+export const patchAdminMarketingPost = asyncHandler(async (req: Request, res: Response) => {
+  const { campaignCode, postCode } = marketingPostParamsSchema.parse(req.params);
+  const body = marketingPostUpdateBodySchema.parse(req.body ?? {});
+  const post = await updateMarketingPost(campaignCode, postCode, body);
+  res.json({ ok: true, post });
 });
 
 export const getAdminMarketingAnalyticsInsights = asyncHandler(async (_req: Request, res: Response) => {

--- a/apps/api/src/modules/admin/admin.routes.ts
+++ b/apps/api/src/modules/admin/admin.routes.ts
@@ -40,9 +40,11 @@ import {
   putAdminUserModeUpgradeCtaOverride,
   deleteAdminUserModeUpgradeCtaOverride,
   getAdminMonthlyPipelineStatus,
+  getAdminMarketingCampaigns,
   getAdminMarketingAnalyticsInsights,
   getAdminMarketingAnalyticsStatus,
   getAdminMarketingR2Status,
+  patchAdminMarketingPost,
   postAdminMonthlyPipelineRun,
   postAdminMarketingAnalyticsSync,
   postAdminMarketingR2Assets,
@@ -55,6 +57,8 @@ const adminRouter = Router();
 
 adminRouter.get('/me', getAdminMe);
 adminRouter.get('/users', getAdminUsers);
+adminRouter.get('/marketing/campaigns', getAdminMarketingCampaigns);
+adminRouter.patch('/marketing/campaigns/:campaignCode/posts/:postCode', patchAdminMarketingPost);
 adminRouter.get('/marketing/analytics/status', getAdminMarketingAnalyticsStatus);
 adminRouter.get('/marketing/analytics/insights', getAdminMarketingAnalyticsInsights);
 adminRouter.post('/marketing/analytics/sync', postAdminMarketingAnalyticsSync);

--- a/apps/api/src/modules/admin/admin.schemas.ts
+++ b/apps/api/src/modules/admin/admin.schemas.ts
@@ -287,6 +287,44 @@ export const feedbackUserNotificationUpdateSchema = z.object({
   muteUntil: z.string().datetime().nullable().optional(),
 });
 
+export const marketingCampaignParamsSchema = z.object({
+  campaignCode: z.string().trim().min(1).max(120),
+});
+
+export const marketingPostParamsSchema = marketingCampaignParamsSchema.extend({
+  postCode: z.string().trim().min(1).max(120),
+});
+
+const marketingPostAssetSchema = z.object({
+  file: z.string().trim().min(1).max(500),
+  title: z.string().trim().min(1).max(500),
+  type: z.string().trim().min(1).max(120).optional(),
+  url: z.string().trim().max(2000).optional(),
+  selected: z.boolean().optional(),
+});
+
+export const marketingPostUpdateBodySchema = z.object({
+  status: z.enum(['draft', 'needs_review', 'approved', 'rejected', 'published', 'measured', 'archived']).optional(),
+  hook: z.string().max(1000).optional(),
+  caption: z.string().max(10000).optional(),
+  hypothesis: z.string().max(3000).optional(),
+  targetMetric: z.string().max(1000).optional(),
+  trackingUrl: z.string().max(2000).optional(),
+  assetUrls: z.array(marketingPostAssetSchema).max(20).optional(),
+  agentNotes: z.string().max(3000).optional(),
+  decisionNote: z.string().max(3000).optional(),
+  rejectionReason: z.string().max(3000).optional(),
+  scheduledAt: z.string().datetime().nullable().optional(),
+}).superRefine((value, ctx) => {
+  if (!Object.keys(value).length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'At least one property must be provided',
+      path: [],
+    });
+  }
+});
+
 export type ListUsersQuery = z.infer<typeof listUsersQuerySchema>;
 export type LogsQuery = z.infer<typeof logsQuerySchema>;
 export type InsightQuery = z.infer<typeof insightQuerySchema>;
@@ -309,3 +347,4 @@ export type AdminSubscriptionUpdateBody = z.infer<typeof adminSubscriptionUpdate
 export type SubscriptionNotificationsTriggerBody = z.infer<typeof subscriptionNotificationsTriggerBodySchema>;
 export type FeedbackDefinitionUpdateInput = z.infer<typeof feedbackDefinitionUpdateSchema>;
 export type FeedbackUserNotificationUpdateInput = z.infer<typeof feedbackUserNotificationUpdateSchema>;
+export type MarketingPostUpdateBody = z.infer<typeof marketingPostUpdateBodySchema>;

--- a/apps/api/src/services/marketingCampaignService.ts
+++ b/apps/api/src/services/marketingCampaignService.ts
@@ -1,0 +1,400 @@
+import { pool } from '../db.js';
+import { HttpError } from '../lib/http-error.js';
+
+export type MarketingPostStatus =
+  | 'draft'
+  | 'needs_review'
+  | 'approved'
+  | 'rejected'
+  | 'published'
+  | 'measured'
+  | 'archived';
+
+export type MarketingAssetPayload = {
+  file: string;
+  title: string;
+  type?: string;
+  url?: string;
+  selected?: boolean;
+};
+
+export type MarketingPostPayload = {
+  postCode: string;
+  platform: string;
+  format: string;
+  status: MarketingPostStatus;
+  hook: string;
+  caption: string;
+  hypothesis: string;
+  targetMetric: string;
+  trackingUrl: string;
+  assetUrls: MarketingAssetPayload[];
+  agentNotes: string;
+  decisionNote: string;
+  rejectionReason: string;
+  scheduledAt: string | null;
+  approvedAt: string | null;
+  rejectedAt: string | null;
+  publishedAt: string | null;
+  measuredAt: string | null;
+  updatedAt: string;
+};
+
+export type MarketingCampaignPayload = {
+  id: string;
+  periodKey: string;
+  campaignCode: string;
+  title: string;
+  objective: string;
+  status: string;
+  strategySummary: string;
+  sourceContext: Record<string, unknown>;
+  posts: MarketingPostPayload[];
+  updatedAt: string;
+};
+
+export type MarketingPostUpdateInput = Partial<{
+  status: MarketingPostStatus;
+  hook: string;
+  caption: string;
+  hypothesis: string;
+  targetMetric: string;
+  trackingUrl: string;
+  assetUrls: MarketingAssetPayload[];
+  agentNotes: string;
+  decisionNote: string;
+  rejectionReason: string;
+  scheduledAt: string | null;
+}>;
+
+const DEFAULT_CAMPAIGN = {
+  periodKey: '2026-06',
+  campaignCode: 'ib20_mvp',
+  title: 'Innerbloom 2.0 Marketing MVP - English Test',
+  objective: 'new_users',
+  status: 'review',
+  strategySummary: 'Validate the first acquisition loop with two simple Instagram posts before scaling to a monthly system.',
+  sourceContext: {
+    primaryUrl: 'https://innerbloomjourney.org/',
+    driveRootUrl: 'https://drive.google.com/drive/folders/1OMs5zzPQcx9Db9RjpA7J-xL5h1b5V9cZ',
+    strategyMemoryUrl: 'https://drive.google.com/file/d/1FGQPOJ1Gp0A7--yNbPDMKhgdOP89Gres/view?usp=drivesdk',
+    assetsFolderUrl: 'https://drive.google.com/drive/folders/1FplCAOvdgLA9p73fA7-piQH16d0nSuEg',
+    campaignsFolderUrl: 'https://drive.google.com/drive/folders/1S3J3aFgtd1np7mjBKGBpN1w5xuyuGyuH',
+  },
+  posts: [
+    {
+      postCode: 'post_001',
+      platform: 'instagram',
+      format: 'carousel',
+      status: 'needs_review' as MarketingPostStatus,
+      hook: 'Your habits should adapt to your real life.',
+      caption:
+        'Most habit apps assume every day is the same. Then a busy week hits, your streak breaks, and the whole plan starts feeling useless. Innerbloom is built around adaptive rhythm: lower the intensity when life gets heavy, keep visible progress, recalibrate instead of starting over, and build a Journey that can survive real weeks.',
+      hypothesis: 'People who have failed with streak-based apps will respond to adaptive rhythm and real weeks.',
+      targetMetric: 'page_view -> landing_cta_clicked -> auth_started -> auth_completed -> dashboard_view',
+      trackingUrl:
+        'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_001&ib_post=001',
+      scheduledAt: '2026-06-30T19:30:00+02:00',
+      assetUrls: [
+        { file: 'post-001-carousel-01.png', title: 'Your habits should adapt to your real life.', type: 'image', selected: true },
+        { file: 'post-001-carousel-02.png', title: 'Most habit apps assume every day is the same.', type: 'split', selected: true },
+        { file: 'post-001-carousel-03.png', title: 'Lower the intensity. Keep the direction.', type: 'image', selected: true },
+        { file: 'post-001-carousel-04.png', title: 'Build a Journey that can survive real weeks.', type: 'brand', selected: true },
+      ],
+    },
+    {
+      postCode: 'post_002',
+      platform: 'instagram',
+      format: 'static',
+      status: 'needs_review' as MarketingPostStatus,
+      hook: 'If your plan only works on perfect days, it is not a plan.',
+      caption:
+        'Most people do not fail habits because they are lazy. They fail because the system expects the same output from them every day, even when their energy, stress, sleep, and schedule change. Innerbloom is an adaptive habit app. It helps you keep direction without forcing the same rhythm all the time.',
+      hypothesis: 'A direct anti-perfect-days message will perform better for people tired of rigid productivity systems.',
+      targetMetric: 'page_view, scroll depth, landing_cta_clicked, and dashboard_view',
+      trackingUrl:
+        'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_002&ib_post=002',
+      scheduledAt: '2026-07-02T22:30:00+02:00',
+      assetUrls: [
+        { file: 'post-002-static-pain-proposal.png', title: 'If your plan only works on perfect days, it is not a plan.', type: 'static', selected: true },
+      ],
+    },
+    {
+      postCode: 'post_003',
+      platform: 'instagram',
+      format: 'static',
+      status: 'needs_review' as MarketingPostStatus,
+      hook: 'A daily quest should fit the day you actually have.',
+      caption:
+        'Innerbloom turns daily habit work into a small adaptive quest. Pick what fits your energy, keep the direction visible, and avoid throwing away progress when the day gets messy.',
+      hypothesis: 'A concrete Daily Quest product screenshot will make the adaptive habit promise easier to understand than abstract habit advice.',
+      targetMetric: 'page_view -> landing_cta_clicked -> auth_started -> dashboard_view',
+      trackingUrl:
+        'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_003&ib_post=003',
+      scheduledAt: '2026-07-04T19:30:00+02:00',
+      assetUrls: [
+        {
+          file: 'innerbloom_mobile_dailyquest_dark_tasks_selection.png',
+          title: 'Daily Quest task selection screen',
+          type: 'drive-image',
+          url: 'https://drive.google.com/file/d/1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA/view?usp=drivesdk',
+          selected: true,
+        },
+      ],
+    },
+  ],
+};
+
+export async function listMarketingCampaigns(): Promise<MarketingCampaignPayload[]> {
+  await ensureDefaultCampaign();
+
+  const campaigns = await pool.query<CampaignRow>(
+    `SELECT marketing_campaign_id, period_key, campaign_code, title, objective, status, strategy_summary,
+            source_context, updated_at
+       FROM marketing_campaigns
+      ORDER BY period_key DESC, created_at DESC`,
+  );
+
+  const posts = await pool.query<PostRow>(
+    `SELECT mp.*
+       FROM marketing_posts mp
+       JOIN marketing_campaigns mc ON mc.marketing_campaign_id = mp.marketing_campaign_id
+      ORDER BY mc.period_key DESC, mp.scheduled_at NULLS LAST, mp.post_code`,
+  );
+
+  const postsByCampaign = new Map<string, MarketingPostPayload[]>();
+  for (const row of posts.rows) {
+    const items = postsByCampaign.get(row.marketing_campaign_id) ?? [];
+    items.push(mapPostRow(row));
+    postsByCampaign.set(row.marketing_campaign_id, items);
+  }
+
+  return campaigns.rows.map((row) => ({
+    id: row.marketing_campaign_id,
+    periodKey: row.period_key,
+    campaignCode: row.campaign_code,
+    title: row.title,
+    objective: row.objective,
+    status: row.status,
+    strategySummary: row.strategy_summary,
+    sourceContext: normalizeRecord(row.source_context),
+    posts: postsByCampaign.get(row.marketing_campaign_id) ?? [],
+    updatedAt: toIso(row.updated_at),
+  }));
+}
+
+export async function updateMarketingPost(
+  campaignCode: string,
+  postCode: string,
+  input: MarketingPostUpdateInput,
+): Promise<MarketingPostPayload> {
+  await ensureDefaultCampaign();
+
+  const existing = await pool.query<PostRow>(
+    `SELECT mp.*
+       FROM marketing_posts mp
+       JOIN marketing_campaigns mc ON mc.marketing_campaign_id = mp.marketing_campaign_id
+      WHERE mc.campaign_code = $1
+        AND mp.post_code = $2
+      LIMIT 1`,
+    [campaignCode, postCode],
+  );
+
+  const current = existing.rows[0];
+  if (!current) {
+    throw new HttpError(404, 'marketing_post_not_found', 'Marketing post not found.');
+  }
+
+  const nextStatus = input.status ?? current.status;
+  const now = new Date();
+  const approvedAt = nextStatus === 'approved' && current.status !== 'approved'
+    ? now
+    : current.approved_at;
+  const rejectedAt = nextStatus === 'rejected' && current.status !== 'rejected'
+    ? now
+    : current.rejected_at;
+
+  const result = await pool.query<PostRow>(
+    `UPDATE marketing_posts
+        SET status = $3,
+            hook = $4,
+            caption = $5,
+            hypothesis = $6,
+            target_metric = $7,
+            tracking_url = $8,
+            asset_urls = $9::jsonb,
+            agent_notes = $10,
+            decision_note = $11,
+            rejection_reason = $12,
+            scheduled_at = $13,
+            approved_at = $14,
+            rejected_at = $15,
+            updated_at = now()
+      WHERE marketing_post_id = $1
+        AND post_code = $2
+      RETURNING *`,
+    [
+      current.marketing_post_id,
+      postCode,
+      nextStatus,
+      input.hook ?? current.hook,
+      input.caption ?? current.caption,
+      input.hypothesis ?? current.hypothesis,
+      input.targetMetric ?? current.target_metric,
+      input.trackingUrl ?? current.tracking_url,
+      JSON.stringify(input.assetUrls ?? normalizeAssets(current.asset_urls)),
+      input.agentNotes ?? current.agent_notes,
+      input.decisionNote ?? current.decision_note,
+      input.rejectionReason ?? current.rejection_reason,
+      input.scheduledAt === undefined ? current.scheduled_at : input.scheduledAt,
+      approvedAt,
+      rejectedAt,
+    ],
+  );
+
+  return mapPostRow(result.rows[0]);
+}
+
+async function ensureDefaultCampaign() {
+  const result = await pool.query<{ marketing_campaign_id: string }>(
+    `INSERT INTO marketing_campaigns (period_key, campaign_code, title, objective, status, strategy_summary, source_context)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+     ON CONFLICT (campaign_code) DO UPDATE
+       SET title = EXCLUDED.title,
+           strategy_summary = CASE
+             WHEN marketing_campaigns.strategy_summary = '' THEN EXCLUDED.strategy_summary
+             ELSE marketing_campaigns.strategy_summary
+           END,
+           source_context = marketing_campaigns.source_context || EXCLUDED.source_context,
+           updated_at = now()
+     RETURNING marketing_campaign_id`,
+    [
+      DEFAULT_CAMPAIGN.periodKey,
+      DEFAULT_CAMPAIGN.campaignCode,
+      DEFAULT_CAMPAIGN.title,
+      DEFAULT_CAMPAIGN.objective,
+      DEFAULT_CAMPAIGN.status,
+      DEFAULT_CAMPAIGN.strategySummary,
+      JSON.stringify(DEFAULT_CAMPAIGN.sourceContext),
+    ],
+  );
+
+  const campaignId = result.rows[0].marketing_campaign_id;
+
+  for (const post of DEFAULT_CAMPAIGN.posts) {
+    await pool.query(
+      `INSERT INTO marketing_posts (
+         marketing_campaign_id, post_code, platform, format, status, hook, caption, hypothesis,
+         target_metric, tracking_url, asset_urls, scheduled_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12)
+       ON CONFLICT (marketing_campaign_id, post_code) DO NOTHING`,
+      [
+        campaignId,
+        post.postCode,
+        post.platform,
+        post.format,
+        post.status,
+        post.hook,
+        post.caption,
+        post.hypothesis,
+        post.targetMetric,
+        post.trackingUrl,
+        JSON.stringify(post.assetUrls),
+        post.scheduledAt,
+      ],
+    );
+  }
+}
+
+type CampaignRow = {
+  marketing_campaign_id: string;
+  period_key: string;
+  campaign_code: string;
+  title: string;
+  objective: string;
+  status: string;
+  strategy_summary: string;
+  source_context: unknown;
+  updated_at: string | Date;
+};
+
+type PostRow = {
+  marketing_post_id: string;
+  marketing_campaign_id: string;
+  post_code: string;
+  platform: string;
+  format: string;
+  status: MarketingPostStatus;
+  hook: string;
+  caption: string;
+  hypothesis: string;
+  target_metric: string;
+  tracking_url: string;
+  asset_urls: unknown;
+  agent_notes: string;
+  decision_note: string;
+  rejection_reason: string;
+  scheduled_at: string | Date | null;
+  approved_at: string | Date | null;
+  rejected_at: string | Date | null;
+  published_at: string | Date | null;
+  measured_at: string | Date | null;
+  updated_at: string | Date;
+};
+
+function mapPostRow(row: PostRow): MarketingPostPayload {
+  return {
+    postCode: row.post_code,
+    platform: row.platform,
+    format: row.format,
+    status: row.status,
+    hook: row.hook,
+    caption: row.caption,
+    hypothesis: row.hypothesis,
+    targetMetric: row.target_metric,
+    trackingUrl: row.tracking_url,
+    assetUrls: normalizeAssets(row.asset_urls),
+    agentNotes: row.agent_notes,
+    decisionNote: row.decision_note,
+    rejectionReason: row.rejection_reason,
+    scheduledAt: toIsoOrNull(row.scheduled_at),
+    approvedAt: toIsoOrNull(row.approved_at),
+    rejectedAt: toIsoOrNull(row.rejected_at),
+    publishedAt: toIsoOrNull(row.published_at),
+    measuredAt: toIsoOrNull(row.measured_at),
+    updatedAt: toIso(row.updated_at),
+  };
+}
+
+function normalizeAssets(value: unknown): MarketingAssetPayload[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((asset): asset is Record<string, unknown> => Boolean(asset) && typeof asset === 'object')
+    .map((asset) => ({
+      file: String(asset.file ?? ''),
+      title: String(asset.title ?? asset.file ?? ''),
+      type: typeof asset.type === 'string' ? asset.type : undefined,
+      url: typeof asset.url === 'string' ? asset.url : undefined,
+      selected: typeof asset.selected === 'boolean' ? asset.selected : true,
+    }))
+    .filter((asset) => asset.file);
+}
+
+function normalizeRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function toIsoOrNull(value: string | Date | null): string | null {
+  return value ? toIso(value) : null;
+}

--- a/apps/web/src/content/marketingAdminSeed.ts
+++ b/apps/web/src/content/marketingAdminSeed.ts
@@ -144,6 +144,39 @@ export const marketingCampaignSeeds: MarketingCampaignSeed[] = [{
         },
       ],
     },
+    {
+      id: 'post_003',
+      number: '003',
+      platform: 'instagram',
+      format: 'static',
+      status: 'needs_review',
+      scheduledDate: '2026-07-04',
+      scheduledTime: '19:30:00',
+      hypothesis:
+        'A concrete Daily Quest product screenshot will make the adaptive habit promise easier to understand than abstract habit advice.',
+      metric: 'page_view -> landing_cta_clicked -> auth_started -> dashboard_view',
+      trackingUrl:
+        'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_003&ib_post=003',
+      caption: [
+        'A daily quest should fit the day you actually have.',
+        '',
+        'Innerbloom turns daily habit work into a small adaptive quest.',
+        '',
+        'Pick what fits your energy, keep the direction visible, and avoid throwing away progress when the day gets messy.',
+        '',
+        'Try it here:',
+        'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_003&ib_post=003',
+        '',
+        '#habits #selfimprovement #wellbeing #productivity #habittracker #buildinpublic',
+      ].join('\n'),
+      assets: [
+        {
+          file: 'innerbloom_mobile_dailyquest_dark_tasks_selection.png',
+          title: 'Daily Quest task selection screen',
+          url: 'https://drive.google.com/file/d/1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA/view?usp=drivesdk',
+        },
+      ],
+    },
   ],
 }];
 

--- a/apps/web/src/lib/marketingCampaigns.ts
+++ b/apps/web/src/lib/marketingCampaigns.ts
@@ -1,0 +1,107 @@
+import { apiAuthorizedFetch } from './api';
+
+export type MarketingPostStatus =
+  | 'draft'
+  | 'needs_review'
+  | 'approved'
+  | 'rejected'
+  | 'published'
+  | 'measured'
+  | 'archived';
+
+export type MarketingAssetRecord = {
+  file: string;
+  title: string;
+  type?: string;
+  url?: string;
+  selected?: boolean;
+};
+
+export type MarketingPostRecord = {
+  postCode: string;
+  platform: string;
+  format: string;
+  status: MarketingPostStatus;
+  hook: string;
+  caption: string;
+  hypothesis: string;
+  targetMetric: string;
+  trackingUrl: string;
+  assetUrls: MarketingAssetRecord[];
+  agentNotes: string;
+  decisionNote: string;
+  rejectionReason: string;
+  scheduledAt: string | null;
+  approvedAt: string | null;
+  rejectedAt: string | null;
+  publishedAt: string | null;
+  measuredAt: string | null;
+  updatedAt: string;
+};
+
+export type MarketingCampaignRecord = {
+  id: string;
+  periodKey: string;
+  campaignCode: string;
+  title: string;
+  objective: string;
+  status: string;
+  strategySummary: string;
+  sourceContext: Record<string, unknown>;
+  posts: MarketingPostRecord[];
+  updatedAt: string;
+};
+
+export type MarketingPostUpdate = Partial<Pick<
+  MarketingPostRecord,
+  | 'status'
+  | 'hook'
+  | 'caption'
+  | 'hypothesis'
+  | 'targetMetric'
+  | 'trackingUrl'
+  | 'assetUrls'
+  | 'agentNotes'
+  | 'decisionNote'
+  | 'rejectionReason'
+  | 'scheduledAt'
+>>;
+
+export async function fetchMarketingCampaigns() {
+  const response = await apiAuthorizedFetch('/admin/marketing/campaigns', {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Marketing campaigns request failed with HTTP ${response.status}`);
+  }
+
+  return response.json() as Promise<{ ok: boolean; campaigns: MarketingCampaignRecord[] }>;
+}
+
+export async function updateMarketingCampaignPost(
+  campaignCode: string,
+  postCode: string,
+  payload: MarketingPostUpdate,
+) {
+  const response = await apiAuthorizedFetch(
+    `/admin/marketing/campaigns/${encodeURIComponent(campaignCode)}/posts/${encodeURIComponent(postCode)}`,
+    {
+      method: 'PATCH',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Marketing post update failed with HTTP ${response.status}: ${body}`);
+  }
+
+  return response.json() as Promise<{ ok: boolean; post: MarketingPostRecord }>;
+}

--- a/apps/web/src/pages/admin2/MarketingPage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPage.tsx
@@ -21,6 +21,13 @@ import {
   type MarketingPostSeed,
   type MarketingPostStatus,
 } from '../../content/marketingAdminSeed';
+import {
+  fetchMarketingCampaigns,
+  updateMarketingCampaignPost,
+  type MarketingAssetRecord,
+  type MarketingCampaignRecord,
+  type MarketingPostRecord,
+} from '../../lib/marketingCampaigns';
 import { downloadMetricoolCalendarCsv } from '../../lib/marketingMetricoolCsv';
 import {
   buildMarketingAssetKey,
@@ -42,8 +49,6 @@ const STATUS_LABELS: Record<MarketingPostStatus, string> = {
   needs_review: 'Needs review',
   approved: 'Approved',
 };
-
-const STORAGE_PREFIX = 'innerbloom:admin-marketing:posts:';
 
 const iconButtonBase =
   'inline-flex h-9 w-9 items-center justify-center rounded-lg border text-[color:var(--admin-text)] transition hover:border-[color:var(--admin-accent)] hover:bg-[color:var(--admin-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--admin-accent)] disabled:cursor-not-allowed disabled:opacity-35';
@@ -425,15 +430,19 @@ function PostCard({
 }
 
 export function MarketingPage() {
+  const [campaigns, setCampaigns] = useState<MarketingCampaignSeed[]>(marketingCampaignSeeds);
   const [selectedCampaignCode, setSelectedCampaignCode] = useState(marketingCampaignSeeds[0].campaignCode);
   const selectedCampaign = useMemo(
-    () => marketingCampaignSeeds.find((campaign) => campaign.campaignCode === selectedCampaignCode) ?? marketingCampaignSeeds[0],
-    [selectedCampaignCode],
+    () => campaigns.find((campaign) => campaign.campaignCode === selectedCampaignCode) ?? campaigns[0] ?? marketingCampaignSeeds[0],
+    [campaigns, selectedCampaignCode],
   );
   const [postCount, setPostCount] = useState(selectedCampaign.postCount);
-  const [posts, setPosts] = useState(() => readStoredCampaignPosts(selectedCampaign));
+  const [posts, setPosts] = useState(() => cloneCampaignPosts(selectedCampaign));
   const [expandedPostIds, setExpandedPostIds] = useState<Set<string>>(() => new Set());
   const [editingPostId, setEditingPostId] = useState<string | null>(null);
+  const [campaignError, setCampaignError] = useState<string | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [savingPostId, setSavingPostId] = useState<string | null>(null);
   const [r2Status, setR2Status] = useState<MarketingR2Status | null>(null);
   const [r2StatusError, setR2StatusError] = useState<string | null>(null);
   const [isUploadingAssets, setIsUploadingAssets] = useState(false);
@@ -458,8 +467,12 @@ export function MarketingPage() {
   );
 
   useEffect(() => {
+    void loadCampaigns();
+  }, []);
+
+  useEffect(() => {
     setPostCount(selectedCampaign.postCount);
-    setPosts(readStoredCampaignPosts(selectedCampaign));
+    setPosts(cloneCampaignPosts(selectedCampaign));
     setExpandedPostIds(new Set());
     setEditingPostId(null);
     setUploadMessage(null);
@@ -503,16 +516,51 @@ export function MarketingPage() {
     }
   }
 
+  async function loadCampaigns() {
+    try {
+      const result = await fetchMarketingCampaigns();
+      const nextCampaigns = result.campaigns.map(mapApiCampaignToSeed);
+
+      if (nextCampaigns.length === 0) {
+        setCampaigns(marketingCampaignSeeds);
+        return;
+      }
+
+      setCampaigns(nextCampaigns);
+      setCampaignError(null);
+      setSelectedCampaignCode((currentCode) =>
+        nextCampaigns.some((campaign) => campaign.campaignCode === currentCode)
+          ? currentCode
+          : nextCampaigns[0].campaignCode,
+      );
+    } catch (error) {
+      setCampaigns(marketingCampaignSeeds);
+      setCampaignError(error instanceof Error ? error.message : 'Unable to load marketing campaigns from backend.');
+    }
+  }
+
   function updateStatus(postId: string, status: MarketingPostStatus) {
     updatePost(postId, (post) => ({ ...post, status }));
   }
 
   function updatePost(postId: string, updater: (post: MarketingPostSeed) => MarketingPostSeed) {
-    setPosts((currentPosts) => {
-      const nextPosts = currentPosts.map((post) => (post.id === postId ? updater(post) : post));
-      persistCampaignPosts(selectedCampaign.campaignCode, nextPosts);
-      return nextPosts;
-    });
+    const currentPost = posts.find((post) => post.id === postId);
+    if (!currentPost) {
+      return;
+    }
+
+    const nextPost = updater(currentPost);
+    const nextPosts = posts.map((post) => (post.id === postId ? nextPost : post));
+
+    setPosts(nextPosts);
+    setCampaigns((currentCampaigns) =>
+      currentCampaigns.map((campaign) =>
+        campaign.campaignCode === selectedCampaign.campaignCode
+          ? { ...campaign, posts: clonePosts(nextPosts) }
+          : campaign,
+      ),
+    );
+    void persistPost(selectedCampaign.campaignCode, nextPost);
   }
 
   function togglePost(postId: string) {
@@ -537,7 +585,7 @@ export function MarketingPage() {
     setPosts(nextPosts);
     setEditingPostId(null);
     setExpandedPostIds(new Set());
-    window.localStorage.removeItem(storageKeyForCampaign(selectedCampaign.campaignCode));
+    setSaveMessage('Reloaded campaign posts from backend state.');
   }
 
   function downloadApprovedCsv() {
@@ -572,8 +620,7 @@ export function MarketingPage() {
       const result = await uploadMarketingAssetsToR2(uploadInputs);
       const uploadedByKey = new Map(result.assets.map((asset) => [asset.key, asset]));
 
-      setPosts((currentPosts) => {
-        const nextPosts = currentPosts.map((post) => ({
+      const nextPosts = posts.map((post) => ({
           ...post,
           assets: post.assets.map((asset) => {
             const key = buildMarketingAssetKey({
@@ -587,15 +634,54 @@ export function MarketingPage() {
           }),
         }));
 
-        persistCampaignPosts(selectedCampaign.campaignCode, nextPosts);
-        return nextPosts;
-      });
+      setPosts(nextPosts);
+      setCampaigns((currentCampaigns) =>
+        currentCampaigns.map((campaign) =>
+          campaign.campaignCode === selectedCampaign.campaignCode
+            ? { ...campaign, posts: clonePosts(nextPosts) }
+            : campaign,
+        ),
+      );
+      await Promise.all(nextPosts.map((post) => persistPost(selectedCampaign.campaignCode, post, { silent: true })));
 
       setUploadMessage(`Uploaded ${result.assets.length} approved asset${result.assets.length === 1 ? '' : 's'} to R2.`);
     } catch (error) {
       setUploadMessage(error instanceof Error ? error.message : 'R2 upload failed.');
     } finally {
       setIsUploadingAssets(false);
+    }
+  }
+
+  async function persistPost(campaignCode: string, post: MarketingPostSeed, options: { silent?: boolean } = {}) {
+    setSavingPostId(post.id);
+    if (!options.silent) {
+      setSaveMessage(null);
+    }
+
+    try {
+      const result = await updateMarketingCampaignPost(campaignCode, post.id, seedPostToApiUpdate(post));
+      const nextPost = mapApiPostToSeed(result.post);
+
+      setPosts((currentPosts) => currentPosts.map((currentPost) => (currentPost.id === post.id ? nextPost : currentPost)));
+      setCampaigns((currentCampaigns) =>
+        currentCampaigns.map((campaign) =>
+          campaign.campaignCode === campaignCode
+            ? {
+                ...campaign,
+                posts: campaign.posts.map((currentPost) => (currentPost.id === post.id ? nextPost : currentPost)),
+              }
+            : campaign,
+        ),
+      );
+
+      if (!options.silent) {
+        setSaveMessage(`Saved ${post.id} in Neon.`);
+      }
+    } catch (error) {
+      setSaveMessage(error instanceof Error ? error.message : `Could not save ${post.id}.`);
+      await loadCampaigns();
+    } finally {
+      setSavingPostId((currentPostId) => (currentPostId === post.id ? null : currentPostId));
     }
   }
 
@@ -645,6 +731,11 @@ export function MarketingPage() {
             </p>
           </div>
           <div className="flex items-center gap-2">
+            {savingPostId ? (
+              <span className="rounded-full border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-1 text-xs font-semibold text-[color:var(--admin-muted)]">
+                Saving {savingPostId}
+              </span>
+            ) : null}
             <button
               type="button"
               className="admin2-btn admin2-btn--primary inline-flex items-center gap-2"
@@ -659,6 +750,16 @@ export function MarketingPage() {
             </IconButton>
           </div>
         </div>
+        {campaignError ? (
+          <p className="mt-3 rounded-xl border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-200">
+            Backend campaign fallback: {campaignError}
+          </p>
+        ) : null}
+        {saveMessage ? (
+          <p className="mt-3 rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-xs text-[color:var(--admin-muted)]">
+            {saveMessage}
+          </p>
+        ) : null}
       </header>
 
       <section className="grid gap-4 md:grid-cols-5">
@@ -693,7 +794,7 @@ export function MarketingPage() {
               onChange={(event) => setSelectedCampaignCode(event.target.value)}
               className="w-full rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-sm font-semibold text-[color:var(--admin-text)]"
             >
-              {marketingCampaignSeeds.map((campaign) => (
+              {campaigns.map((campaign) => (
                 <option key={campaign.campaignCode} value={campaign.campaignCode}>
                   {campaign.campaignCode}
                 </option>
@@ -984,10 +1085,117 @@ export function MarketingPage() {
 }
 
 function cloneCampaignPosts(campaign: MarketingCampaignSeed) {
-  return campaign.posts.map((post) => ({
+  return clonePosts(campaign.posts);
+}
+
+function clonePosts(posts: MarketingPostSeed[]) {
+  return posts.map((post) => ({
     ...post,
     assets: post.assets.map((asset) => ({ ...asset })),
   }));
+}
+
+function mapApiCampaignToSeed(campaign: MarketingCampaignRecord): MarketingCampaignSeed {
+  const sourceContext = campaign.sourceContext ?? {};
+  const posts = campaign.posts.map(mapApiPostToSeed);
+
+  return {
+    title: campaign.title,
+    campaignCode: campaign.campaignCode,
+    primaryUrl: readString(sourceContext.primaryUrl, 'https://innerbloomjourney.org/'),
+    postCount: posts.length || marketingCampaignSeeds[0].postCount,
+    language: readLanguage(sourceContext.language),
+    driveRootUrl: readString(sourceContext.driveRootUrl, ''),
+    strategyMemoryUrl: readString(sourceContext.strategyMemoryUrl, ''),
+    assetsFolderUrl: readString(sourceContext.assetsFolderUrl, ''),
+    campaignsFolderUrl: readString(sourceContext.campaignsFolderUrl, ''),
+    posts,
+  };
+}
+
+function mapApiPostToSeed(post: MarketingPostRecord): MarketingPostSeed {
+  const { scheduledDate, scheduledTime } = splitScheduledAt(post.scheduledAt);
+
+  return {
+    id: post.postCode,
+    number: post.postCode.replace(/^post_?/, '').padStart(3, '0'),
+    platform: 'instagram',
+    format: post.format === 'carousel' ? 'carousel' : 'static',
+    status: normalizePostStatus(post.status),
+    scheduledDate,
+    scheduledTime,
+    hypothesis: post.hypothesis,
+    metric: post.targetMetric,
+    caption: post.caption,
+    trackingUrl: post.trackingUrl,
+    assets: post.assetUrls.map(mapApiAssetToSeed),
+  };
+}
+
+function mapApiAssetToSeed(asset: MarketingAssetRecord): MarketingAsset {
+  return {
+    file: asset.file,
+    title: asset.title,
+    url: asset.url ?? '',
+  };
+}
+
+function seedPostToApiUpdate(post: MarketingPostSeed) {
+  return {
+    status: post.status,
+    caption: post.caption,
+    hypothesis: post.hypothesis,
+    targetMetric: post.metric,
+    trackingUrl: post.trackingUrl,
+    scheduledAt: toScheduledAt(post.scheduledDate, post.scheduledTime),
+    assetUrls: post.assets.map((asset) => ({
+      file: asset.file,
+      title: asset.title,
+      url: asset.url,
+      selected: true,
+    })),
+  };
+}
+
+function normalizePostStatus(status: MarketingPostRecord['status']): MarketingPostStatus {
+  if (status === 'approved' || status === 'draft') {
+    return status;
+  }
+
+  return 'needs_review';
+}
+
+function splitScheduledAt(value: string | null) {
+  if (!value) {
+    return { scheduledDate: '', scheduledTime: '19:30:00' };
+  }
+
+  const match = value.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}(?::\d{2})?)/);
+  if (!match) {
+    return { scheduledDate: '', scheduledTime: '19:30:00' };
+  }
+
+  return {
+    scheduledDate: match[1],
+    scheduledTime: match[2].length === 5 ? `${match[2]}:00` : match[2],
+  };
+}
+
+function toScheduledAt(date: string, time: string) {
+  if (!date) {
+    return null;
+  }
+
+  const normalizedTime = time.length === 5 ? `${time}:00` : time || '19:30:00';
+  return `${date}T${normalizedTime}+02:00`;
+}
+
+function readString(value: unknown, fallback: string) {
+  return typeof value === 'string' && value.trim() ? value : fallback;
+}
+
+function readLanguage(value: unknown): MarketingCampaignSeed['language'] {
+  return value === 'Spanish' ? 'Spanish' : 'English';
 }
 
 function InsightStat({ label, value }: { label: string; value: string }) {
@@ -1085,45 +1293,6 @@ function formatNumber(value: number | string | null | undefined) {
   }
 
   return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(numberValue);
-}
-
-function storageKeyForCampaign(campaignCode: string) {
-  return `${STORAGE_PREFIX}${campaignCode}`;
-}
-
-function readStoredCampaignPosts(campaign: MarketingCampaignSeed) {
-  if (typeof window === 'undefined') {
-    return cloneCampaignPosts(campaign);
-  }
-
-  const raw = window.localStorage.getItem(storageKeyForCampaign(campaign.campaignCode));
-  if (!raw) {
-    return cloneCampaignPosts(campaign);
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as { posts?: MarketingPostSeed[] };
-    if (!Array.isArray(parsed.posts)) {
-      return cloneCampaignPosts(campaign);
-    }
-
-    return parsed.posts.map((post) => ({
-      ...post,
-      assets: Array.isArray(post.assets) ? post.assets.map((asset) => ({ ...asset })) : [],
-    }));
-  } catch {
-    return cloneCampaignPosts(campaign);
-  }
-}
-
-function persistCampaignPosts(campaignCode: string, posts: MarketingPostSeed[]) {
-  window.localStorage.setItem(
-    storageKeyForCampaign(campaignCode),
-    JSON.stringify({
-      updatedAt: new Date().toISOString(),
-      posts,
-    }),
-  );
 }
 
 function fileToMarketingAsset(file: File) {


### PR DESCRIPTION
## Summary

- Adds lightweight marketing campaign/post/metric/learning tables for the admin marketing workflow.
- Adds admin API endpoints to list marketing campaigns and persist post edits/status decisions.
- Connects `/admin/marketing` to the backend so approvals and edits update Neon instead of staying in local React state.
- Seeds `ib20_mvp` with existing MVP posts plus `post_003`, a localized approval test using a Google Drive Daily Quest asset.

## Test data

The Neon `development` branch (`br-falling-union-adzbgpvc`) has been prepared with:

- `marketing_campaigns`
- `marketing_posts`
- `marketing_post_metrics`
- `marketing_learnings`
- `ib20_mvp` posts `post_001`, `post_002`, and `post_003` in `needs_review`

`post_003` uses this Drive asset:
`https://drive.google.com/file/d/1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA/view?usp=drivesdk`

## Validation

- Rebased onto latest `main`; PR is mergeable.
- Verified the new tables and seeded rows in Neon `development` with SQL queries.
- Ran web typecheck in the temp worktree; it is blocked by existing non-marketing TypeScript issues on `main`, and the filtered output emitted no errors for the marketing files changed here.
- Ran API typecheck in the temp worktree; it is blocked by dependency resolution for `@aws-sdk/client-s3` in the temporary worktree, and the filtered output emitted no errors for the marketing files changed here.
- `git diff --check` passes.

## Manual QA

After deployment, open `/admin/marketing`, approve `post_003`, then verify in Neon `development`:

```sql
SELECT mc.campaign_code, mp.post_code, mp.status, mp.approved_at
FROM marketing_campaigns mc
JOIN marketing_posts mp ON mp.marketing_campaign_id = mc.marketing_campaign_id
WHERE mc.campaign_code = 'ib20_mvp'
ORDER BY mp.post_code;
```