### PR TITLE
feat marketing Head of Content context builder

### DIFF
--- a/.github/workflows/marketing-content-context.yml
+++ b/.github/workflows/marketing-content-context.yml
@@ -1,0 +1,162 @@
+name: Generate Head of Content context
+
+on:
+  workflow_dispatch:
+    inputs:
+      period_key:
+        description: Approved CMO strategy period in YYYY-MM format
+        required: true
+        type: string
+      approve_strategy:
+        description: I reviewed and approve the CMO strategy for campaign development
+        required: true
+        default: false
+        type: boolean
+      force:
+        description: Rebuild content-context.json when it already exists
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: marketing-content-context-${{ github.event.inputs.period_key }}
+  cancel-in-progress: false
+
+jobs:
+  generate-content-context:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Validate approval and period
+        id: period
+        shell: bash
+        env:
+          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          APPROVED: ${{ github.event.inputs.approve_strategy }}
+        run: |
+          set -euo pipefail
+          node -e '
+            const value = process.argv[1];
+            const match = /^(\d{4})-(\d{2})$/.exec(value);
+            if (!match || Number(match[2]) < 1 || Number(match[2]) > 12) process.exit(1);
+          ' "${PERIOD_KEY}"
+          if [[ "${APPROVED}" != "true" ]]; then
+            echo "Strategy approval must be confirmed." >&2
+            exit 1
+          fi
+          echo "branch=automation/marketing-cycle-${PERIOD_KEY}" >> "${GITHUB_OUTPUT}"
+          echo "output_path=marketing/agent-inputs/${PERIOD_KEY}/content-context.json" >> "${GITHUB_OUTPUT}"
+
+      - name: Check out monthly marketing branch
+        shell: bash
+        env:
+          CYCLE_BRANCH: ${{ steps.period.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --prune
+          if ! git ls-remote --exit-code --heads origin "${CYCLE_BRANCH}" >/dev/null 2>&1; then
+            echo "Monthly branch ${CYCLE_BRANCH} does not exist." >&2
+            exit 1
+          fi
+          git fetch origin "${CYCLE_BRANCH}:${CYCLE_BRANCH}"
+          git checkout "${CYCLE_BRANCH}"
+          git merge --no-edit origin/main
+
+      - name: Verify approved strategy inputs
+        shell: bash
+        env:
+          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+        run: |
+          set -euo pipefail
+          test -s "marketing/agent-inputs/${PERIOD_KEY}/cmo-context.json"
+          test -s "marketing/agent-outputs/${PERIOD_KEY}/cmo-strategy.json"
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Typecheck API
+        run: npm -w @innerbloom/api run typecheck
+
+      - name: Validate CMO strategy
+        env:
+          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-agent-json.ts
+          --schema=prompts/marketing/agent-system/schemas/cmo-output-v1.schema.json
+          --input="marketing/agent-outputs/${PERIOD_KEY}/cmo-strategy.json"
+
+      - name: Generate Head of Content context
+        shell: bash
+        env:
+          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          FORCE_INPUT: ${{ github.event.inputs.force }}
+        run: |
+          set -euo pipefail
+          args=(--period="${PERIOD_KEY}" --approve-strategy)
+          if [[ "${FORCE_INPUT}" == "true" ]]; then args+=(--force); fi
+          npx tsx apps/api/scripts/export-marketing-content-context.ts "${args[@]}"
+
+      - name: Validate Head of Content context
+        env:
+          OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-agent-json.ts
+          --schema=prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json
+          --input="${OUTPUT_PATH}"
+
+      - name: Commit and push monthly branch
+        shell: bash
+        env:
+          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          CYCLE_BRANCH: ${{ steps.period.outputs.branch }}
+          OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- "${OUTPUT_PATH}"
+          if git diff --cached --quiet; then
+            echo "The validated content context is unchanged."
+          else
+            git commit -m "chore(marketing): approve strategy and generate content context for ${PERIOD_KEY}"
+          fi
+          git push origin "${CYCLE_BRANCH}"
+
+      - name: Upload content context artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: marketing-content-context-${{ github.event.inputs.period_key }}
+          path: ${{ steps.period.outputs.output_path }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Report next step
+        shell: bash
+        env:
+          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          CYCLE_BRANCH: ${{ steps.period.outputs.branch }}
+          OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
+        run: |
+          {
+            echo "## Head of Content context ready"
+            echo "- Period: \`${PERIOD_KEY}\`"
+            echo "- Branch: \`${CYCLE_BRANCH}\`"
+            echo "- Input: \`${OUTPUT_PATH}\`"
+            echo "- CMO strategy approval: confirmed by workflow dispatch"
+            echo "- Validation: passed"
+            echo "- Next step: run the Head of Content agent on the same branch"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/Docs/marketing/content-context-builder.md
+++ b/Docs/marketing/content-context-builder.md
@@ -1,0 +1,84 @@
+# Head of Content Context Builder
+
+## Purpose
+
+The builder converts an approved monthly CMO strategy and its original CMO context into the deterministic input for the Head of Content agent.
+
+Output:
+
+`marketing/agent-inputs/<YYYY-MM>/content-context.json`
+
+It does not execute the Head of Content agent, generate campaign posts, upload assets, write to Neon, or publish content.
+
+## Human approval model
+
+The CMO strategy remains `review_status: draft` in its source artifact. Human approval is recorded by manually running the `Generate Head of Content context` workflow and checking the approval confirmation input.
+
+The generated Head of Content input contains:
+
+- `strategy.review_status: approved`;
+- the complete original CMO output under `strategy.cmo_output`;
+- a source-manifest entry for the workflow-dispatch approval.
+
+The source strategy is never modified automatically.
+
+## CLI
+
+From the repository root:
+
+```bash
+npx tsx apps/api/scripts/export-marketing-content-context.ts \
+  --period=2026-07 \
+  --approve-strategy \
+  --force
+```
+
+Required inputs:
+
+- `marketing/agent-inputs/<PERIOD>/cmo-context.json`
+- `marketing/agent-outputs/<PERIOD>/cmo-strategy.json`
+
+The CLI refuses to run without `--approve-strategy`.
+
+## GitHub Actions
+
+Workflow:
+
+`.github/workflows/marketing-content-context.yml`
+
+Manual flow:
+
+1. Open **Actions**.
+2. Select **Generate Head of Content context**.
+3. Enter the approved strategy period.
+4. Check the strategy-approval confirmation.
+5. Run the workflow.
+
+The workflow:
+
+1. checks out `automation/marketing-cycle-<PERIOD>`;
+2. merges the current `main` into the monthly branch;
+3. validates the CMO strategy;
+4. generates and validates `content-context.json`;
+5. commits and pushes the file to the same monthly branch;
+6. does not open or merge a pull request.
+
+The monthly branch is then ready for Codex Head of Content.
+
+## Derived configuration
+
+- Campaign code: `ib_YYYYMM`
+- Publishing window: full target calendar month
+- Default tracking source: `instagram`
+- Default tracking medium: `social`
+- Base URL: approved `primaryUrl` from the asset/context manifest, falling back to `https://innerbloomjourney.org/`
+- Formats: normalized from the CMO operational constraints
+- Assets: copied from the validated CMO context
+
+## Safety
+
+- The builder does not invent analytics or assets.
+- The source strategy and CMO context are read-only.
+- Human approval is mandatory.
+- The output is validated against `head-of-content-input-v1.schema.json` before it is committed.
+- No PR to `main` is opened at this stage.

--- a/apps/api/scripts/export-marketing-content-context.ts
+++ b/apps/api/scripts/export-marketing-content-context.ts
@@ -1,0 +1,122 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+
+const readArg = (name: string): string | null => {
+  const prefix = `--${name}=`;
+  return process.argv.slice(2).find((value) => value.startsWith(prefix))?.slice(prefix.length) ?? null;
+};
+
+const hasFlag = (name: string): boolean => process.argv.slice(2).includes(`--${name}`);
+const sha256 = (value: string): string => `sha256:${createHash('sha256').update(value).digest('hex')}`;
+
+function monthEnd(period: string): string {
+  const [year, month] = period.split('-').map(Number);
+  return new Date(Date.UTC(year, month, 0)).toISOString().slice(0, 10);
+}
+
+async function loadJson(path: string): Promise<{ raw: string; value: any }> {
+  const raw = await readFile(path, 'utf8');
+  return { raw, value: JSON.parse(raw) };
+}
+
+async function main(): Promise<void> {
+  const period = readArg('period');
+  const force = hasFlag('force');
+  if (!period || !/^\d{4}-(0[1-9]|1[0-2])$/.test(period)) throw new Error('Usage: --period=YYYY-MM --approve-strategy [--force]');
+  if (!hasFlag('approve-strategy')) throw new Error('Explicit human approval is required');
+
+  const root = process.cwd();
+  const contextPath = resolve(root, `marketing/agent-inputs/${period}/cmo-context.json`);
+  const strategyPath = resolve(root, `marketing/agent-outputs/${period}/cmo-strategy.json`);
+  const outputPath = resolve(root, `marketing/agent-inputs/${period}/content-context.json`);
+
+  if (!force) {
+    try {
+      await readFile(outputPath, 'utf8');
+      console.log(JSON.stringify({ status: 'already_exists', outputPath }, null, 2));
+      return;
+    } catch {}
+  }
+
+  const [{ raw: contextRaw, value: context }, { raw: strategyRaw, value: strategy }] = await Promise.all([
+    loadJson(contextPath),
+    loadJson(strategyPath),
+  ]);
+
+  if (context?.period?.current_period !== period || strategy?.period !== period) throw new Error('Period mismatch');
+  if (!['draft', 'approved'].includes(strategy?.review_status)) throw new Error('Strategy is not eligible for approval');
+
+  const campaignCode = `ib_${period.replace('-', '')}`;
+  const supported = context.operational_constraints?.supported_formats ?? [];
+  const formats = supported.map((value: string) => value.includes('carousel') ? 'carousel' : value.includes('static') ? 'static' : value);
+  const primaryUrl = context.available_assets?.existing_visuals?.find((asset: any) => asset.label === 'primaryUrl')?.url ?? 'https://innerbloomjourney.org/';
+  const now = new Date().toISOString();
+
+  const output = {
+    schema_version: '1.0',
+    period: {
+      period_key: period,
+      campaign_code: campaignCode,
+      timezone: context.period.timezone,
+      target_post_count: context.period.target_post_count,
+      publishing_start_date: `${period}-01`,
+      publishing_end_date: monthEnd(period),
+    },
+    strategy: {
+      review_status: 'approved',
+      cmo_output_path: `marketing/agent-outputs/${period}/cmo-strategy.json`,
+      cmo_output: strategy,
+    },
+    brand: {
+      objective: context.business_context?.current_marketing_objective,
+      positioning: context.strategy_memory?.current_positioning ?? [],
+      content_rules: context.strategy_memory?.content_rules ?? [],
+      language: context.strategy_memory?.campaign_defaults?.default_language ?? 'English',
+      human_approval: true,
+    },
+    product_context: {
+      stage: context.business_context?.product_stage,
+      known_product_changes: context.business_context?.known_product_changes ?? [],
+      product_pages: context.analytics?.product_pages ?? [],
+      product_totals: context.analytics?.product_totals ?? {},
+      approved_claim_source: strategy.messaging_guidelines ?? {},
+    },
+    available_assets: context.available_assets ?? {},
+    operational_constraints: {
+      platforms: context.operational_constraints?.platforms ?? ['instagram'],
+      formats,
+      max_carousel_slides: 10,
+      max_assets_per_post: 10,
+      publishing_method: context.operational_constraints?.publishing ?? 'Metricool CSV after approval',
+      public_asset_store: context.operational_constraints?.public_storage ?? 'Cloudflare R2',
+      review_required: true,
+      calendar_rules: ['Use dates inside the publishing window', 'Use contiguous sequence numbers', 'Do not publish or approve posts'],
+    },
+    tracking: {
+      base_url: primaryUrl,
+      utm_source: 'instagram',
+      utm_medium: 'social',
+      campaign_code: campaignCode,
+      additional_parameters: { utm_content: 'post_code', ib_post: 'sequence_number' },
+    },
+    source_manifest: [
+      ...(Array.isArray(context.source_manifest) ? context.source_manifest : []),
+      { source_type: 'repo_file', source_path_or_id: `marketing/agent-inputs/${period}/cmo-context.json`, captured_at: now, checksum: sha256(contextRaw) },
+      { source_type: 'approved_strategy', source_path_or_id: `marketing/agent-outputs/${period}/cmo-strategy.json`, captured_at: now, checksum: sha256(strategyRaw) },
+      { source_type: 'human_approval', source_path_or_id: 'workflow_dispatch:approve_strategy', captured_at: now, checksum: sha256(`${period}:${campaignCode}:approved`) },
+    ],
+  };
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  const tempPath = `${outputPath}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
+  await rename(tempPath, outputPath);
+  console.log(JSON.stringify({ status: 'written', outputPath, period, campaignCode }, null, 2));
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : 'Unknown content context export error');
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Adds the deterministic Head of Content context builder and a manual GitHub Actions approval workflow.

- Reads the monthly CMO context and CMO strategy.
- Requires explicit human approval through workflow dispatch.
- Generates `marketing/agent-inputs/<PERIOD>/content-context.json`.
- Validates the CMO strategy and Head of Content input schemas.
- Commits the generated context to the existing `automation/marketing-cycle-<PERIOD>` branch.
- Does not modify the source strategy, open a technical PR, write to Neon, generate campaign content, or publish anything.
- Documents the approval and branch workflow.