### PR TITLE
fix web google oauth onboarding redirect

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -7,6 +7,7 @@ type GoogleOAuthButtonProps = {
   language: 'es' | 'en';
   mode: GoogleOAuthMode;
   redirectUrlComplete: string;
+  oauthMode?: GoogleOAuthMode;
   className?: string;
   forceAccountSelection?: boolean;
   allowCrossModeCompletion?: boolean;
@@ -18,6 +19,7 @@ export function GoogleOAuthButton({
   language,
   mode,
   redirectUrlComplete,
+  oauthMode = mode,
   className = '',
   forceAccountSelection = false,
   allowCrossModeCompletion = false,
@@ -26,7 +28,7 @@ export function GoogleOAuthButton({
   const { isLoaded: isSignUpLoaded, signUp } = useSignUp();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
-  const isLoaded = mode === 'sign-up' ? isSignUpLoaded : isSignInLoaded;
+  const isLoaded = oauthMode === 'sign-up' ? isSignUpLoaded : isSignInLoaded;
   const isDisabled = !isLoaded || isRedirecting;
   const shouldForceAccountSelection = forceAccountSelection || mode === 'sign-up';
 
@@ -58,7 +60,7 @@ export function GoogleOAuthButton({
     setIsRedirecting(true);
 
     try {
-      if (mode === 'sign-up') {
+      if (oauthMode === 'sign-up') {
         if (!signUp) {
           throw new Error('Clerk sign-up resource is not ready');
         }
@@ -87,7 +89,7 @@ export function GoogleOAuthButton({
       console.error('[auth] Google OAuth redirect failed', error);
       setIsRedirecting(false);
     }
-  }, [allowCrossModeCompletion, isLoaded, isRedirecting, mode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
+  }, [allowCrossModeCompletion, isLoaded, isRedirecting, mode, oauthMode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
 
   return (
     <button

--- a/apps/web/src/onboarding/steps/ClerkGate.tsx
+++ b/apps/web/src/onboarding/steps/ClerkGate.tsx
@@ -275,6 +275,7 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
         <GoogleOAuthButton
           language={language}
           mode={tab}
+          oauthMode="sign-in"
           redirectUrlComplete={currentUrl}
           allowCrossModeCompletion
         />

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -128,8 +128,10 @@ export default function SignUpPage({
         <GoogleOAuthButton
           language={language}
           mode="sign-up"
+          oauthMode="sign-in"
           redirectUrlComplete={fallbackRedirectUrl}
           forceAccountSelection
+          allowCrossModeCompletion
         />
         <div className={`${AUTH_DIVIDER_CLASS} ${isLightTheme ? '!text-[#3b305f]/76' : ''}`}>
           <span className={`h-px flex-1 ${isLightTheme ? 'bg-[#5a478f]/28' : 'bg-white/12'}`} aria-hidden />


### PR DESCRIPTION
## What changed

- Adds an explicit `oauthMode` to the shared Google OAuth button so the displayed auth intent can differ from the Clerk resource used to start OAuth.
- Routes web Google sign-up and the onboarding auth gate through Clerk's `signIn` OAuth resource while preserving the sign-up/onboarding redirect target.
- Enables Clerk cross-mode completion for web Google sign-up, matching the safer mobile OAuth pattern already used in the app.

## Why

The web onboarding flow could get stuck on `/sso-callback` after Google OAuth. The browser console showed Clerk failing `POST /v1/client/sign_ups` with `400 Bad Request`, which happens before the app can create a session or redirect to onboarding.

Using Clerk's sign-in OAuth resource for Google avoids forcing the callback through the failing `sign_ups` endpoint when the selected Google account already exists, while still allowing Clerk to complete sign-up when needed.

## Impact

- Web Google sign-up should complete and redirect to `/intro-journey` or the requested onboarding target.
- Existing Google users entering from a sign-up CTA should no longer get stranded on `/sso-callback`.
- Native Android/iOS files are untouched in this hotfix branch.

## Validation

- Confirmed the hotfix branch diff contains only 3 web auth files.
- Ran `pnpm install --offline` in the clean worktree to install local dependencies.
- Ran `pnpm --filter @innerbloom/web typecheck`; it still fails on existing `origin/main` TypeScript errors unrelated to this change, including `src/auth/runtimeAuth.tsx`, dashboard/demo test types, `replaceAll` lib target issues, avatar profile test fixtures, Clerk localization typing, and mobile premium lab types.