### PR TITLE
Fix monthly branch checkout in content-context workflow

### DIFF
--- a/.github/workflows/marketing-content-context.yml
+++ b/.github/workflows/marketing-content-context.yml
@@ -69,13 +69,12 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin main --prune
           if ! git ls-remote --exit-code --heads origin "${CYCLE_BRANCH}" >/dev/null 2>&1; then
             echo "Monthly branch ${CYCLE_BRANCH} does not exist." >&2
             exit 1
           fi
-          git fetch origin "${CYCLE_BRANCH}:${CYCLE_BRANCH}"
-          git checkout "${CYCLE_BRANCH}"
+          git fetch origin main "${CYCLE_BRANCH}" --prune
+          git checkout -B "${CYCLE_BRANCH}" "origin/${CYCLE_BRANCH}"
           git merge --no-edit origin/main
 
       - name: Verify approved strategy inputs


### PR DESCRIPTION
Fixes the Generate Head of Content context workflow when it is dispatched from the monthly branch.

Changes:
- stop fetching directly into the currently checked-out monthly branch;
- fetch `main` and the monthly branch as remote refs;
- reset the local monthly branch from `origin/<monthly-branch>` safely;
- keep the merge from `origin/main` unchanged.

This addresses the failure:
`fatal: refusing to fetch into branch ... checked out`.

After merge, rerun the workflow for `2026-07` with approval and force enabled.