### PR TITLE
[codex] Generalize marketing asset URL model

### DIFF
--- a/apps/api/src/modules/admin/admin.schemas.ts
+++ b/apps/api/src/modules/admin/admin.schemas.ts
@@ -309,6 +309,8 @@ const marketingPostAssetSchema = z.object({
   title: z.string().trim().min(1).max(500),
   type: z.string().trim().min(1).max(120).optional(),
   url: z.string().trim().max(2000).optional(),
+  previewUrl: z.string().trim().max(2000).optional(),
+  sourceUrl: z.string().trim().max(2000).optional(),
   selected: z.boolean().optional(),
 });
 

--- a/apps/api/src/services/marketingCampaignService.ts
+++ b/apps/api/src/services/marketingCampaignService.ts
@@ -15,6 +15,8 @@ export type MarketingAssetPayload = {
   title: string;
   type?: string;
   url?: string;
+  previewUrl?: string;
+  sourceUrl?: string;
   selected?: boolean;
 };
 
@@ -148,6 +150,8 @@ const DEFAULT_CAMPAIGN = {
           title: 'Daily Quest task selection screen',
           type: 'static',
           url: CAMPAIGN_ASSET_URLS.innerbloom_mobile_dailyquest_dark_tasks_selection,
+          previewUrl: CAMPAIGN_ASSET_URLS.innerbloom_mobile_dailyquest_dark_tasks_selection,
+          sourceUrl: 'https://drive.google.com/file/d/1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA/view?usp=drivesdk',
           selected: true,
         },
       ],
@@ -392,10 +396,35 @@ function normalizeAssets(value: unknown): MarketingAssetPayload[] {
         title: String(asset.title ?? asset.file ?? ''),
         type: typeof asset.type === 'string' ? asset.type : undefined,
         url: resolveMarketingAssetUrl(file, typeof asset.url === 'string' ? asset.url : undefined),
+        previewUrl: resolveMarketingAssetPreviewUrl(
+          file,
+          typeof asset.previewUrl === 'string' ? asset.previewUrl : undefined,
+          typeof asset.url === 'string' ? asset.url : undefined,
+          typeof asset.sourceUrl === 'string' ? asset.sourceUrl : undefined,
+        ),
+        sourceUrl: typeof asset.sourceUrl === 'string' ? asset.sourceUrl : undefined,
         selected: typeof asset.selected === 'boolean' ? asset.selected : true,
       };
     })
     .filter((asset) => asset.file);
+}
+
+function resolveMarketingAssetPreviewUrl(
+  file: string,
+  previewUrl: string | undefined,
+  url: string | undefined,
+  sourceUrl: string | undefined,
+) {
+  if (previewUrl?.trim()) {
+    return previewUrl.trim();
+  }
+
+  const sourceDriveId = extractDriveFileId(String(sourceUrl ?? ''));
+  if (sourceDriveId) {
+    return `https://drive.google.com/thumbnail?id=${sourceDriveId}&sz=w1200`;
+  }
+
+  return resolveMarketingAssetUrl(file, url);
 }
 
 function resolveMarketingAssetUrl(file: string, url: string | undefined) {

--- a/apps/web/src/content/marketingAdminSeed.ts
+++ b/apps/web/src/content/marketingAdminSeed.ts
@@ -2,6 +2,8 @@ export type MarketingAsset = {
   file: string;
   title: string;
   url: string;
+  previewUrl?: string;
+  sourceUrl?: string;
 };
 
 export type MarketingPostStatus = 'draft' | 'needs_review' | 'approved';
@@ -174,6 +176,8 @@ export const marketingCampaignSeeds: MarketingCampaignSeed[] = [{
           file: 'innerbloom_mobile_dailyquest_dark_tasks_selection.png',
           title: 'Daily Quest task selection screen',
           url: `${assetBaseUrl}/innerbloom_mobile_dailyquest_dark_tasks_selection.png`,
+          previewUrl: `${assetBaseUrl}/innerbloom_mobile_dailyquest_dark_tasks_selection.png`,
+          sourceUrl: 'https://drive.google.com/file/d/1gCF5MqvQduPvc6s4t5FJg6WszFgjNSSA/view?usp=drivesdk',
         },
       ],
     },

--- a/apps/web/src/lib/marketingCampaigns.ts
+++ b/apps/web/src/lib/marketingCampaigns.ts
@@ -14,6 +14,8 @@ export type MarketingAssetRecord = {
   title: string;
   type?: string;
   url?: string;
+  previewUrl?: string;
+  sourceUrl?: string;
   selected?: boolean;
 };
 

--- a/apps/web/src/lib/marketingR2Assets.ts
+++ b/apps/web/src/lib/marketingR2Assets.ts
@@ -67,14 +67,16 @@ export async function uploadMarketingAssetsToR2(inputs: UploadAssetInput[]) {
         }),
       };
 
-      if (/^https?:\/\//i.test(asset.url)) {
+      const sourceUrl = asset.sourceUrl || asset.url;
+
+      if (/^https?:\/\//i.test(sourceUrl)) {
         return {
           ...basePayload,
-          sourceUrl: asset.url,
+          sourceUrl,
         };
       }
 
-      const fetchedAsset = await fetchAssetAsBase64(asset.url);
+      const fetchedAsset = await fetchAssetAsBase64(sourceUrl);
       return {
         ...basePayload,
         contentBase64: fetchedAsset.contentBase64,

--- a/apps/web/src/pages/admin2/MarketingPage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPage.tsx
@@ -256,7 +256,7 @@ function PostCard({
               >
                 <div className="relative aspect-square bg-[color:var(--admin-bg)]">
                   <img
-                    src={asset.url}
+                    src={asset.previewUrl || asset.url}
                     alt={asset.title}
                     className="h-full w-full object-cover"
                     loading="lazy"
@@ -1144,10 +1144,14 @@ function mapApiPostToSeed(post: MarketingPostRecord): MarketingPostSeed {
 }
 
 function mapApiAssetToSeed(asset: MarketingAssetRecord): MarketingAsset {
+  const url = resolveMarketingAssetUrl(asset.file, asset.url);
+
   return {
     file: asset.file,
     title: asset.title,
-    url: resolveMarketingAssetUrl(asset.file, asset.url),
+    url,
+    previewUrl: resolveMarketingAssetPreviewUrl(asset.file, asset.previewUrl, url, asset.sourceUrl),
+    sourceUrl: asset.sourceUrl,
   };
 }
 
@@ -1163,6 +1167,8 @@ function seedPostToApiUpdate(post: MarketingPostSeed) {
       file: asset.file,
       title: asset.title,
       url: asset.url,
+      previewUrl: asset.previewUrl,
+      sourceUrl: asset.sourceUrl,
       selected: true,
     })),
   };
@@ -1226,6 +1232,24 @@ function resolveMarketingAssetUrl(file: string, url: string | undefined) {
 
   const campaignAssetUrl = CAMPAIGN_ASSET_URLS[file.replace(/[^a-z0-9]+/gi, '_').replace(/^_+|_+$/g, '')];
   return campaignAssetUrl || '';
+}
+
+function resolveMarketingAssetPreviewUrl(
+  file: string,
+  previewUrl: string | undefined,
+  url: string,
+  sourceUrl: string | undefined,
+) {
+  if (previewUrl?.trim()) {
+    return previewUrl.trim();
+  }
+
+  const sourceDriveId = extractDriveFileId(String(sourceUrl ?? ''));
+  if (sourceDriveId) {
+    return `https://drive.google.com/thumbnail?id=${sourceDriveId}&sz=w1200`;
+  }
+
+  return resolveMarketingAssetUrl(file, url);
 }
 
 function extractDriveFileId(url: string) {


### PR DESCRIPTION
## Summary

- Generalizes marketing assets into three separate URL roles:
  - `sourceUrl`: original source, e.g. Google Drive.
  - `previewUrl`: URL used by `/admin/marketing` to render previews.
  - `url`: final public URL used by Metricool CSV, expected to become Cloudflare R2 after upload.
- Updates admin preview rendering to use `previewUrl || url`.
- Updates R2 upload payloads to prefer `sourceUrl` over `url`, so future Drive assets can be uploaded to R2 without using the preview URL as the canonical source.
- Persists `sourceUrl` and `previewUrl` through the admin campaign API.

## Intended flow

1. Agent/generated campaign can store Drive assets as `sourceUrl` plus a renderable `previewUrl`.
2. Admin can see the image before approval/R2.
3. After approval, R2 upload uses `sourceUrl` when available.
4. Backend returns the R2 public URL and the post asset `url` is updated.
5. CSV export uses only the final `url`, and the current UI keeps CSV disabled until approved assets are on R2.

## Data applied

Updated Neon `development` `ib20_mvp/post_003` to include `sourceUrl`, `previewUrl`, and current public `url` fields.

## Validation

- `git diff --check` passes.
- Web typecheck filtered for touched marketing files emitted no errors.
- API typecheck in the temp worktree is still blocked by `@aws-sdk/client-s3` dependency resolution, same environment limitation as before.