### PR TITLE
Fix iOS sign-up Google OAuth callback redirect

### DIFF
--- a/apps/web/src/mobile/NativeMobileBridge.tsx
+++ b/apps/web/src/mobile/NativeMobileBridge.tsx
@@ -17,7 +17,6 @@ import {
   getCapacitorStatusBarPlugin,
   isNativeAuthCallbackUrl,
   isNativeCapacitorPlatform,
-  NATIVE_AUTH_CALLBACK_EVENT,
   normalizeAppUrlToPath,
   scheduleCapacitorBrowserCloseRetries,
   shouldOpenExternalUrl,
@@ -25,6 +24,8 @@ import {
 import { DAILY_REMINDER_NOTIFICATION_TARGET_PATH } from './localNotifications';
 import {
   getMobileAuthSession,
+  getNativePostAuthPath,
+  type MobileAuthSession,
   resolveMobileAuthSessionFromCallback,
   shouldForceNativeWelcome,
 } from './mobileAuthSession';
@@ -106,6 +107,25 @@ function getCurrentAppPath(): string {
   return `${pathname || '/'}${search || ''}${hash || ''}`;
 }
 
+function normalizeNativeInnerbloom2Path(path: string): string {
+  if (!isSafeInternalPath(path)) {
+    return INNERBLOOM2_DASHBOARD_PATH;
+  }
+
+  const [pathnameWithQuery] = path.split('#', 1);
+  const pathname = pathnameWithQuery.split('?', 1)[0]?.replace(/\/+$/, '') || '/';
+
+  if (pathname === '/dashboard' || pathname === '/dashboard-v3') {
+    return INNERBLOOM2_DASHBOARD_PATH;
+  }
+
+  if (pathname === '/login' || pathname === '/sign-up') {
+    return '/';
+  }
+
+  return path;
+}
+
 function coerceIncomingUrl(value: unknown): string | null {
   if (typeof value === 'string') {
     const trimmed = value.trim();
@@ -144,14 +164,20 @@ function coerceIncomingUrl(value: unknown): string | null {
   return null;
 }
 
-function resolveCallbackTargetPath(
-  authMode: string | null | undefined,
+export function resolveCallbackTargetPath(
+  session: Pick<MobileAuthSession, 'authMode' | 'redirectPath'>,
   currentPath: string,
 ): string {
-  const dashboardPath = INNERBLOOM2_DASHBOARD_PATH;
+  const { authMode, redirectPath } = session;
+
+  // A creation intent wins even when Google resolves an existing account through
+  // Clerk's sign-in branch. The native callback must continue V2 onboarding.
+  if (redirectPath === INNERBLOOM2_INTRO_JOURNEY_PATH) {
+    return INNERBLOOM2_INTRO_JOURNEY_PATH;
+  }
 
   if (authMode === 'sign-in') {
-    return consumePendingNotificationTargetPath() ?? dashboardPath;
+    return consumePendingNotificationTargetPath() ?? INNERBLOOM2_DASHBOARD_PATH;
   }
 
   if (authMode === 'sign-up') {
@@ -159,10 +185,12 @@ function resolveCallbackTargetPath(
   }
 
   if (authMode === 'refresh') {
-    return currentPath || dashboardPath;
+    return normalizeNativeInnerbloom2Path(currentPath || INNERBLOOM2_DASHBOARD_PATH);
   }
 
-  return '/';
+  // A callback without a mode must never fall back to the native welcome route.
+  // Use the validated V2 destination embedded by the browser auth page instead.
+  return redirectPath ?? getNativePostAuthPath('sign-in') ?? INNERBLOOM2_DASHBOARD_PATH;
 }
 
 function useNativeDocumentClass(enabled: boolean) {
@@ -360,7 +388,7 @@ function useDeepLinkNavigation(enabled: boolean) {
           clearPendingCallbackUrl();
           const currentPath = getCurrentAppPath();
           const nextPath = resolution.type === 'session'
-            ? resolveCallbackTargetPath(resolution.session.authMode, currentPath)
+            ? resolveCallbackTargetPath(resolution.session, currentPath)
             : '/';
 
           console.info('[mobile-auth] bridge consumed callback', {
@@ -387,7 +415,7 @@ function useDeepLinkNavigation(enabled: boolean) {
 
         const nextPath = normalizeAppUrlToPath(url);
         if (nextPath) {
-          navigateRef.current(nextPath, { replace: true });
+          navigateRef.current(normalizeNativeInnerbloom2Path(nextPath), { replace: true });
         }
       } catch (error) {
         console.error('[mobile-auth] handleUrl failed', {
@@ -428,14 +456,6 @@ function useDeepLinkNavigation(enabled: boolean) {
       listenerHandle = handle;
     });
 
-    const handleNativeAuthCallback = (event: Event) => {
-      const resolvedUrl = coerceIncomingUrl(event);
-      console.info(`[mobile-auth] native auth callback event url=${resolvedUrl ?? 'null'}`);
-      void handleUrl(resolvedUrl, 'event');
-    };
-
-    window.addEventListener(NATIVE_AUTH_CALLBACK_EVENT, handleNativeAuthCallback);
-
     const localNotifications = getCapacitorLocalNotificationsPlugin();
     if (localNotifications) {
       void Promise.resolve(
@@ -460,7 +480,6 @@ function useDeepLinkNavigation(enabled: boolean) {
 
     return () => {
       console.info('[mobile-auth] NativeMobileBridge unmounted');
-      window.removeEventListener(NATIVE_AUTH_CALLBACK_EVENT, handleNativeAuthCallback);
       void listenerHandle?.remove();
       void localNotificationHandle?.remove();
     };

--- a/apps/web/src/mobile/mobileAuthSession.ts
+++ b/apps/web/src/mobile/mobileAuthSession.ts
@@ -22,6 +22,7 @@ export type MobileAuthSession = {
   email: string | null;
   clerkImageUrl: string | null;
   authMode: MobileAuthMode | null;
+  redirectPath: string | null;
   expiresAt: number | null;
   updatedAt: number;
 };
@@ -211,6 +212,26 @@ function normalizeAuthMode(value: string | null | undefined): MobileAuthMode | n
   return null;
 }
 
+export function getNativePostAuthPath(mode: MobileAuthMode): string | null {
+  if (mode === 'sign-up') {
+    return INNERBLOOM2_INTRO_JOURNEY_PATH;
+  }
+
+  if (mode === 'sign-in' || mode === 'refresh') {
+    return INNERBLOOM2_DASHBOARD_PATH;
+  }
+
+  return null;
+}
+
+export function normalizeNativePostAuthPath(value: string | null | undefined): string | null {
+  if (value === INNERBLOOM2_INTRO_JOURNEY_PATH || value === INNERBLOOM2_DASHBOARD_PATH) {
+    return value;
+  }
+
+  return null;
+}
+
 function decodeJwtExp(token: string): number | null {
   const parts = token.split('.');
   if (parts.length < 2 || !parts[1]) {
@@ -235,6 +256,7 @@ function normalizeSession(session: Partial<MobileAuthSession> & { token: string 
     email: typeof session.email === 'string' ? session.email : null,
     clerkImageUrl: typeof session.clerkImageUrl === 'string' ? session.clerkImageUrl : null,
     authMode: normalizeAuthMode(session.authMode),
+    redirectPath: normalizeNativePostAuthPath(session.redirectPath),
     expiresAt: typeof session.expiresAt === 'number' ? session.expiresAt : decodeJwtExp(session.token),
     updatedAt: typeof session.updatedAt === 'number' ? session.updatedAt : Date.now(),
   };
@@ -261,6 +283,7 @@ export function buildNativeMobileAuthUrl(
   options?: {
     provider?: 'google';
     hideGoogle?: boolean;
+    redirectPath?: string;
   },
 ): string {
   const resolvedLanguage =
@@ -270,10 +293,13 @@ export function buildNativeMobileAuthUrl(
   const mobileAuthUrl = new URL(buildWebAbsoluteUrl(buildLocalizedAuthPath('/mobile-auth', resolvedLanguage)));
   mobileAuthUrl.searchParams.set('mode', mode);
   mobileAuthUrl.searchParams.set('experience', 'innerbloom2');
-  mobileAuthUrl.searchParams.set(
-    'redirect_path',
-    mode === 'sign-up' ? INNERBLOOM2_INTRO_JOURNEY_PATH : INNERBLOOM2_DASHBOARD_PATH,
-  );
+  const requestedRedirectPath = normalizeNativePostAuthPath(options?.redirectPath);
+  const redirectPath = mode === 'sign-up'
+    ? INNERBLOOM2_INTRO_JOURNEY_PATH
+    : requestedRedirectPath ?? getNativePostAuthPath(mode);
+  if (redirectPath) {
+    mobileAuthUrl.searchParams.set('redirect_path', redirectPath);
+  }
   mobileAuthUrl.searchParams.set(
     'return_to',
     buildNativeAppUrl(mode === 'logout' ? CAPACITOR_SIGNED_OUT_HOST : CAPACITOR_CALLBACK_HOST),
@@ -538,6 +564,7 @@ export function resolveMobileAuthSessionFromCallback(url: string): MobileAuthCal
       email: parsed?.params.get('email')?.trim() || null,
       clerkImageUrl: parsed?.params.get('clerk_image_url')?.trim() || null,
       authMode: normalizeAuthMode(parsed?.params.get('auth_mode')?.trim()),
+      redirectPath: normalizeNativePostAuthPath(parsed?.params.get('redirect_path')?.trim()),
       expiresAt: decodeJwtExp(token),
       updatedAt: Date.now(),
     });

--- a/apps/web/src/pages/MobileBrowserAuth.tsx
+++ b/apps/web/src/pages/MobileBrowserAuth.tsx
@@ -9,6 +9,7 @@ import { buildLocalizedAuthPath, resolveAuthLanguage, type AuthLanguage } from '
 import { AUTH_DIVIDER_CLASS, AUTH_STACK_CLASS, createAuthAppearance } from '../lib/clerkAppearance';
 import { buildWebAbsoluteUrl } from '../lib/siteUrl';
 import { CAPACITOR_APP_SCHEME, CAPACITOR_CALLBACK_HOST, CAPACITOR_SIGNED_OUT_HOST } from '../mobile/capacitor';
+import { getNativePostAuthPath, normalizeNativePostAuthPath, type MobileAuthMode } from '../mobile/mobileAuthSession';
 
 type BrowserAuthMode = 'sign-in' | 'sign-up' | 'logout' | 'refresh';
 
@@ -53,6 +54,7 @@ function buildSignedOutUrl(search: string): string {
 
 type MobileCallbackLegacyOptions = {
   includeLegacyImageUrl: boolean;
+  redirectPath: string | null;
 };
 
 export function shouldIncludeLegacyProfileImage(search: string): boolean {
@@ -70,6 +72,9 @@ export function buildRedirectUrl(
   const callbackUrl = new URL(baseUrl);
   callbackUrl.searchParams.set('token', token);
   callbackUrl.searchParams.set('auth_mode', mode);
+  if (options.redirectPath) {
+    callbackUrl.searchParams.set('redirect_path', options.redirectPath);
+  }
 
   if (user?.id) {
     callbackUrl.searchParams.set('user_id', user.id);
@@ -97,6 +102,19 @@ export function buildRedirectUrl(
   }
 
   return callbackUrl.toString();
+}
+
+function resolvePostAuthPath(search: string, mode: BrowserAuthMode): string | null {
+  const params = new URLSearchParams(search);
+  const requestedPath = normalizeNativePostAuthPath(params.get('redirect_path'));
+  const defaultPath = getNativePostAuthPath(mode as MobileAuthMode);
+
+  if (mode === 'sign-up') {
+    return getNativePostAuthPath('sign-up');
+  }
+
+  // Never let an arbitrary URL determine the destination of a native auth callback.
+  return requestedPath ?? defaultPath;
 }
 
 export function buildModeUrl(language: AuthLanguage, mode: 'sign-in' | 'sign-up', search: string): string {
@@ -194,6 +212,10 @@ export default function MobileBrowserAuthPage() {
     const params = new URLSearchParams(location.search);
     return params.get('return_to')?.trim() ?? null;
   }, [location.search]);
+  const postAuthPath = useMemo(
+    () => resolvePostAuthPath(location.search, mode),
+    [location.search, mode],
+  );
   const isHandoffStep = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return params.get('handoff') === '1';
@@ -366,8 +388,8 @@ export default function MobileBrowserAuthPage() {
         strategy: 'oauth_google',
         redirectUrl: '/sso-callback',
         redirectUrlComplete: handoffUrl,
-        continueSignIn: false,
-        continueSignUp: false,
+        continueSignIn: true,
+        continueSignUp: true,
         oidcPrompt: 'select_account',
       })
       .catch((cause) => {
@@ -483,7 +505,7 @@ export default function MobileBrowserAuthPage() {
             user,
             token,
             mode === 'refresh' ? 'refresh' : mode,
-            { includeLegacyImageUrl },
+            { includeLegacyImageUrl, redirectPath: postAuthPath },
           );
           console.info('[mobile-auth-page] callback-build', {
             callbackUrl: resolvedCallbackUrl,
@@ -545,6 +567,7 @@ export default function MobileBrowserAuthPage() {
     returnTo,
     isHandoffStep,
     includeLegacyImageUrl,
+    postAuthPath,
     session?.id,
     signOut,
     shouldResetBrowserSession,
@@ -643,6 +666,7 @@ export default function MobileBrowserAuthPage() {
               mode={mode === 'sign-up' ? 'sign-up' : 'sign-in'}
               redirectUrlComplete={handoffUrl}
               forceAccountSelection
+              allowCrossModeCompletion
             />
             <div className={AUTH_DIVIDER_CLASS}>
               <span className="h-px flex-1 bg-white/12" aria-hidden />

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -63,7 +63,7 @@ export default function SignUpPage({
   });
 
   if (isNativeApp) {
-    const googleAuthUrl = buildNativeMobileAuthUrl('sign-up', language, { provider: 'google' });
+    const googleAuthUrl = buildNativeMobileAuthUrl('sign-up', language, { provider: 'google', redirectPath: fallbackRedirectUrl });
 
     return (
       <AuthLayout

--- a/apps/web/src/pages/__tests__/MobileBrowserAuth.test.ts
+++ b/apps/web/src/pages/__tests__/MobileBrowserAuth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CLERK_TOKEN_TEMPLATE } from '../../config/auth';
-import { buildRedirectUrl, shouldIncludeLegacyProfileImage } from '../MobileBrowserAuth';
+import { buildModeUrl, buildRedirectUrl, shouldIncludeLegacyProfileImage } from '../MobileBrowserAuth';
 
 describe('MobileBrowserAuth callback URL hardening', () => {
   const baseUrl = 'innerbloom://auth-callback';
@@ -15,10 +15,12 @@ describe('MobileBrowserAuth callback URL hardening', () => {
   it('omits legacy image_url by default and writes clerk_image_url', () => {
     const callbackUrl = new URL(buildRedirectUrl(baseUrl, user as never, token, mode, {
       includeLegacyImageUrl: false,
+      redirectPath: '/innerbloom2/dashboard',
     }));
 
     expect(callbackUrl.searchParams.get('token')).toBe(token);
     expect(callbackUrl.searchParams.get('auth_mode')).toBe(mode);
+    expect(callbackUrl.searchParams.get('redirect_path')).toBe('/innerbloom2/dashboard');
     expect(callbackUrl.searchParams.get('user_id')).toBe(user.id);
     expect(callbackUrl.searchParams.get('email')).toBe('test@example.com');
     expect(callbackUrl.searchParams.get('clerk_image_url')).toBe(user.imageUrl);
@@ -28,6 +30,7 @@ describe('MobileBrowserAuth callback URL hardening', () => {
   it('supports short compatibility dual-write when legacy flag is enabled', () => {
     const callbackUrl = new URL(buildRedirectUrl(baseUrl, user as never, token, mode, {
       includeLegacyImageUrl: true,
+      redirectPath: '/innerbloom2/dashboard',
     }));
 
     expect(callbackUrl.searchParams.get('clerk_image_url')).toBe(user.imageUrl);
@@ -42,5 +45,21 @@ describe('MobileBrowserAuth callback URL hardening', () => {
 
   it('uses the shared Clerk token template configuration', () => {
     expect(CLERK_TOKEN_TEMPLATE).toBeNull();
+  });
+
+  it('preserves Innerbloom 2 mobile auth parameters when switching modes', () => {
+    const url = buildModeUrl(
+      'es',
+      'sign-up',
+      '?lang=es&return_to=innerbloom%3A%2F%2Fauth-callback&fresh=1&experience=innerbloom2&redirect_path=%2Finnerbloom2%2Fdashboard&hide_google=1',
+    );
+
+    const parsed = new URL(url, 'https://innerbloomjourney.org');
+    expect(parsed.pathname).toBe('/mobile-auth');
+    expect(parsed.searchParams.get('mode')).toBe('sign-up');
+    expect(parsed.searchParams.get('experience')).toBe('innerbloom2');
+    expect(parsed.searchParams.get('redirect_path')).toBe('/innerbloom2/dashboard');
+    expect(parsed.searchParams.get('return_to')).toBe('innerbloom://auth-callback');
+    expect(parsed.searchParams.get('fresh')).toBe('1');
   });
 });


### PR DESCRIPTION
## What changed

- Preserve the validated V2 post-auth destination through the mobile OAuth callback.
- Keep a sign-up intent on `/intro-journey2` even when Clerk completes an existing Google account through its sign-in branch.
- Keep sign-in on `/innerbloom2/dashboard` and refresh on the current V2 route.
- Allow the visible Google button in `mobile-auth` to continue a cross-mode Clerk completion.
- Add coverage for the mobile callback URL contract.

## Root cause

The Capacitor browser loads the deployed `/mobile-auth` page. Its callback relied on `auth_mode` alone, so a Google account resolved by Clerk as sign-in could lose the original sign-up destination and never send the native app to onboarding V2.

## Validation

- `pnpm --filter web build`
- `pnpm exec cap sync ios` from `apps/mobile`

The PR intentionally excludes unrelated local changes, iOS project configuration, generated files, assets, and marketing content.