### PR TITLE
fix marketing content context git identity

### DIFF
--- a/.github/workflows/marketing-content-context.yml
+++ b/.github/workflows/marketing-content-context.yml
@@ -67,6 +67,8 @@ jobs:
           CYCLE_BRANCH: ${{ steps.period.outputs.branch }}
         run: |
           set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main --prune
           if ! git ls-remote --exit-code --heads origin "${CYCLE_BRANCH}" >/dev/null 2>&1; then
             echo "Monthly branch ${CYCLE_BRANCH} does not exist." >&2


### PR DESCRIPTION
Configures the GitHub Actions bot identity before merging `main` into the monthly marketing branch. This fixes the `Committer identity unknown` failure in the Head of Content context workflow.