### PR TITLE
[codex] harden CMO context exporter analytics

### DIFF
--- a/Docs/marketing/cmo-context-exporter.md
+++ b/Docs/marketing/cmo-context-exporter.md
@@ -24,11 +24,18 @@ The exporter reads:
 
 - Strategy memory from `Docs/marketing/strategy-memory.md` when present, otherwise `Docs/marketing/STRATEGY_MEMORY.md`.
 - Recent persisted marketing campaigns and post metrics from Neon through `marketingCampaignService`.
-- Persisted analytics snapshots from `marketing_analytics_snapshots`.
+- Persisted analytics from the real marketing analytics tables:
+  - `marketing_analytics_sync_runs`
+  - `marketing_insights`
+  - `marketing_ga4_page_metrics`
+  - `marketing_ga4_source_metrics`
+  - `marketing_ga4_event_metrics`
+  - `marketing_gsc_query_page_metrics`
+  - `marketing_analytics_settings`
 - Repository marketing assets under `Docs/marketing`, `apps/web/public/marketing`, and `assest visuales`.
 - Documented service defaults such as Europe/Madrid timezone, a monthly capacity fallback of 20 posts, and a recent campaign limit of 12 campaigns.
 
-The current repository does not include the requested `apps/api/src/services/marketingAnalyticsService.ts` or the original prompt files under `prompts/marketing`. The exporter therefore expects analytics to already be persisted in `marketing_analytics_snapshots` and blocks clearly when no valid snapshot exists.
+The exporter uses `getPersistedMarketingAnalyticsContextForPeriod` from `apps/api/src/services/marketingAnalyticsService.ts`. It requires a completed persisted run that exactly matches the previous-period date window. It does not trigger a new GA4 or Search Console sync.
 
 ## CLI
 
@@ -86,13 +93,13 @@ If validation fails, the final file is not written. The error includes AJV paths
 ## Expected Errors
 
 - `invalid_period_key`: the requested period is not `YYYY-MM`.
-- `marketing_analytics_snapshot_missing`: no persisted analytics table or no valid previous-period snapshot exists.
+- `marketing_analytics_run_missing`: no completed persisted analytics run exists for the previous period.
+- `marketing_analytics_run_not_completed`: a run exists for the previous period but is still running or failed.
 - `cmo_context_schema_invalid`: generated context failed schema validation.
 - `already_exists`: not an error; the file already exists and `force` was false.
 
 ## Next Work
 
-- Add or connect the real marketing analytics persistence service when available.
-- Backfill `marketing_analytics_snapshots` from the approved analytics sync process.
-- Version the missing CMO prompt files if they are still required by the agent runtime.
 - Add richer structured business configuration if marketing objectives, product stage, and audience move out of docs/campaign records into a dedicated table.
+- Add Metricool performance ingestion once it is no longer manual.
+- Add an explicit audience field to strategy memory or structured marketing settings when audience targeting becomes stable enough to encode.

--- a/apps/api/src/services/marketingAnalyticsService.test.ts
+++ b/apps/api/src/services/marketingAnalyticsService.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getPersistedMarketingAnalyticsContextForPeriod } from './marketingAnalyticsService.js';
+
+describe('getPersistedMarketingAnalyticsContextForPeriod', () => {
+  it('loads a completed persisted run for an exact period', async () => {
+    const dbPool = createAnalyticsPool();
+
+    const result = await getPersistedMarketingAnalyticsContextForPeriod({
+      periodStart: '2026-06-01',
+      periodEnd: '2026-06-30',
+      dbPool,
+    });
+
+    expect(result.syncRunId).toBe('run-completed');
+    expect(result.context.sync_run_id).toBe('run-completed');
+    expect(result.context.period_start).toBe('2026-06-01');
+    expect(result.context.period_end).toBe('2026-06-30');
+    expect(result.context.data_quality.status).toBe('valid');
+  });
+
+  it('fails clearly when no run exists for the period', async () => {
+    const dbPool = createAnalyticsPool({ completedRun: null, latestRun: null });
+
+    await expect(getPersistedMarketingAnalyticsContextForPeriod({
+      periodStart: '2026-06-01',
+      periodEnd: '2026-06-30',
+      dbPool,
+    })).rejects.toMatchObject({
+      status: 409,
+      code: 'marketing_analytics_run_missing',
+    });
+  });
+
+  it('fails clearly when the latest period run is not completed', async () => {
+    const dbPool = createAnalyticsPool({
+      completedRun: null,
+      latestRun: { run_id: 'run-running', status: 'running', error_message: null },
+    });
+
+    await expect(getPersistedMarketingAnalyticsContextForPeriod({
+      periodStart: '2026-06-01',
+      periodEnd: '2026-06-30',
+      dbPool,
+    })).rejects.toMatchObject({
+      status: 409,
+      code: 'marketing_analytics_run_not_completed',
+    });
+  });
+
+  it('applies source and page exclusions from settings', async () => {
+    const dbPool = createAnalyticsPool();
+    const result = await getPersistedMarketingAnalyticsContextForPeriod({
+      periodStart: '2026-06-01',
+      periodEnd: '2026-06-30',
+      dbPool,
+    });
+
+    expect(result.context.clean_sources.map((source) => source.source)).toEqual(['instagram']);
+    expect(result.context.marketing_pages.map((page) => page.page_path)).toEqual(['/']);
+    expect(result.context.top_pages.map((page) => page.page_path)).toContain('/login');
+    expect(result.context.marketing_pages.map((page) => page.page_path)).not.toContain('/login');
+  });
+
+  it('calculates registered users with internal exclusions', async () => {
+    const dbPool = createAnalyticsPool();
+    const result = await getPersistedMarketingAnalyticsContextForPeriod({
+      periodStart: '2026-06-01',
+      periodEnd: '2026-06-30',
+      dbPool,
+    });
+
+    expect(result.context.registered_users).toEqual({
+      total: 10,
+      newInPeriod: 3,
+      excludedInternal: 2,
+    });
+  });
+
+  it('classifies marketing pages, product pages, and funnel events', async () => {
+    const dbPool = createAnalyticsPool();
+    const result = await getPersistedMarketingAnalyticsContextForPeriod({
+      periodStart: '2026-06-01',
+      periodEnd: '2026-06-30',
+      dbPool,
+    });
+
+    expect(result.context.marketing_totals.pageViews).toBe(15);
+    expect(result.context.product_totals.pageViews).toBe(8);
+    expect(result.context.product_pages.map((page) => page.page_path)).toEqual(['/innerbloom2/dashboard']);
+    expect(result.context.funnel_events.map((event) => event.event_name)).toEqual(['page_view', 'landing_cta_clicked']);
+  });
+});
+
+type AnalyticsPoolOptions = {
+  completedRun?: Record<string, unknown> | null;
+  latestRun?: Record<string, unknown> | null;
+};
+
+function createAnalyticsPool(options: AnalyticsPoolOptions = {}) {
+  const completedRun = options.completedRun === undefined
+    ? {
+        run_id: 'run-completed',
+        status: 'completed',
+        period_start: '2026-06-01',
+        period_end: '2026-06-30',
+        started_at: '2026-07-01T00:00:00.000Z',
+        completed_at: '2026-07-01T00:05:00.000Z',
+        error_message: null,
+      }
+    : options.completedRun;
+  const latestRun = options.latestRun === undefined
+    ? null
+    : options.latestRun;
+
+  return {
+    query: vi.fn(async (sql: string) => {
+      if (sql.includes("AND status = 'completed'")) {
+        return { rows: completedRun ? [completedRun] : [] };
+      }
+
+      if (sql.includes('FROM marketing_analytics_sync_runs')) {
+        return { rows: latestRun ? [latestRun] : [] };
+      }
+
+      if (sql.includes('FROM marketing_analytics_settings')) {
+        return {
+          rows: [
+            {
+              excluded_sources: ['accounts.google.com'],
+              excluded_page_prefixes: ['/login'],
+              product_page_prefixes: ['/innerbloom2'],
+              marketing_page_paths: ['/'],
+              internal_user_emails: ['admin@example.com'],
+              internal_user_ids: [],
+            },
+          ],
+        };
+      }
+
+      if (sql.includes('FROM marketing_insights')) {
+        return { rows: [{ summary: { totals: { sessions: 20 }, highlights: ['Persisted insight'] } }] };
+      }
+
+      if (sql.includes('FROM marketing_ga4_page_metrics')) {
+        return {
+          rows: [
+            { page_path: '/', page_title: 'Landing', active_users: 9, sessions: 12, screen_page_views: 15, event_count: 20 },
+            { page_path: '/innerbloom2/dashboard', page_title: 'Dashboard', active_users: 4, sessions: 5, screen_page_views: 8, event_count: 12 },
+            { page_path: '/login', page_title: 'Login', active_users: 2, sessions: 2, screen_page_views: 4, event_count: 5 },
+          ],
+        };
+      }
+
+      if (sql.includes('FROM marketing_ga4_source_metrics')) {
+        return {
+          rows: [
+            { source: 'instagram', medium: 'social', campaign: 'ib20_mvp', active_users: 8, sessions: 10, screen_page_views: 15 },
+            { source: 'accounts.google.com', medium: 'referral', campaign: '', active_users: 2, sessions: 2, screen_page_views: 4 },
+          ],
+        };
+      }
+
+      if (sql.includes('FROM marketing_ga4_event_metrics')) {
+        return {
+          rows: [
+            { event_name: 'page_view', event_count: 20 },
+            { event_name: 'landing_cta_clicked', event_count: 5 },
+            { event_name: 'scroll', event_count: 10 },
+          ],
+        };
+      }
+
+      if (sql.includes('FROM marketing_gsc_query_page_metrics')) {
+        return {
+          rows: [
+            { query: 'innerbloom', page: 'https://innerbloomjourney.org/', clicks: 1, impressions: 20, ctr: 0.05, position: 8 },
+          ],
+        };
+      }
+
+      if (sql.includes('FROM users')) {
+        return {
+          rows: [
+            { total: '10', new_in_period: '3', excluded_internal: '2' },
+          ],
+        };
+      }
+
+      return { rows: [] };
+    }),
+  };
+}

--- a/apps/api/src/services/marketingAnalyticsService.ts
+++ b/apps/api/src/services/marketingAnalyticsService.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { importPKCS8, SignJWT } from 'jose';
+import type { Pool } from 'pg';
 import { HttpError } from '../lib/http-error.js';
 import { pool, withClient } from '../db.js';
 
@@ -113,6 +114,41 @@ type RegisteredUserStats = {
   total: number;
   newInPeriod: number;
   excludedInternal: number;
+};
+
+type DbPool = Pick<Pool, 'query'>;
+
+export type PersistedMarketingAnalyticsContextParams = {
+  periodStart: string;
+  periodEnd: string;
+  dbPool?: DbPool;
+};
+
+export type PersistedMarketingAnalyticsContext = {
+  context: {
+    sync_run_id: string;
+    period_start: string;
+    period_end: string;
+    data_quality: {
+      status: 'valid' | 'warning';
+      issues: string[];
+    };
+    marketing_totals: ReturnType<typeof sumPageRecords>;
+    product_totals: ReturnType<typeof sumPageRecords>;
+    registered_users: RegisteredUserStats;
+    top_pages: PageMetricRecord[];
+    marketing_pages: PageMetricRecord[];
+    product_pages: PageMetricRecord[];
+    top_sources: SourceMetricRecord[];
+    clean_sources: SourceMetricRecord[];
+    top_events: { event_name: string; event_count: number }[];
+    search_console_queries: QueryMetricRecord[];
+    funnel_events: { event_name: string; event_count: number }[];
+    insights: Record<string, unknown> | null;
+    settings: MarketingAnalyticsSettings;
+  };
+  syncRunId: string;
+  updatedAt: string;
 };
 
 const DEFAULT_MARKETING_ANALYTICS_SETTINGS: MarketingAnalyticsSettings = {
@@ -239,6 +275,151 @@ export async function getMarketingAnalyticsInsights() {
     topEvents: eventResult.rows,
     topQueries,
     registeredUsers,
+  };
+}
+
+export async function getPersistedMarketingAnalyticsContextForPeriod({
+  periodStart,
+  periodEnd,
+  dbPool = pool,
+}: PersistedMarketingAnalyticsContextParams): Promise<PersistedMarketingAnalyticsContext> {
+  const [startDate, endDate] = [
+    assertDateOnly(periodStart, 'periodStart'),
+    assertDateOnly(periodEnd, 'periodEnd'),
+  ];
+  const completedRun = await dbPool.query<{
+    run_id: string;
+    status: string;
+    period_start: string | Date;
+    period_end: string | Date;
+    started_at: string | Date;
+    completed_at: string | Date | null;
+    error_message: string | null;
+  }>(
+    `SELECT run_id, status, period_start, period_end, started_at, completed_at, error_message
+       FROM marketing_analytics_sync_runs
+      WHERE period_start = $1::date
+        AND period_end = $2::date
+        AND status = 'completed'
+      ORDER BY completed_at DESC NULLS LAST, started_at DESC
+      LIMIT 1`,
+    [startDate, endDate],
+  );
+
+  const run = completedRun.rows[0];
+  if (!run) {
+    const latestRunForPeriod = await dbPool.query<{
+      run_id: string;
+      status: string;
+      error_message: string | null;
+    }>(
+      `SELECT run_id, status, error_message
+         FROM marketing_analytics_sync_runs
+        WHERE period_start = $1::date
+          AND period_end = $2::date
+        ORDER BY started_at DESC
+        LIMIT 1`,
+      [startDate, endDate],
+    );
+    const latest = latestRunForPeriod.rows[0];
+    if (latest) {
+      throw new HttpError(
+        409,
+        'marketing_analytics_run_not_completed',
+        `Marketing analytics run ${latest.run_id} for ${startDate} -> ${endDate} is ${latest.status}.`,
+      );
+    }
+
+    throw new HttpError(
+      409,
+      'marketing_analytics_run_missing',
+      `No completed marketing analytics run found for ${startDate} -> ${endDate}.`,
+    );
+  }
+
+  const settings = await getMarketingAnalyticsSettings(dbPool);
+  const [insightResult, pageResult, sourceResult, eventResult, queryResult] = await Promise.all([
+    dbPool.query<{ summary: unknown }>('SELECT summary FROM marketing_insights WHERE run_id = $1 LIMIT 1', [run.run_id]),
+    dbPool.query<PageMetricRecord>(
+      `SELECT page_path, page_title, active_users, sessions, screen_page_views, event_count
+         FROM marketing_ga4_page_metrics
+        WHERE run_id = $1
+        ORDER BY screen_page_views DESC, active_users DESC
+        LIMIT 100`,
+      [run.run_id],
+    ),
+    dbPool.query<SourceMetricRecord>(
+      `SELECT source, medium, campaign, active_users, sessions, screen_page_views
+         FROM marketing_ga4_source_metrics
+        WHERE run_id = $1
+        ORDER BY sessions DESC, active_users DESC
+        LIMIT 100`,
+      [run.run_id],
+    ),
+    dbPool.query<{ event_name: string; event_count: number }>(
+      `SELECT event_name, event_count
+         FROM marketing_ga4_event_metrics
+        WHERE run_id = $1
+        ORDER BY event_count DESC
+        LIMIT 100`,
+      [run.run_id],
+    ),
+    dbPool.query<QueryMetricRecord>(
+      `SELECT query, page, clicks, impressions, ctr::float AS ctr, position::float AS position
+         FROM marketing_gsc_query_page_metrics
+        WHERE run_id = $1
+        ORDER BY impressions DESC, clicks DESC
+        LIMIT 100`,
+      [run.run_id],
+    ),
+  ]);
+
+  const topPages = pageResult.rows.map(normalizePageMetricRecord);
+  const topSources = sourceResult.rows.map(normalizeSourceMetricRecord);
+  const topEvents = eventResult.rows.map((row) => ({
+    event_name: String(row.event_name ?? ''),
+    event_count: toInteger(row.event_count),
+  }));
+  const searchConsoleQueries = queryResult.rows.map(normalizeQueryMetricRecord);
+  const visiblePages = topPages.filter((row) => !isExcludedPage(row.page_path, settings));
+  const marketingPages = visiblePages.filter((row) => isMarketingPage(row.page_path, settings));
+  const productPages = visiblePages.filter((row) => isProductPage(row.page_path, settings));
+  const cleanSources = topSources.filter((row) => !isExcludedSource(row.source, settings));
+  const registeredUsers = await getRegisteredUserStats(startDate, endDate, settings, dbPool);
+  const insights = readSummaryRecord(insightResult.rows[0]?.summary);
+  const issues = [
+    ...(insights ? [] : ['marketing_insights row is missing for the selected run.']),
+    ...(topPages.length ? [] : ['No GA4 page metrics are available for the selected run.']),
+    ...(topSources.length ? [] : ['No GA4 source metrics are available for the selected run.']),
+    ...(topEvents.length ? [] : ['No GA4 event metrics are available for the selected run.']),
+    ...(searchConsoleQueries.length ? [] : ['No Search Console query metrics are available for the selected run.']),
+  ];
+
+  return {
+    syncRunId: run.run_id,
+    updatedAt: run.completed_at ? toIsoString(run.completed_at) : toIsoString(run.started_at),
+    context: {
+      sync_run_id: run.run_id,
+      period_start: toDateString(run.period_start),
+      period_end: toDateString(run.period_end),
+      data_quality: {
+        status: issues.length ? 'warning' : 'valid',
+        issues,
+      },
+      marketing_totals: sumPageRecords(marketingPages),
+      product_totals: sumPageRecords(productPages),
+      registered_users: registeredUsers,
+      top_pages: topPages,
+      marketing_pages: marketingPages,
+      product_pages: productPages,
+      top_sources: topSources,
+      clean_sources: cleanSources,
+      top_events: topEvents,
+      search_console_queries: searchConsoleQueries,
+      funnel_events: topEvents.filter((row) => isFunnelEvent(row.event_name)),
+      insights,
+      settings,
+    },
   };
 }
 
@@ -674,12 +855,24 @@ function isExcludedSource(source: string, settings: MarketingAnalyticsSettings) 
   });
 }
 
+function isFunnelEvent(eventName: string) {
+  return new Set([
+    'page_view',
+    'landing_cta_clicked',
+    'auth_started',
+    'auth_completed',
+    'dashboard_view',
+    'sign_up',
+    'login',
+  ]).has(eventName);
+}
+
 function formatSourceLabel(row: SourceMetricRecord) {
   return [row.source || '(direct)', row.medium || '(none)'].join(' / ');
 }
 
-async function getMarketingAnalyticsSettings(): Promise<MarketingAnalyticsSettings> {
-  const result = await pool.query<MarketingAnalyticsSettingsRow>(
+async function getMarketingAnalyticsSettings(dbPool: DbPool = pool): Promise<MarketingAnalyticsSettings> {
+  const result = await dbPool.query<MarketingAnalyticsSettingsRow>(
     `SELECT
       excluded_sources,
       excluded_page_prefixes,
@@ -693,7 +886,7 @@ async function getMarketingAnalyticsSettings(): Promise<MarketingAnalyticsSettin
   );
 
   if (!result.rows[0]) {
-    await pool.query('INSERT INTO marketing_analytics_settings (id) VALUES (true) ON CONFLICT (id) DO NOTHING');
+    await dbPool.query('INSERT INTO marketing_analytics_settings (id) VALUES (true) ON CONFLICT (id) DO NOTHING');
     return DEFAULT_MARKETING_ANALYTICS_SETTINGS;
   }
 
@@ -749,10 +942,15 @@ function normalizeUuidList(value: unknown, fallback: string[]) {
     .filter((item) => /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(item));
 }
 
-async function getRegisteredUserStats(periodStart: string, periodEnd: string, settings: MarketingAnalyticsSettings) {
+async function getRegisteredUserStats(
+  periodStart: string,
+  periodEnd: string,
+  settings: MarketingAnalyticsSettings,
+  dbPool: DbPool = pool,
+) {
   const emails = settings.internalUserEmails.map((email) => email.toLowerCase());
   const ids = settings.internalUserIds;
-  const result = await pool.query<{
+  const result = await dbPool.query<{
     total: string | number;
     new_in_period: string | number;
     excluded_internal: string | number;

--- a/apps/api/src/services/marketingCmoContextService.test.ts
+++ b/apps/api/src/services/marketingCmoContextService.test.ts
@@ -6,6 +6,7 @@ import { HttpError } from '../lib/http-error.js';
 import {
   buildMarketingCmoContextWithDeps,
   buildMarketingPeriod,
+  parseMarkdownSections,
   type MarketingAnalyticsContext,
 } from './marketingCmoContextService.js';
 import type { MarketingCampaignWithMetricsPayload } from './marketingCampaignService.js';
@@ -38,14 +39,16 @@ describe('marketingCmoContextService', () => {
     expect(json.analytics.top_pages).toHaveLength(1);
   });
 
-  it('fails clearly when no analytics snapshot table exists', async () => {
-    const fixture = await createFixture({ analyticsTableExists: false });
+  it('fails clearly when no analytics run exists', async () => {
+    const fixture = await createFixture({
+      analyticsError: new HttpError(409, 'marketing_analytics_run_missing', 'No completed marketing analytics run found.'),
+    });
 
     await expect(
       buildMarketingCmoContextWithDeps({ periodKey: '2026-07' }, fixture.deps),
     ).rejects.toMatchObject({
       status: 409,
-      code: 'marketing_analytics_snapshot_missing',
+      code: 'marketing_analytics_run_missing',
     });
   });
 
@@ -122,32 +125,139 @@ describe('marketingCmoContextService', () => {
     expect(contents).not.toContain('user-123');
     expect(contents).toContain('[redacted]');
   });
+
+  it('parses markdown headings, bullets, and numbered lists', () => {
+    const sections = parseMarkdownSections(`
+## Current Objective
+
+Acquire early adopters.
+
+## Known Gaps
+
+- Metrics are sparse.
+1. Metricool is manual.
+`);
+
+    expect(sections.get('current objective')).toEqual(['Acquire early adopters.']);
+    expect(sections.get('known gaps')).toEqual(['Metrics are sparse.', 'Metricool is manual.']);
+  });
+
+  it('extracts objective, known gaps, campaign defaults, and keeps audience explicit-only', async () => {
+    const fixture = await createFixture();
+    const result = await buildMarketingCmoContextWithDeps(
+      { periodKey: '2026-07', force: true },
+      fixture.deps,
+    );
+    const json = JSON.parse(await readFile(result.outputPath, 'utf8')) as {
+      business_context: {
+        current_marketing_objective: string;
+        product_stage: string;
+        audience: string[];
+        notes: string[];
+      };
+      strategy_memory: {
+        known_risks: string[];
+        open_questions: string[];
+        campaign_defaults: {
+          default_platform: string;
+          default_language: string;
+          default_monthly_post_count: number;
+          current_tested_formats: string[];
+        };
+      };
+      period: { target_post_count: number };
+      available_assets: {
+        existing_visuals: { file_path?: string }[];
+        reusable_templates: { file_path?: string }[];
+      };
+    };
+
+    expect(json.business_context.current_marketing_objective).toContain('Acquire early adopter users');
+    expect(json.business_context.product_stage).toBe('early-stage MVP');
+    expect(json.business_context.audience).toEqual([]);
+    expect(json.business_context.notes).toContain('No explicit audience section found in strategy memory or structured configuration.');
+    expect(json.strategy_memory.known_risks).toContain('Monthly draft generation is not automated yet.');
+    expect(json.strategy_memory.open_questions).toContain('Metricool performance data is manual export for now.');
+    expect(json.strategy_memory.campaign_defaults).toMatchObject({
+      default_platform: 'Instagram',
+      default_language: 'English',
+      default_monthly_post_count: 20,
+      current_tested_formats: ['square static', 'square carousel'],
+    });
+    expect(json.period.target_post_count).toBe(20);
+    expect(JSON.stringify(json.available_assets)).not.toContain('notes.md');
+    expect(JSON.stringify(json.available_assets)).not.toContain('asset-manifest.json');
+    expect(json.available_assets.reusable_templates.some((asset) => asset.file_path?.endsWith('template.html'))).toBe(true);
+  });
 });
 
 async function createFixture(options: {
-  analyticsTableExists?: boolean;
   analyticsPayload?: Record<string, unknown>;
+  analyticsError?: Error;
 } = {}) {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'innerbloom-cmo-'));
   const outputRoot = path.join(repoRoot, 'marketing/agent-inputs');
   await mkdir(path.join(repoRoot, 'Docs/marketing'), { recursive: true });
   await mkdir(path.join(repoRoot, 'Docs/marketing/campaigns/2026-06-mvp/assets'), { recursive: true });
   await writeFile(path.join(repoRoot, 'Docs/marketing/campaigns/2026-06-mvp/assets/post.png'), 'not-binary');
+  await writeFile(path.join(repoRoot, 'Docs/marketing/campaigns/2026-06-mvp/assets/template.html'), '<html></html>');
+  await writeFile(path.join(repoRoot, 'Docs/marketing/campaigns/2026-06-mvp/assets/notes.md'), '# Notes');
+  await writeFile(path.join(repoRoot, 'Docs/marketing/campaigns/2026-06-mvp/assets/asset-manifest.json'), '{}');
   await writeFile(
-    path.join(repoRoot, 'Docs/marketing/STRATEGY_MEMORY.md'),
+    path.join(repoRoot, 'Docs/marketing/strategy-memory.md'),
     `# Innerbloom Marketing Strategy Memory
 
-### 2026-06-29 | 2026-06 MVP baseline
+## Current Objective
 
-- **Insights detected:** Instagram / social is the top acquisition source after hygiene filters
-- **Hypotheses:** Adaptive rhythm can differentiate Innerbloom from rigid streak-based habit apps
-- **Decisions taken:** Keep the 2026-06 MVP campaign as a small validation loop; export only approved posts to Metricool
-- **Changes vs previous strategy:** Move from one long operational board to a tabbed monthly workflow
-- **What worked:** Clear anti-perfect-days hook
-- **What did not work:** Ambiguous internal shorthand
-- **Learnings:** Every post should map to a measurable funnel event
-- **Next experiments:** Test dashboard walkthrough carousel
-- **Recommendations for future content proposals:** Tie each hook to one user pain and one product mechanism
+Acquire early adopter users for Innerbloom 2.0 with lightweight, measurable social content.
+
+## Current Positioning
+
+Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks.
+
+- adaptive habits
+- early product, feedback welcome
+
+## Campaign Defaults
+
+- Default platform: Instagram
+- Default language: English
+- Default monthly post count: 20
+- Current MVP campaign code: \`ib20_mvp\`
+- Current tested format: square static + square carousel
+
+## Baseline: 2026-06 MVP
+
+- Metricool CSV import works.
+- Cloudflare R2 is now the publishing asset store for CSV exports.
+- GA4 and Search Console snapshots can be synced into Neon and shown in \`/admin/marketing\`.
+
+## Data Interpretation Rules
+
+- Treat landing page views as acquisition signal.
+- Treat \`/innerbloom2/...\` pages as product usage signal.
+
+## First 20-Post Strategy Proposal
+
+Planned mix:
+
+- 8 pain/friction posts.
+- 5 product mechanism/demo posts.
+
+Creative rules:
+
+1. Prefer real Innerbloom 2.0 screenshots over generic lifestyle imagery.
+2. Use R2 URLs in Metricool CSV output.
+
+## Known Gaps
+
+- Monthly draft generation is not automated yet.
+- Metricool performance data is manual export for now.
+
+## Next Run Instructions
+
+1. Keep the number of configurable knobs small.
+2. Preserve every decision and result in this strategy memory.
 `,
   );
 
@@ -166,26 +276,34 @@ async function createFixture(options: {
     ...options.analyticsPayload,
   };
 
-  const dbPool = {
-    query: vi.fn(async (sql: string) => {
-      if (sql.includes('information_schema.tables')) {
-        return { rows: [{ exists: options.analyticsTableExists ?? true }] };
-      }
+  const dbPool = { query: vi.fn() };
+  const analyticsLoader = vi.fn(async () => {
+    if (options.analyticsError) {
+      throw options.analyticsError;
+    }
 
-      return {
-        rows: [
-          {
-            sync_run_id: 'sync-1',
-            period_start: '2026-06-01',
-            period_end: '2026-06-30',
-            snapshot_payload: analyticsPayload,
-            data_quality: { status: 'valid', issues: [] },
-            updated_at: '2026-07-01T00:00:00.000Z',
-          },
-        ],
-      };
-    }),
-  };
+    return {
+      syncRunId: 'sync-1',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+      context: {
+        sync_run_id: 'sync-1',
+        period_start: '2026-06-01',
+        period_end: '2026-06-30',
+        data_quality: { status: 'valid', issues: [] },
+        marketing_totals: analyticsPayload.marketing_totals,
+        product_totals: analyticsPayload.product_totals,
+        registered_users: analyticsPayload.registered_users,
+        top_pages: analyticsPayload.top_pages,
+        marketing_pages: analyticsPayload.marketing_pages,
+        product_pages: analyticsPayload.product_pages,
+        top_sources: analyticsPayload.top_sources,
+        clean_sources: analyticsPayload.clean_sources,
+        top_events: analyticsPayload.top_events,
+        search_console_queries: analyticsPayload.search_console_queries,
+        funnel_events: analyticsPayload.funnel_events,
+      },
+    };
+  });
 
   const campaigns: MarketingCampaignWithMetricsPayload[] = [
     {
@@ -251,6 +369,7 @@ async function createFixture(options: {
       schemaPath,
       dbPool,
       campaignLoader: vi.fn(async () => campaigns),
+      analyticsLoader,
     },
   };
 }

--- a/apps/api/src/services/marketingCmoContextService.ts
+++ b/apps/api/src/services/marketingCmoContextService.ts
@@ -9,6 +9,10 @@ import type { ErrorObject } from 'ajv';
 import type { Pool } from 'pg';
 import { HttpError } from '../lib/http-error.js';
 import {
+  getPersistedMarketingAnalyticsContextForPeriod,
+  type PersistedMarketingAnalyticsContext,
+} from './marketingAnalyticsService.js';
+import {
   listRecentMarketingCampaignsForContext,
   type MarketingCampaignWithMetricsPayload,
 } from './marketingCampaignService.js';
@@ -70,6 +74,7 @@ export type MarketingCmoContext = {
 
 export type MarketingStrategyMemoryContext = {
   document_path: string;
+  current_objective: string;
   current_positioning: string[];
   historical_learnings: string[];
   previous_experiments: string[];
@@ -77,6 +82,13 @@ export type MarketingStrategyMemoryContext = {
   content_rules: string[];
   known_risks: string[];
   open_questions: string[];
+  campaign_defaults: {
+    default_platform: string;
+    default_language: string;
+    default_monthly_post_count: number | null;
+    current_tested_formats: string[];
+    current_mvp_campaign_code: string;
+  };
 };
 
 export type MarketingAnalyticsContext = {
@@ -172,15 +184,11 @@ type MarketingCmoContextDeps = {
   schemaPath?: string;
   dbPool?: Pick<Pool, 'query'>;
   campaignLoader?: (limit: number) => Promise<MarketingCampaignWithMetricsPayload[]>;
-};
-
-type AnalyticsSnapshotRow = {
-  sync_run_id: string;
-  period_start: string | Date;
-  period_end: string | Date;
-  snapshot_payload: unknown;
-  data_quality: unknown;
-  updated_at: string | Date;
+  analyticsLoader?: (params: {
+    periodStart: string;
+    periodEnd: string;
+    dbPool: Pick<Pool, 'query'>;
+  }) => Promise<PersistedMarketingAnalyticsContext>;
 };
 
 export async function buildMarketingCmoContext(
@@ -247,13 +255,18 @@ export async function buildMarketingCmoContextWithDeps(
 
   const dbPool = deps.dbPool ?? (await import('../db.js')).pool;
   const campaignLoader = deps.campaignLoader ?? listRecentMarketingCampaignsForContext;
+  const analyticsLoader = deps.analyticsLoader ?? getPersistedMarketingAnalyticsContextForPeriod;
   const schemaPath = deps.schemaPath ?? path.join(repoRoot, 'prompts/marketing/agent-system/schemas/cmo-input-v1.schema.json');
   const strategyPath = resolveStrategyMemoryPath(repoRoot);
 
   const [strategyMemory, campaigns, analytics] = await Promise.all([
     readStrategyMemory(strategyPath, repoRoot),
     campaignLoader(MAX_CONTEXT_CAMPAIGNS),
-    loadPersistedAnalyticsSnapshot(dbPool, period),
+    analyticsLoader({
+      periodStart: period.analyticsWindow.period_start,
+      periodEnd: period.analyticsWindow.period_end,
+      dbPool,
+    }),
   ]);
 
   const campaignContext = normalizeCampaigns(campaigns);
@@ -263,14 +276,15 @@ export async function buildMarketingCmoContextWithDeps(
   sourceManifest.push(buildCampaignSourceManifest(campaigns));
 
   const availableAssets = await buildAvailableAssets(repoRoot, campaigns, sourceManifest);
-  const operationalConstraints = buildOperationalConstraints(campaigns);
+  const operationalConstraints = buildOperationalConstraints(campaigns, strategyMemory);
+  const targetPostCount = strategyMemory.campaign_defaults.default_monthly_post_count ?? DEFAULT_MONTHLY_CAPACITY_POSTS;
   const context: MarketingCmoContext = scrubSensitiveValues({
     schema_version: SCHEMA_VERSION,
     period: {
       current_period: params.periodKey,
       previous_period: period.previousPeriodKey,
       timezone: MARKETING_TIMEZONE,
-      target_post_count: DEFAULT_MONTHLY_CAPACITY_POSTS,
+      target_post_count: targetPostCount,
       analysis_window: {
         start_date: period.analyticsWindow.period_start,
         end_date: period.analyticsWindow.period_end,
@@ -386,118 +400,146 @@ function resolveStrategyMemoryPath(repoRoot: string): string {
 
 async function readStrategyMemory(strategyPath: string, repoRoot: string): Promise<MarketingStrategyMemoryContext> {
   const markdown = await readFile(strategyPath, 'utf8');
-  const bullets = extractMarkdownBullets(markdown);
+  const sections = parseMarkdownSections(markdown);
+  const campaignDefaults = parseCampaignDefaults(sections.get('campaign defaults') ?? []);
+  const knownGaps = sectionItems(sections, 'Known Gaps');
+  const nextRunInstructions = sectionItems(sections, 'Next Run Instructions');
+  const firstStrategyProposal = sectionItems(sections, 'First 20-Post Strategy Proposal');
 
   return {
     document_path: path.relative(repoRoot, strategyPath),
-    current_positioning: filterBullets(bullets, ['hypotheses']),
-    historical_learnings: filterBullets(bullets, ['learnings', 'what worked', 'what did not work', 'insights detected']),
-    previous_experiments: filterBullets(bullets, ['next experiments']),
-    previous_decisions: filterBullets(bullets, ['decisions taken']),
-    content_rules: filterBullets(bullets, ['recommendations for future content proposals']),
-    known_risks: filterBullets(bullets, ['what did not work']),
-    open_questions: [],
+    current_objective: firstSectionText(sections, 'Current Objective'),
+    current_positioning: sectionItems(sections, 'Current Positioning'),
+    historical_learnings: sectionItemsByPrefix(sections, 'Baseline:'),
+    previous_experiments: firstStrategyProposal,
+    previous_decisions: nextRunInstructions,
+    content_rules: [
+      ...sectionItems(sections, 'Data Interpretation Rules'),
+      ...firstStrategyProposal,
+      ...nextRunInstructions,
+    ],
+    known_risks: knownGaps,
+    open_questions: knownGaps,
+    campaign_defaults: campaignDefaults,
   };
 }
 
-function extractMarkdownBullets(markdown: string): { label: string; text: string }[] {
-  const result: { label: string; text: string }[] = [];
-  const bulletPattern = /^-\s+\*\*(.+?):\*\*\s*(.+)$/gm;
-  let match: RegExpExecArray | null;
+export function parseMarkdownSections(markdown: string): Map<string, string[]> {
+  const sections = new Map<string, string[]>();
+  let currentSection = '';
+  let currentLines: string[] = [];
 
-  while ((match = bulletPattern.exec(markdown)) !== null) {
-    result.push({
-      label: match[1].trim().toLowerCase(),
-      text: match[2].trim(),
-    });
-  }
-
-  return result;
-}
-
-function filterBullets(bullets: { label: string; text: string }[], labels: string[]): string[] {
-  const labelSet = new Set(labels.map((label) => label.toLowerCase()));
-  return bullets
-    .filter((item) => labelSet.has(item.label))
-    .flatMap((item) => splitSemicolonText(item.text));
-}
-
-function splitSemicolonText(text: string): string[] {
-  return text
-    .split(';')
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
-
-async function loadPersistedAnalyticsSnapshot(
-  dbPool: Pick<Pool, 'query'>,
-  period: ReturnType<typeof buildMarketingPeriod>,
-): Promise<{ context: MarketingAnalyticsContext; updatedAt: string; syncRunId: string }> {
-  const tableExists = await dbPool.query<{ exists: boolean }>(
-    `SELECT EXISTS (
-       SELECT 1
-         FROM information_schema.tables
-        WHERE table_schema = 'public'
-          AND table_name = 'marketing_analytics_snapshots'
-     ) AS exists`,
-  );
-
-  if (!tableExists.rows[0]?.exists) {
-    throw new HttpError(
-      409,
-      'marketing_analytics_snapshot_missing',
-      'No persisted marketing analytics snapshot table is available for the previous period.',
-    );
-  }
-
-  const result = await dbPool.query<AnalyticsSnapshotRow>(
-    `SELECT sync_run_id, period_start, period_end, snapshot_payload, data_quality, updated_at
-       FROM marketing_analytics_snapshots
-      WHERE period_start = $1::date
-        AND period_end = $2::date
-        AND COALESCE((data_quality->>'status') NOT IN ('invalid', 'blocked'), true)
-      ORDER BY updated_at DESC
-      LIMIT 1`,
-    [period.analyticsWindow.period_start, period.analyticsWindow.period_end],
-  );
-
-  const row = result.rows[0];
-  if (!row) {
-    throw new HttpError(
-      409,
-      'marketing_analytics_snapshot_missing',
-      `No valid persisted marketing analytics snapshot found for ${period.previousPeriodKey}.`,
-    );
-  }
-
-  const payload = normalizeRecord(row.snapshot_payload);
-  const dataQuality = normalizeRecord(row.data_quality);
-  const context: MarketingAnalyticsContext = {
-    sync_run_id: String(row.sync_run_id),
-    period_start: toDateOnly(row.period_start),
-    period_end: toDateOnly(row.period_end),
-    data_quality: {
-      status: stringFrom(dataQuality.status, 'valid'),
-      issues: stringArrayFrom(dataQuality.issues),
-    },
-    marketing_totals: normalizeRecord(payload.marketing_totals),
-    product_totals: normalizeRecord(payload.product_totals),
-    registered_users: normalizeRecord(payload.registered_users),
-    top_pages: recordArrayFrom(payload.top_pages),
-    marketing_pages: recordArrayFrom(payload.marketing_pages),
-    product_pages: recordArrayFrom(payload.product_pages),
-    top_sources: recordArrayFrom(payload.top_sources),
-    clean_sources: recordArrayFrom(payload.clean_sources),
-    top_events: recordArrayFrom(payload.top_events),
-    search_console_queries: recordArrayFrom(payload.search_console_queries),
-    funnel_events: recordArrayFrom(payload.funnel_events),
+  const flush = () => {
+    if (!currentSection) {
+      return;
+    }
+    sections.set(normalizeSectionName(currentSection), normalizeMarkdownContent(currentLines));
   };
 
-  return {
-    context,
-    updatedAt: toIso(row.updated_at),
-    syncRunId: String(row.sync_run_id),
+  for (const line of markdown.split(/\r?\n/)) {
+    const heading = line.match(/^##\s+(.+?)\s*$/);
+    if (heading) {
+      flush();
+      currentSection = heading[1].trim();
+      currentLines = [];
+      continue;
+    }
+
+    if (currentSection) {
+      currentLines.push(line);
+    }
+  }
+
+  flush();
+  return sections;
+}
+
+function normalizeSectionName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/`/g, '')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function normalizeMarkdownContent(lines: string[]): string[] {
+  const items: string[] = [];
+  const paragraph: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) {
+      return;
+    }
+    items.push(paragraph.join(' ').trim());
+    paragraph.length = 0;
   };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      flushParagraph();
+      continue;
+    }
+
+    const bullet = line.match(/^[-*]\s+(.+)$/);
+    const numbered = line.match(/^\d+\.\s+(.+)$/);
+    if (bullet || numbered) {
+      flushParagraph();
+      items.push((bullet?.[1] ?? numbered?.[1] ?? '').trim());
+      continue;
+    }
+
+    paragraph.push(line);
+  }
+
+  flushParagraph();
+  return items.filter(Boolean);
+}
+
+function sectionItems(sections: Map<string, string[]>, name: string): string[] {
+  return sections.get(normalizeSectionName(name)) ?? [];
+}
+
+function sectionItemsByPrefix(sections: Map<string, string[]>, prefix: string): string[] {
+  const normalizedPrefix = normalizeSectionName(prefix);
+  return Array.from(sections.entries())
+    .filter(([name]) => name.startsWith(normalizedPrefix))
+    .flatMap(([, items]) => items);
+}
+
+function firstSectionText(sections: Map<string, string[]>, name: string): string {
+  return sectionItems(sections, name)[0] ?? '';
+}
+
+function parseCampaignDefaults(items: string[]): MarketingStrategyMemoryContext['campaign_defaults'] {
+  const defaults: MarketingStrategyMemoryContext['campaign_defaults'] = {
+    default_platform: '',
+    default_language: '',
+    default_monthly_post_count: null,
+    current_tested_formats: [],
+    current_mvp_campaign_code: '',
+  };
+
+  for (const item of items) {
+    const [rawKey, ...rest] = item.split(':');
+    const key = rawKey.trim().toLowerCase();
+    const value = rest.join(':').trim().replace(/^`|`$/g, '');
+    if (key === 'default platform') {
+      defaults.default_platform = value;
+    } else if (key === 'default language') {
+      defaults.default_language = value;
+    } else if (key === 'default monthly post count') {
+      const parsed = Number.parseInt(value, 10);
+      defaults.default_monthly_post_count = Number.isFinite(parsed) ? parsed : null;
+    } else if (key === 'current tested format') {
+      defaults.current_tested_formats = value.split('+').map((part) => part.trim()).filter(Boolean);
+    } else if (key === 'current mvp campaign code') {
+      defaults.current_mvp_campaign_code = value;
+    }
+  }
+
+  return defaults;
 }
 
 function normalizeCampaigns(campaigns: MarketingCampaignWithMetricsPayload[]): MarketingCmoCampaignContext[] {
@@ -599,12 +641,13 @@ async function buildAvailableAssets(
   });
 
   const allAssets = stableUniqueAssets([...campaignAssets, ...repoAssets.assets]);
+  const contentAssets = allAssets.filter((asset) => isContentAssetKind(asset.kind));
 
   return {
-    product_screenshots: allAssets.filter((asset) => asset.kind === 'product_screenshot'),
-    brand_assets: allAssets.filter((asset) => asset.kind === 'brand_asset'),
-    reusable_templates: allAssets.filter((asset) => asset.kind === 'reusable_template'),
-    existing_visuals: allAssets.filter((asset) => asset.kind === 'existing_visual'),
+    product_screenshots: contentAssets.filter((asset) => asset.kind === 'product_screenshot'),
+    brand_assets: contentAssets.filter((asset) => asset.kind === 'brand_asset'),
+    reusable_templates: contentAssets.filter((asset) => asset.kind === 'reusable_template'),
+    existing_visuals: contentAssets.filter((asset) => asset.kind === 'existing_visual'),
     missing_assets: [],
   };
 }
@@ -680,8 +723,20 @@ async function walkFiles(root: string): Promise<string[]> {
 
 function classifyAssetKind(fileOrType: string): string {
   const value = fileOrType.toLowerCase();
-  if (value.includes('template') || value.endsWith('.html') || value.endsWith('.csv')) {
+  if (value.endsWith('.md')) {
+    return 'reference_document';
+  }
+  if (value.endsWith('.json') || value.endsWith('.csv')) {
+    return 'data_file';
+  }
+  if (value.includes('template') || value.endsWith('.html')) {
     return 'reusable_template';
+  }
+  if (value.includes('asset') && value.includes('drive.google.com')) {
+    return 'existing_visual';
+  }
+  if (/^https?:/.test(value) && !/\.(png|jpe?g|webp|gif)(\?|#|$)/i.test(value)) {
+    return 'reference_document';
   }
   if (value.includes('logo') || value.includes('brand')) {
     return 'brand_asset';
@@ -690,6 +745,10 @@ function classifyAssetKind(fileOrType: string): string {
     return 'product_screenshot';
   }
   return 'existing_visual';
+}
+
+function isContentAssetKind(kind: string): boolean {
+  return ['product_screenshot', 'brand_asset', 'reusable_template', 'existing_visual'].includes(kind);
 }
 
 function stableUniqueAssets(assets: MarketingCmoAsset[]): MarketingCmoAsset[] {
@@ -706,15 +765,16 @@ function buildBusinessContext(
   constraints: MarketingOperationalConstraints,
 ): MarketingCmoContext['business_context'] {
   const latestCampaign = campaigns[0];
-  const currentObjective = latestCampaign?.objective ?? '';
-  const audience = campaigns
-    .flatMap((campaign) => campaign.posts.map((post) => post.hypothesis))
-    .filter(Boolean)
-    .slice(0, 8);
+  const currentObjective = strategyMemory.current_objective || latestCampaign?.objective || '';
+  const audience: string[] = [];
+  const notes = [
+    ...(audience.length === 0 ? ['No explicit audience section found in strategy memory or structured configuration.'] : []),
+    ...(strategyMemory.current_objective ? [] : ['No explicit Current Objective section found in strategy memory.']),
+  ];
 
   return {
     current_marketing_objective: currentObjective,
-    product_stage: strategyMemory.previous_decisions.join('; ').includes('MVP') ? 'MVP validation loop' : '',
+    product_stage: detectProductStage(strategyMemory),
     audience,
     current_priorities: [
       ...strategyMemory.previous_experiments,
@@ -726,20 +786,44 @@ function buildBusinessContext(
       ...constraints.legal_and_brand,
     ],
     known_product_changes: strategyMemory.historical_learnings.filter((item) =>
-      /change|move|ui|copy|dashboard|source|workflow/i.test(item),
+      /r2|drive|ga4|search console|neon|admin|dashboard|metricool|publishing|asset|csv/i.test(item),
     ),
-    notes: strategyMemory.open_questions.length === 0 ? ['No explicit open questions section found in strategy memory.'] : [],
+    notes,
   };
 }
 
-function buildOperationalConstraints(campaigns: MarketingCampaignWithMetricsPayload[]): MarketingOperationalConstraints {
-  const platforms = Array.from(new Set(campaigns.flatMap((campaign) => campaign.posts.map((post) => post.platform)))).sort();
+function detectProductStage(strategyMemory: MarketingStrategyMemoryContext): string {
+  const text = [
+    ...strategyMemory.current_positioning,
+    ...strategyMemory.historical_learnings,
+    strategyMemory.campaign_defaults.current_mvp_campaign_code,
+  ].join(' ').toLowerCase();
+
+  if (text.includes('mvp') || text.includes('early product') || text.includes('early version')) {
+    return 'early-stage MVP';
+  }
+
+  return '';
+}
+
+function buildOperationalConstraints(
+  campaigns: MarketingCampaignWithMetricsPayload[],
+  strategyMemory: MarketingStrategyMemoryContext,
+): MarketingOperationalConstraints {
+  const platforms = Array.from(new Set([
+    strategyMemory.campaign_defaults.default_platform.toLowerCase(),
+    ...campaigns.flatMap((campaign) => campaign.posts.map((post) => post.platform)),
+  ].filter(Boolean))).sort();
+  const configuredFormats = strategyMemory.campaign_defaults.current_tested_formats.length
+    ? strategyMemory.campaign_defaults.current_tested_formats
+    : ['carousel', 'static', 'reel', 'story', 'thread', 'short_video'];
+
   return {
     platforms: platforms.length ? platforms : ['instagram'],
-    supported_formats: ['carousel', 'static', 'reel', 'story', 'thread', 'short_video'],
+    supported_formats: configuredFormats,
     publishing: 'Approved posts are exported to Metricool CSV; this exporter does not publish content.',
     public_storage: 'Public marketing files can be served from R2 or repository public assets; this exporter does not upload binaries.',
-    monthly_capacity_posts: DEFAULT_MONTHLY_CAPACITY_POSTS,
+    monthly_capacity_posts: strategyMemory.campaign_defaults.default_monthly_post_count ?? DEFAULT_MONTHLY_CAPACITY_POSTS,
     asset_limits: ['Do not download or duplicate binary assets during context export.', 'Use stable asset IDs that trace to campaign, URL, or repository paths.'],
     legal_and_brand: ['Human review is required before publishing.', 'Do not include secrets, service account keys, unnecessary PII, or individual user identifiers.'],
     human_review_required: true,
@@ -861,38 +945,6 @@ function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
     Number(values.get('second')),
   );
   return (asUtc - date.getTime()) / 60_000;
-}
-
-function normalizeRecord(value: unknown): Record<string, unknown> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return {};
-  }
-  return value as Record<string, unknown>;
-}
-
-function recordArrayFrom(value: unknown): Record<string, unknown>[] {
-  return Array.isArray(value)
-    ? value.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
-    : [];
-}
-
-function stringArrayFrom(value: unknown): string[] {
-  return Array.isArray(value) ? value.map((item) => String(item)).filter(Boolean) : [];
-}
-
-function stringFrom(value: unknown, fallback: string): string {
-  return typeof value === 'string' && value.trim() ? value : fallback;
-}
-
-function toIso(value: string | Date): string {
-  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
-}
-
-function toDateOnly(value: string | Date): string {
-  if (value instanceof Date) {
-    return value.toISOString().slice(0, 10);
-  }
-  return String(value).slice(0, 10);
 }
 
 function checksumBuffer(buffer: Buffer): string {


### PR DESCRIPTION
## Summary

Correction and hardening pass for the CMO context exporter added by PR #2222.

- Replaces the fictitious `marketing_analytics_snapshots` dependency with persisted analytics from the real tables: `marketing_analytics_sync_runs`, `marketing_insights`, GA4 page/source/event metrics, GSC query-page metrics, and analytics settings.
- Adds `getPersistedMarketingAnalyticsContextForPeriod` in `marketingAnalyticsService.ts` for exact-period completed-run context loading without Google calls.
- Reworks strategy memory parsing to deterministic `##` section parsing and maps Current Objective, Current Positioning, Baseline, Data Interpretation Rules, First 20-Post Strategy Proposal, Known Gaps, Next Run Instructions, and Campaign Defaults.
- Stops deriving audience from previous post hypotheses; missing audience is explicit in notes.
- Tightens asset classification so markdown/json/csv references do not become visual assets.
- Updates docs to describe the real analytics service and current schema/prompt state.

## Validation

- `npm -w @innerbloom/api run lint`
- `npm -w @innerbloom/api run typecheck`
- `npm -w @innerbloom/api exec vitest run src/services/marketingAnalyticsService.test.ts src/services/marketingCmoContextService.test.ts src/modules/admin/admin.cmo-context.routes.test.ts`

No OpenAI API, agent execution, GA4/GSC sync, R2 upload, Drive access, Metricool change, or schema change.