### PR TITLE
Refresh onboarding2 foundations flow

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2269,6 +2269,170 @@
     outline: none;
   }
 
+  .onboarding2-premium-root { background: #080910; }
+  .onboarding2-premium-root .onboarding-flow-panel { background: transparent; }
+  .onboarding2-premium-root .quickstart-premium-root { background: #080910; }
+
+  .onboarding2-premium-root .onboarding-rhythm-selector__header {
+    padding-top: 1.5rem;
+    text-align: center;
+  }
+
+  .onboarding2-premium-root .onboarding-rhythm-selector__header p {
+    color: var(--ib-onboarding-violet);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+  }
+
+  .onboarding2-premium-root .onboarding-rhythm-selector__header h2 {
+    margin-top: 0.85rem;
+    color: var(--ib-onboarding-text);
+    font-size: 1.65rem;
+    font-weight: 650;
+    line-height: 1.15;
+  }
+
+  .onboarding2-premium-root .onboarding-rhythm-selector__header span {
+    display: block;
+    margin-top: 1rem;
+    color: var(--ib-onboarding-text-secondary);
+    font-size: 0.9rem;
+    font-weight: 650;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+  }
+
+  .onboarding2-premium-root .onboarding-rhythm-card--segments {
+    display: grid !important;
+    min-height: 6.35rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
+    gap: 0.8rem 1rem;
+    border: 1px solid color-mix(in srgb, var(--ib-onboarding-violet) 20%, var(--ib-onboarding-border)) !important;
+    border-radius: 1.4rem !important;
+    background: rgba(255, 255, 255, 0.025) !important;
+    padding: 1rem !important;
+    text-align: left;
+  }
+
+  .onboarding2-premium-root .onboarding-rhythm-card--segments.onboarding-rhythm-card--selected {
+    border-color: color-mix(in srgb, var(--ib-onboarding-violet) 50%, var(--ib-onboarding-border)) !important;
+    background: rgba(255, 255, 255, 0.04) !important;
+    box-shadow: inset 3px 0 0 color-mix(in srgb, var(--ib-onboarding-violet) 68%, transparent) !important;
+  }
+
+  .onboarding2-premium-root .onboarding-rhythm-card__copy h3 {
+    color: var(--ib-onboarding-text);
+    font-size: 1.2rem;
+    font-weight: 750;
+    letter-spacing: 0.13em;
+    line-height: 1;
+  }
+
+  .onboarding2-premium-root .onboarding-rhythm-card__copy small,
+  .onboarding2-premium-root .onboarding-rhythm-card__days small {
+    display: block;
+    margin-top: 0.45rem;
+    color: var(--ib-onboarding-text-muted);
+    font-size: 0.78rem;
+    line-height: 1.1;
+  }
+
+  .onboarding2-premium-root .onboarding-rhythm-card__days { text-align: right; }
+  .onboarding2-premium-root .onboarding-rhythm-card__days strong { color: var(--ib-onboarding-text); font-size: 1.9rem; font-weight: 760; line-height: 0.8; }
+  .onboarding2-premium-root .onboarding-rhythm-card__days small { font-size: 0.74rem; }
+  .onboarding2-premium-root .onboarding-rhythm-segments { display: grid; grid-column: 1 / -1; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.5rem; width: 100%; }
+  .onboarding2-premium-root .onboarding-rhythm-segments i { height: 0.42rem; border-radius: 999px; background: rgba(255,255,255,0.14); }
+  .onboarding2-premium-root .onboarding-rhythm-segments i[data-active="true"] { background: linear-gradient(90deg, #8f5bf2, #bc80e8); }
+
+  .onboarding2-premium-root .quickstart-foundations-header {
+    border-top: 1px solid var(--ib-onboarding-border);
+    padding-top: 1.35rem;
+  }
+
+  .onboarding2-premium-root .quickstart-foundations-header > p {
+    color: var(--ib-onboarding-violet);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+  }
+
+  .onboarding2-premium-root .quickstart-foundations-header h1 {
+    margin-top: 0.6rem;
+    color: var(--ib-onboarding-text);
+    font-size: 1.78rem;
+    font-weight: 650;
+    line-height: 1.08;
+  }
+
+  .onboarding2-premium-root .quickstart-foundations-header > span {
+    display: block;
+    margin-top: 0.7rem;
+    color: var(--ib-onboarding-text-secondary);
+    font-size: 0.96rem;
+    line-height: 1.45;
+  }
+
+  .onboarding2-premium-root .quickstart-pillar-status {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.15rem;
+    margin-top: 1.3rem;
+    padding: 0.2rem;
+    border: 1px solid var(--ib-onboarding-border);
+    border-radius: 0.8rem;
+    background: rgba(255,255,255,0.025);
+  }
+
+  .onboarding2-premium-root .quickstart-pillar-status span {
+    min-width: 0;
+    padding: 0.66rem 0.3rem;
+    border-radius: 0.6rem;
+    color: var(--ib-onboarding-text-muted);
+    font-size: 0.69rem;
+    font-weight: 700;
+    text-align: center;
+  }
+
+  .onboarding2-premium-root .quickstart-pillar-status span[data-current="true"] { background: color-mix(in srgb, var(--ib-onboarding-violet) 24%, transparent); color: #dfccff; }
+  .onboarding2-premium-root .quickstart-pillar-status small { color: inherit; font-size: 0.63rem; }
+  .onboarding2-premium-root .quickstart-foundation-count { display:flex; justify-content:space-between; gap:1rem; margin-top:1.25rem; color:var(--ib-onboarding-text-secondary); font-size:0.76rem; font-weight:650; }
+  .onboarding2-premium-root .quickstart-foundation-count strong { color:#c9adff; font-size:1.28rem; line-height:0.8; }
+  .onboarding2-premium-root .quickstart-foundation-count span:last-child { color:#dfc5ef; }
+  .onboarding2-premium-root .quickstart-foundation-progress { height:0.34rem; margin-top:0.55rem; overflow:hidden; border-radius:999px; background:rgba(255,255,255,0.09); }
+  .onboarding2-premium-root .quickstart-foundation-progress span { display:block; height:100%; border-radius:inherit; background:linear-gradient(90deg,#8f5bf2,#c685e8 55%,#efaa91); transition:width 200ms ease; }
+
+  .onboarding2-premium-root .quickstart-task-row--foundation {
+    min-height: 6.8rem;
+    border: 1px solid var(--ib-onboarding-border);
+    border-radius: 1.45rem;
+    background: rgba(255,255,255,0.025);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.035);
+  }
+
+  .onboarding2-premium-root .quickstart-task-row--foundation.quickstart-task-row--selected {
+    border-color: color-mix(in srgb, var(--ib-onboarding-violet) 62%, var(--ib-onboarding-border));
+    background: linear-gradient(90deg, rgba(105,74,165,0.31), rgba(255,255,255,0.025) 72%);
+    box-shadow: inset 3px 0 0 var(--ib-onboarding-violet);
+  }
+
+  .onboarding2-premium-root .quickstart-task-title { color: var(--ib-onboarding-text); font-size: 1rem; line-height: 1.28; }
+  .onboarding2-premium-root .quickstart-task-row--foundation .quickstart-selected-trait { margin-top:0.5rem; color: var(--ib-onboarding-text-muted); text-shadow:none; }
+  .onboarding2-premium-root .quickstart-task-row--foundation.quickstart-task-row--selected .quickstart-selected-trait { color:#c9adff; }
+  .onboarding2-premium-root .quickstart-task-resolved { margin-top:0.38rem; overflow:hidden; color:var(--ib-onboarding-text-secondary); font-size:0.69rem; line-height:1.15; text-overflow:ellipsis; white-space:nowrap; }
+  .onboarding2-premium-root .quickstart-quantity { display:grid; min-width:3.75rem; grid-template-columns:2.45rem 0.88rem; column-gap:0.18rem; justify-items:end; color:var(--ib-onboarding-text-muted); cursor:text; }
+  .onboarding2-premium-root .quickstart-quantity > span { display:flex; grid-column:1 / -1; align-items:center; gap:0.18rem; }
+  .onboarding2-premium-root .quickstart-quantity input { width:2.45rem; margin:0; border:0; border-bottom:1px solid rgba(255,255,255,0.18); background:transparent; color:inherit; font-size:1.65rem; font-weight:760; line-height:1; text-align:center; outline:0; }
+  .onboarding2-premium-root .quickstart-quantity small { grid-column:1; justify-self:center; margin-top:0.35rem; color:inherit; font-size:0.56rem; font-weight:700; letter-spacing:0.14em; line-height:1; text-transform:uppercase; }
+  .onboarding2-premium-root .quickstart-quantity svg { color:#ab8dea; }
+  .onboarding2-premium-root .quickstart-quantity--selected { color:var(--ib-onboarding-text); }
+  .onboarding2-premium-root .quickstart-quantity--selected input { border-bottom-color:#bda0f8; }
+  .onboarding2-premium-root .quickstart-quantity input:disabled { opacity:0.45; }
+  .onboarding2-premium-root .quickstart-quantity input::-webkit-outer-spin-button, .onboarding2-premium-root .quickstart-quantity input::-webkit-inner-spin-button { margin:0; -webkit-appearance:none; }
+
   :root[data-theme="light"] .quickstart-task-row {
     box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
   }

--- a/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
+++ b/apps/web/src/onboarding/IntegratedQuickStartFlow.tsx
@@ -715,6 +715,7 @@ function ControlledQuickStartFlow({
   onFinish,
   onExit,
   onRestart,
+  variant = 'default',
 }: {
   language: OnboardingLanguage;
   gameMode: GameMode;
@@ -732,6 +733,7 @@ function ControlledQuickStartFlow({
   onFinish: () => void;
   onExit: () => void;
   onRestart: () => void;
+  variant: 'default' | 'onboarding2';
 }) {
   const quickStartGp = computeQuickStartGp(selectedTasksByPillar);
   const route = [
@@ -749,9 +751,11 @@ function ControlledQuickStartFlow({
       tasks={QUICK_START_TASKS[language][pillar]}
       selectedIds={selectedTasksByPillar[pillar]}
       inputValues={editableTaskValues}
-      minimum={QUICK_START_MINIMUMS[gameMode]}
+      minimum={variant === 'onboarding2' ? 3 : QUICK_START_MINIMUMS[gameMode]}
       gameMode={gameMode}
       balancedBonusActive={quickStartGp.balancedBonusActive}
+      selectedTasksByPillar={selectedTasksByPillar}
+      variant={variant}
       onToggleTask={(taskId) => onToggleTask(pillar, taskId)}
       onInputChange={(taskId, value) => onTaskInputChange(`${pillar}-${taskId}`, value)}
       onBack={onBack}
@@ -760,7 +764,7 @@ function ControlledQuickStartFlow({
   );
 
   return (
-    <div className="quickstart-premium-root onboarding-premium-root min-h-screen min-h-dvh pb-12 pt-28 text-white sm:pt-32">
+    <div className={`quickstart-premium-root onboarding-premium-root ${variant === 'onboarding2' ? 'onboarding2-premium-root' : ''} min-h-screen min-h-dvh pb-12 pt-28 text-white sm:pt-32`}>
       <HUD
         language={language}
         mode={gameMode}
@@ -821,6 +825,7 @@ export function IntegratedQuickStartFlow({
   onBack,
   onConfirm,
   onFinish,
+  variant = 'default',
 }: IntegratedQuickStartFlowProps) {
   if (routeStepId) {
     return (
@@ -841,6 +846,7 @@ export function IntegratedQuickStartFlow({
         onFinish={onFinish ?? onConfirm ?? (() => undefined)}
         onExit={onExit}
         onRestart={onRestart}
+        variant={variant}
       />
     );
   }

--- a/apps/web/src/onboarding/IntroJourney.tsx
+++ b/apps/web/src/onboarding/IntroJourney.tsx
@@ -30,6 +30,7 @@ interface IntroJourneyProps {
   isSubmitting?: boolean;
   submitError?: string | null;
   skipAuthGateForDev?: boolean;
+  variant?: 'default' | 'onboarding2';
 }
 
 const OPEN_TEXT_FIELDS: Partial<Record<StepId, 'bodyOpen' | 'soulOpen' | 'mindOpen'>> = {
@@ -49,6 +50,7 @@ export function IntroJourney({
   isSubmitting = false,
   submitError = null,
   skipAuthGateForDev = false,
+  variant = 'default',
 }: IntroJourneyProps) {
   const {
     state,
@@ -336,6 +338,7 @@ export function IntroJourney({
               goNext();
             }}
             onBack={() => goToStep('clerk-gate')}
+            variant={variant}
           />
         );
       case 'structure-intro':
@@ -647,6 +650,7 @@ export function IntroJourney({
             onBackToPathSelect={() => goToStep('structure-intro')}
             onExit={handleExit}
             onRestart={handleRestart}
+            variant={variant}
           />
         </div>
         {isGpExplainerOpen ? <GpExplainerOverlay language={language} onClose={handleCloseGpExplainer} /> : null}
@@ -655,7 +659,7 @@ export function IntroJourney({
   }
 
   return (
-    <div className="onboarding-premium-root relative flex min-h-screen min-h-dvh flex-col overflow-x-hidden pb-16">
+    <div className={`onboarding-premium-root ${variant === 'onboarding2' ? 'onboarding2-premium-root' : ''} relative flex min-h-screen min-h-dvh flex-col overflow-x-hidden pb-16`}>
       <HUD
         language={language}
         mode={answers.mode}

--- a/apps/web/src/onboarding/__tests__/payload.test.ts
+++ b/apps/web/src/onboarding/__tests__/payload.test.ts
@@ -77,7 +77,7 @@ describe('buildPayload onboarding_path', () => {
     expect(payload.data.foundations.body).toContain('MODERACION');
     expect(payload.data.quick_start?.manual_task_candidates).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        task: 'Caminar durante',
+        task: 'Caminar durante 20 minutos',
         pillar_code: 'BODY',
         trait_code: 'ENERGIA',
         input_value: '20',
@@ -148,7 +148,7 @@ describe('buildPayload onboarding_path', () => {
     expect(traitCodes).not.toContain('POSTURE');
     expect(traitCodes).not.toContain('GRATITUDE');
     expect(payload.data.quick_start?.manual_task_candidates[0]).toEqual(expect.objectContaining({
-      task: 'Sleep at least',
+      task: 'Sleep at least 7 hours per night',
       trait_code: 'SUENO',
       input_value: '7',
     }));

--- a/apps/web/src/onboarding/quickStart.ts
+++ b/apps/web/src/onboarding/quickStart.ts
@@ -230,6 +230,15 @@ export interface QuickStartManualTaskCandidate {
   };
 }
 
+export function formatQuickStartTask(task: QuickStartTask, inputValue?: string): string {
+  const value = inputValue?.trim();
+  if (!value) {
+    return task.text;
+  }
+
+  return [task.inputBefore, task.text, value, task.inputAfter].filter(Boolean).join(' ');
+}
+
 export const QUICK_START_MODE_SOFT_STYLES: Record<GameMode, { tint: string; border: string; glow: string }> = {
   LOW: { tint: ONBOARDING_RHYTHM_THEME.LOW.softTint, border: ONBOARDING_RHYTHM_THEME.LOW.border, glow: ONBOARDING_RHYTHM_THEME.LOW.glow },
   CHILL: { tint: ONBOARDING_RHYTHM_THEME.CHILL.softTint, border: ONBOARDING_RHYTHM_THEME.CHILL.border, glow: ONBOARDING_RHYTHM_THEME.CHILL.glow },
@@ -252,7 +261,7 @@ export function buildQuickStartManualCandidates(args: {
 
       const inputValue = args.editableTaskValues[`${pillar}-${taskId}`]?.trim();
       return [{
-        task: task.text,
+        task: formatQuickStartTask(task, inputValue),
         pillar_code: pillar.toUpperCase(),
         trait_code: task.id.toUpperCase(),
         input_value: inputValue || undefined,

--- a/apps/web/src/onboarding/steps/GameModeStep.tsx
+++ b/apps/web/src/onboarding/steps/GameModeStep.tsx
@@ -1,15 +1,14 @@
 import { motion } from 'framer-motion';
-import { useId } from 'react';
 import type { GameMode } from '../state';
 import type { OnboardingLanguage } from '../constants';
 import { GAME_MODE_META } from '../../lib/gameModeMeta';
-import { useThemePreference } from '../../theme/ThemePreferenceProvider';
 
 interface GameModeStepProps {
   language?: OnboardingLanguage;
   selected: GameMode | null;
   onSelect: (mode: GameMode) => void;
   onBack?: () => void;
+  variant?: 'default' | 'onboarding2';
 }
 
 export const MODE_CARD_CONTENT = {
@@ -21,107 +20,40 @@ export const MODE_CARD_CONTENT = {
 
 const MODE_ORDER: GameMode[] = ['LOW', 'CHILL', 'FLOW', 'EVOLVE'];
 
-const RHYTHM_WAVE_CONFIG: Record<GameMode, { oscillations: number; amplitude: number; activeRatio: number }> = {
-  LOW: { oscillations: 2, amplitude: 18, activeRatio: 0.25 },
-  CHILL: { oscillations: 2.25, amplitude: 20, activeRatio: 0.37 },
-  FLOW: { oscillations: 2.75, amplitude: 22, activeRatio: 0.52 },
-  EVOLVE: { oscillations: 3.25, amplitude: 24, activeRatio: 0.62 },
-};
-
-const SVG_WIDTH = 320;
-const SVG_HEIGHT = 88;
-const WAVE_START_X = 18;
-const WAVE_END_X = 302;
-const WAVE_CENTER_Y = 44;
-const WAVE_PHASE = -0.34;
-
-function buildSinePath(mode: GameMode, phase = WAVE_PHASE) {
-  const config = RHYTHM_WAVE_CONFIG[mode];
-  const points = Array.from({ length: 116 }, (_, index) => {
-    const progress = index / 115;
-    const x = WAVE_START_X + (WAVE_END_X - WAVE_START_X) * progress;
-    const y = WAVE_CENTER_Y + Math.sin(progress * config.oscillations * Math.PI * 2 + phase) * config.amplitude;
-    return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`;
-  });
-
-  return points.join(' ');
+function RhythmSegments({ intensity }: { intensity: number }) {
+  return <span className="onboarding-rhythm-segments" aria-hidden>{[1, 2, 3, 4].map((segment) => <i key={segment} data-active={segment <= intensity} />)}</span>;
 }
 
-function buildAnimatedSinePathValues(mode: GameMode) {
-  return [WAVE_PHASE, WAVE_PHASE + 0.3, WAVE_PHASE + 0.62, WAVE_PHASE]
-    .map((phase) => buildSinePath(mode, phase))
-    .join('; ');
-}
-
-function RhythmWave({ mode, active }: { mode: GameMode; active: boolean }) {
-  const rawId = useId().replace(/:/g, '');
-  const gradientId = `onboarding-rhythm-wave-gradient-${rawId}`;
-  const clipId = `onboarding-rhythm-wave-clip-${rawId}`;
-  const path = buildSinePath(mode);
-  const animatedPathValues = buildAnimatedSinePathValues(mode);
-  const activeWidth = WAVE_START_X + (WAVE_END_X - WAVE_START_X) * RHYTHM_WAVE_CONFIG[mode].activeRatio;
-  const animationDuration = active ? '7.6s' : `${8.8 + RHYTHM_WAVE_CONFIG[mode].activeRatio * 2}s`;
-
-  return (
-    <div className="relative h-[3.35rem] w-full min-w-[8.25rem] overflow-visible sm:h-16" role="img" aria-label={`${mode} weekly rhythm wave`}>
-      <svg className="absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`} preserveAspectRatio="none" aria-hidden="true">
-        <defs>
-          <linearGradient id={gradientId} x1="0" x2="1" y1="0" y2="0">
-            <stop offset="0%" stopColor="#8B5CF6" />
-            <stop offset="50%" stopColor="#D977FF" />
-            <stop offset="100%" stopColor="#FF86C8" />
-          </linearGradient>
-          <clipPath id={clipId}>
-            <rect x="0" y="0" width={activeWidth} height={SVG_HEIGHT} />
-          </clipPath>
-        </defs>
-        <path d={path} fill="none" stroke="rgba(125,128,159,0.34)" strokeLinecap="round" strokeLinejoin="round" strokeWidth={active ? 5.8 : 5.2}>
-          <animate attributeName="d" dur={animationDuration} repeatCount="indefinite" values={animatedPathValues} />
-        </path>
-        <path d={path} fill="none" stroke={`url(#${gradientId})`} strokeLinecap="round" strokeLinejoin="round" strokeWidth={active ? 14 : 10} opacity={active ? 0.5 : 0.22} clipPath={`url(#${clipId})`} filter="blur(4px)">
-          <animate attributeName="d" dur={animationDuration} repeatCount="indefinite" values={animatedPathValues} />
-        </path>
-        <path d={path} fill="none" stroke={`url(#${gradientId})`} strokeLinecap="round" strokeLinejoin="round" strokeWidth={active ? 6.8 : 5.8} opacity={active ? 0.98 : 0.86} clipPath={`url(#${clipId})`}>
-          <animate attributeName="d" dur={animationDuration} repeatCount="indefinite" values={animatedPathValues} />
-        </path>
-      </svg>
-    </div>
-  );
-}
-
-export function GameModeStep({ language = 'es', selected, onSelect, onBack }: GameModeStepProps) {
-  const { theme } = useThemePreference();
-  const isLight = theme === 'light';
+export function GameModeStep({ language = 'es', selected, onSelect, onBack, variant = 'default' }: GameModeStepProps) {
   const copy = language === 'en'
     ? {
-        step: 'Step 1 · Choose your rhythm',
-        title: 'What is your rhythm today?',
-        subtitle: 'Choose the weekly intensity that best adapts to you.',
-        selected: 'Selected',
+        step: 'Step 1',
+        title: 'Start possible, not perfect.',
+        subtitle: 'Choose your rhythm.',
         back: 'Back',
         selectedSuffix: ' selected',
       }
     : {
-        step: 'Paso 1 · Elegí tu ritmo',
-        title: '¿Cuál es tu ritmo hoy?',
-        subtitle: 'Elegí la intensidad semanal que mejor se adapta a vos.',
-        selected: 'Seleccionado',
+        step: 'Paso 1',
+        title: 'Empezá posible, no perfecto.',
+        subtitle: 'Elegí tu ritmo.',
         back: 'Volver',
         selectedSuffix: ' seleccionado',
       };
 
   return (
     <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2 }}>
-      <div className="onboarding-flow-panel mx-auto max-w-4xl p-4 sm:p-6">
-        <header className="flex flex-col gap-2">
-          <p className="text-xs uppercase tracking-[0.2em] text-white/50">{copy.step}</p>
-          <h2 className="text-3xl font-semibold text-white">{copy.title}</h2>
-          <p className="text-sm text-white/70">{copy.subtitle}</p>
+      <div className={`onboarding-flow-panel ${variant === 'onboarding2' ? 'onboarding-rhythm-selector' : ''} mx-auto max-w-4xl p-4 sm:p-6`}>
+        <header className="onboarding-rhythm-selector__header">
+          <p>{copy.step}</p>
+          <h2>{copy.title}</h2>
+          <span>{copy.subtitle}</span>
         </header>
         <div className="mt-7 space-y-3 md:space-y-4" role="group" aria-label={copy.title}>
           {MODE_ORDER.map((mode) => {
             const content = MODE_CARD_CONTENT[mode];
             const isActive = selected === mode;
+            const intensity = MODE_ORDER.indexOf(mode) + 1;
 
             return (
               <motion.button
@@ -133,27 +65,17 @@ export function GameModeStep({ language = 'es', selected, onSelect, onBack }: Ga
                 aria-label={`${content.title} · ${content.frequency[language]}${isActive ? copy.selectedSuffix : ''}`}
                 data-selected={isActive ? 'true' : 'false'}
                 className={[
-                  'onboarding-rhythm-card group relative grid min-h-[4.75rem] w-full grid-cols-[4.25rem_minmax(0,1fr)_4.9rem] items-center gap-2 overflow-hidden rounded-[1.45rem] border px-3 py-2 text-left transition-all duration-300 ease-out focus-visible:outline-none sm:grid-cols-[5.5rem_minmax(0,1fr)_6.6rem] sm:gap-4 sm:px-5 md:min-h-[6.05rem] md:grid-cols-[7rem_minmax(0,1fr)_7.5rem] md:rounded-[1.8rem] md:px-6',
-                  isLight
-                    ? isActive
-                      ? 'border-[#8b5cf6]/70 bg-[linear-gradient(135deg,rgba(255,255,255,0.96),rgba(245,240,255,0.88))] shadow-[0_18px_42px_rgba(139,92,246,0.16)]'
-                      : 'border-slate-200/90 bg-[linear-gradient(135deg,rgba(255,255,255,0.94),rgba(248,250,252,0.82))] shadow-[0_10px_24px_rgba(15,23,42,0.06)] hover:border-[#c4b5fd] hover:bg-white'
-                    : isActive
-                      ? 'border-[#b66cff]/80 bg-[linear-gradient(135deg,rgba(33,25,62,0.72),rgba(14,14,30,0.74))] shadow-[inset_0_0_32px_rgba(169,85,247,0.13),0_20px_56px_rgba(87,50,156,0.22)]'
-                      : 'border-white/10 bg-[linear-gradient(135deg,rgba(255,255,255,0.055),rgba(10,12,27,0.48))] shadow-[inset_0_1px_0_rgba(255,255,255,0.055)] hover:border-white/18 hover:bg-[linear-gradient(135deg,rgba(255,255,255,0.08),rgba(10,12,27,0.56))]',
+                  'onboarding-rhythm-card',
+                  variant === 'onboarding2' ? 'onboarding-rhythm-card--segments' : 'relative grid min-h-[4.75rem] w-full grid-cols-[4.25rem_minmax(0,1fr)_4.9rem] items-center gap-2 overflow-hidden rounded-[1.45rem] border px-3 py-2 text-left transition-all duration-300 ease-out sm:grid-cols-[5.5rem_minmax(0,1fr)_6.6rem] sm:gap-4 sm:px-5',
+                  isActive && variant === 'onboarding2' ? 'onboarding-rhythm-card--selected' : '',
                 ]
                   .filter(Boolean)
                   .join(' ')}
               >
-                <h3 className="relative z-10 min-w-0 text-[1rem] font-semibold text-white/94 sm:text-[1.2rem] md:text-[1.58rem]">
+                <span className="onboarding-rhythm-card__copy"><h3>
                   {content.title.replace(' MOOD', '').replace(' Mood', '')}
-                </h3>
-                <div className="relative z-10 min-w-0">
-                  <RhythmWave mode={mode} active={isActive} />
-                </div>
-                <div className="relative z-10 justify-self-end text-right text-[0.78rem] font-semibold text-white/88 sm:text-sm md:text-base">
-                  {content.frequency[language]}
-                </div>
+                </h3><small>{variant === 'onboarding2' ? content.state[language] : content.frequency[language]}</small></span>
+                {variant === 'onboarding2' ? <><span className="onboarding-rhythm-card__days"><strong>{intensity}</strong><small>{language === 'en' ? 'days/week' : 'días/semana'}</small></span><RhythmSegments intensity={intensity} /></> : null}
               </motion.button>
             );
           })}

--- a/apps/web/src/onboarding/steps/QuickStartTasksStep.tsx
+++ b/apps/web/src/onboarding/steps/QuickStartTasksStep.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
+import { Pencil } from 'lucide-react';
 import type { OnboardingLanguage } from '../constants';
 import { NavButtons } from '../ui/NavButtons';
 import type { GameMode, Pillar } from '../state';
-import { getQuickStartSuggestedRule, type QuickStartTask } from '../quickStart';
+import { formatQuickStartTask, type QuickStartTask } from '../quickStart';
 import { TraitIcon } from '../../pages/labs/mobile-premium/MobilePremiumPrimitives';
 
 interface QuickStartTasksStepProps {
@@ -15,6 +16,8 @@ interface QuickStartTasksStepProps {
   minimum: number;
   gameMode: GameMode;
   balancedBonusActive: boolean;
+  selectedTasksByPillar?: Record<Pillar, string[]>;
+  variant?: 'default' | 'onboarding2';
   onToggleTask: (taskId: string) => void;
   onInputChange: (taskId: string, value: string) => void;
   onBack: () => void;
@@ -41,6 +44,7 @@ function InlineTaskRow({
   };
 }) {
   const hasInput = Boolean(task.inputAfter || task.inputBefore);
+  const unit = task.inputAfter?.startsWith('minut') ? 'min' : task.inputAfter?.startsWith('hour') || task.inputAfter?.startsWith('hora') ? 'hrs' : task.inputAfter?.startsWith('meal') || task.inputAfter?.startsWith('comida') ? 'meals' : task.inputAfter?.startsWith('glass') || task.inputAfter?.startsWith('vaso') ? 'glasses' : task.inputAfter?.startsWith('person') || task.inputAfter?.startsWith('persona') ? 'people' : task.inputAfter?.startsWith('thing') || task.inputAfter?.startsWith('cosa') ? 'things' : '';
   const [showSuggestions, setShowSuggestions] = useState(false);
   const rowRef = useRef<HTMLDivElement | null>(null);
 
@@ -73,7 +77,7 @@ function InlineTaskRow({
         role="button"
         tabIndex={0}
         data-selected={selected ? 'true' : undefined}
-        className={`quickstart-task-row onboarding-surface-inner relative z-10 grid w-full grid-cols-[38px_minmax(0,1fr)_auto] items-center gap-3 rounded-[1.15rem] px-3 py-3.5 text-left text-white/85 transition ${selected ? 'quickstart-task-row--selected' : ''}`}
+        className={`quickstart-task-row quickstart-task-row--foundation relative z-10 grid w-full grid-cols-[42px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-4 text-left text-white/85 transition ${selected ? 'quickstart-task-row--selected' : ''}`}
       >
         <span className="quickstart-task-icon grid h-9 w-9 place-items-center rounded-full border">
           {selected ? (
@@ -84,32 +88,17 @@ function InlineTaskRow({
         </span>
 
         <div className="min-w-0">
-          <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1.5 text-[0.98rem] leading-6 text-white/90">
-            {task.inputBefore ? <span>{task.inputBefore}</span> : null}
-            <span>{task.text}</span>
-            {hasInput ? (
-              <input
-                value={inputValue}
-                disabled={!selected}
-                inputMode="numeric"
-                onClick={(event) => event.stopPropagation()}
-                onChange={(event) => onInputChange(event.target.value)}
-                className="quickstart-task-input h-6 w-12 rounded-md border px-1.5 text-center text-xs focus:outline-none focus-visible:ring-2 disabled:opacity-40 sm:h-7 sm:w-14"
-                placeholder={copy.countPlaceholder}
-              />
-            ) : null}
-            {task.inputAfter ? <span>{task.inputAfter}</span> : null}
-            {task.helper ? <span className="w-full text-xs text-white/55">{task.helper}</span> : null}
-          </div>
-          {selected ? (
-            <p className="quickstart-selected-trait mt-2 text-[0.66rem] font-semibold uppercase tracking-[0.2em]">
-              <span className="mr-1.5 text-white/38">{copy.traitLabel}</span>
-              {task.trait}
-            </p>
-          ) : null}
+          <p className="quickstart-task-title">{task.inputBefore ? `${task.inputBefore} ${task.text}` : task.text}</p>
+          <p className="quickstart-selected-trait mt-2 text-[0.66rem] font-semibold uppercase tracking-[0.2em]">{copy.traitLabel} {task.trait}</p>
+          {selected && hasInput ? <p className="quickstart-task-resolved">{formatQuickStartTask(task, inputValue)}</p> : null}
         </div>
 
-        {task.suggestions?.length ? (
+        {hasInput ? (
+          <label className={`quickstart-quantity ${selected ? 'quickstart-quantity--selected' : ''}`} onClick={(event) => event.stopPropagation()}>
+            <span><input value={inputValue} disabled={!selected} inputMode="numeric" onChange={(event) => onInputChange(event.target.value)} placeholder={copy.countPlaceholder} aria-label={`${copy.countPlaceholder} ${unit}`} /><Pencil size={14} aria-hidden /></span>
+            {unit ? <small>{unit}</small> : null}
+          </label>
+        ) : task.suggestions?.length ? (
             <button
               type="button"
               onClick={(event) => {
@@ -153,6 +142,8 @@ export function QuickStartTasksStep({
   minimum,
   gameMode,
   balancedBonusActive,
+  selectedTasksByPillar,
+  variant = 'default',
   onToggleTask,
   onInputChange,
   onBack,
@@ -160,16 +151,10 @@ export function QuickStartTasksStep({
 }: QuickStartTasksStepProps) {
   const copy = language === 'en'
     ? {
-        title: `Quick Start · ${pillar === 'Body' ? 'Body 🫀' : pillar === 'Mind' ? 'Mind 🧠' : 'Soul 🏵️'}`,
-        subtitle: pillar === 'Body'
-          ? 'Review all 10 tasks and activate what you want to sustain.'
-          : pillar === 'Mind'
-            ? 'Tune your mental focus while keeping the current onboarding feel.'
-            : 'Choose habits that support connection and inner alignment.',
-        minRule: `Minimum: ${minimum} tasks`,
-        suggestedRule: getQuickStartSuggestedRule(gameMode, language),
-        minimumRequired: 'You need to select the minimum to continue.',
-        continue: 'Continue',
+        title: 'Build a rhythm you can keep.',
+        subtitle: 'Start with three foundations. You can always add more later.',
+        minimumRequired: 'Choose the minimum to unlock the next pillar.',
+        continue: pillar === 'Body' ? 'Continue to Mind' : pillar === 'Mind' ? 'Continue to Soul' : 'Review my foundations',
         inputRequired: 'Complete the selected quantities before continuing.',
         back: 'Back',
         countPlaceholder: 'qty',
@@ -179,16 +164,10 @@ export function QuickStartTasksStep({
         bonusPending: 'Balance Body, Mind and Soul to earn x1.5 GP',
       }
     : {
-        title: `Inicio rápido · ${pillar === 'Body' ? 'Cuerpo 🫀' : pillar === 'Mind' ? 'Mente 🧠' : 'Alma 🏵️'}`,
-        subtitle: pillar === 'Body'
-          ? 'Elegí 10 tareas visibles y activá las que querés sostener.'
-          : pillar === 'Mind'
-            ? 'Ajustá tu foco mental sin salir del ritmo del onboarding actual.'
-            : 'Definí hábitos que te ayuden a mantener centro y conexión.',
-        minRule: `Mínimo: ${minimum} tareas`,
-        suggestedRule: getQuickStartSuggestedRule(gameMode, language),
-        minimumRequired: 'Necesitás seleccionar el mínimo para continuar.',
-        continue: 'Continuar',
+        title: 'Construí un ritmo que puedas sostener.',
+        subtitle: 'Empezá con tres foundations. Después podés sumar más.',
+        minimumRequired: 'Elegí el mínimo para desbloquear el siguiente pilar.',
+        continue: pillar === 'Body' ? 'Continuar a Mente' : pillar === 'Mind' ? 'Continuar a Alma' : 'Revisar mis foundations',
         inputRequired: 'Completá las cantidades seleccionadas antes de continuar.',
         back: 'Volver',
         countPlaceholder: 'n',
@@ -207,28 +186,21 @@ export function QuickStartTasksStep({
   });
   const canContinue = selectedIds.length >= minimum && !hasMissingInput;
 
+  const pillarLabel = language === 'en' ? pillar : pillar === 'Body' ? 'Cuerpo' : pillar === 'Mind' ? 'Mente' : 'Alma';
+  const pillarLabels = language === 'en' ? { Body: 'Body', Mind: 'Mind', Soul: 'Soul' } : { Body: 'Cuerpo', Mind: 'Mente', Soul: 'Alma' };
+  const displayedSelections = selectedTasksByPillar ?? { Body: pillar === 'Body' ? selectedIds : [], Mind: pillar === 'Mind' ? selectedIds : [], Soul: pillar === 'Soul' ? selectedIds : [] };
+
   return (
-    <section className="onboarding-premium-root quickstart-premium-card onboarding-flow-panel mx-auto w-full max-w-3xl p-5 sm:p-7">
-      <header className="mb-6">
-        <p className="text-xs uppercase tracking-[0.25em] text-white/55">{gameMode} · Quick Start</p>
-        <h1 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">{copy.title}</h1>
-        <p className="mt-2 text-sm text-white/70">{copy.subtitle}</p>
-        <div
-          className="quickstart-min-rule mt-4 inline-flex max-w-full items-center gap-2 rounded-full border px-4 py-1.5 text-xs font-semibold"
-        >
-          <span className="whitespace-nowrap">{copy.minRule}</span>
-          <span className="quickstart-min-rule__dot" aria-hidden>·</span>
-          <span className="whitespace-nowrap">{copy.suggestedRule}</span>
+    <section className={`quickstart-premium-card onboarding-flow-panel ${variant === 'onboarding2' ? 'onboarding2-foundations' : ''} mx-auto w-full max-w-3xl p-5 sm:p-7`}>
+      <header className="quickstart-foundations-header mb-6">
+        <p>Step 2 · {pillarLabel}</p>
+        <h1>{copy.title}</h1>
+        <span>{copy.subtitle}</span>
+        <div className="quickstart-pillar-status" aria-label="Pillar progress">
+          {(['Body', 'Mind', 'Soul'] as Pillar[]).map((item) => <span key={item} data-current={item === pillar}>{pillarLabels[item]} <small>{displayedSelections[item].length}/{minimum}</small></span>)}
         </div>
-        <div className="mt-2.5 flex flex-wrap items-center gap-2 text-xs">
-          <span
-            className={`quickstart-bonus-pill inline-flex text-[0.68rem] font-medium sm:text-[0.72rem] ${
-              balancedBonusActive ? 'quickstart-bonus-pill--ready' : 'quickstart-bonus-pill--pending'
-            }`}
-          >
-            {balancedBonusActive ? copy.bonusReady : copy.bonusPending}
-          </span>
-        </div>
+        <div className="quickstart-foundation-count" aria-live="polite"><span><strong>{selectedIds.length}</strong> / {minimum} foundations</span><span>{selectedIds.length * 3} GP ready</span></div>
+        <div className="quickstart-foundation-progress" aria-hidden><span style={{ width: `${Math.min(100, (selectedIds.length / minimum) * 100)}%` }} /></div>
       </header>
 
       <div className="space-y-2.5">

--- a/apps/web/src/pages/OnboardingIntro.tsx
+++ b/apps/web/src/pages/OnboardingIntro.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { IntroJourney } from '../onboarding/IntroJourney';
 import { type JourneyPayload } from '../onboarding/payload';
 import { JourneyGeneratingScreen } from '../onboarding/screens/JourneyGeneratingScreen';
@@ -50,6 +50,8 @@ export default function OnboardingIntroPage({
   quickStartPreviewDashboardPath = '/labs/mobile-premium/dashboard?onboardingPreview=1',
 }: OnboardingIntroPageProps = {}) {
   const navigate = useNavigate();
+  const location = useLocation();
+  const variant = location.pathname === '/onboarding2' || location.pathname === '/intro-journey2' ? 'onboarding2' : 'default';
   const language = typeof window !== 'undefined' ? resolveOnboardingLanguage(window.location.search) : 'es';
   const devQuickStartPreview =
     import.meta.env.DEV
@@ -202,6 +204,7 @@ export default function OnboardingIntroPage({
         isSubmitting={isSubmitting}
         submitError={submitError}
         skipAuthGateForDev={devQuickStartPreview}
+        variant={variant}
       />
     </OnboardingProvider>
   );


### PR DESCRIPTION
## Cambios
- Incorpora el selector de ritmo con segmentos horizontales en `/onboarding2` y `/intro-journey2`.
- Rediseña la selección de foundations: cantidades editables con lápiz y unidad, progreso por pilar y CTA contextual.
- Exige tres foundations por pilar únicamente en onboarding2.
- Persiste las tareas cuantificadas con su valor resuelto, por ejemplo `Caminar durante 20 minutos`.
- El fondo de onboarding2 queda sólido, sin halo violeta.

## Alcance
La variante se determina solo para `/onboarding2` y `/intro-journey2`; `/onboarding` conserva su flujo y reglas actuales.

## Validación
- `npm run build`
- `npm test -- --run src/onboarding/__tests__/payload.test.ts`

El typecheck global conserva errores preexistentes fuera de esta PR.