### PR TITLE
Fix landing method steps to fill the desktop viewport

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/png" href="/IB-COLOR-LOGO-v2.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="stylesheet" href="/landing-method-scroll-fix.css" />
     <meta name="theme-color" content="#000c40" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/apps/web/public/landing-method-scroll-fix.css
+++ b/apps/web/public/landing-method-scroll-fix.css
@@ -1,0 +1,66 @@
+/* Desktop-only viewport correction for the guided Landing V3 method sequence.
+   Keep each active step inside the usable viewport below the fixed navigation. */
+@media (min-width: 901px) {
+  .landing.landing--v3-conversion {
+    --v3-method-nav-offset: 82px;
+    --v3-method-viewport: calc(100dvh - var(--v3-method-nav-offset));
+  }
+
+  .landing.landing--v3-conversion .v3-method-card-grid {
+    gap: 0;
+  }
+
+  .landing.landing--v3-conversion .v3-method-snap-panel,
+  .landing.landing--v3-conversion .v3-method-card,
+  .landing.landing--v3-conversion .v3-method-card:first-child {
+    box-sizing: border-box;
+    width: 100%;
+    height: var(--v3-method-viewport);
+    min-height: var(--v3-method-viewport);
+    max-height: var(--v3-method-viewport);
+    margin: 0;
+    padding-top: clamp(24px, 4vh, 52px);
+    padding-bottom: clamp(24px, 4vh, 52px);
+    overflow: clip;
+    scroll-margin-top: var(--v3-method-nav-offset);
+    scroll-snap-align: start;
+    scroll-snap-stop: always;
+  }
+
+  .landing.landing--v3-conversion .v3-method-card {
+    align-content: center;
+  }
+
+  .landing.landing--v3-conversion .v3-method-card .v3-step-visual,
+  .landing.landing--v3-conversion .v3-method-card:first-child .v3-step-visual {
+    max-height: calc(var(--v3-method-viewport) - 96px);
+  }
+}
+
+/* Short desktop displays need tighter internal spacing, not a shorter step. */
+@media (min-width: 901px) and (max-height: 820px) {
+  .landing.landing--v3-conversion .v3-method-card,
+  .landing.landing--v3-conversion .v3-method-card:first-child {
+    gap: clamp(22px, 4vw, 54px);
+    padding-top: 18px;
+    padding-bottom: 18px;
+  }
+
+  .landing.landing--v3-conversion .v3-method-card-copy {
+    gap: 12px;
+  }
+
+  .landing.landing--v3-conversion .v3-method-card-copy .v2-method-step-title {
+    font-size: clamp(2.25rem, 3.1vw, 3.65rem);
+  }
+
+  .landing.landing--v3-conversion .v3-method-card-copy .v2-method-step-description {
+    font-size: clamp(1rem, 1vw + 0.72rem, 1.3rem);
+  }
+
+  .landing.landing--v3-conversion .v3-method-card .v3-step-visual,
+  .landing.landing--v3-conversion .v3-method-card:first-child .v3-step-visual {
+    min-height: min(52vh, 430px);
+    max-height: min(52vh, 430px);
+  }
+}


### PR DESCRIPTION
## Qué corrige
- Cada panel del método V3 ocupa el viewport útil debajo de la navegación fija.
- El primer paso deja de usar la excepción de `58vh` que permitía que se asomara el paso siguiente.
- Se elimina el gap vertical entre pasos en desktop.
- Se añade una variante compacta para pantallas de poca altura sin acortar el panel.
- Mobile queda sin cambios.

## Implementación
- Nueva hoja `apps/web/public/landing-method-scroll-fix.css` con overrides acotados a `.landing--v3-conversion` y desktop.
- Carga explícita desde `apps/web/index.html`.

## Validación pendiente
Revisar visualmente en preview/deploy con alturas aproximadas de 768, 900 y 1080 px antes de mergear.