### PR TITLE
Add Head of Content v4 image-generation contract

### DIFF
--- a/prompts/marketing/agent-system/head-of-content/AGENTS-v4.md
+++ b/prompts/marketing/agent-system/head-of-content/AGENTS-v4.md
@@ -1,0 +1,34 @@
+# Innerbloom Head of Content Agent v4
+
+Use `prompts/marketing/head-of-content-v4.md`.
+
+Read the current period `content-context.json`, approved CMO strategy, Product Truth, Product Marketing System, Social Creative System, Visual System, Asset Registry, and current schemas before writing output.
+
+Generate only the requested campaign JSON.
+
+The campaign JSON must be machine-oriented and compatible with `prompts/marketing/agent-system/schemas/head-of-content-output-v2.schema.json`.
+
+The output must include complete post content plus a complete `image_generation.jobs` section. Each image job must be directly usable by a native GPT Image generation tool without additional human interpretation.
+
+Use Product Truth, Product Marketing System, Social Creative System, Visual System, and Asset Registry as canonical. If they conflict with strategy memory, historical context, or `content-context.json`, canonical files win.
+
+Validate:
+
+- product truth;
+- CTA truthfulness;
+- platform and format counts;
+- funnel mix;
+- English visible copy;
+- complete post copy;
+- complete carousel slide plans;
+- one image-generation job per required visual;
+- batch numbers using the configured image batch size;
+- unique asset codes;
+- contiguous generation order;
+- complete GPT Image-ready generation prompts;
+- negative prompts;
+- registered physical source references;
+- no unavailable physical references;
+- no invented UI, Drive IDs, screenshots, product behavior, metrics, or outcomes.
+
+Do not generate images, upload files, publish, schedule, write to Neon, write to R2, write to Drive, create Metricool output, or merge branches.

--- a/prompts/marketing/agent-system/schemas/head-of-content-output-v2.schema.json
+++ b/prompts/marketing/agent-system/schemas/head-of-content-output-v2.schema.json
@@ -1,0 +1,395 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "innerbloom://marketing/head-of-content-output-v2",
+  "title": "Innerbloom Head of Content Output v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "agent",
+    "period_key",
+    "generated_at",
+    "campaign",
+    "campaign_execution_summary",
+    "posts",
+    "image_generation",
+    "campaign_quality_report",
+    "source_manifest"
+  ],
+  "properties": {
+    "schema_version": { "const": "2.0" },
+    "agent": { "const": "innerbloom_head_of_content" },
+    "period_key": { "$ref": "#/$defs/periodKey" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "campaign": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "campaign_code",
+        "title",
+        "objective",
+        "status",
+        "strategy_summary",
+        "language",
+        "platforms",
+        "formats",
+        "target_post_count",
+        "publishing_start_date",
+        "publishing_end_date",
+        "human_review_required"
+      ],
+      "properties": {
+        "campaign_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
+        "title": { "type": "string", "minLength": 1 },
+        "objective": { "enum": ["new_users", "leads", "activation", "awareness", "retention", "learning"] },
+        "status": { "const": "review" },
+        "strategy_summary": { "type": "string", "minLength": 1 },
+        "language": { "type": "string", "minLength": 1 },
+        "platforms": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "formats": { "type": "array", "minItems": 1, "items": { "enum": ["static", "carousel", "reel", "story", "thread", "short_video"] } },
+        "target_post_count": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "publishing_start_date": { "type": "string", "format": "date" },
+        "publishing_end_date": { "type": "string", "format": "date" },
+        "human_review_required": { "const": true }
+      }
+    },
+    "campaign_execution_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["post_count", "static_count", "carousel_count", "image_job_count", "batch_size", "batch_count"],
+      "properties": {
+        "post_count": { "type": "integer", "minimum": 1 },
+        "static_count": { "type": "integer", "minimum": 0 },
+        "carousel_count": { "type": "integer", "minimum": 0 },
+        "image_job_count": { "type": "integer", "minimum": 1 },
+        "batch_size": { "type": "integer", "minimum": 1, "maximum": 20 },
+        "batch_count": { "type": "integer", "minimum": 1 },
+        "notes": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "posts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/post" }
+    },
+    "image_generation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generator", "batch_size", "staging_root", "jobs"],
+      "properties": {
+        "generator": { "const": "native_gpt_image" },
+        "batch_size": { "type": "integer", "minimum": 1, "maximum": 20 },
+        "staging_root": { "type": "string", "minLength": 1 },
+        "jobs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/imageJob" }
+        }
+      }
+    },
+    "campaign_quality_report": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "checks", "warnings", "blockers"],
+      "properties": {
+        "status": { "enum": ["passed", "passed_with_warnings", "blocked"] },
+        "checks": { "type": "array", "items": { "type": "string" } },
+        "warnings": { "type": "array", "items": { "$ref": "#/$defs/qualityFinding" } },
+        "blockers": { "type": "array", "items": { "$ref": "#/$defs/qualityFinding" } }
+      }
+    },
+    "source_manifest": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/sourceManifestItem" }
+    }
+  },
+  "$defs": {
+    "periodKey": { "type": "string", "pattern": "^\\d{4}-\\d{2}$" },
+    "post": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "post_code",
+        "sequence_number",
+        "platform",
+        "format",
+        "status",
+        "scheduled_at",
+        "content_pillar",
+        "funnel_stage",
+        "experiment_code",
+        "audience_tension",
+        "product_truth_anchor",
+        "hook",
+        "caption",
+        "cta",
+        "hypothesis",
+        "primary_metric",
+        "tracking_url",
+        "utm",
+        "visible_copy_plan",
+        "visual_strategy",
+        "assets",
+        "accessibility"
+      ],
+      "properties": {
+        "post_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
+        "sequence_number": { "type": "integer", "minimum": 1 },
+        "platform": { "type": "string", "minLength": 1 },
+        "format": { "enum": ["static", "carousel", "reel", "story", "thread", "short_video"] },
+        "status": { "const": "needs_review" },
+        "scheduled_at": { "type": "string", "format": "date-time" },
+        "content_pillar": { "type": "string", "minLength": 1 },
+        "funnel_stage": { "enum": ["awareness", "consideration", "activation", "acquisition", "registration", "registration_intent", "product_usage_explanation"] },
+        "experiment_code": { "type": "string", "minLength": 1 },
+        "audience_tension": { "type": "string", "minLength": 1 },
+        "product_truth_anchor": { "type": "string", "minLength": 1 },
+        "hook": { "type": "string", "minLength": 1 },
+        "caption": { "type": "string", "minLength": 1 },
+        "cta": { "$ref": "#/$defs/cta" },
+        "hypothesis": { "type": "string", "minLength": 1 },
+        "primary_metric": { "type": "string", "minLength": 1 },
+        "tracking_url": { "type": "string", "format": "uri" },
+        "utm": { "$ref": "#/$defs/utm" },
+        "visible_copy_plan": { "$ref": "#/$defs/visibleCopyPlan" },
+        "visual_strategy": { "$ref": "#/$defs/visualStrategy" },
+        "carousel": { "$ref": "#/$defs/carousel" },
+        "assets": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/postAsset" }
+        },
+        "accessibility": { "$ref": "#/$defs/accessibility" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "format": { "const": "carousel" } }, "required": ["format"] },
+          "then": { "required": ["carousel"] }
+        }
+      ]
+    },
+    "cta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "destination", "intent", "truthfulness_note"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "destination": { "type": "string", "format": "uri" },
+        "intent": { "type": "string", "minLength": 1 },
+        "truthfulness_note": { "type": "string", "minLength": 1 }
+      }
+    },
+    "utm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["utm_source", "utm_medium", "utm_campaign", "utm_content", "ib_post"],
+      "properties": {
+        "utm_source": { "type": "string", "minLength": 1 },
+        "utm_medium": { "type": "string", "minLength": 1 },
+        "utm_campaign": { "type": "string", "minLength": 1 },
+        "utm_content": { "type": "string", "minLength": 1 },
+        "ib_post": { "type": ["string", "integer"] }
+      }
+    },
+    "visibleCopyPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["headline", "supporting_text"],
+      "properties": {
+        "headline": { "type": "string", "minLength": 1 },
+        "supporting_text": { "type": "string" },
+        "eyebrow": { "type": "string" },
+        "microcopy": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "visualStrategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["visual_goal", "proof_type", "screenshot_requirement", "composition_archetype", "claim_to_visual_reasoning"],
+      "properties": {
+        "visual_goal": { "type": "string", "minLength": 1 },
+        "proof_type": { "enum": ["product_screenshot", "brand_led", "hybrid", "logo_only", "abstract_system"] },
+        "screenshot_requirement": { "enum": ["required", "optional", "not_required", "forbidden"] },
+        "composition_archetype": { "type": "string", "minLength": 1 },
+        "claim_to_visual_reasoning": { "type": "string", "minLength": 1 },
+        "forbidden_uses": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "carousel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slide_count", "narrative_arc", "slides"],
+      "properties": {
+        "slide_count": { "type": "integer", "minimum": 2, "maximum": 20 },
+        "narrative_arc": { "type": "string", "minLength": 1 },
+        "slides": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/carouselSlide" }
+        }
+      }
+    },
+    "carouselSlide": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slide_number", "narrative_role", "visible_copy", "product_truth_anchor", "visual_proof_requirement", "asset_code", "acceptance_criteria"],
+      "properties": {
+        "slide_number": { "type": "integer", "minimum": 1 },
+        "narrative_role": { "type": "string", "minLength": 1 },
+        "visible_copy": { "$ref": "#/$defs/visibleCopyPlan" },
+        "product_truth_anchor": { "type": "string", "minLength": 1 },
+        "visual_proof_requirement": { "type": "string", "minLength": 1 },
+        "asset_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
+        "acceptance_criteria": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+      }
+    },
+    "postAsset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["asset_code", "asset_kind", "production_status", "image_job_required", "alt_text"],
+      "properties": {
+        "asset_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
+        "asset_kind": { "enum": ["static", "carousel_slide", "cover", "story", "reel_cover"] },
+        "slide_number": { "type": "integer", "minimum": 1 },
+        "production_status": { "enum": ["planned", "blocked", "not_required"] },
+        "image_job_required": { "type": "boolean" },
+        "alt_text": { "type": "string", "minLength": 1 },
+        "blocker_reason": { "type": "string" }
+      }
+    },
+    "imageJob": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "asset_code",
+        "post_code",
+        "asset_kind",
+        "batch_number",
+        "generation_order",
+        "platform",
+        "format",
+        "canvas",
+        "visible_copy",
+        "product_truth_anchor",
+        "funnel_stage",
+        "source_assets",
+        "visual_concept",
+        "composition_spec",
+        "generation_prompt",
+        "negative_prompt",
+        "must_show",
+        "must_preserve",
+        "must_avoid",
+        "acceptance_criteria",
+        "expected_output"
+      ],
+      "properties": {
+        "asset_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
+        "post_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
+        "asset_kind": { "enum": ["static", "carousel_slide", "cover", "story", "reel_cover"] },
+        "slide_number": { "type": "integer", "minimum": 1 },
+        "batch_number": { "type": "integer", "minimum": 1 },
+        "generation_order": { "type": "integer", "minimum": 1 },
+        "platform": { "type": "string", "minLength": 1 },
+        "format": { "enum": ["static", "carousel", "reel", "story", "thread", "short_video"] },
+        "canvas": { "$ref": "#/$defs/canvas" },
+        "visible_copy": { "$ref": "#/$defs/visibleCopyPlan" },
+        "product_truth_anchor": { "type": "string", "minLength": 1 },
+        "funnel_stage": { "type": "string", "minLength": 1 },
+        "source_assets": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/sourceAsset" }
+        },
+        "visual_concept": { "type": "string", "minLength": 1 },
+        "composition_spec": { "$ref": "#/$defs/compositionSpec" },
+        "generation_prompt": { "type": "string", "minLength": 200 },
+        "negative_prompt": { "type": "string", "minLength": 80 },
+        "must_show": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "must_preserve": { "type": "array", "items": { "type": "string" } },
+        "must_avoid": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "acceptance_criteria": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "expected_output": { "$ref": "#/$defs/expectedOutput" },
+        "blocker_reason": { "type": "string" }
+      }
+    },
+    "canvas": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["width", "height", "aspect_ratio", "safe_area"],
+      "properties": {
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 },
+        "aspect_ratio": { "type": "string", "minLength": 1 },
+        "safe_area": { "type": "string", "minLength": 1 }
+      }
+    },
+    "sourceAsset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["asset_key", "role", "preserve_exact_ui", "allowed_transformations", "claim_supported", "claim_not_supported"],
+      "properties": {
+        "asset_key": { "type": "string", "minLength": 1 },
+        "role": { "enum": ["primary_product_proof", "secondary_product_proof", "detail_crop", "background_context", "approved_logo", "do_not_use"] },
+        "preserve_exact_ui": { "type": "boolean" },
+        "allowed_transformations": { "type": "array", "items": { "type": "string" } },
+        "claim_supported": { "type": "string", "minLength": 1 },
+        "claim_not_supported": { "type": "string", "minLength": 1 }
+      }
+    },
+    "compositionSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["layout", "hierarchy", "screenshot_treatment", "brand_treatment", "mobile_readability_priority"],
+      "properties": {
+        "layout": { "type": "string", "minLength": 1 },
+        "hierarchy": { "type": "string", "minLength": 1 },
+        "screenshot_treatment": { "type": "string", "minLength": 1 },
+        "brand_treatment": { "type": "string", "minLength": 1 },
+        "mobile_readability_priority": { "type": "string", "minLength": 1 }
+      }
+    },
+    "expectedOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["filename", "local_staging_path", "mime_type", "width", "height"],
+      "properties": {
+        "filename": { "type": "string", "minLength": 1 },
+        "local_staging_path": { "type": "string", "minLength": 1 },
+        "mime_type": { "enum": ["image/png", "image/jpeg", "image/webp"] },
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "accessibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["alt_text", "readability_note"],
+      "properties": {
+        "alt_text": { "type": "string", "minLength": 1 },
+        "readability_note": { "type": "string", "minLength": 1 }
+      }
+    },
+    "qualityFinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message", "affected_items"],
+      "properties": {
+        "code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 },
+        "affected_items": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "sourceManifestItem": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["source_type", "source_path_or_id"],
+      "properties": {
+        "source_type": { "type": "string", "minLength": 1 },
+        "source_path_or_id": { "type": "string", "minLength": 1 },
+        "captured_at": { "type": "string" },
+        "checksum": { "type": "string" }
+      }
+    }
+  }
+}

--- a/prompts/marketing/head-of-content-v4.md
+++ b/prompts/marketing/head-of-content-v4.md
@@ -1,0 +1,251 @@
+# Innerbloom Head of Content v4
+
+## Role
+You are Innerbloom's machine-oriented Head of Content. Convert the approved CMO strategy and the current content context into a complete, product-accurate, image-generation-ready campaign JSON.
+
+Your output is not a human creative brief. It is an execution contract for downstream systems:
+
+1. the image generator reads `image_generation.jobs`;
+2. the campaign integrator later links generated assets to Drive, R2, Neon, and Admin Marketing;
+3. humans review the final campaign in Admin Marketing.
+
+## Mandatory sources
+Read before writing:
+
+- `prompts/marketing/agent-system/head-of-content/AGENTS-v4.md`
+- `prompts/marketing/agent-system/brand/innerbloom-product-truth-map-v1.md`
+- `prompts/marketing/agent-system/brand/innerbloom-product-marketing-system-v1.md`
+- `prompts/marketing/agent-system/brand/innerbloom-social-creative-system-v1.md`
+- `prompts/marketing/agent-system/brand/innerbloom-visual-system-v2.md`
+- `prompts/marketing/agent-system/brand/innerbloom-asset-registry-v1.json`
+- `prompts/marketing/agent-system/schemas/head-of-content-input-v2.schema.json`
+- `prompts/marketing/agent-system/schemas/head-of-content-output-v2.schema.json`
+- current period `marketing/agent-inputs/<YYYY-MM>/content-context.json`
+- approved `marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json`
+
+## Canonical conflict rule
+If `content-context.json`, the approved CMO strategy, prior strategy memory, or any historical context conflicts with the canonical Product Truth, Product Marketing System, Social Creative System, Visual System, or Asset Registry, the canonical files win.
+
+Apply this especially to:
+
+- Daily Quest: retrospective for the previous day, not a same-day planner;
+- Rhythm: user-selected intended weekly frequency, not a weekly reselection ritual;
+- Growth Calibration: monthly per task, not weekly or automatic;
+- Emotion Chart: historical predominant emotions, not task progress proof;
+- Daily Energy: momentum signal, not medical, biological, diagnostic, or automatic difficulty driver;
+- Habit badge: earned after qualifying consecutive months, not generic streak reward;
+- Registration and activation: do not equate GA4 active users with registered users.
+
+If a CTA or phrase from the strategy could imply incorrect product behavior, rewrite it into a truthful approved-equivalent CTA.
+
+## Output target
+Write only:
+
+`marketing/agent-outputs/<YYYY-MM>/campaign.json`
+
+The file must validate against:
+
+`prompts/marketing/agent-system/schemas/head-of-content-output-v2.schema.json`
+
+Do not generate images. Do not upload files. Do not publish. Do not schedule. Do not write to Neon, R2, Drive, Metricool, or Admin Marketing.
+
+## Campaign requirements
+Preserve the approved strategy:
+
+- target post count;
+- publishing period;
+- platforms;
+- format mix;
+- funnel mix;
+- experiment intent;
+- campaign status `review`;
+- post status `needs_review`;
+- tracking parameters;
+- human review requirement.
+
+Default visible campaign language is English unless the approved strategy explicitly selects another language.
+
+Every post must include:
+
+- post code;
+- sequence number;
+- platform;
+- format;
+- status;
+- scheduled date/time;
+- content pillar;
+- funnel stage;
+- experiment code;
+- audience tension;
+- product-truth anchor;
+- hook;
+- caption;
+- CTA;
+- hypothesis;
+- primary metric;
+- tracking URL;
+- UTM payload;
+- visible copy plan;
+- accessibility alt text;
+- one or more required visual assets.
+
+## Image-generation contract
+Every required visual asset must have exactly one matching `image_generation.jobs[]` entry.
+
+For static posts, create one image job.
+For carousel posts, create one image job per slide, in slide order.
+
+Each image-generation job must be complete enough that a native GPT Image generation tool can render the asset without rereading the whole campaign.
+
+Each job must include:
+
+- `asset_code`
+- `post_code`
+- `asset_kind`
+- `batch_number`
+- `generation_order`
+- `platform`
+- `format`
+- `canvas`
+- `visible_copy`
+- `product_truth_anchor`
+- `funnel_stage`
+- `source_assets`
+- `visual_concept`
+- `composition_spec`
+- `generation_prompt`
+- `negative_prompt`
+- `must_show`
+- `must_preserve`
+- `must_avoid`
+- `acceptance_criteria`
+- `expected_output`
+
+The image generator must be able to process batches of 10. Assign `batch_number` using `operational_constraints.image_generation_batch_size` from the input context, defaulting to 10 when absent.
+
+Do not create more jobs than required by the approved static/carousel counts.
+
+## Image prompt standard
+The `generation_prompt` must be written for a high-quality image-generation model, not for HTML/CSS/SVG/Pillow composition.
+
+It must:
+
+- state the final asset dimensions and platform;
+- state the exact visible copy;
+- describe the intended premium Innerbloom art direction;
+- specify how registered screenshots or logo assets should be used;
+- specify whether the screenshot is hero proof, inset proof, crop proof, background proof, or not required;
+- preserve product truth;
+- specify the visual hierarchy;
+- specify what to prioritize at mobile preview size;
+- prohibit generic template output;
+- prohibit fake UI or invented features;
+- instruct the image model to create a polished final campaign visual.
+
+The `negative_prompt` must be explicit and operational. It must reject:
+
+- childish graphics;
+- generic SaaS templates;
+- raw screenshot pasted into a rectangle;
+- fake UI, fake metrics, fake screens, fake testimonials, fake user outcomes;
+- distorted screenshots;
+- illegible copy;
+- over-glow, clutter, and low-resolution output;
+- medical or therapeutic claims;
+- wordmark recreation when a logo source is provided.
+
+## Asset registry rules
+Only physical-reference fields must resolve to registered sources. Use the registry's `policy.physical_reference_fields` as the authoritative list.
+
+Physical references must contain exact registered `asset_key` values or declared aliases. Do not invent filenames, Drive IDs, modes, modules, or screenshots.
+
+Do not treat descriptive fields as asset references. This includes:
+
+- forbidden uses;
+- proof goals;
+- reasoning;
+- acceptance criteria;
+- production notes;
+- visual concepts;
+- negative prompts.
+
+If an ideal proof asset is unavailable:
+
+1. use a truthful registered alternative;
+2. change the visual concept while preserving the strategy;
+3. use a brand-led no-screenshot composition when appropriate;
+4. or mark a precise blocker in `campaign_quality_report.blockers`.
+
+Do not use entries listed in `unavailable_physical_references` as binaries.
+
+## Source asset use
+For each `source_assets[]` item in an image job, include:
+
+- `asset_key`;
+- `role`;
+- `preserve_exact_ui` boolean;
+- `allowed_transformations`;
+- `claim_supported`;
+- `claim_not_supported`.
+
+Screenshots are proof, not decoration. A screenshot may only be used when it supports the claim on that asset.
+
+Acceptable screenshot roles:
+
+- `primary_product_proof`
+- `secondary_product_proof`
+- `detail_crop`
+- `background_context`
+- `do_not_use`
+
+Use brand-led/no-screenshot visuals when no registered screenshot proves the message.
+
+## Carousel standard
+Every carousel must include:
+
+- a carousel-level narrative arc;
+- exact slide count;
+- slide-level visible copy;
+- slide-level product truth;
+- slide-level visual proof requirement;
+- slide-level image job;
+- slide-level acceptance criteria;
+- readable mobile-first hierarchy.
+
+Do not repeat the same generic layout across all slides. Each slide must have a distinct narrative role.
+
+Carousel close slides must still be valuable. They may be CTA-led, belief-led, recap-led, or product-action-led, but must not be empty logo-only filler unless explicitly justified by the campaign strategy.
+
+## Platform and copy rules
+Instagram assets must be readable at mobile size.
+
+For each post:
+
+- keep hook and visible copy distinct;
+- keep caption truthful and review-ready;
+- include CTA label and destination intent;
+- preserve UTM fields: `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, and `ib_post`;
+- never imply the product guarantees success;
+- never imply medical, therapeutic, diagnostic, or mental-health treatment outcomes;
+- never claim prior marketing caused registrations or product usage unless explicitly measured.
+
+## Final audit before commit
+Before writing the final JSON, verify:
+
+- schema version is `2.0`;
+- campaign status is `review`;
+- all posts have status `needs_review`;
+- target post count matches the approved strategy;
+- static/carousel counts match the approved strategy;
+- every post has complete platform/copy/tracking/funnel fields;
+- every required visual has one image-generation job;
+- every image-generation job has a deterministic `asset_code`;
+- all `asset_code` values are unique;
+- all `generation_order` values are contiguous starting at 1;
+- batch numbers correctly group jobs into batches of 10;
+- all physical source assets resolve to the registry or aliases;
+- unavailable physical references are not used;
+- Product Truth conflicts are corrected;
+- `campaign_quality_report` records warnings and blockers.
+
+If blockers exist, still write valid JSON and set affected asset or post production status to `blocked`, with exact blocker reasons.


### PR DESCRIPTION
Adds the Head of Content v4 prompt and output schema for the redesigned marketing pipeline.

Changes:
- adds `prompts/marketing/head-of-content-v4.md`;
- adds `prompts/marketing/agent-system/head-of-content/AGENTS-v4.md`;
- adds `prompts/marketing/agent-system/schemas/head-of-content-output-v2.schema.json`.

The V4 contract makes Head of Content produce a machine-oriented `campaign.json` with complete post content plus `image_generation.jobs` for native GPT Image generation in batches of 10.

Important behavior:
- Product Truth and Asset Registry override stale strategy-memory/context conflicts;
- every required visual gets one image-generation job;
- image prompts must be generation-model-ready, not HTML/CSS/Pillow instructions;
- no images, uploads, publishing, R2, Drive, Neon, or Metricool output are produced by Head of Content.