### PR TITLE
Introduce Head of Content context v2

### DIFF
--- a/.github/workflows/marketing-content-context.yml
+++ b/.github/workflows/marketing-content-context.yml
@@ -86,6 +86,11 @@ jobs:
           set -euo pipefail
           test -s "marketing/agent-inputs/${PERIOD_KEY}/cmo-context.json"
           test -s "marketing/agent-outputs/${PERIOD_KEY}/cmo-strategy.json"
+          test -s "prompts/marketing/agent-system/brand/innerbloom-product-truth-map-v1.md"
+          test -s "prompts/marketing/agent-system/brand/innerbloom-product-marketing-system-v1.md"
+          test -s "prompts/marketing/agent-system/brand/innerbloom-social-creative-system-v1.md"
+          test -s "prompts/marketing/agent-system/brand/innerbloom-visual-system-v2.md"
+          test -s "prompts/marketing/agent-system/brand/innerbloom-asset-registry-v1.json"
 
       - name: Install dependencies
         run: npm install --no-audit --no-fund
@@ -101,7 +106,7 @@ jobs:
           --schema=prompts/marketing/agent-system/schemas/cmo-output-v1.schema.json
           --input="marketing/agent-outputs/${PERIOD_KEY}/cmo-strategy.json"
 
-      - name: Generate Head of Content context
+      - name: Generate Head of Content context v2
         shell: bash
         env:
           PERIOD_KEY: ${{ github.event.inputs.period_key }}
@@ -112,12 +117,12 @@ jobs:
           if [[ "${FORCE_INPUT}" == "true" ]]; then args+=(--force); fi
           npx tsx apps/api/scripts/export-marketing-content-context.ts "${args[@]}"
 
-      - name: Validate Head of Content context
+      - name: Validate Head of Content context v2
         env:
           OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
         run: >-
           npx tsx apps/api/scripts/validate-marketing-agent-json.ts
-          --schema=prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json
+          --schema=prompts/marketing/agent-system/schemas/head-of-content-input-v2.schema.json
           --input="${OUTPUT_PATH}"
 
       - name: Commit and push monthly branch
@@ -134,7 +139,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "The validated content context is unchanged."
           else
-            git commit -m "chore(marketing): approve strategy and generate content context for ${PERIOD_KEY}"
+            git commit -m "chore(marketing): approve strategy and generate content context v2 for ${PERIOD_KEY}"
           fi
           git push origin "${CYCLE_BRANCH}"
 
@@ -154,11 +159,12 @@ jobs:
           OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
         run: |
           {
-            echo "## Head of Content context ready"
+            echo "## Head of Content context v2 ready"
             echo "- Period: \`${PERIOD_KEY}\`"
             echo "- Branch: \`${CYCLE_BRANCH}\`"
             echo "- Input: \`${OUTPUT_PATH}\`"
             echo "- CMO strategy approval: confirmed by workflow dispatch"
-            echo "- Validation: passed"
-            echo "- Next step: run the Head of Content agent on the same branch"
+            echo "- Canonical product and asset sources: verified"
+            echo "- Validation: head-of-content-input-v2 passed"
+            echo "- Next step: run the Head of Content v4 agent after its implementation"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/apps/api/scripts/export-marketing-content-context.ts
+++ b/apps/api/scripts/export-marketing-content-context.ts
@@ -21,6 +21,24 @@ async function loadJson(path: string): Promise<{ raw: string; value: any }> {
   return { raw, value: JSON.parse(raw) };
 }
 
+function compactEvidence(strategy: any): Record<string, unknown> {
+  const assessment = strategy?.input_assessment ?? {};
+  const diagnosis = strategy?.strategic_diagnosis ?? {};
+  const previous = strategy?.previous_period_analysis ?? {};
+
+  return {
+    data_quality: assessment.data_quality ?? 'unknown',
+    relevant_learnings: Array.isArray(strategy?.learnings) ? strategy.learnings : [],
+    previous_period_summary: previous.performance_summary ?? null,
+    primary_problem: diagnosis.primary_problem ?? null,
+    supporting_problems: Array.isArray(diagnosis.supporting_problems) ? diagnosis.supporting_problems : [],
+    decision_needed_after_period: diagnosis.decision_needed_after_this_period ?? null,
+    evidence_gaps: Array.isArray(assessment.data_gaps) ? assessment.data_gaps : [],
+    tracking_issues: Array.isArray(assessment.tracking_issues) ? assessment.tracking_issues : [],
+    assumptions: Array.isArray(assessment.assumptions) ? assessment.assumptions : [],
+  };
+}
+
 async function main(): Promise<void> {
   const period = readArg('period');
   const force = hasFlag('force');
@@ -49,13 +67,13 @@ async function main(): Promise<void> {
   if (!['draft', 'approved'].includes(strategy?.review_status)) throw new Error('Strategy is not eligible for approval');
 
   const campaignCode = `ib_${period.replace('-', '')}`;
-  const supported = context.operational_constraints?.supported_formats ?? [];
-  const formats = supported.map((value: string) => value.includes('carousel') ? 'carousel' : value.includes('static') ? 'static' : value);
+  const supportedFormats = context.operational_constraints?.supported_formats ?? [];
+  const formats = supportedFormats.map((value: string) => value.includes('carousel') ? 'carousel' : value.includes('static') ? 'static' : value);
   const primaryUrl = context.available_assets?.existing_visuals?.find((asset: any) => asset.label === 'primaryUrl')?.url ?? 'https://innerbloomjourney.org/';
   const now = new Date().toISOString();
 
   const output = {
-    schema_version: '1.0',
+    schema_version: '2.0',
     period: {
       period_key: period,
       campaign_code: campaignCode,
@@ -64,37 +82,53 @@ async function main(): Promise<void> {
       publishing_start_date: `${period}-01`,
       publishing_end_date: monthEnd(period),
     },
-    strategy: {
+    approval: {
       review_status: 'approved',
       approval_authority: 'human_workflow_dispatch',
       approval_recorded_at: now,
       original_cmo_review_status: strategy.review_status,
       cmo_output_path: `marketing/agent-outputs/${period}/cmo-strategy.json`,
-      cmo_output: strategy,
     },
-    brand: {
-      objective: context.business_context?.current_marketing_objective,
+    approved_strategy: {
+      executive_summary: strategy.executive_summary,
+      primary_objective: strategy.strategy?.primary_objective,
+      secondary_objectives: strategy.strategy?.secondary_objectives ?? [],
+      core_value_proposition: strategy.strategy?.core_value_proposition,
+      period_narrative: strategy.strategy?.period_narrative,
+      strategic_priorities: strategy.strategy?.strategic_priorities ?? [],
+      content_pillars: strategy.strategy?.content_pillars ?? [],
+      content_mix: strategy.strategy?.content_mix ?? {},
+      experiments: strategy.experiments ?? [],
+      head_of_content_brief: strategy.head_of_content_brief ?? {},
+    },
+    audience: strategy.strategy?.priority_audience ?? {},
+    messaging: {
+      language: context.strategy_memory?.campaign_defaults?.default_language ?? 'English',
       positioning: context.strategy_memory?.current_positioning ?? [],
       content_rules: context.strategy_memory?.content_rules ?? [],
-      language: context.strategy_memory?.campaign_defaults?.default_language ?? 'English',
-      human_approval: true,
+      approved_guidelines: strategy.messaging_guidelines ?? {},
     },
-    product_context: {
-      stage: context.business_context?.product_stage,
+    visual_direction: strategy.visual_direction ?? {},
+    product_and_brand_sources: {
+      product_stage: context.business_context?.product_stage ?? null,
       known_product_changes: context.business_context?.known_product_changes ?? [],
-      product_pages: context.analytics?.product_pages ?? [],
-      product_totals: context.analytics?.product_totals ?? {},
-      approved_claim_source: strategy.messaging_guidelines ?? {},
+      product_truth_path: 'prompts/marketing/agent-system/brand/innerbloom-product-truth-map-v1.md',
+      product_marketing_path: 'prompts/marketing/agent-system/brand/innerbloom-product-marketing-system-v1.md',
+      social_creative_path: 'prompts/marketing/agent-system/brand/innerbloom-social-creative-system-v1.md',
+      visual_system_path: 'prompts/marketing/agent-system/brand/innerbloom-visual-system-v2.md',
+      asset_registry_path: 'prompts/marketing/agent-system/brand/innerbloom-asset-registry-v1.json',
+      source_policy: 'Canonical product truth and the asset registry override stale or conflicting historical context.',
     },
-    available_assets: context.available_assets ?? {},
+    evidence: compactEvidence(strategy),
     operational_constraints: {
       platforms: context.operational_constraints?.platforms ?? ['instagram'],
       formats,
       max_carousel_slides: 10,
       max_assets_per_post: 10,
+      image_generation_batch_size: 10,
       publishing_method: context.operational_constraints?.publishing ?? 'Metricool CSV after approval',
       public_asset_store: context.operational_constraints?.public_storage ?? 'Cloudflare R2',
-      review_required: true,
+      human_review_required: true,
       calendar_rules: ['Use dates inside the publishing window', 'Use contiguous sequence numbers', 'Do not publish or approve posts'],
     },
     tracking: {
@@ -104,8 +138,8 @@ async function main(): Promise<void> {
       campaign_code: campaignCode,
       additional_parameters: { utm_content: 'post_code', ib_post: 'sequence_number' },
     },
+    measurement: strategy.measurement_plan ?? {},
     source_manifest: [
-      ...(Array.isArray(context.source_manifest) ? context.source_manifest : []),
       { source_type: 'repo_file', source_path_or_id: `marketing/agent-inputs/${period}/cmo-context.json`, captured_at: now, checksum: sha256(contextRaw) },
       { source_type: 'approved_strategy', source_path_or_id: `marketing/agent-outputs/${period}/cmo-strategy.json`, captured_at: now, checksum: sha256(strategyRaw) },
       { source_type: 'human_approval', source_path_or_id: 'workflow_dispatch:approve_strategy', captured_at: now, checksum: sha256(`${period}:${campaignCode}:approved`) },
@@ -116,7 +150,7 @@ async function main(): Promise<void> {
   const tempPath = `${outputPath}.tmp`;
   await writeFile(tempPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
   await rename(tempPath, outputPath);
-  console.log(JSON.stringify({ status: 'written', outputPath, period, campaignCode }, null, 2));
+  console.log(JSON.stringify({ status: 'written', outputPath, period, campaignCode, schemaVersion: '2.0' }, null, 2));
 }
 
 main().catch((error: unknown) => {

--- a/prompts/marketing/agent-system/schemas/head-of-content-input-v2.schema.json
+++ b/prompts/marketing/agent-system/schemas/head-of-content-input-v2.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "innerbloom://marketing/head-of-content-input-v2",
+  "title": "Innerbloom Head of Content Input v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "period",
+    "approval",
+    "approved_strategy",
+    "audience",
+    "messaging",
+    "visual_direction",
+    "product_and_brand_sources",
+    "evidence",
+    "operational_constraints",
+    "tracking",
+    "measurement",
+    "source_manifest"
+  ],
+  "properties": {
+    "schema_version": { "const": "2.0" },
+    "period": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["period_key", "campaign_code", "timezone", "target_post_count", "publishing_start_date", "publishing_end_date"],
+      "properties": {
+        "period_key": { "$ref": "#/$defs/periodKey" },
+        "campaign_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
+        "timezone": { "type": "string", "minLength": 1 },
+        "target_post_count": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "publishing_start_date": { "type": "string", "format": "date" },
+        "publishing_end_date": { "type": "string", "format": "date" }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["review_status", "approval_authority", "approval_recorded_at", "original_cmo_review_status", "cmo_output_path"],
+      "properties": {
+        "review_status": { "const": "approved" },
+        "approval_authority": { "const": "human_workflow_dispatch" },
+        "approval_recorded_at": { "type": "string", "format": "date-time" },
+        "original_cmo_review_status": { "enum": ["draft", "approved"] },
+        "cmo_output_path": { "type": "string", "minLength": 1 }
+      }
+    },
+    "approved_strategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["executive_summary", "primary_objective", "secondary_objectives", "core_value_proposition", "period_narrative", "strategic_priorities", "content_pillars", "content_mix", "experiments", "head_of_content_brief"],
+      "properties": {
+        "executive_summary": { "type": "string", "minLength": 1 },
+        "primary_objective": { "type": "string", "minLength": 1 },
+        "secondary_objectives": { "type": "array", "items": { "type": "string" } },
+        "core_value_proposition": { "type": "string", "minLength": 1 },
+        "period_narrative": { "type": "string", "minLength": 1 },
+        "strategic_priorities": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "content_pillars": { "type": "array", "minItems": 1, "items": { "type": "object" } },
+        "content_mix": { "type": "object" },
+        "experiments": { "type": "array", "items": { "type": "object" } },
+        "head_of_content_brief": { "type": "object" }
+      }
+    },
+    "audience": { "type": "object" },
+    "messaging": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["language", "positioning", "content_rules", "approved_guidelines"],
+      "properties": {
+        "language": { "type": "string", "minLength": 1 },
+        "positioning": { "type": "array", "items": { "type": "string" } },
+        "content_rules": { "type": "array", "items": { "type": "string" } },
+        "approved_guidelines": { "type": "object" }
+      }
+    },
+    "visual_direction": { "type": "object" },
+    "product_and_brand_sources": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["product_stage", "known_product_changes", "product_truth_path", "product_marketing_path", "social_creative_path", "visual_system_path", "asset_registry_path", "source_policy"],
+      "properties": {
+        "product_stage": { "type": ["string", "null"] },
+        "known_product_changes": { "type": "array", "items": { "type": "string" } },
+        "product_truth_path": { "$ref": "#/$defs/repoPath" },
+        "product_marketing_path": { "$ref": "#/$defs/repoPath" },
+        "social_creative_path": { "$ref": "#/$defs/repoPath" },
+        "visual_system_path": { "$ref": "#/$defs/repoPath" },
+        "asset_registry_path": { "$ref": "#/$defs/repoPath" },
+        "source_policy": { "type": "string", "minLength": 1 }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["data_quality", "relevant_learnings", "previous_period_summary", "primary_problem", "supporting_problems", "decision_needed_after_period", "evidence_gaps", "tracking_issues", "assumptions"],
+      "properties": {
+        "data_quality": { "type": "string" },
+        "relevant_learnings": { "type": "array", "items": { "type": "object" } },
+        "previous_period_summary": { "type": ["string", "null"] },
+        "primary_problem": { "type": ["string", "null"] },
+        "supporting_problems": { "type": "array", "items": { "type": "string" } },
+        "decision_needed_after_period": { "type": ["string", "null"] },
+        "evidence_gaps": { "type": "array", "items": { "type": "string" } },
+        "tracking_issues": { "type": "array", "items": { "type": "string" } },
+        "assumptions": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "operational_constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platforms", "formats", "max_carousel_slides", "max_assets_per_post", "image_generation_batch_size", "publishing_method", "public_asset_store", "human_review_required", "calendar_rules"],
+      "properties": {
+        "platforms": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "formats": { "type": "array", "minItems": 1, "items": { "enum": ["static", "carousel", "reel", "story", "thread", "short_video"] } },
+        "max_carousel_slides": { "type": "integer", "minimum": 1, "maximum": 20 },
+        "max_assets_per_post": { "type": "integer", "minimum": 1, "maximum": 20 },
+        "image_generation_batch_size": { "type": "integer", "minimum": 1, "maximum": 10 },
+        "publishing_method": { "type": "string", "minLength": 1 },
+        "public_asset_store": { "type": "string", "minLength": 1 },
+        "human_review_required": { "const": true },
+        "calendar_rules": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "tracking": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["base_url", "utm_source", "utm_medium", "campaign_code", "additional_parameters"],
+      "properties": {
+        "base_url": { "type": "string", "format": "uri" },
+        "utm_source": { "type": "string", "minLength": 1 },
+        "utm_medium": { "type": "string", "minLength": 1 },
+        "campaign_code": { "type": "string", "minLength": 1 },
+        "additional_parameters": { "type": "object" }
+      }
+    },
+    "measurement": { "type": "object" },
+    "source_manifest": { "type": "array", "minItems": 1, "items": { "type": "object" } }
+  },
+  "$defs": {
+    "periodKey": { "type": "string", "pattern": "^\\d{4}-\\d{2}$" },
+    "repoPath": { "type": "string", "minLength": 1, "pattern": "^[^/].+" }
+  }
+}


### PR DESCRIPTION
Phase 1 of the marketing pipeline redesign.

Changes:
- export a focused machine-oriented content context
- reference canonical product and asset sources
- add the v2 input schema
- validate the GitHub Action against the v2 schema
- set image generation batch size to 10

After merge, rerun Generate Head of Content context for 2026-07 with approval and force enabled.