### PR TITLE
fix marketing CMO partial analytics coverage

### DIFF
--- a/apps/api/scripts/export-marketing-cmo-context.ts
+++ b/apps/api/scripts/export-marketing-cmo-context.ts
@@ -1,6 +1,7 @@
 import process from 'node:process';
-import { buildMarketingCmoContext } from '../src/services/marketingCmoContextService.js';
-import { endPool } from '../src/db.js';
+import { buildMarketingCmoContextWithDeps } from '../src/services/marketingCmoContextService.js';
+import { getBestAvailableMarketingAnalyticsContextForPeriod } from '../src/services/marketingCmoAnalyticsFallback.js';
+import { endPool, pool } from '../src/db.js';
 
 function readArgs(argv: string[]): { periodKey: string; force: boolean } {
   const periodArg = argv.find((arg) => arg.startsWith('--period='));
@@ -16,10 +17,16 @@ function readArgs(argv: string[]): { periodKey: string; force: boolean } {
 
 async function main(): Promise<void> {
   const args = readArgs(process.argv.slice(2));
-  const result = await buildMarketingCmoContext({
-    periodKey: args.periodKey,
-    force: args.force,
-  });
+  const result = await buildMarketingCmoContextWithDeps(
+    {
+      periodKey: args.periodKey,
+      force: args.force,
+    },
+    {
+      dbPool: pool,
+      analyticsLoader: getBestAvailableMarketingAnalyticsContextForPeriod,
+    },
+  );
 
   console.log(JSON.stringify(result, null, 2));
 }

--- a/apps/api/src/services/marketingCmoAnalyticsFallback.ts
+++ b/apps/api/src/services/marketingCmoAnalyticsFallback.ts
@@ -1,0 +1,1 @@
+export const MARKETING_CMO_PARTIAL_ANALYTICS_ENABLED = true;

--- a/apps/api/src/services/marketingCmoAnalyticsFallback.ts
+++ b/apps/api/src/services/marketingCmoAnalyticsFallback.ts
@@ -1,1 +1,79 @@
-export const MARKETING_CMO_PARTIAL_ANALYTICS_ENABLED = true;
+import type { Pool } from 'pg';
+import {
+  getPersistedMarketingAnalyticsContextForPeriod,
+  type PersistedMarketingAnalyticsContext,
+} from './marketingAnalyticsService.js';
+
+type DbPool = Pick<Pool, 'query'>;
+
+type LoaderParams = {
+  periodStart: string;
+  periodEnd: string;
+  dbPool: DbPool;
+};
+
+type RunRow = {
+  run_id: string;
+  period_start: string | Date;
+  period_end: string | Date;
+};
+
+export async function getBestAvailableMarketingAnalyticsContextForPeriod({
+  periodStart,
+  periodEnd,
+  dbPool,
+}: LoaderParams): Promise<PersistedMarketingAnalyticsContext> {
+  let exactError: unknown;
+
+  try {
+    return await getPersistedMarketingAnalyticsContextForPeriod({
+      periodStart,
+      periodEnd,
+      dbPool,
+    });
+  } catch (error) {
+    exactError = error;
+  }
+
+  const fallback = await dbPool.query<RunRow>(
+    `SELECT run_id, period_start, period_end
+       FROM marketing_analytics_sync_runs
+      WHERE status = 'completed'
+        AND period_start >= $1::date
+        AND period_end <= $2::date
+      ORDER BY (period_end - period_start) DESC, completed_at DESC NULLS LAST, started_at DESC
+      LIMIT 1`,
+    [periodStart, periodEnd],
+  );
+
+  const run = fallback.rows[0];
+  if (!run) {
+    throw exactError;
+  }
+
+  const actualStart = normalizeDate(run.period_start);
+  const actualEnd = normalizeDate(run.period_end);
+  const result = await getPersistedMarketingAnalyticsContextForPeriod({
+    periodStart: actualStart,
+    periodEnd: actualEnd,
+    dbPool,
+  });
+
+  return {
+    ...result,
+    context: {
+      ...result.context,
+      data_quality: {
+        status: 'warning',
+        issues: [
+          `Partial analytics coverage: requested ${periodStart} -> ${periodEnd}; using ${actualStart} -> ${actualEnd}. No unavailable dates were inferred.`,
+          ...result.context.data_quality.issues,
+        ],
+      },
+    },
+  };
+}
+
+function normalizeDate(value: string | Date): string {
+  return value instanceof Date ? value.toISOString().slice(0, 10) : String(value).slice(0, 10);
+}


### PR DESCRIPTION
Allows the CMO export CLI to use the widest completed analytics run contained inside the requested month when an exact full-month run does not exist. The exported analytics keeps the real period_start and period_end, adds a data_quality warning, and does not infer missing dates. Exact full-month runs remain preferred.