### PR TITLE
fix clerk captcha mount on sso callback

### DIFF
--- a/apps/web/src/pages/SsoCallback.tsx
+++ b/apps/web/src/pages/SsoCallback.tsx
@@ -1,5 +1,10 @@
 import { AuthenticateWithRedirectCallback } from '@clerk/clerk-react';
 
 export default function SsoCallbackPage() {
-  return <AuthenticateWithRedirectCallback />;
+  return (
+    <>
+      <div id="clerk-captcha" className="sr-only" />
+      <AuthenticateWithRedirectCallback />
+    </>
+  );
 }


### PR DESCRIPTION
## What changed

- Adds the `#clerk-captcha` mount point to `/sso-callback` before rendering `AuthenticateWithRedirectCallback`.

## Why

The production callback can fail during Google OAuth completion with Clerk/Cloudflare returning `captcha_invalid`. The browser console explicitly reports that Clerk cannot initialize Smart CAPTCHA because the `clerk-captcha` DOM element is missing, then falls back to invisible CAPTCHA and fails.

This is a focused follow-up to the Google OAuth sign-up redirect fix. It covers the callback path where Clerk may still need to complete bot-protected sign-up during OAuth.

## Impact

- Web `/sso-callback` gives Clerk a CAPTCHA container during OAuth completion.
- No native iOS/Android files changed.
- No routing behavior changed.

## Validation

- Confirmed diff is limited to `apps/web/src/pages/SsoCallback.tsx`.
- Ran `pnpm --filter @innerbloom/web exec tsc --noEmit --pretty false`; it still fails on existing `main` TypeScript errors unrelated to this file, including `runtimeAuth.tsx`, dashboard/demo test types, `replaceAll` lib target issues, Clerk localization typing, and mobile premium lab types.