### PR TITLE
Fix Google sign-up redirect to onboarding2

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -13,6 +13,61 @@ type GoogleOAuthButtonProps = {
 };
 
 const SSO_CALLBACK_PATH = '/sso-callback';
+export const OAUTH_REDIRECT_INTENT_STORAGE_KEY = 'innerbloom:oauth-redirect-intent';
+const OAUTH_REDIRECT_INTENT_TTL_MS = 10 * 60 * 1000;
+
+export type OAuthRedirectIntent = {
+  mode: GoogleOAuthMode;
+  redirectUrlComplete: string;
+  createdAt: number;
+};
+
+function persistOAuthRedirectIntent(intent: OAuthRedirectIntent) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(OAUTH_REDIRECT_INTENT_STORAGE_KEY, JSON.stringify(intent));
+  } catch (error) {
+    console.warn('[auth] Failed to persist OAuth redirect intent', error);
+  }
+}
+
+export function readOAuthRedirectIntent(): OAuthRedirectIntent | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const rawIntent = window.sessionStorage.getItem(OAUTH_REDIRECT_INTENT_STORAGE_KEY);
+    if (!rawIntent) {
+      return null;
+    }
+
+    const intent = JSON.parse(rawIntent) as Partial<OAuthRedirectIntent>;
+    const isSafeRedirect =
+      typeof intent.redirectUrlComplete === 'string' &&
+      intent.redirectUrlComplete.startsWith('/') &&
+      !intent.redirectUrlComplete.startsWith('//');
+    const isValidMode = intent.mode === 'sign-in' || intent.mode === 'sign-up';
+    const isRecent =
+      typeof intent.createdAt === 'number' &&
+      Date.now() - intent.createdAt >= 0 &&
+      Date.now() - intent.createdAt <= OAUTH_REDIRECT_INTENT_TTL_MS;
+
+    if (!isSafeRedirect || !isValidMode || !isRecent) {
+      window.sessionStorage.removeItem(OAUTH_REDIRECT_INTENT_STORAGE_KEY);
+      return null;
+    }
+
+    return intent as OAuthRedirectIntent;
+  } catch (error) {
+    console.warn('[auth] Failed to read OAuth redirect intent', error);
+    window.sessionStorage.removeItem(OAUTH_REDIRECT_INTENT_STORAGE_KEY);
+    return null;
+  }
+}
 
 export function GoogleOAuthButton({
   language,
@@ -56,6 +111,7 @@ export function GoogleOAuthButton({
     }
 
     setIsRedirecting(true);
+    persistOAuthRedirectIntent({ mode, redirectUrlComplete, createdAt: Date.now() });
 
     try {
       if (mode === 'sign-up') {

--- a/apps/web/src/pages/SsoCallback.tsx
+++ b/apps/web/src/pages/SsoCallback.tsx
@@ -1,10 +1,20 @@
 import { AuthenticateWithRedirectCallback } from '@clerk/clerk-react';
+import { readOAuthRedirectIntent } from '../components/auth/GoogleOAuthButton';
 
 export default function SsoCallbackPage() {
+  const redirectIntent = readOAuthRedirectIntent();
+  const signInFallbackRedirectUrl =
+    redirectIntent?.mode === 'sign-in' ? redirectIntent.redirectUrlComplete : undefined;
+  const signUpFallbackRedirectUrl =
+    redirectIntent?.mode === 'sign-up' ? redirectIntent.redirectUrlComplete : undefined;
+
   return (
     <>
       <div id="clerk-captcha" className="sr-only" />
-      <AuthenticateWithRedirectCallback />
+      <AuthenticateWithRedirectCallback
+        signInFallbackRedirectUrl={signInFallbackRedirectUrl}
+        signUpFallbackRedirectUrl={signUpFallbackRedirectUrl}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Problema

En web, **Crear cuenta con Google** completa correctamente la autenticación con Clerk, pero puede terminar dejando al usuario autenticado en la landing o enviándolo fuera del flujo esperado, en vez de continuar a `/intro-journey2`.

## Solución

- Persiste temporalmente en `sessionStorage` la intención OAuth antes de salir hacia Google:
  - modo (`sign-in` o `sign-up`)
  - destino post-auth esperado
  - timestamp con TTL de 10 minutos
- En `/sso-callback`, usa esa intención como fallback específico de Clerk para recuperar el destino correcto si `redirectUrlComplete` no se conserva durante el round-trip OAuth.
- Valida que el destino sea una ruta local segura antes de utilizarlo.

## Alcance

Esta PR es intencionalmente pequeña y no mezcla cambios visuales ni funcionales del onboarding.

No toca:
- iOS, Android, Xcode o Capacitor
- diseño/look & feel de onboarding2
- reglas de foundations
- payloads
- navegación interna del onboarding
- dependencias

## Resultado esperado

- `Crear cuenta con Google` desde `/sign-up2` → `/intro-journey2`
- `Iniciar sesión con Google` conserva su destino normal
- otros flujos continúan usando su `redirectUrlComplete` original

## Validación manual requerida antes de merge

1. Crear cuenta con Google nueva desde la landing V3.
2. Confirmar que termina en `/intro-journey2`.
3. Probar una cuenta Google ya existente desde el CTA de crear cuenta.
4. Probar iniciar sesión con Google y confirmar que no entra al onboarding.
5. Confirmar que no queda detenido en `/sso-callback`.

> Producción está temporalmente estabilizada mediante redeploy del estado de la PR #2265. No cambiar ese deployment hasta validar y mergear esta PR.