### PR TITLE
Hotfix: restore Google OAuth onboarding

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -7,7 +7,6 @@ type GoogleOAuthButtonProps = {
   language: 'es' | 'en';
   mode: GoogleOAuthMode;
   redirectUrlComplete: string;
-  oauthMode?: GoogleOAuthMode;
   className?: string;
   forceAccountSelection?: boolean;
   allowCrossModeCompletion?: boolean;
@@ -19,7 +18,6 @@ export function GoogleOAuthButton({
   language,
   mode,
   redirectUrlComplete,
-  oauthMode = mode,
   className = '',
   forceAccountSelection = false,
   allowCrossModeCompletion = false,
@@ -28,7 +26,7 @@ export function GoogleOAuthButton({
   const { isLoaded: isSignUpLoaded, signUp } = useSignUp();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
-  const isLoaded = oauthMode === 'sign-up' ? isSignUpLoaded : isSignInLoaded;
+  const isLoaded = mode === 'sign-up' ? isSignUpLoaded : isSignInLoaded;
   const isDisabled = !isLoaded || isRedirecting;
   const shouldForceAccountSelection = forceAccountSelection || mode === 'sign-up';
 
@@ -60,7 +58,7 @@ export function GoogleOAuthButton({
     setIsRedirecting(true);
 
     try {
-      if (oauthMode === 'sign-up') {
+      if (mode === 'sign-up') {
         if (!signUp) {
           throw new Error('Clerk sign-up resource is not ready');
         }
@@ -89,7 +87,7 @@ export function GoogleOAuthButton({
       console.error('[auth] Google OAuth redirect failed', error);
       setIsRedirecting(false);
     }
-  }, [allowCrossModeCompletion, isLoaded, isRedirecting, mode, oauthMode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
+  }, [allowCrossModeCompletion, isLoaded, isRedirecting, mode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
 
   return (
     <button

--- a/apps/web/src/onboarding/steps/ClerkGate.tsx
+++ b/apps/web/src/onboarding/steps/ClerkGate.tsx
@@ -275,7 +275,6 @@ export function ClerkGate({ language = 'es', onContinue, autoAdvance = false }: 
         <GoogleOAuthButton
           language={language}
           mode={tab}
-          oauthMode="sign-in"
           redirectUrlComplete={currentUrl}
           allowCrossModeCompletion
         />

--- a/apps/web/src/pages/SignUp.tsx
+++ b/apps/web/src/pages/SignUp.tsx
@@ -128,10 +128,8 @@ export default function SignUpPage({
         <GoogleOAuthButton
           language={language}
           mode="sign-up"
-          oauthMode="sign-in"
           redirectUrlComplete={fallbackRedirectUrl}
           forceAccountSelection
-          allowCrossModeCompletion
         />
         <div className={`${AUTH_DIVIDER_CLASS} ${isLightTheme ? '!text-[#3b305f]/76' : ''}`}>
           <span className={`h-px flex-1 ${isLightTheme ? 'bg-[#5a478f]/28' : 'bg-white/12'}`} aria-hidden />


### PR DESCRIPTION
Reverts #2268 (`fix web google oauth onboarding redirect`).

The production error `ClerkJS: Response: transferable not supported yet` occurs before onboarding, in `GoogleOAuthButton`, and prevents Google login/sign-up. This hotfix restores the previous OAuth path while retaining the onboarding2 visual changes from #2267.

Validated with `npm run build` and `npm test -- --run src/onboarding/__tests__/payload.test.ts`.