### PR TITLE
Register iOS auth browser plugin

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@capacitor/core": "^8.3.0",
     "@clerk/clerk-react": "^5.8.1",
     "@clerk/types": "^4.27.0",
     "@innerbloom/missions-v2-contracts": "file:../../packages/missions-v2-contracts",

--- a/apps/web/src/mobile/capacitor.ts
+++ b/apps/web/src/mobile/capacitor.ts
@@ -1,3 +1,5 @@
+import { registerPlugin } from '@capacitor/core';
+
 type CapacitorPluginListenerHandle = {
   remove: () => Promise<void> | void;
 };
@@ -102,6 +104,8 @@ type CapacitorGlobal = {
   Plugins?: Record<string, unknown>;
 };
 
+const innerbloomAuthBrowserPlugin = registerPlugin<InnerbloomAuthBrowserPlugin>('InnerbloomAuthBrowser');
+
 export const CAPACITOR_APP_SCHEME = 'innerbloom';
 export const CAPACITOR_APP_HOST = 'localhost';
 export const CAPACITOR_CALLBACK_HOST = 'callback';
@@ -154,7 +158,11 @@ export function getCapacitorBrowserPlugin(): CapacitorBrowserPlugin | null {
 }
 
 export function getInnerbloomAuthBrowserPlugin(): InnerbloomAuthBrowserPlugin | null {
-  return getCapacitorPlugin<InnerbloomAuthBrowserPlugin>('InnerbloomAuthBrowser');
+  if (!isNativeCapacitorPlatform()) {
+    return null;
+  }
+
+  return innerbloomAuthBrowserPlugin;
 }
 
 export function getCapacitorHttpPlugin(): CapacitorHttpPlugin | null {
@@ -264,8 +272,17 @@ function dispatchNativeAuthCallback(url: string): void {
 }
 
 export async function openUrlInCapacitorBrowser(url: string): Promise<void> {
-  const authBrowser = getInnerbloomAuthBrowserPlugin();
-  if (authBrowser && shouldUseEphemeralIOSGoogleAuth(url)) {
+  if (shouldUseEphemeralIOSGoogleAuth(url)) {
+    const authBrowser = getInnerbloomAuthBrowserPlugin();
+    if (!authBrowser) {
+      console.error('[mobile-auth] InnerbloomAuthBrowser unavailable for fresh iOS Google auth', {
+        url,
+        platform: getCapacitorPlatform(),
+        hasCapacitor: Boolean(getCapacitorGlobal()),
+      });
+      throw new Error('InnerbloomAuthBrowser is unavailable for fresh iOS Google auth.');
+    }
+
     const startedAt = Date.now();
     console.info('[mobile-auth] InnerbloomAuthBrowser.open() start', { url, startedAt });
     const result = await authBrowser.open({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@capacitor/core':
+        specifier: ^8.3.0
+        version: 8.3.0
       '@clerk/clerk-react':
         specifier: ^5.8.1
         version: 5.59.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
## Summary

Fixes the follow-up issue where iOS still opened the Capacitor Browser/Safari-style auth view after PR #2257, so Google could reuse the previous browser session and skip account selection.

## Root Cause

PR #2257 added the native `InnerbloomAuthBrowserPlugin` Swift implementation, but the web bundle looked it up via `window.Capacitor.Plugins.InnerbloomAuthBrowser`. For this local app plugin, the JS proxy was not registered, so the lookup returned `null` and the iOS fresh Google flow silently fell back to `Browser.open()`.

That matches the observed screens: the user still saw the Browser UI on `innerbloomjourney.org` instead of the native `ASWebAuthenticationSession` path.

## Changes

- Registers `InnerbloomAuthBrowser` with Capacitor's `registerPlugin()` in `apps/web/src/mobile/capacitor.ts`.
- Uses the registered plugin proxy for iOS Google fresh auth URLs.
- Throws/logs a clear error if that specific iOS fresh auth path cannot access the native plugin, instead of silently falling back to the old Browser flow.
- Adds `@capacitor/core` as an explicit `@innerbloom/web` dependency because the web bundle now imports `registerPlugin` directly.

## Validation

- `pnpm --dir apps/web exec tsc --noEmit --pretty false --jsx react-jsx --lib DOM,DOM.Iterable,ES2022 --module ESNext --moduleResolution Bundler --target ES2022 --skipLibCheck --allowSyntheticDefaultImports --esModuleInterop --types vite/client src/mobile/capacitor.ts src/mobile/NativeMobileBridge.tsx`
- `pnpm --filter @innerbloom/mobile run sync:ios`
- `xcodebuild -list -project apps/mobile/ios/App/App.xcodeproj`
- `xcodebuild -project apps/mobile/ios/App/App.xcodeproj -scheme App -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`

Note: validation ran on Node v24.11.1, so pnpm printed the existing engine warning for the repo's Node 20.x requirement.