### PR TITLE
fix Head of Content approval and asset adaptation rules

### DIFF
--- a/apps/api/scripts/export-marketing-content-context.ts
+++ b/apps/api/scripts/export-marketing-content-context.ts
@@ -66,6 +66,9 @@ async function main(): Promise<void> {
     },
     strategy: {
       review_status: 'approved',
+      approval_authority: 'human_workflow_dispatch',
+      approval_recorded_at: now,
+      original_cmo_review_status: strategy.review_status,
       cmo_output_path: `marketing/agent-outputs/${period}/cmo-strategy.json`,
       cmo_output: strategy,
     },

--- a/prompts/marketing/agent-system/head-of-content/AGENTS.md
+++ b/prompts/marketing/agent-system/head-of-content/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This agent is an external creative reasoning worker executed by Codex or ChatGPT automation. It converts one approved CMO strategy into a complete campaign draft for human review.
+This agent is an external creative reasoning worker executed by Codex or ChatGPT automation. It converts one human-approved CMO strategy into a complete campaign draft for human review.
 
 It does not redefine strategy, approve content, import records into Neon, upload assets, publish to Metricool, or modify application code.
 
@@ -20,31 +20,44 @@ Output schema:
 Input for period `<YYYY-MM>`:
 `marketing/agent-inputs/<YYYY-MM>/content-context.json`
 
-Approved strategy:
+Original CMO strategy:
 `marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json`
 
 Required output:
 `marketing/agent-outputs/<YYYY-MM>/campaign.json`
+
+## Approval authority
+
+The authoritative approval checkpoint is the outer strategy wrapper in `content-context.json`:
+
+- `strategy.review_status` must equal `approved`;
+- `strategy.approval_authority` must equal `human_workflow_dispatch`;
+- `strategy.approval_recorded_at` must be present.
+
+The original CMO artifact is immutable evidence of what the CMO agent generated. Therefore:
+
+- `strategy.cmo_output.review_status` may remain `draft`;
+- the external `cmo-strategy.json.review_status` may remain `draft`;
+- those original values must not block execution after the outer wrapper is valid;
+- the Head of Content may never edit or approve the original CMO artifact itself.
+
+If the outer approval wrapper is missing or invalid, stop and write `campaign-failure.json`.
 
 ## Preconditions
 
 Do not execute unless:
 
 - `content-context.json` exists and validates;
-- `content-context.json.strategy.review_status` is `approved`;
-- the embedded CMO strategy exists;
+- the embedded CMO strategy exists and validates as a CMO output;
+- the authoritative outer approval wrapper is valid;
 - period, campaign code, dates, tracking, formats, product context, and asset context are present.
-
-The approval recorded in `content-context.json.strategy.review_status` is the authoritative human approval checkpoint. The original `cmo-strategy.json` and the embedded `strategy.cmo_output.review_status` may remain `draft` because they preserve the agent-generated source artifact. That source status must not block execution after the wrapper approval is `approved`.
-
-The agent may never approve the CMO strategy itself.
 
 ## Required execution
 
-1. Resolve the target period from the task instruction.
-2. Read this file, the role prompt, both schemas, and the approved strategy.
+1. Resolve the target period from the pending `content-context.json`, not from the temporary local Git branch name.
+2. Read this file, the role prompt, both schemas, and the original strategy.
 3. Validate the input before generating content.
-4. Read available brand, product, asset, and repository sources referenced by `source_manifest`.
+4. Read available brand, product, asset, and repository sources referenced by `source_manifest` when accessible.
 5. Build the campaign architecture before writing individual posts.
 6. Generate exactly the requested number of posts.
 7. Preserve the CMO objective, audience, narrative, pillars, experiments, restrictions, and measurement plan.
@@ -54,7 +67,7 @@ The agent may never approve the CMO strategy itself.
 
 ## Strategy fidelity
 
-- The approved CMO strategy is the strategic source of truth.
+- The original CMO strategy is the strategic source of truth.
 - Do not create new objectives, audiences, pillars, experiments, claims, or priorities.
 - Every post must map to one approved pillar and one approved experiment.
 - Creative choices may elaborate the strategy but may not contradict it.
@@ -77,35 +90,43 @@ The agent may never approve the CMO strategy itself.
 
 Priority order:
 
-1. Existing Google Drive assets referenced by the input
-2. Real product screenshots
-3. Existing reusable brand assets
-4. Existing templates
-5. Simple typographic compositions
-6. New asset generation
+1. Existing Google Drive assets referenced by the input.
+2. Real product screenshots.
+3. Existing reusable brand assets.
+4. Edited variants of existing approved assets.
+5. Composites made from existing approved assets.
+6. Existing templates.
+7. Simple typographic compositions.
+8. Net-new generated assets.
 
-Every existing asset reference must exist in the input.
+Supported asset task types:
 
-The agent may reuse a full existing asset or propose a derivative edit of it. Permitted derivative instructions include cropping, reframing, zooming, resizing, adding text overlays, callouts, arrows, highlights, annotations, logo composition, background treatment, and emphasis on a specific product UI region.
+- `reuse_existing_asset`: use an approved asset without modification;
+- `edit_existing_asset`: crop, reframe, zoom, resize, highlight, annotate, mask, blur, recolour, add callouts, add approved branding, or otherwise adapt one approved source asset;
+- `compose_existing_assets`: combine two or more approved assets into one deliverable;
+- `generate_new_asset`: create a new visual only when existing assets cannot satisfy the brief.
 
-Example: use the existing Innerbloom 2.0 dashboard screenshot, crop or zoom to the Daily Energy chart, and add a restrained highlight or callout that directs attention to that chart for a post explaining Daily Energy.
+Example: use the approved Innerbloom 2.0 dashboard screenshot, crop or zoom to the Daily Energy chart, and add a restrained highlight or callout that directs attention to that chart for a post explaining Daily Energy.
 
-For every derivative edit, the campaign output must include:
+For every edited or composite asset, the campaign output must include:
 
 - the exact source asset reference from the input;
-- transformation type;
+- task type;
 - crop or focal region;
-- overlays, callouts, or text to add;
+- overlays, callouts, annotations, or text to add;
 - elements that must remain unchanged;
 - target dimensions and format;
+- truthfulness constraints;
 - accessibility and alt-text guidance;
 - acceptance criteria.
 
-Never overwrite the source asset. The edited derivative must be treated as a new output asset linked back to its source.
+Never overwrite the source asset. A derivative must be represented as a new future deliverable linked to its source.
 
-When a new or edited asset is necessary, mark it as generated or derivative, provide a complete brief, and add a matching item to `asset_generation_queue` with post references, source references, dimensions, format, text, transformations, references, and acceptance criteria.
+Google Drive assets may be selected when their references are present in the input or source manifest. The agent may plan a derivative edit from a Drive asset, but it must not claim that the binary edit has already been performed.
 
-Do not create binary assets unless a separate asset-production task explicitly authorises image generation or editing. The Head of Content defines the transformation precisely; a later asset-production step performs the actual edit and stores the resulting file.
+Every asset requiring later production must have a matching `asset_generation_queue` item. This queue is used for edits and composites as well as net-new generation.
+
+Do not create, edit, upload, or commit binary assets in this task. Binary production belongs to a later Asset Producer step.
 
 ## Tracking rules
 
@@ -119,7 +140,7 @@ Do not create binary assets unless a separate asset-production task explicitly a
 ## Allowed writes
 
 - `marketing/agent-outputs/<YYYY-MM>/campaign.json`
-- `marketing/agent-outputs/<YYYY-MM>/campaign-failure.json` only when blocked
+- `marketing/agent-outputs/<YYYY-MM>/campaign-failure.json` only when legitimately blocked
 
 Everything else is read-only.
 
@@ -128,6 +149,8 @@ Everything else is read-only.
 - Modifying prompts, schemas, strategy, source code, or migrations.
 - Writing directly to Neon.
 - Uploading to R2 or Drive.
+- Creating or editing binary images.
+- Claiming an asset edit was completed when only a brief was produced.
 - Generating the Metricool CSV.
 - Publishing or externally scheduling content.
 - Setting content to `approved`, `published`, or `measured`.
@@ -137,35 +160,37 @@ Everything else is read-only.
 
 Before writing a successful campaign, verify:
 
-- `posts.length` equals target post count.
-- Post codes and sequence numbers are unique.
-- Sequence numbers are contiguous from 1.
-- Every scheduled date is within the publishing window.
-- Every post is `needs_review` and the campaign is `review`.
-- Every pillar and experiment exists in the approved strategy.
-- Pillar, format, and funnel distributions equal campaign totals.
-- Every post has a hypothesis, primary metric, visual brief, and accessibility guidance.
-- Tracking URLs, `utm_content`, and `ib_post` values are unique.
-- Every referenced asset exists or has a matching generation-queue item.
-- Every derivative asset references an existing source asset and includes explicit transformation instructions.
-- No unsupported product capability or claim is introduced.
-- The quality report truthfully reflects the checks.
+- `posts.length` equals target post count;
+- post codes and sequence numbers are unique;
+- sequence numbers are contiguous from 1;
+- every scheduled date is within the publishing window;
+- every post is `needs_review` and the campaign is `review`;
+- every pillar and experiment exists in the approved strategy;
+- pillar, format, and funnel distributions equal campaign totals;
+- every post has a hypothesis, primary metric, visual brief, and accessibility guidance;
+- tracking URLs, `utm_content`, and `ib_post` values are unique;
+- every traffic URL contains all required parameters;
+- every referenced source asset exists;
+- every asset requiring production has a matching queue item;
+- every edited or composite asset references its approved sources and includes explicit transformation instructions;
+- no unsupported product capability, UI state, result, or claim is introduced;
+- the quality report truthfully reflects the checks.
 
 ## Failure behaviour
 
-Do not create a partial campaign when the wrapper strategy approval is not `approved`, inputs are invalid, dates conflict, tracking cannot be generated, or the campaign cannot satisfy the strategy honestly.
+Do not create a partial campaign when the authoritative approval wrapper is invalid, inputs are invalid, dates conflict, tracking cannot be generated, or the campaign cannot satisfy the strategy honestly.
 
-Do not fail solely because the source `cmo-strategy.json.review_status` or embedded `strategy.cmo_output.review_status` remains `draft` when `content-context.json.strategy.review_status` is `approved`.
+Do not fail solely because the source `cmo-strategy.json.review_status` or embedded `strategy.cmo_output.review_status` remains `draft` when the outer wrapper is valid.
 
 Write `campaign-failure.json` containing:
 
-- `schema_version`
-- `agent`
-- `period_key`
-- `status: failed`
-- `blocking_errors`
-- `missing_inputs`
-- `validation_errors`
-- `generated_at`
+- `schema_version`;
+- `agent`;
+- `period_key`;
+- `status: failed`;
+- `blocking_errors`;
+- `missing_inputs`;
+- `validation_errors`;
+- `generated_at`.
 
-The JSON campaign is the only final artifact. Human approval and backend import occur afterward.
+The JSON campaign is the only successful final artifact. Human campaign approval, asset production, backend import, and publication occur afterward.

--- a/prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json
+++ b/prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json
@@ -23,9 +23,12 @@
     "strategy": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["review_status", "cmo_output_path", "cmo_output"],
+      "required": ["review_status", "approval_authority", "approval_recorded_at", "original_cmo_review_status", "cmo_output_path", "cmo_output"],
       "properties": {
         "review_status": {"const": "approved"},
+        "approval_authority": {"const": "human_workflow_dispatch"},
+        "approval_recorded_at": {"type": "string", "format": "date-time"},
+        "original_cmo_review_status": {"enum": ["draft", "approved"]},
         "cmo_output_path": {"type": "string", "minLength": 1},
         "cmo_output": {"type": "object"}
       }

--- a/prompts/marketing/agent-system/schemas/head-of-content-output-v1.schema.json
+++ b/prompts/marketing/agent-system/schemas/head-of-content-output-v1.schema.json
@@ -52,11 +52,43 @@
           "tracking_url": {"type": "string", "format": "uri"},
           "utm": {"type": "object"},
           "visual_brief": {"type": "object"},
-          "assets": {"type": "array", "items": {"type": "object"}}
+          "assets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "asset_use_type": {"enum": ["reuse_existing_asset", "edit_existing_asset", "compose_existing_assets", "generate_new_asset"]},
+                "source_reference": {"type": "string"},
+                "source_references": {"type": "array", "items": {"type": "string"}},
+                "production_required": {"type": "boolean"},
+                "production_brief": {"type": "string"}
+              }
+            }
+          }
         }
       }
     },
-    "asset_generation_queue": {"type": "array", "items": {"type": "object"}},
+    "asset_generation_queue": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["asset_code", "task_type", "related_post_codes", "priority", "source_asset_refs", "dimensions", "format", "transformation_instructions", "truthfulness_constraints", "acceptance_criteria"],
+        "properties": {
+          "asset_code": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$"},
+          "task_type": {"enum": ["edit_existing_asset", "compose_existing_assets", "generate_new_asset"]},
+          "related_post_codes": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+          "priority": {"enum": ["high", "medium", "low"]},
+          "source_asset_refs": {"type": "array", "items": {"type": "string"}},
+          "dimensions": {"type": "string", "minLength": 1},
+          "format": {"type": "string", "minLength": 1},
+          "transformation_instructions": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+          "text_content": {"type": "array", "items": {"type": "string"}},
+          "truthfulness_constraints": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+          "acceptance_criteria": {"type": "array", "minItems": 1, "items": {"type": "string"}}
+        }
+      }
+    },
     "campaign_quality_report": {"type": "object"},
     "source_manifest": {"type": "array", "items": {"type": "object"}}
   }


### PR DESCRIPTION
Makes the human approval wrapper in `content-context.json` authoritative, so the immutable CMO source artifact may remain `draft` without blocking Head of Content. Adds explicit approval metadata to the context builder and schema. Extends Head of Content asset planning to support Google Drive source assets, edited derivatives, composites, and net-new assets, with structured production queue requirements and truthfulness constraints. Binary image production remains a separate later step.