### PR TITLE
[codex] Fix marketing approval and asset previews

### DIFF
--- a/apps/api/src/modules/admin/admin.schemas.ts
+++ b/apps/api/src/modules/admin/admin.schemas.ts
@@ -198,8 +198,17 @@ export const marketingR2AssetUploadBodySchema = z.object({
     .array(
       z.object({
         key: z.string().trim().min(1).max(240),
-        contentBase64: z.string().trim().min(1),
+        contentBase64: z.string().trim().min(1).optional(),
+        sourceUrl: z.string().trim().url().max(2000).optional(),
         contentType: z.string().trim().min(1).max(100).optional(),
+      }).superRefine((value, ctx) => {
+        if (!value.contentBase64 && !value.sourceUrl) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'contentBase64 or sourceUrl is required',
+            path: ['contentBase64'],
+          });
+        }
       }),
     )
     .min(1)
@@ -314,7 +323,7 @@ export const marketingPostUpdateBodySchema = z.object({
   agentNotes: z.string().max(3000).optional(),
   decisionNote: z.string().max(3000).optional(),
   rejectionReason: z.string().max(3000).optional(),
-  scheduledAt: z.string().datetime().nullable().optional(),
+  scheduledAt: z.string().datetime({ offset: true }).nullable().optional(),
 }).superRefine((value, ctx) => {
   if (!Object.keys(value).length) {
     ctx.addIssue({

--- a/apps/api/src/services/marketingCampaignService.ts
+++ b/apps/api/src/services/marketingCampaignService.ts
@@ -67,6 +67,16 @@ export type MarketingPostUpdateInput = Partial<{
   scheduledAt: string | null;
 }>;
 
+const CAMPAIGN_ASSET_BASE_URL =
+  'https://raw.githubusercontent.com/rfullivarri/innerbloomv3/main/Docs/marketing/campaigns/2026-06-mvp/assets';
+
+const DRIVE_THUMBNAIL_URLS: Record<string, string> = {
+  innerbloom_mobile_dailyquest_dark_tasks_selection:
+    'https://drive.google.com/thumbnail?id=1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA&sz=w1200',
+  innerbloom_mobile_dailyquest_dark_tasks_selection_png:
+    'https://drive.google.com/thumbnail?id=1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA&sz=w1200',
+};
+
 const DEFAULT_CAMPAIGN = {
   periodKey: '2026-06',
   campaignCode: 'ib20_mvp',
@@ -96,10 +106,10 @@ const DEFAULT_CAMPAIGN = {
         'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_001&ib_post=001',
       scheduledAt: '2026-06-30T19:30:00+02:00',
       assetUrls: [
-        { file: 'post-001-carousel-01.png', title: 'Your habits should adapt to your real life.', type: 'image', selected: true },
-        { file: 'post-001-carousel-02.png', title: 'Most habit apps assume every day is the same.', type: 'split', selected: true },
-        { file: 'post-001-carousel-03.png', title: 'Lower the intensity. Keep the direction.', type: 'image', selected: true },
-        { file: 'post-001-carousel-04.png', title: 'Build a Journey that can survive real weeks.', type: 'brand', selected: true },
+        { file: 'post-001-carousel-01.png', title: 'Your habits should adapt to your real life.', type: 'image', url: `${CAMPAIGN_ASSET_BASE_URL}/post-001-carousel-01.png`, selected: true },
+        { file: 'post-001-carousel-02.png', title: 'Most habit apps assume every day is the same.', type: 'split', url: `${CAMPAIGN_ASSET_BASE_URL}/post-001-carousel-02.png`, selected: true },
+        { file: 'post-001-carousel-03.png', title: 'Lower the intensity. Keep the direction.', type: 'image', url: `${CAMPAIGN_ASSET_BASE_URL}/post-001-carousel-03.png`, selected: true },
+        { file: 'post-001-carousel-04.png', title: 'Build a Journey that can survive real weeks.', type: 'brand', url: `${CAMPAIGN_ASSET_BASE_URL}/post-001-carousel-04.png`, selected: true },
       ],
     },
     {
@@ -116,7 +126,7 @@ const DEFAULT_CAMPAIGN = {
         'https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib20_mvp&utm_content=post_002&ib_post=002',
       scheduledAt: '2026-07-02T22:30:00+02:00',
       assetUrls: [
-        { file: 'post-002-static-pain-proposal.png', title: 'If your plan only works on perfect days, it is not a plan.', type: 'static', selected: true },
+        { file: 'post-002-static-pain-proposal.png', title: 'If your plan only works on perfect days, it is not a plan.', type: 'static', url: `${CAMPAIGN_ASSET_BASE_URL}/post-002-static-pain-proposal.png`, selected: true },
       ],
     },
     {
@@ -137,7 +147,7 @@ const DEFAULT_CAMPAIGN = {
           file: 'innerbloom_mobile_dailyquest_dark_tasks_selection.png',
           title: 'Daily Quest task selection screen',
           type: 'drive-image',
-          url: 'https://drive.google.com/file/d/1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA/view?usp=drivesdk',
+          url: DRIVE_THUMBNAIL_URLS.innerbloom_mobile_dailyquest_dark_tasks_selection,
           selected: true,
         },
       ],
@@ -374,14 +384,45 @@ function normalizeAssets(value: unknown): MarketingAssetPayload[] {
 
   return value
     .filter((asset): asset is Record<string, unknown> => Boolean(asset) && typeof asset === 'object')
-    .map((asset) => ({
-      file: String(asset.file ?? ''),
-      title: String(asset.title ?? asset.file ?? ''),
-      type: typeof asset.type === 'string' ? asset.type : undefined,
-      url: typeof asset.url === 'string' ? asset.url : undefined,
-      selected: typeof asset.selected === 'boolean' ? asset.selected : true,
-    }))
+    .map((asset) => {
+      const file = String(asset.file ?? '');
+
+      return {
+        file,
+        title: String(asset.title ?? asset.file ?? ''),
+        type: typeof asset.type === 'string' ? asset.type : undefined,
+        url: resolveMarketingAssetUrl(file, typeof asset.url === 'string' ? asset.url : undefined),
+        selected: typeof asset.selected === 'boolean' ? asset.selected : true,
+      };
+    })
     .filter((asset) => asset.file);
+}
+
+function resolveMarketingAssetUrl(file: string, url: string | undefined) {
+  const trimmedUrl = String(url ?? '').trim();
+  const driveId = extractDriveFileId(trimmedUrl);
+  if (driveId) {
+    return `https://drive.google.com/thumbnail?id=${driveId}&sz=w1200`;
+  }
+
+  if (trimmedUrl) {
+    return trimmedUrl;
+  }
+
+  if (/^post-\d{3}-.+\.png$/i.test(file)) {
+    return `${CAMPAIGN_ASSET_BASE_URL}/${encodeURIComponent(file)}`;
+  }
+
+  const driveThumbnail = DRIVE_THUMBNAIL_URLS[file.replace(/[^a-z0-9]+/gi, '_').replace(/^_+|_+$/g, '')];
+  return driveThumbnail || undefined;
+}
+
+function extractDriveFileId(url: string) {
+  if (!url.includes('drive.google.com')) {
+    return null;
+  }
+
+  return url.match(/\/d\/([^/]+)/)?.[1] ?? url.match(/[?&]id=([^&]+)/)?.[1] ?? null;
 }
 
 function normalizeRecord(value: unknown): Record<string, unknown> {

--- a/apps/api/src/services/marketingR2AssetService.ts
+++ b/apps/api/src/services/marketingR2AssetService.ts
@@ -3,7 +3,8 @@ import { HttpError } from '../lib/http-error.js';
 
 export type MarketingR2AssetUpload = {
   key: string;
-  contentBase64: string;
+  contentBase64?: string;
+  sourceUrl?: string;
   contentType?: string;
 };
 
@@ -53,7 +54,8 @@ export async function uploadMarketingR2Assets(assets: MarketingR2AssetUpload[]) 
 
   for (const asset of assets) {
     const key = sanitizeAssetKey(asset.key);
-    const bytes = parseBase64Asset(asset.contentBase64);
+    const source = await readAssetBytes(asset);
+    const bytes = source.bytes;
 
     if (bytes.length === 0 || bytes.length > 10 * 1024 * 1024) {
       throw new HttpError(400, 'invalid_asset_size', `Invalid asset size for ${key}.`);
@@ -63,7 +65,7 @@ export async function uploadMarketingR2Assets(assets: MarketingR2AssetUpload[]) 
       Bucket: config.bucket,
       Key: key,
       Body: bytes,
-      ContentType: normalizeContentType(asset.contentType),
+      ContentType: normalizeContentType(asset.contentType ?? source.contentType),
       CacheControl: 'public, max-age=31536000, immutable',
     }));
 
@@ -155,6 +157,52 @@ function parseBase64Asset(value: string) {
   } catch {
     throw new HttpError(400, 'invalid_asset_content', 'Invalid base64 asset content.');
   }
+}
+
+async function readAssetBytes(asset: MarketingR2AssetUpload) {
+  if (asset.contentBase64) {
+    return {
+      bytes: parseBase64Asset(asset.contentBase64),
+      contentType: asset.contentType,
+    };
+  }
+
+  if (!asset.sourceUrl) {
+    throw new HttpError(400, 'invalid_asset_content', 'contentBase64 or sourceUrl is required.');
+  }
+
+  const url = normalizeSourceUrl(asset.sourceUrl);
+  const response = await fetch(url, {
+    redirect: 'follow',
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw new HttpError(400, 'asset_source_fetch_failed', `Asset fetch failed with HTTP ${response.status}.`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+
+  return {
+    bytes: Buffer.from(arrayBuffer),
+    contentType: response.headers.get('content-type') ?? asset.contentType,
+  };
+}
+
+function normalizeSourceUrl(value: string) {
+  let url: URL;
+
+  try {
+    url = new URL(value);
+  } catch {
+    throw new HttpError(400, 'invalid_asset_source_url', 'Invalid asset source URL.');
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new HttpError(400, 'invalid_asset_source_url', 'Asset source URL must be HTTP or HTTPS.');
+  }
+
+  return url.toString();
 }
 
 function normalizeContentType(value: string | undefined) {

--- a/apps/web/src/content/marketingAdminSeed.ts
+++ b/apps/web/src/content/marketingAdminSeed.ts
@@ -173,7 +173,7 @@ export const marketingCampaignSeeds: MarketingCampaignSeed[] = [{
         {
           file: 'innerbloom_mobile_dailyquest_dark_tasks_selection.png',
           title: 'Daily Quest task selection screen',
-          url: 'https://drive.google.com/file/d/1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA/view?usp=drivesdk',
+          url: 'https://drive.google.com/thumbnail?id=1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA&sz=w1200',
         },
       ],
     },

--- a/apps/web/src/lib/marketingR2Assets.ts
+++ b/apps/web/src/lib/marketingR2Assets.ts
@@ -59,13 +59,24 @@ export async function fetchMarketingR2Status() {
 export async function uploadMarketingAssetsToR2(inputs: UploadAssetInput[]) {
   const assets = await Promise.all(
     inputs.map(async ({ asset, campaignCode, postId }) => {
-      const fetchedAsset = await fetchAssetAsBase64(asset.url);
-      return {
+      const basePayload = {
         key: buildMarketingAssetKey({
           campaignCode,
           postId,
           file: asset.file,
         }),
+      };
+
+      if (/^https?:\/\//i.test(asset.url)) {
+        return {
+          ...basePayload,
+          sourceUrl: asset.url,
+        };
+      }
+
+      const fetchedAsset = await fetchAssetAsBase64(asset.url);
+      return {
+        ...basePayload,
         contentBase64: fetchedAsset.contentBase64,
         contentType: fetchedAsset.contentType,
       };

--- a/apps/web/src/pages/admin2/MarketingPage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPage.tsx
@@ -70,6 +70,16 @@ const DEFAULT_PAGE_TOTALS = {
   events: 0,
 };
 
+const CAMPAIGN_ASSET_BASE_URL =
+  'https://raw.githubusercontent.com/rfullivarri/innerbloomv3/main/Docs/marketing/campaigns/2026-06-mvp/assets';
+
+const DRIVE_THUMBNAIL_URLS: Record<string, string> = {
+  innerbloom_mobile_dailyquest_dark_tasks_selection:
+    'https://drive.google.com/thumbnail?id=1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA&sz=w1200',
+  innerbloom_mobile_dailyquest_dark_tasks_selection_png:
+    'https://drive.google.com/thumbnail?id=1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA&sz=w1200',
+};
+
 function statusClass(status: MarketingPostStatus) {
   if (status === 'approved') {
     return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200';
@@ -1136,7 +1146,7 @@ function mapApiAssetToSeed(asset: MarketingAssetRecord): MarketingAsset {
   return {
     file: asset.file,
     title: asset.title,
-    url: asset.url ?? '',
+    url: resolveMarketingAssetUrl(asset.file, asset.url),
   };
 }
 
@@ -1196,6 +1206,33 @@ function readString(value: unknown, fallback: string) {
 
 function readLanguage(value: unknown): MarketingCampaignSeed['language'] {
   return value === 'Spanish' ? 'Spanish' : 'English';
+}
+
+function resolveMarketingAssetUrl(file: string, url: string | undefined) {
+  const trimmedUrl = String(url ?? '').trim();
+  const driveId = extractDriveFileId(trimmedUrl);
+  if (driveId) {
+    return `https://drive.google.com/thumbnail?id=${driveId}&sz=w1200`;
+  }
+
+  if (trimmedUrl) {
+    return trimmedUrl;
+  }
+
+  if (/^post-\d{3}-.+\.png$/i.test(file)) {
+    return `${CAMPAIGN_ASSET_BASE_URL}/${encodeURIComponent(file)}`;
+  }
+
+  const driveThumbnail = DRIVE_THUMBNAIL_URLS[file.replace(/[^a-z0-9]+/gi, '_').replace(/^_+|_+$/g, '')];
+  return driveThumbnail || '';
+}
+
+function extractDriveFileId(url: string) {
+  if (!url.includes('drive.google.com')) {
+    return null;
+  }
+
+  return url.match(/\/d\/([^/]+)/)?.[1] ?? url.match(/[?&]id=([^&]+)/)?.[1] ?? null;
 }
 
 function InsightStat({ label, value }: { label: string; value: string }) {


### PR DESCRIPTION
## Summary

- Accepts timezone-offset datetimes for marketing post approvals, fixing the `Invalid datetime` 400 when the frontend sends values like `2026-07-02T20:30:00+02:00`.
- Normalizes marketing asset URLs so existing posts with only `file/title` still render previews in `/admin/marketing`.
- Converts Google Drive file URLs to thumbnail URLs for image preview before R2.
- Lets R2 uploads send `sourceUrl` to the backend, so the backend downloads external assets directly instead of relying on browser fetch/CORS.

## Data applied

Updated Neon `development` rows for `ib20_mvp` posts `post_001`, `post_002`, and `post_003` so `asset_urls` now contain renderable URLs.

## Validation

- Confirmed Zod accepts `2026-07-02T20:30:00+02:00` with the new schema.
- Confirmed raw GitHub asset URL responds `200 image/png`.
- `git diff --check` passes.
- Web typecheck filtered for touched marketing files emitted no errors.
- API typecheck in the temp worktree is still blocked by `@aws-sdk/client-s3` dependency resolution, same environment limitation as before.