### PR TITLE
chore(marketing): automate CMO context generation

### DIFF
--- a/.github/workflows/marketing-cmo-context.yml
+++ b/.github/workflows/marketing-cmo-context.yml
@@ -1,0 +1,184 @@
+name: Generate marketing CMO context
+
+on:
+  workflow_dispatch:
+    inputs:
+      period_key:
+        description: Target campaign period in YYYY-MM format
+        required: true
+        type: string
+      force:
+        description: Rebuild the context even when the file already exists
+        required: false
+        default: false
+        type: boolean
+      open_pull_request:
+        description: Commit the generated context to a period branch and open or update a pull request
+        required: false
+        default: true
+        type: boolean
+  schedule:
+    - cron: '15 6 1 * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: marketing-cmo-context-${{ github.event.inputs.period_key || github.event.schedule || 'scheduled' }}
+  cancel-in-progress: false
+
+jobs:
+  generate-context:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Resolve target period
+        id: period
+        shell: bash
+        env:
+          MANUAL_PERIOD: ${{ github.event.inputs.period_key }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            period_key="${MANUAL_PERIOD}"
+          else
+            period_key="$(TZ=Europe/Madrid date +%Y-%m)"
+          fi
+
+          node -e '
+            const value = process.argv[1];
+            const match = /^(\d{4})-(\d{2})$/.exec(value);
+            if (!match || Number(match[2]) < 1 || Number(match[2]) > 12) {
+              console.error("period_key must be a valid YYYY-MM value");
+              process.exit(1);
+            }
+          ' "${period_key}"
+
+          previous_period="$(node -e '
+            const [year, month] = process.argv[1].split("-").map(Number);
+            const date = new Date(Date.UTC(year, month - 2, 1));
+            process.stdout.write(`${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`);
+          ' "${period_key}")"
+
+          echo "period_key=${period_key}" >> "${GITHUB_OUTPUT}"
+          echo "previous_period=${previous_period}" >> "${GITHUB_OUTPUT}"
+          echo "output_path=marketing/agent-inputs/${period_key}/cmo-context.json" >> "${GITHUB_OUTPUT}"
+
+      - name: Check required configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${DATABASE_URL:-}" ]]; then
+            echo "The repository secret DATABASE_URL is required." >&2
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck API
+        run: npm -w @innerbloom/api run typecheck
+
+      - name: Test CMO context exporter
+        run: >-
+          npm -w @innerbloom/api exec vitest run
+          src/services/marketingAnalyticsService.test.ts
+          src/services/marketingCmoContextService.test.ts
+          src/modules/admin/admin.cmo-context.routes.test.ts
+
+      - name: Generate CMO context
+        id: generate
+        shell: bash
+        env:
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
+          FORCE_INPUT: ${{ github.event.inputs.force }}
+        run: |
+          set -euo pipefail
+          args=(--period="${PERIOD_KEY}")
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${FORCE_INPUT:-false}" == "true" ]]; then
+            args+=(--force)
+          fi
+          npx tsx apps/api/scripts/export-marketing-cmo-context.ts "${args[@]}"
+
+      - name: Verify generated file
+        shell: bash
+        env:
+          OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
+        run: |
+          set -euo pipefail
+          test -s "${OUTPUT_PATH}"
+          git diff --check -- "${OUTPUT_PATH}"
+
+      - name: Validate generated JSON
+        env:
+          OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-agent-json.ts
+          --schema=prompts/marketing/agent-system/schemas/cmo-input-v1.schema.json
+          --input="${OUTPUT_PATH}"
+
+      - name: Build pull request summary
+        id: summary
+        shell: bash
+        env:
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
+          PREVIOUS_PERIOD: ${{ steps.period.outputs.previous_period }}
+          OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
+        run: |
+          set -euo pipefail
+          source_count="$(node -e '
+            const fs = require("fs");
+            const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            process.stdout.write(String(Array.isArray(payload.source_manifest) ? payload.source_manifest.length : 0));
+          ' "${OUTPUT_PATH}")"
+
+          cat > /tmp/marketing-cmo-context-pr-body.md <<EOF
+          ## Generated CMO context
+
+          - Target period: \`${PERIOD_KEY}\`
+          - Analysed period: \`${PREVIOUS_PERIOD}\`
+          - Output: \`${OUTPUT_PATH}\`
+          - Source manifest entries: ${source_count}
+          - Schema validation: passed
+          - Agent execution: not performed
+
+          Generated by the \`Generate marketing CMO context\` workflow from persisted Neon analytics, campaign state, repository strategy memory, and repository assets.
+          EOF
+
+      - name: Upload generated context artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: marketing-cmo-context-${{ steps.period.outputs.period_key }}
+          path: ${{ steps.period.outputs.output_path }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Create or update context pull request
+        if: github.event_name == 'schedule' || github.event.inputs.open_pull_request == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          base: main
+          branch: automation/marketing-cmo-context-${{ steps.period.outputs.period_key }}
+          delete-branch: false
+          commit-message: chore(marketing): generate CMO context for ${{ steps.period.outputs.period_key }}
+          title: chore(marketing): CMO context ${{ steps.period.outputs.period_key }}
+          body-path: /tmp/marketing-cmo-context-pr-body.md
+          add-paths: |
+            marketing/agent-inputs/${{ steps.period.outputs.period_key }}/**

--- a/Docs/marketing/cmo-context-exporter.md
+++ b/Docs/marketing/cmo-context-exporter.md
@@ -12,11 +12,13 @@ It does not call OpenAI, Codex, GA4, Search Console, R2, Drive, Metricool, or an
 
 - Service: `apps/api/src/services/marketingCmoContextService.ts`
 - CLI: `apps/api/scripts/export-marketing-cmo-context.ts`
+- JSON validator: `apps/api/scripts/validate-marketing-agent-json.ts`
 - Admin endpoint: `POST /admin/marketing/agents/cmo/context`
 - Status endpoint: `GET /admin/marketing/agents/cmo/context/status?periodKey=YYYY-MM`
 - Schema: `prompts/marketing/agent-system/schemas/cmo-input-v1.schema.json`
+- GitHub workflow: `.github/workflows/marketing-cmo-context.yml`
 
-The reusable service is the source of truth. The CLI and admin handler only parse inputs and call the service.
+The reusable service is the source of truth. The CLI, admin handler, and GitHub workflow call the same service.
 
 ## Sources
 
@@ -67,6 +69,67 @@ The route is mounted under `/api` as well, so `/api/admin/marketing/agents/cmo/c
 
 The response returns status, output path, periods, and source summaries. It does not return the full context.
 
+## GitHub Actions workflow
+
+The workflow is named `Generate marketing CMO context` and lives at:
+
+`.github/workflows/marketing-cmo-context.yml`
+
+It is the recommended production path because GitHub Actions checks out the complete repository, can read the strategy and schema files outside `apps/api`, can connect to Neon through a repository secret, and can version the generated context in a pull request.
+
+### Required repository secret
+
+Create an Actions repository secret named:
+
+`DATABASE_URL`
+
+Use the same Neon connection string consumed by the API. The workflow checks that the secret exists without printing its value.
+
+### Manual execution
+
+In GitHub, open:
+
+`Actions` → `Generate marketing CMO context` → `Run workflow`
+
+Inputs:
+
+- `period_key`: required target period in `YYYY-MM` format.
+- `force`: rebuild an existing context file.
+- `open_pull_request`: create or update the period pull request. When false, the workflow still uploads the generated JSON as a temporary workflow artifact.
+
+For `period_key = 2026-07`, the exporter analyses the completed persisted analytics run for June 2026.
+
+### Scheduled execution
+
+The workflow runs monthly on day 1 at `06:15 UTC`. It resolves the current month using the `Europe/Madrid` timezone and analyses the previous calendar month.
+
+### Branch and pull request
+
+The workflow never writes directly to `main`.
+
+For `2026-07` it uses:
+
+- Branch: `automation/marketing-cmo-context-2026-07`
+- Pull request title: `chore(marketing): CMO context 2026-07`
+- Commit message: `chore(marketing): generate CMO context for 2026-07`
+
+Only files under `marketing/agent-inputs/2026-07/` are added to the automated commit. Re-running the workflow updates the same branch and pull request. If the generated file is unchanged, the workflow does not create an empty commit.
+
+### Workflow validation
+
+Before opening the pull request, the workflow:
+
+1. installs dependencies with `npm ci`;
+2. typechecks the API;
+3. runs the focused analytics, exporter, and admin route tests;
+4. generates the context from persisted Neon data;
+5. verifies that the file exists;
+6. validates it again with AJV using `validate-marketing-agent-json.ts`;
+7. uploads the JSON as a 30-day workflow artifact;
+8. opens or updates the review pull request.
+
+No CMO or Head of Content agent is executed by this workflow.
+
 ## Period Handling
 
 For `periodKey = 2026-07`:
@@ -84,11 +147,19 @@ If `force` is true, the context is rebuilt, validated, serialized, written to a 
 
 ## Validation
 
-The service validates the generated object with AJV against:
+The service and reusable validator validate the generated object with AJV against:
 
 `prompts/marketing/agent-system/schemas/cmo-input-v1.schema.json`
 
-If validation fails, the final file is not written. The error includes AJV paths and messages, without dumping the full context.
+Manual validator example:
+
+```bash
+npx tsx apps/api/scripts/validate-marketing-agent-json.ts \
+  --schema=prompts/marketing/agent-system/schemas/cmo-input-v1.schema.json \
+  --input=marketing/agent-inputs/2026-07/cmo-context.json
+```
+
+If validation fails, the final file is not written. The error includes AJV paths and messages without dumping the complete context.
 
 ## Expected Errors
 
@@ -97,9 +168,11 @@ If validation fails, the final file is not written. The error includes AJV paths
 - `marketing_analytics_run_not_completed`: a run exists for the previous period but is still running or failed.
 - `cmo_context_schema_invalid`: generated context failed schema validation.
 - `already_exists`: not an error; the file already exists and `force` was false.
+- Missing `DATABASE_URL` secret: the GitHub workflow stops before dependency execution or database access.
 
 ## Next Work
 
 - Add richer structured business configuration if marketing objectives, product stage, and audience move out of docs/campaign records into a dedicated table.
 - Add Metricool performance ingestion once it is no longer manual.
 - Add an explicit audience field to strategy memory or structured marketing settings when audience targeting becomes stable enough to encode.
+- After reviewing and merging a generated context PR, configure the scheduled CMO agent task to consume the versioned JSON.

--- a/apps/api/scripts/validate-marketing-agent-json.ts
+++ b/apps/api/scripts/validate-marketing-agent-json.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+import * as Ajv2020Module from 'ajv/dist/2020.js';
+import type { ErrorObject } from 'ajv';
+
+function readArg(name: string): string | null {
+  const prefix = `--${name}=`;
+  return process.argv.slice(2).find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? null;
+}
+
+function formatErrors(errors: ErrorObject[]): string {
+  return errors
+    .map((error) => `${error.instancePath || '/'}: ${error.message ?? 'invalid'}`)
+    .join('\n');
+}
+
+async function main(): Promise<void> {
+  const schemaPath = readArg('schema');
+  const inputPath = readArg('input');
+
+  if (!schemaPath || !inputPath) {
+    throw new Error(
+      'Usage: tsx apps/api/scripts/validate-marketing-agent-json.ts --schema=<schema.json> --input=<input.json>',
+    );
+  }
+
+  const [schemaText, inputText] = await Promise.all([
+    readFile(schemaPath, 'utf8'),
+    readFile(inputPath, 'utf8'),
+  ]);
+
+  const schema = JSON.parse(schemaText) as Record<string, unknown>;
+  const input = JSON.parse(inputText) as unknown;
+  const ajv = new Ajv2020Module.Ajv2020({ allErrors: true, strict: false });
+  ajv.addFormat('date', /^\d{4}-\d{2}-\d{2}$/);
+  ajv.addFormat('date-time', {
+    type: 'string',
+    validate: (value: string) => !Number.isNaN(Date.parse(value)),
+  });
+
+  const validate = ajv.compile(schema);
+  if (!validate(input)) {
+    throw new Error(`JSON validation failed:\n${formatErrors(validate.errors ?? [])}`);
+  }
+
+  console.log(`Validated ${inputPath} against ${schemaPath}`);
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : 'Unknown validation error');
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds the GitHub Actions workflow for generating and versioning monthly CMO context files.

- Adds `.github/workflows/marketing-cmo-context.yml` with manual and monthly triggers.
- Resolves the target month in `Europe/Madrid` and analyses the previous calendar month.
- Uses the repository `DATABASE_URL` secret to read persisted Neon analytics and campaign state.
- Runs API typecheck and focused exporter tests before generation.
- Validates the generated JSON again with a reusable AJV CLI.
- Uploads the generated context as a workflow artifact.
- Creates or updates a stable period branch and pull request instead of writing to `main`.
- Documents setup, execution, branch naming, validation, and review flow.

## Required setup after merge

1. Add an Actions repository secret named `DATABASE_URL` using the Neon connection string.
2. Ensure repository Actions settings allow GitHub Actions to create pull requests.
3. Run `Generate marketing CMO context` manually with a period such as `2026-07`.

## Safety

This workflow does not execute Codex, OpenAI, the CMO agent, Head of Content, asset generation, Metricool, or publishing.