### PR TITLE
Fix iOS Google account picker

### DIFF
--- a/apps/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2A1E3DBB2E14A00100000001 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1E3DBA2E14A00100000001 /* SceneDelegate.swift */; };
+		2A1E3DBD2E14A00100000001 /* InnerbloomAuthBrowserPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1E3DBC2E14A00100000001 /* InnerbloomAuthBrowserPlugin.swift */; };
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
@@ -20,6 +21,7 @@
 
 /* Begin PBXFileReference section */
 		2A1E3DBA2E14A00100000001 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		2A1E3DBC2E14A00100000001 /* InnerbloomAuthBrowserPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InnerbloomAuthBrowserPlugin.swift; sourceTree = "<group>"; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -67,6 +69,7 @@
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
 				2A1E3DBA2E14A00100000001 /* SceneDelegate.swift */,
+				2A1E3DBC2E14A00100000001 /* InnerbloomAuthBrowserPlugin.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -161,6 +164,7 @@
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
 				2A1E3DBB2E14A00100000001 /* SceneDelegate.swift in Sources */,
+				2A1E3DBD2E14A00100000001 /* InnerbloomAuthBrowserPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/mobile/ios/App/App/InnerbloomAuthBrowserPlugin.swift
+++ b/apps/mobile/ios/App/App/InnerbloomAuthBrowserPlugin.swift
@@ -1,0 +1,81 @@
+import AuthenticationServices
+import Capacitor
+import UIKit
+
+@objc(InnerbloomAuthBrowserPlugin)
+public class InnerbloomAuthBrowserPlugin: CAPPlugin, CAPBridgedPlugin, ASWebAuthenticationPresentationContextProviding {
+    public let identifier = "InnerbloomAuthBrowserPlugin"
+    public let jsName = "InnerbloomAuthBrowser"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "open", returnType: CAPPluginReturnPromise)
+    ]
+
+    private var activeSession: ASWebAuthenticationSession?
+    private var activeCall: CAPPluginCall?
+
+    @objc func open(_ call: CAPPluginCall) {
+        guard activeCall == nil else {
+            call.reject("An authentication session is already active", "AUTH_SESSION_ACTIVE")
+            return
+        }
+
+        guard let urlString = call.getString("url"), let url = URL(string: urlString) else {
+            call.reject("Must provide a valid URL to open", "AUTH_INVALID_URL")
+            return
+        }
+
+        guard let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme) else {
+            call.reject("Authentication URL must use HTTP or HTTPS", "AUTH_INVALID_URL_SCHEME")
+            return
+        }
+
+        let callbackScheme = call.getString("callbackScheme") ?? "innerbloom"
+        let prefersEphemeralSession = call.getBool("prefersEphemeralWebBrowserSession", false)
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+
+            let session = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackScheme) { [weak self] callbackURL, error in
+                guard let self else { return }
+                let pendingCall = self.activeCall
+                self.activeCall = nil
+                self.activeSession = nil
+
+                if let callbackURL {
+                    pendingCall?.resolve(["url": callbackURL.absoluteString])
+                    return
+                }
+
+                if let authError = error as? ASWebAuthenticationSessionError, authError.code == .canceledLogin {
+                    pendingCall?.reject("Authentication session was cancelled", "AUTH_CANCELLED", authError)
+                    return
+                }
+
+                pendingCall?.reject(error?.localizedDescription ?? "Authentication session failed", "AUTH_FAILED", error)
+            }
+
+            session.presentationContextProvider = self
+            session.prefersEphemeralWebBrowserSession = prefersEphemeralSession
+
+            self.activeCall = call
+            self.activeSession = session
+
+            if !session.start() {
+                self.activeCall = nil
+                self.activeSession = nil
+                call.reject("Unable to start authentication session", "AUTH_START_FAILED")
+            }
+        }
+    }
+
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        if let window = bridge?.viewController?.view.window {
+            return window
+        }
+
+        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow } ?? ASPresentationAnchor()
+    }
+}

--- a/apps/web/src/mobile/NativeMobileBridge.tsx
+++ b/apps/web/src/mobile/NativeMobileBridge.tsx
@@ -17,6 +17,7 @@ import {
   getCapacitorStatusBarPlugin,
   isNativeAuthCallbackUrl,
   isNativeCapacitorPlatform,
+  NATIVE_AUTH_CALLBACK_EVENT,
   normalizeAppUrlToPath,
   scheduleCapacitorBrowserCloseRetries,
   shouldOpenExternalUrl,
@@ -427,6 +428,14 @@ function useDeepLinkNavigation(enabled: boolean) {
       listenerHandle = handle;
     });
 
+    const handleNativeAuthCallback = (event: Event) => {
+      const resolvedUrl = coerceIncomingUrl(event);
+      console.info(`[mobile-auth] native auth callback event url=${resolvedUrl ?? 'null'}`);
+      void handleUrl(resolvedUrl, 'event');
+    };
+
+    window.addEventListener(NATIVE_AUTH_CALLBACK_EVENT, handleNativeAuthCallback);
+
     const localNotifications = getCapacitorLocalNotificationsPlugin();
     if (localNotifications) {
       void Promise.resolve(
@@ -451,6 +460,7 @@ function useDeepLinkNavigation(enabled: boolean) {
 
     return () => {
       console.info('[mobile-auth] NativeMobileBridge unmounted');
+      window.removeEventListener(NATIVE_AUTH_CALLBACK_EVENT, handleNativeAuthCallback);
       void listenerHandle?.remove();
       void localNotificationHandle?.remove();
     };

--- a/apps/web/src/mobile/capacitor.ts
+++ b/apps/web/src/mobile/capacitor.ts
@@ -15,6 +15,14 @@ type CapacitorBrowserPlugin = {
   close?: () => Promise<void>;
 };
 
+type InnerbloomAuthBrowserPlugin = {
+  open: (options: {
+    url: string;
+    callbackScheme: string;
+    prefersEphemeralWebBrowserSession?: boolean;
+  }) => Promise<{ url?: string } | undefined>;
+};
+
 type CapacitorHttpPlugin = {
   request: (options: {
     url: string;
@@ -101,6 +109,7 @@ export const CAPACITOR_SIGNED_OUT_HOST = 'signed-out';
 export const CAPACITOR_STATUS_BAR_STYLE_DARK = 'DARK' as const;
 export const CAPACITOR_KEYBOARD_STYLE_DARK = 'DARK' as const;
 export const CAPACITOR_KEYBOARD_RESIZE_NATIVE = 'native' as const;
+export const NATIVE_AUTH_CALLBACK_EVENT = 'innerbloom:native-auth-callback';
 
 function buildNativeCallbackPrefixes(): string[] {
   return [
@@ -142,6 +151,10 @@ export function getCapacitorAppPlugin(): CapacitorAppPlugin | null {
 
 export function getCapacitorBrowserPlugin(): CapacitorBrowserPlugin | null {
   return getCapacitorPlugin<CapacitorBrowserPlugin>('Browser');
+}
+
+export function getInnerbloomAuthBrowserPlugin(): InnerbloomAuthBrowserPlugin | null {
+  return getCapacitorPlugin<InnerbloomAuthBrowserPlugin>('InnerbloomAuthBrowser');
 }
 
 export function getCapacitorHttpPlugin(): CapacitorHttpPlugin | null {
@@ -225,7 +238,53 @@ export function buildNativeAppUrl(host: string): string {
   return `${CAPACITOR_APP_SCHEME}://${CAPACITOR_APP_HOST}/${host}`;
 }
 
+function shouldUseEphemeralIOSGoogleAuth(url: string): boolean {
+  if (getCapacitorPlatform() !== 'ios') {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    const mode = parsed.searchParams.get('mode');
+    return parsed.pathname.endsWith('/mobile-auth')
+      && parsed.searchParams.get('provider') === 'google'
+      && parsed.searchParams.get('fresh') === '1'
+      && (mode === 'sign-in' || mode === 'sign-up');
+  } catch {
+    return false;
+  }
+}
+
+function dispatchNativeAuthCallback(url: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent(NATIVE_AUTH_CALLBACK_EVENT, { detail: { url } }));
+}
+
 export async function openUrlInCapacitorBrowser(url: string): Promise<void> {
+  const authBrowser = getInnerbloomAuthBrowserPlugin();
+  if (authBrowser && shouldUseEphemeralIOSGoogleAuth(url)) {
+    const startedAt = Date.now();
+    console.info('[mobile-auth] InnerbloomAuthBrowser.open() start', { url, startedAt });
+    const result = await authBrowser.open({
+      url,
+      callbackScheme: CAPACITOR_APP_SCHEME,
+      prefersEphemeralWebBrowserSession: true,
+    });
+    console.info('[mobile-auth] InnerbloomAuthBrowser.open() end', {
+      url,
+      callbackUrl: result?.url ?? null,
+      finishedAt: Date.now(),
+    });
+
+    if (result?.url) {
+      dispatchNativeAuthCallback(result.url);
+    }
+    return;
+  }
+
   const browser = getCapacitorBrowserPlugin();
   if (browser) {
     const startedAt = Date.now();


### PR DESCRIPTION
## What changed

- Adds a local iOS Capacitor plugin that opens Google mobile auth with `ASWebAuthenticationSession`.
- Uses `prefersEphemeralWebBrowserSession` only for fresh native iOS Google sign-in/sign-up URLs (`/mobile-auth?provider=google&fresh=1`).
- Dispatches the returned native auth callback back into the existing mobile auth bridge so the current callback/session handling remains unchanged.
- Leaves Android on the existing `@capacitor/browser` path.

## Why

iOS can reuse the prior browser/provider session after Clerk logout, causing Google OAuth to silently return the last Google account. `main` already forces `oidcPrompt: 'select_account'`; this adds an iOS-specific browser-session boundary for the native Google auth handoff so stale Safari/SFSafariViewController cookies do not auto-select the previous account.

## Validation

- `pnpm --dir apps/web exec tsc --noEmit --pretty false --jsx react-jsx --lib DOM,DOM.Iterable,ES2022 --module ESNext --moduleResolution Bundler --target ES2022 --skipLibCheck --allowSyntheticDefaultImports --esModuleInterop --types vite/client src/mobile/capacitor.ts src/mobile/NativeMobileBridge.tsx`
- `xcodebuild -list -project apps/mobile/ios/App/App.xcodeproj`
- `xcodebuild -project apps/mobile/ios/App/App.xcodeproj -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build` with temporary generated Capacitor resource placeholders; Swift/iOS build reached `BUILD SUCCEEDED`.

Note: full `pnpm --filter @innerbloom/web typecheck` and `pnpm --filter @innerbloom/mobile sync:ios` are currently blocked by pre-existing `main` issues unrelated to this PR, including Clerk type mismatches and `LandingV2.tsx` missing a default export for `App.tsx`.