### PR TITLE
fix marketing CMO workflow install step

### DIFF
--- a/.github/workflows/marketing-cmo-context.yml
+++ b/.github/workflows/marketing-cmo-context.yml
@@ -44,8 +44,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: npm
+          node-version: 24
 
       - name: Resolve target period
         id: period
@@ -90,7 +89,7 @@ jobs:
           fi
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install --no-audit --no-fund
 
       - name: Typecheck API
         run: npm -w @innerbloom/api run typecheck


### PR DESCRIPTION
Fixes the GitHub Actions failure caused by the repository not having a lockfile. The workflow now uses Node 24, disables npm cache setup, and installs dependencies with npm install instead of npm ci.