### PR TITLE
Fix iOS Google sign-up return to onboarding

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -7,6 +7,7 @@ type GoogleOAuthButtonProps = {
   language: 'es' | 'en';
   mode: GoogleOAuthMode;
   redirectUrlComplete: string;
+  oauthMode?: GoogleOAuthMode;
   className?: string;
   forceAccountSelection?: boolean;
   allowCrossModeCompletion?: boolean;
@@ -18,6 +19,7 @@ export function GoogleOAuthButton({
   language,
   mode,
   redirectUrlComplete,
+  oauthMode = mode,
   className = '',
   forceAccountSelection = false,
   allowCrossModeCompletion = false,
@@ -26,7 +28,7 @@ export function GoogleOAuthButton({
   const { isLoaded: isSignUpLoaded, signUp } = useSignUp();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
-  const isLoaded = mode === 'sign-up' ? isSignUpLoaded : isSignInLoaded;
+  const isLoaded = oauthMode === 'sign-up' ? isSignUpLoaded : isSignInLoaded;
   const isDisabled = !isLoaded || isRedirecting;
   const shouldForceAccountSelection = forceAccountSelection || mode === 'sign-up';
 
@@ -58,7 +60,7 @@ export function GoogleOAuthButton({
     setIsRedirecting(true);
 
     try {
-      if (mode === 'sign-up') {
+      if (oauthMode === 'sign-up') {
         if (!signUp) {
           throw new Error('Clerk sign-up resource is not ready');
         }
@@ -87,7 +89,7 @@ export function GoogleOAuthButton({
       console.error('[auth] Google OAuth redirect failed', error);
       setIsRedirecting(false);
     }
-  }, [allowCrossModeCompletion, isLoaded, isRedirecting, mode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
+  }, [allowCrossModeCompletion, isLoaded, isRedirecting, mode, oauthMode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
 
   return (
     <button

--- a/apps/web/src/pages/MobileBrowserAuth.tsx
+++ b/apps/web/src/pages/MobileBrowserAuth.tsx
@@ -187,7 +187,7 @@ export default function MobileBrowserAuthPage() {
   const clerk = useClerk();
   const { session } = useSession();
   const { isLoaded: signInLoaded, signIn } = useSignIn();
-  const { isLoaded: signUpLoaded, signUp } = useSignUp();
+  const { signUp } = useSignUp();
   const { user } = useUser();
   const [error, setError] = useState<string | null>(null);
   const [isResettingBrowserSession, setIsResettingBrowserSession] = useState(false);
@@ -375,14 +375,17 @@ export default function MobileBrowserAuthPage() {
       return;
     }
 
-    const oauthMode = mode === 'sign-up' ? 'sign-up' : 'sign-in';
-    const resourceReady = oauthMode === 'sign-up' ? signUpLoaded && signUp : signInLoaded && signIn;
+    // Google OAuth uses Clerk's sign-in resource for both entry intents. Clerk
+    // creates a user when needed and reliably completes existing Google users
+    // through this resource. The URL still carries mode=sign-up, so the native
+    // callback goes to the V2 onboarding rather than the dashboard.
+    const resourceReady = signInLoaded && signIn;
     if (!isLoaded || !resourceReady) {
       return;
     }
 
     googleRedirectStartedRef.current = true;
-    const resource = oauthMode === 'sign-up' ? signUp : signIn;
+    const resource = signIn;
     void resource
       ?.authenticateWithRedirect({
         strategy: 'oauth_google',
@@ -417,7 +420,6 @@ export default function MobileBrowserAuthPage() {
     signIn,
     signInLoaded,
     signUp,
-    signUpLoaded,
     isResettingBrowserSession,
   ]);
 
@@ -664,6 +666,7 @@ export default function MobileBrowserAuthPage() {
             <GoogleOAuthButton
               language={language}
               mode={mode === 'sign-up' ? 'sign-up' : 'sign-in'}
+              oauthMode="sign-in"
               redirectUrlComplete={handoffUrl}
               forceAccountSelection
               allowCrossModeCompletion


### PR DESCRIPTION
## Root cause
`Crear cuenta` started Google OAuth through Clerk's `SignUp` resource. When the selected Google identity already existed, Clerk transitioned internally to sign-in and did not complete the native handoff consistently. The browser therefore remained on the web flow instead of invoking the app callback.

## Change
- Keep the native transaction as `mode=sign-up` with `redirect_path=/intro-journey2`.
- Start Google OAuth through Clerk's `SignIn` resource for the mobile auth page, matching the working native login path.
- Keep the visible label and native callback intent as **Crear cuenta**. Clerk social OAuth creates a user when no account exists and signs in when it does.

Expected result: after Google, the browser opens `innerbloom://localhost/callback`, closes, and `NativeMobileBridge` sends the app to `/intro-journey2`.

## Validation
- `pnpm --filter web build` passed.
- No iOS/Xcode, Android, dependency, or web-login changes.