### PR TITLE
Fix mobile auth transition background to Innerbloom 2 dark

### DIFF
--- a/apps/web/src/pages/MobileBrowserAuth.tsx
+++ b/apps/web/src/pages/MobileBrowserAuth.tsx
@@ -143,11 +143,8 @@ function MinimalAuthTransitionLayout({
   secondaryActionHref: string;
 }) {
   return (
-    <div className="relative flex min-h-screen min-h-dvh flex-col items-center justify-center overflow-hidden bg-[#0b1335] px-4 pb-[calc(env(safe-area-inset-bottom)+2.5rem)] pt-[calc(env(safe-area-inset-top,0px)+1.15rem)] text-white sm:px-6 sm:pb-[calc(env(safe-area-inset-bottom)+3rem)] sm:pt-[calc(env(safe-area-inset-top,0px)+1.35rem)]">
-      <div aria-hidden="true" className="pointer-events-none absolute inset-0 opacity-100">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(104,69,255,0.28),transparent_34%),radial-gradient(circle_at_78%_18%,rgba(167,139,250,0.18),transparent_22%),linear-gradient(180deg,#10193f_0%,#0b1335_50%,#090f2d_100%)]" />
-        <div className="absolute inset-x-0 top-0 h-44 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),transparent)]" />
-      </div>
+    <div className="relative flex min-h-screen min-h-dvh flex-col items-center justify-center overflow-hidden bg-[#05070b] px-4 pb-[calc(env(safe-area-inset-bottom)+2.5rem)] pt-[calc(env(safe-area-inset-top,0px)+1.15rem)] text-white sm:px-6 sm:pb-[calc(env(safe-area-inset-bottom)+3rem)] sm:pt-[calc(env(safe-area-inset-top,0px)+1.35rem)]">
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,#05070b_0%,#05070b_68%,#07101e_100%)]" />
       <a
         href={secondaryActionHref}
         className="absolute left-4 top-[calc(env(safe-area-inset-top,0px)+0.45rem)] z-20 inline-flex items-center justify-center gap-2 rounded-full border border-white/10 bg-white/[0.055] px-3 py-2 text-sm font-semibold text-white/68 shadow-[0_12px_28px_rgba(0,0,0,0.16)] backdrop-blur transition-colors duration-200 hover:border-white/18 hover:bg-white/[0.08] hover:text-white sm:left-6 lg:left-8"


### PR DESCRIPTION
### Motivation
- The mobile auth transition page (`/mobile-auth`) was still showing the legacy blue/purple radial gradients in production and must use the exact Innerbloom 2 dark background palette instead. 
- Changes must apply to all mobile auth transition states (login, refresh, logout) while preserving spinner, copy and the deep-link handoff (`innerbloom://...`).

### Description
- Updated `MinimalAuthTransitionLayout` in `apps/web/src/pages/MobileBrowserAuth.tsx` to use a solid base `#05070b` and a subtle lower transition to `#07101e`, removing the legacy radial/blue-violet gradients. 
- Kept the existing spinner, transition text and the return link behavior intact, without modifying Clerk flows, tokens, callbacks or route logic. 
- Detected deployment platform in repo: Railway is configured for the web service with build command `npm --workspace apps/web run build` and start `npm --workspace apps/web run start` (see `railway.toml`).

### Testing
- Ran `npm run build:web` (equivalent to `npm --workspace apps/web run build`) and the production build completed successfully and produced updated `dist` assets. 
- Ran `npm run typecheck:web` and it failed due to preexisting TypeScript issues unrelated to this visual change (Clerk typings and multiple existing test/type errors). 
- Attempted to validate production (`https://innerbloomjourney.org/mobile-auth?mode=refresh...`) via HTTP from this environment but requests failed due to network/DNS/proxy restrictions (could not resolve host / tunnel 403), so I could not confirm the live URL after deploy. 
- Attempted to use the Railway CLI (`npx @railway/cli`) from this environment but the install failed with npm `403` so I could not run a remote deploy from this container; the change is committed and ready for deployment via the Railway pipeline which uses the build command above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50ff4eb97c8332997f91c58253b552)