### PR TITLE
Scope onboarding2 redesign to look and feel only

### DIFF
--- a/apps/web/src/onboarding/quickStart.ts
+++ b/apps/web/src/onboarding/quickStart.ts
@@ -18,7 +18,7 @@ export const QUICK_START_MINIMUMS: Record<GameMode, number> = {
   LOW: 1,
   CHILL: 2,
   FLOW: 3,
-  EVOLVE: 3,
+  EVOLVE: 4,
 };
 
 export const QUICK_START_SUGGESTED_RANGES: Record<GameMode, { min: number; max: number }> = {

--- a/apps/web/src/onboarding/steps/GameModeStep.tsx
+++ b/apps/web/src/onboarding/steps/GameModeStep.tsx
@@ -1,7 +1,9 @@
 import { motion } from 'framer-motion';
+import { useId } from 'react';
 import type { GameMode } from '../state';
 import type { OnboardingLanguage } from '../constants';
 import { GAME_MODE_META } from '../../lib/gameModeMeta';
+import { useThemePreference } from '../../theme/ThemePreferenceProvider';
 
 interface GameModeStepProps {
   language?: OnboardingLanguage;
@@ -20,35 +22,121 @@ export const MODE_CARD_CONTENT = {
 
 const MODE_ORDER: GameMode[] = ['LOW', 'CHILL', 'FLOW', 'EVOLVE'];
 
+const RHYTHM_WAVE_CONFIG: Record<GameMode, { oscillations: number; amplitude: number; activeRatio: number }> = {
+  LOW: { oscillations: 2, amplitude: 18, activeRatio: 0.25 },
+  CHILL: { oscillations: 2.25, amplitude: 20, activeRatio: 0.37 },
+  FLOW: { oscillations: 2.75, amplitude: 22, activeRatio: 0.52 },
+  EVOLVE: { oscillations: 3.25, amplitude: 24, activeRatio: 0.62 },
+};
+
+const SVG_WIDTH = 320;
+const SVG_HEIGHT = 88;
+const WAVE_START_X = 18;
+const WAVE_END_X = 302;
+const WAVE_CENTER_Y = 44;
+const WAVE_PHASE = -0.34;
+
+function buildSinePath(mode: GameMode, phase = WAVE_PHASE) {
+  const config = RHYTHM_WAVE_CONFIG[mode];
+  return Array.from({ length: 116 }, (_, index) => {
+    const progress = index / 115;
+    const x = WAVE_START_X + (WAVE_END_X - WAVE_START_X) * progress;
+    const y = WAVE_CENTER_Y + Math.sin(progress * config.oscillations * Math.PI * 2 + phase) * config.amplitude;
+    return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`;
+  }).join(' ');
+}
+
+function buildAnimatedSinePathValues(mode: GameMode) {
+  return [WAVE_PHASE, WAVE_PHASE + 0.3, WAVE_PHASE + 0.62, WAVE_PHASE]
+    .map((phase) => buildSinePath(mode, phase))
+    .join('; ');
+}
+
+function RhythmWave({ mode, active }: { mode: GameMode; active: boolean }) {
+  const rawId = useId().replace(/:/g, '');
+  const gradientId = `onboarding-rhythm-wave-gradient-${rawId}`;
+  const clipId = `onboarding-rhythm-wave-clip-${rawId}`;
+  const path = buildSinePath(mode);
+  const animatedPathValues = buildAnimatedSinePathValues(mode);
+  const activeWidth = WAVE_START_X + (WAVE_END_X - WAVE_START_X) * RHYTHM_WAVE_CONFIG[mode].activeRatio;
+  const animationDuration = active ? '7.6s' : `${8.8 + RHYTHM_WAVE_CONFIG[mode].activeRatio * 2}s`;
+
+  return (
+    <div className="relative h-[3.35rem] w-full min-w-[8.25rem] overflow-visible sm:h-16" role="img" aria-label={`${mode} weekly rhythm wave`}>
+      <svg className="absolute inset-0 h-full w-full overflow-visible" viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`} preserveAspectRatio="none" aria-hidden="true">
+        <defs>
+          <linearGradient id={gradientId} x1="0" x2="1" y1="0" y2="0">
+            <stop offset="0%" stopColor="#8B5CF6" />
+            <stop offset="50%" stopColor="#D977FF" />
+            <stop offset="100%" stopColor="#FF86C8" />
+          </linearGradient>
+          <clipPath id={clipId}>
+            <rect x="0" y="0" width={activeWidth} height={SVG_HEIGHT} />
+          </clipPath>
+        </defs>
+        <path d={path} fill="none" stroke="rgba(125,128,159,0.34)" strokeLinecap="round" strokeLinejoin="round" strokeWidth={active ? 5.8 : 5.2}>
+          <animate attributeName="d" dur={animationDuration} repeatCount="indefinite" values={animatedPathValues} />
+        </path>
+        <path d={path} fill="none" stroke={`url(#${gradientId})`} strokeLinecap="round" strokeLinejoin="round" strokeWidth={active ? 14 : 10} opacity={active ? 0.5 : 0.22} clipPath={`url(#${clipId})`} filter="blur(4px)">
+          <animate attributeName="d" dur={animationDuration} repeatCount="indefinite" values={animatedPathValues} />
+        </path>
+        <path d={path} fill="none" stroke={`url(#${gradientId})`} strokeLinecap="round" strokeLinejoin="round" strokeWidth={active ? 6.8 : 5.8} opacity={active ? 0.98 : 0.86} clipPath={`url(#${clipId})`}>
+          <animate attributeName="d" dur={animationDuration} repeatCount="indefinite" values={animatedPathValues} />
+        </path>
+      </svg>
+    </div>
+  );
+}
+
 function RhythmSegments({ intensity }: { intensity: number }) {
-  return <span className="onboarding-rhythm-segments" aria-hidden>{[1, 2, 3, 4].map((segment) => <i key={segment} data-active={segment <= intensity} />)}</span>;
+  return (
+    <span className="onboarding-rhythm-segments" aria-hidden>
+      {[1, 2, 3, 4].map((segment) => <i key={segment} data-active={segment <= intensity} />)}
+    </span>
+  );
 }
 
 export function GameModeStep({ language = 'es', selected, onSelect, onBack, variant = 'default' }: GameModeStepProps) {
-  const copy = language === 'en'
+  const { theme } = useThemePreference();
+  const isLight = theme === 'light';
+  const visualOnly = variant === 'onboarding2';
+  const defaultCopy = language === 'en'
     ? {
-        step: 'Step 1',
-        title: 'Start possible, not perfect.',
-        subtitle: 'Choose your rhythm.',
+        step: 'Step 1 · Choose your rhythm',
+        title: 'What is your rhythm today?',
+        subtitle: 'Choose the weekly intensity that best adapts to you.',
         back: 'Back',
         selectedSuffix: ' selected',
       }
     : {
-        step: 'Paso 1',
-        title: 'Empezá posible, no perfecto.',
-        subtitle: 'Elegí tu ritmo.',
+        step: 'Paso 1 · Elegí tu ritmo',
+        title: '¿Cuál es tu ritmo hoy?',
+        subtitle: 'Elegí la intensidad semanal que mejor se adapta a vos.',
         back: 'Volver',
         selectedSuffix: ' seleccionado',
       };
+  const visualCopy = language === 'en'
+    ? { ...defaultCopy, step: 'Step 1', title: 'Start possible, not perfect.', subtitle: 'Choose your rhythm.' }
+    : { ...defaultCopy, step: 'Paso 1', title: 'Empezá posible, no perfecto.', subtitle: 'Elegí tu ritmo.' };
+  const copy = visualOnly ? visualCopy : defaultCopy;
 
   return (
     <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2 }}>
-      <div className={`onboarding-flow-panel ${variant === 'onboarding2' ? 'onboarding-rhythm-selector' : ''} mx-auto max-w-4xl p-4 sm:p-6`}>
-        <header className="onboarding-rhythm-selector__header">
-          <p>{copy.step}</p>
-          <h2>{copy.title}</h2>
-          <span>{copy.subtitle}</span>
-        </header>
+      <div className={`onboarding-flow-panel ${visualOnly ? 'onboarding-rhythm-selector' : ''} mx-auto max-w-4xl p-4 sm:p-6`}>
+        {visualOnly ? (
+          <header className="onboarding-rhythm-selector__header">
+            <p>{copy.step}</p>
+            <h2>{copy.title}</h2>
+            <span>{copy.subtitle}</span>
+          </header>
+        ) : (
+          <header className="flex flex-col gap-2">
+            <p className="text-xs uppercase tracking-[0.2em] text-white/50">{copy.step}</p>
+            <h2 className="text-3xl font-semibold text-white">{copy.title}</h2>
+            <p className="text-sm text-white/70">{copy.subtitle}</p>
+          </header>
+        )}
+
         <div className="mt-7 space-y-3 md:space-y-4" role="group" aria-label={copy.title}>
           {MODE_ORDER.map((mode) => {
             const content = MODE_CARD_CONTENT[mode];
@@ -64,18 +152,44 @@ export function GameModeStep({ language = 'es', selected, onSelect, onBack, vari
                 aria-pressed={isActive}
                 aria-label={`${content.title} · ${content.frequency[language]}${isActive ? copy.selectedSuffix : ''}`}
                 data-selected={isActive ? 'true' : 'false'}
-                className={[
-                  'onboarding-rhythm-card',
-                  variant === 'onboarding2' ? 'onboarding-rhythm-card--segments' : 'relative grid min-h-[4.75rem] w-full grid-cols-[4.25rem_minmax(0,1fr)_4.9rem] items-center gap-2 overflow-hidden rounded-[1.45rem] border px-3 py-2 text-left transition-all duration-300 ease-out sm:grid-cols-[5.5rem_minmax(0,1fr)_6.6rem] sm:gap-4 sm:px-5',
-                  isActive && variant === 'onboarding2' ? 'onboarding-rhythm-card--selected' : '',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
+                className={visualOnly
+                  ? `onboarding-rhythm-card onboarding-rhythm-card--segments ${isActive ? 'onboarding-rhythm-card--selected' : ''}`
+                  : [
+                      'onboarding-rhythm-card group relative grid min-h-[4.75rem] w-full grid-cols-[4.25rem_minmax(0,1fr)_4.9rem] items-center gap-2 overflow-hidden rounded-[1.45rem] border px-3 py-2 text-left transition-all duration-300 ease-out focus-visible:outline-none sm:grid-cols-[5.5rem_minmax(0,1fr)_6.6rem] sm:gap-4 sm:px-5 md:min-h-[6.05rem] md:grid-cols-[7rem_minmax(0,1fr)_7.5rem] md:rounded-[1.8rem] md:px-6',
+                      isLight
+                        ? isActive
+                          ? 'border-[#8b5cf6]/70 bg-[linear-gradient(135deg,rgba(255,255,255,0.96),rgba(245,240,255,0.88))] shadow-[0_18px_42px_rgba(139,92,246,0.16)]'
+                          : 'border-slate-200/90 bg-[linear-gradient(135deg,rgba(255,255,255,0.94),rgba(248,250,252,0.82))] shadow-[0_10px_24px_rgba(15,23,42,0.06)] hover:border-[#c4b5fd] hover:bg-white'
+                        : isActive
+                          ? 'border-[#b66cff]/80 bg-[linear-gradient(135deg,rgba(33,25,62,0.72),rgba(14,14,30,0.74))] shadow-[inset_0_0_32px_rgba(169,85,247,0.13),0_20px_56px_rgba(87,50,156,0.22)]'
+                          : 'border-white/10 bg-[linear-gradient(135deg,rgba(255,255,255,0.055),rgba(10,12,27,0.48))] shadow-[inset_0_1px_0_rgba(255,255,255,0.055)] hover:border-white/18 hover:bg-[linear-gradient(135deg,rgba(255,255,255,0.08),rgba(10,12,27,0.56))]',
+                    ].join(' ')}
               >
-                <span className="onboarding-rhythm-card__copy"><h3>
-                  {content.title.replace(' MOOD', '').replace(' Mood', '')}
-                </h3><small>{variant === 'onboarding2' ? content.state[language] : content.frequency[language]}</small></span>
-                {variant === 'onboarding2' ? <><span className="onboarding-rhythm-card__days"><strong>{intensity}</strong><small>{language === 'en' ? 'days/week' : 'días/semana'}</small></span><RhythmSegments intensity={intensity} /></> : null}
+                {visualOnly ? (
+                  <>
+                    <span className="onboarding-rhythm-card__copy">
+                      <h3>{content.title.replace(' MOOD', '').replace(' Mood', '')}</h3>
+                      <small>{content.state[language]}</small>
+                    </span>
+                    <span className="onboarding-rhythm-card__days">
+                      <strong>{intensity}</strong>
+                      <small>{language === 'en' ? 'days/week' : 'días/semana'}</small>
+                    </span>
+                    <RhythmSegments intensity={intensity} />
+                  </>
+                ) : (
+                  <>
+                    <h3 className="relative z-10 min-w-0 text-[1rem] font-semibold text-white/94 sm:text-[1.2rem] md:text-[1.58rem]">
+                      {content.title.replace(' MOOD', '').replace(' Mood', '')}
+                    </h3>
+                    <div className="relative z-10 min-w-0">
+                      <RhythmWave mode={mode} active={isActive} />
+                    </div>
+                    <div className="relative z-10 justify-self-end text-right text-[0.78rem] font-semibold text-white/88 sm:text-sm md:text-base">
+                      {content.frequency[language]}
+                    </div>
+                  </>
+                )}
               </motion.button>
             );
           })}

--- a/apps/web/src/onboarding/steps/QuickStartTasksStep.tsx
+++ b/apps/web/src/onboarding/steps/QuickStartTasksStep.tsx
@@ -4,7 +4,7 @@ import { Pencil } from 'lucide-react';
 import type { OnboardingLanguage } from '../constants';
 import { NavButtons } from '../ui/NavButtons';
 import type { GameMode, Pillar } from '../state';
-import { formatQuickStartTask, type QuickStartTask } from '../quickStart';
+import { QUICK_START_MINIMUMS, getQuickStartSuggestedRule, type QuickStartTask } from '../quickStart';
 import { TraitIcon } from '../../pages/labs/mobile-premium/MobilePremiumPrimitives';
 
 interface QuickStartTasksStepProps {
@@ -24,10 +24,28 @@ interface QuickStartTasksStepProps {
   onConfirm: () => void;
 }
 
+function formatTaskPreview(task: QuickStartTask, inputValue: string): string {
+  const value = inputValue.trim();
+  if (!value) return task.text;
+  return [task.inputBefore, task.text, value, task.inputAfter].filter(Boolean).join(' ');
+}
+
+function resolveUnit(task: QuickStartTask): string {
+  const suffix = task.inputAfter?.toLowerCase() ?? '';
+  if (suffix.startsWith('minut')) return 'min';
+  if (suffix.startsWith('hour') || suffix.startsWith('hora')) return 'hrs';
+  if (suffix.startsWith('meal') || suffix.startsWith('comida')) return 'meals';
+  if (suffix.startsWith('glass') || suffix.startsWith('vaso')) return 'glasses';
+  if (suffix.startsWith('person') || suffix.startsWith('persona')) return 'people';
+  if (suffix.startsWith('thing') || suffix.startsWith('cosa')) return 'things';
+  return '';
+}
+
 function InlineTaskRow({
   task,
   selected,
   inputValue,
+  variant,
   onToggle,
   onInputChange,
   copy,
@@ -35,6 +53,7 @@ function InlineTaskRow({
   task: QuickStartTask;
   selected: boolean;
   inputValue: string;
+  variant: 'default' | 'onboarding2';
   onToggle: () => void;
   onInputChange: (value: string) => void;
   copy: {
@@ -44,24 +63,22 @@ function InlineTaskRow({
   };
 }) {
   const hasInput = Boolean(task.inputAfter || task.inputBefore);
-  const unit = task.inputAfter?.startsWith('minut') ? 'min' : task.inputAfter?.startsWith('hour') || task.inputAfter?.startsWith('hora') ? 'hrs' : task.inputAfter?.startsWith('meal') || task.inputAfter?.startsWith('comida') ? 'meals' : task.inputAfter?.startsWith('glass') || task.inputAfter?.startsWith('vaso') ? 'glasses' : task.inputAfter?.startsWith('person') || task.inputAfter?.startsWith('persona') ? 'people' : task.inputAfter?.startsWith('thing') || task.inputAfter?.startsWith('cosa') ? 'things' : '';
+  const unit = resolveUnit(task);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const rowRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (!showSuggestions) {
-      return undefined;
-    }
+    if (!showSuggestions) return undefined;
 
     const handleOutsidePointer = (event: PointerEvent) => {
-      if (!rowRef.current?.contains(event.target as Node)) {
-        setShowSuggestions(false);
-      }
+      if (!rowRef.current?.contains(event.target as Node)) setShowSuggestions(false);
     };
 
     document.addEventListener('pointerdown', handleOutsidePointer);
     return () => document.removeEventListener('pointerdown', handleOutsidePointer);
   }, [showSuggestions]);
+
+  const visualOnly = variant === 'onboarding2';
 
   return (
     <div ref={rowRef} className="relative">
@@ -77,55 +94,89 @@ function InlineTaskRow({
         role="button"
         tabIndex={0}
         data-selected={selected ? 'true' : undefined}
-        className={`quickstart-task-row quickstart-task-row--foundation relative z-10 grid w-full grid-cols-[42px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-4 text-left text-white/85 transition ${selected ? 'quickstart-task-row--selected' : ''}`}
+        className={visualOnly
+          ? `quickstart-task-row quickstart-task-row--foundation relative z-10 grid w-full grid-cols-[42px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-4 text-left text-white/85 transition ${selected ? 'quickstart-task-row--selected' : ''}`
+          : `quickstart-task-row onboarding-surface-inner relative z-10 grid w-full grid-cols-[38px_minmax(0,1fr)_auto] items-center gap-3 rounded-[1.15rem] px-3 py-3.5 text-left text-white/85 transition ${selected ? 'quickstart-task-row--selected' : ''}`}
       >
         <span className="quickstart-task-icon grid h-9 w-9 place-items-center rounded-full border">
-          {selected ? (
-            <span className="text-sm font-semibold">✓</span>
-          ) : (
-            <TraitIcon size={20} trait={task.trait} />
-          )}
+          {selected ? <span className="text-sm font-semibold">✓</span> : <TraitIcon size={20} trait={task.trait} />}
         </span>
 
-        <div className="min-w-0">
-          <p className="quickstart-task-title">{task.inputBefore ? `${task.inputBefore} ${task.text}` : task.text}</p>
-          <p className="quickstart-selected-trait mt-2 text-[0.66rem] font-semibold uppercase tracking-[0.2em]">{copy.traitLabel} {task.trait}</p>
-          {selected && hasInput ? <p className="quickstart-task-resolved">{formatQuickStartTask(task, inputValue)}</p> : null}
-        </div>
+        {visualOnly ? (
+          <div className="min-w-0">
+            <p className="quickstart-task-title">{task.inputBefore ? `${task.inputBefore} ${task.text}` : task.text}</p>
+            <p className="quickstart-selected-trait mt-2 text-[0.66rem] font-semibold uppercase tracking-[0.2em]">
+              {copy.traitLabel} {task.trait}
+            </p>
+            {selected && hasInput ? <p className="quickstart-task-resolved">{formatTaskPreview(task, inputValue)}</p> : null}
+          </div>
+        ) : (
+          <div className="min-w-0">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1.5 text-[0.98rem] leading-6 text-white/90">
+              {task.inputBefore ? <span>{task.inputBefore}</span> : null}
+              <span>{task.text}</span>
+              {hasInput ? (
+                <input
+                  value={inputValue}
+                  disabled={!selected}
+                  inputMode="numeric"
+                  onClick={(event) => event.stopPropagation()}
+                  onChange={(event) => onInputChange(event.target.value)}
+                  className="quickstart-task-input h-6 w-12 rounded-md border px-1.5 text-center text-xs focus:outline-none focus-visible:ring-2 disabled:opacity-40 sm:h-7 sm:w-14"
+                  placeholder={copy.countPlaceholder}
+                />
+              ) : null}
+              {task.inputAfter ? <span>{task.inputAfter}</span> : null}
+              {task.helper ? <span className="w-full text-xs text-white/55">{task.helper}</span> : null}
+            </div>
+            {selected ? (
+              <p className="quickstart-selected-trait mt-2 text-[0.66rem] font-semibold uppercase tracking-[0.2em]">
+                <span className="mr-1.5 text-white/38">{copy.traitLabel}</span>
+                {task.trait}
+              </p>
+            ) : null}
+          </div>
+        )}
 
-        {hasInput ? (
+        {visualOnly && hasInput ? (
           <label className={`quickstart-quantity ${selected ? 'quickstart-quantity--selected' : ''}`} onClick={(event) => event.stopPropagation()}>
-            <span><input value={inputValue} disabled={!selected} inputMode="numeric" onChange={(event) => onInputChange(event.target.value)} placeholder={copy.countPlaceholder} aria-label={`${copy.countPlaceholder} ${unit}`} /><Pencil size={14} aria-hidden /></span>
+            <span>
+              <input
+                value={inputValue}
+                disabled={!selected}
+                inputMode="numeric"
+                onChange={(event) => onInputChange(event.target.value)}
+                placeholder={copy.countPlaceholder}
+                aria-label={`${copy.countPlaceholder} ${unit}`}
+              />
+              <Pencil size={14} aria-hidden />
+            </span>
             {unit ? <small>{unit}</small> : null}
           </label>
         ) : task.suggestions?.length ? (
-            <button
-              type="button"
-              onClick={(event) => {
-                event.stopPropagation();
-                setShowSuggestions((prev) => !prev);
-              }}
-              className="quickstart-task-help relative z-20 ml-auto inline-flex h-7 w-7 shrink-0 items-center justify-center self-start rounded-full border transition"
-              aria-label={copy.taskHelpLabel}
-              aria-expanded={showSuggestions}
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5" aria-hidden>
-                <path d="M9 18h6" />
-                <path d="M10 22h4" />
-                <path d="M8.5 14.3a6 6 0 1 1 7 0c-.7.53-1.17 1.35-1.3 2.2l-.08.5H9.88l-.08-.5a3.5 3.5 0 0 0-1.3-2.2Z" />
-              </svg>
-            </button>
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              setShowSuggestions((prev) => !prev);
+            }}
+            className="quickstart-task-help relative z-20 ml-auto inline-flex h-7 w-7 shrink-0 items-center justify-center self-start rounded-full border transition"
+            aria-label={copy.taskHelpLabel}
+            aria-expanded={showSuggestions}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5" aria-hidden>
+              <path d="M9 18h6" />
+              <path d="M10 22h4" />
+              <path d="M8.5 14.3a6 6 0 1 1 7 0c-.7.53-1.17 1.35-1.3 2.2l-.08.5H9.88l-.08-.5a3.5 3.5 0 0 0-1.3-2.2Z" />
+            </svg>
+          </button>
         ) : <span aria-hidden className="h-5 w-5" />}
       </motion.div>
 
       {task.suggestions?.length && showSuggestions ? (
-        <div
-          className="quickstart-suggestions-panel absolute right-3 bottom-[calc(100%+0.35rem)] z-30 w-[min(18.5rem,calc(100%-1.5rem))] rounded-xl border p-3 text-xs backdrop-blur"
-        >
+        <div className="quickstart-suggestions-panel absolute right-3 bottom-[calc(100%+0.35rem)] z-30 w-[min(18.5rem,calc(100%-1.5rem))] rounded-xl border p-3 text-xs backdrop-blur">
           <ul className="space-y-1.5">
-            {task.suggestions.map((suggestion) => (
-              <li key={suggestion} className="leading-relaxed">• {suggestion}</li>
-            ))}
+            {task.suggestions.map((suggestion) => <li key={suggestion} className="leading-relaxed">• {suggestion}</li>)}
           </ul>
         </div>
       ) : null}
@@ -149,12 +200,20 @@ export function QuickStartTasksStep({
   onBack,
   onConfirm,
 }: QuickStartTasksStepProps) {
-  const copy = language === 'en'
+  const visualOnly = variant === 'onboarding2';
+  const effectiveMinimum = QUICK_START_MINIMUMS[gameMode] ?? minimum;
+  const defaultCopy = language === 'en'
     ? {
-        title: 'Build a rhythm you can keep.',
-        subtitle: 'Start with three foundations. You can always add more later.',
-        minimumRequired: 'Choose the minimum to unlock the next pillar.',
-        continue: pillar === 'Body' ? 'Continue to Mind' : pillar === 'Mind' ? 'Continue to Soul' : 'Review my foundations',
+        title: `Quick Start · ${pillar === 'Body' ? 'Body 🫀' : pillar === 'Mind' ? 'Mind 🧠' : 'Soul 🏵️'}`,
+        subtitle: pillar === 'Body'
+          ? 'Review all 10 tasks and activate what you want to sustain.'
+          : pillar === 'Mind'
+            ? 'Tune your mental focus while keeping the current onboarding feel.'
+            : 'Choose habits that support connection and inner alignment.',
+        minRule: `Minimum: ${effectiveMinimum} tasks`,
+        suggestedRule: getQuickStartSuggestedRule(gameMode, language),
+        minimumRequired: 'You need to select the minimum to continue.',
+        continue: 'Continue',
         inputRequired: 'Complete the selected quantities before continuing.',
         back: 'Back',
         countPlaceholder: 'qty',
@@ -164,10 +223,16 @@ export function QuickStartTasksStep({
         bonusPending: 'Balance Body, Mind and Soul to earn x1.5 GP',
       }
     : {
-        title: 'Construí un ritmo que puedas sostener.',
-        subtitle: 'Empezá con tres foundations. Después podés sumar más.',
-        minimumRequired: 'Elegí el mínimo para desbloquear el siguiente pilar.',
-        continue: pillar === 'Body' ? 'Continuar a Mente' : pillar === 'Mind' ? 'Continuar a Alma' : 'Revisar mis foundations',
+        title: `Inicio rápido · ${pillar === 'Body' ? 'Cuerpo 🫀' : pillar === 'Mind' ? 'Mente 🧠' : 'Alma 🏵️'}`,
+        subtitle: pillar === 'Body'
+          ? 'Elegí 10 tareas visibles y activá las que querés sostener.'
+          : pillar === 'Mind'
+            ? 'Ajustá tu foco mental sin salir del ritmo del onboarding actual.'
+            : 'Definí hábitos que te ayuden a mantener centro y conexión.',
+        minRule: `Mínimo: ${effectiveMinimum} tareas`,
+        suggestedRule: getQuickStartSuggestedRule(gameMode, language),
+        minimumRequired: 'Necesitás seleccionar el mínimo para continuar.',
+        continue: 'Continuar',
         inputRequired: 'Completá las cantidades seleccionadas antes de continuar.',
         back: 'Volver',
         countPlaceholder: 'n',
@@ -175,53 +240,91 @@ export function QuickStartTasksStep({
         taskHelpLabel: 'Abrir ideas rápidas de la tarea',
         bonusReady: 'Balanceado: estás sumando x1.5 GP',
         bonusPending: 'Balanceá Cuerpo, Mente y Alma para sumar x1.5 GP',
-  };
+      };
+
+  const visualCopy = language === 'en'
+    ? {
+        ...defaultCopy,
+        title: 'Build a rhythm you can keep.',
+        subtitle: 'Choose a sustainable foundation. You can always add more later.',
+        minimumRequired: 'Choose the minimum to unlock the next pillar.',
+        continue: pillar === 'Body' ? 'Continue to Mind' : pillar === 'Mind' ? 'Continue to Soul' : 'Review my foundations',
+      }
+    : {
+        ...defaultCopy,
+        title: 'Construí un ritmo que puedas sostener.',
+        subtitle: 'Elegí una base sostenible. Después podés sumar más.',
+        minimumRequired: 'Elegí el mínimo para desbloquear el siguiente pilar.',
+        continue: pillar === 'Body' ? 'Continuar a Mente' : pillar === 'Mind' ? 'Continuar a Alma' : 'Revisar mis foundations',
+      };
+  const copy = visualOnly ? visualCopy : defaultCopy;
 
   const selectedTasks = tasks.filter((task) => selectedIds.includes(task.id));
   const hasMissingInput = selectedTasks.some((task) => {
-    if (!task.inputAfter && !task.inputBefore) {
-      return false;
-    }
+    if (!task.inputAfter && !task.inputBefore) return false;
     return !String(inputValues[`${pillar}-${task.id}`] ?? '').trim();
   });
-  const canContinue = selectedIds.length >= minimum && !hasMissingInput;
+  const canContinue = selectedIds.length >= effectiveMinimum && !hasMissingInput;
 
   const pillarLabel = language === 'en' ? pillar : pillar === 'Body' ? 'Cuerpo' : pillar === 'Mind' ? 'Mente' : 'Alma';
   const pillarLabels = language === 'en' ? { Body: 'Body', Mind: 'Mind', Soul: 'Soul' } : { Body: 'Cuerpo', Mind: 'Mente', Soul: 'Alma' };
   const displayedSelections = selectedTasksByPillar ?? { Body: pillar === 'Body' ? selectedIds : [], Mind: pillar === 'Mind' ? selectedIds : [], Soul: pillar === 'Soul' ? selectedIds : [] };
 
   return (
-    <section className={`quickstart-premium-card onboarding-flow-panel ${variant === 'onboarding2' ? 'onboarding2-foundations' : ''} mx-auto w-full max-w-3xl p-5 sm:p-7`}>
-      <header className="quickstart-foundations-header mb-6">
-        <p>Step 2 · {pillarLabel}</p>
-        <h1>{copy.title}</h1>
-        <span>{copy.subtitle}</span>
-        <div className="quickstart-pillar-status" aria-label="Pillar progress">
-          {(['Body', 'Mind', 'Soul'] as Pillar[]).map((item) => <span key={item} data-current={item === pillar}>{pillarLabels[item]} <small>{displayedSelections[item].length}/{minimum}</small></span>)}
-        </div>
-        <div className="quickstart-foundation-count" aria-live="polite"><span><strong>{selectedIds.length}</strong> / {minimum} foundations</span><span>{selectedIds.length * 3} GP ready</span></div>
-        <div className="quickstart-foundation-progress" aria-hidden><span style={{ width: `${Math.min(100, (selectedIds.length / minimum) * 100)}%` }} /></div>
-      </header>
+    <section className={`quickstart-premium-card onboarding-flow-panel ${visualOnly ? 'onboarding2-foundations' : 'onboarding-premium-root'} mx-auto w-full max-w-3xl p-5 sm:p-7`}>
+      {visualOnly ? (
+        <header className="quickstart-foundations-header mb-6">
+          <p>{language === 'en' ? 'Step 2' : 'Paso 2'} · {pillarLabel}</p>
+          <h1>{copy.title}</h1>
+          <span>{copy.subtitle}</span>
+          <div className="quickstart-pillar-status" aria-label="Pillar progress">
+            {(['Body', 'Mind', 'Soul'] as Pillar[]).map((item) => (
+              <span key={item} data-current={item === pillar}>{pillarLabels[item]} <small>{displayedSelections[item].length}/{effectiveMinimum}</small></span>
+            ))}
+          </div>
+          <div className="quickstart-foundation-count" aria-live="polite">
+            <span><strong>{selectedIds.length}</strong> / {effectiveMinimum} foundations</span>
+            <span>{selectedIds.length * 3} GP ready</span>
+          </div>
+          <div className="quickstart-foundation-progress" aria-hidden>
+            <span style={{ width: `${Math.min(100, (selectedIds.length / effectiveMinimum) * 100)}%` }} />
+          </div>
+        </header>
+      ) : (
+        <header className="mb-6">
+          <p className="text-xs uppercase tracking-[0.25em] text-white/55">{gameMode} · Quick Start</p>
+          <h1 className="mt-2 text-2xl font-semibold text-white sm:text-3xl">{copy.title}</h1>
+          <p className="mt-2 text-sm text-white/70">{copy.subtitle}</p>
+          <div className="quickstart-min-rule mt-4 inline-flex max-w-full items-center gap-2 rounded-full border px-4 py-1.5 text-xs font-semibold">
+            <span className="whitespace-nowrap">{copy.minRule}</span>
+            <span className="quickstart-min-rule__dot" aria-hidden>·</span>
+            <span className="whitespace-nowrap">{copy.suggestedRule}</span>
+          </div>
+          <div className="mt-2.5 flex flex-wrap items-center gap-2 text-xs">
+            <span className={`quickstart-bonus-pill inline-flex text-[0.68rem] font-medium sm:text-[0.72rem] ${balancedBonusActive ? 'quickstart-bonus-pill--ready' : 'quickstart-bonus-pill--pending'}`}>
+              {balancedBonusActive ? copy.bonusReady : copy.bonusPending}
+            </span>
+          </div>
+        </header>
+      )}
 
       <div className="space-y-2.5">
-        {tasks.map((task) => {
-          const selected = selectedIds.includes(task.id);
-          return (
-            <InlineTaskRow
-              key={task.id}
-              task={task}
-              selected={selected}
-              inputValue={inputValues[`${pillar}-${task.id}`] ?? ''}
-              onToggle={() => onToggleTask(task.id)}
-              onInputChange={(value) => onInputChange(task.id, value)}
-              copy={copy}
-            />
-          );
-        })}
+        {tasks.map((task) => (
+          <InlineTaskRow
+            key={task.id}
+            task={task}
+            selected={selectedIds.includes(task.id)}
+            inputValue={inputValues[`${pillar}-${task.id}`] ?? ''}
+            variant={variant}
+            onToggle={() => onToggleTask(task.id)}
+            onInputChange={(value) => onInputChange(task.id, value)}
+            copy={copy}
+          />
+        ))}
       </div>
 
-      {selectedIds.length < minimum ? <p className="mt-4 text-xs text-amber-200">{copy.minimumRequired}</p> : null}
-      {selectedIds.length >= minimum && hasMissingInput ? <p className="mt-4 text-xs text-amber-200">{copy.inputRequired}</p> : null}
+      {selectedIds.length < effectiveMinimum ? <p className="mt-4 text-xs text-amber-200">{copy.minimumRequired}</p> : null}
+      {selectedIds.length >= effectiveMinimum && hasMissingInput ? <p className="mt-4 text-xs text-amber-200">{copy.inputRequired}</p> : null}
 
       <NavButtons
         language={language}


### PR DESCRIPTION
## Objetivo

Conservar el rediseño visual de onboarding2 sin alterar el comportamiento del onboarding existente.

## Qué corrige

- Mantiene el selector segmentado, la nueva jerarquía visual, tarjetas, progreso y edición visual de cantidades únicamente en la variante `onboarding2`.
- Restaura el selector anterior con ondas, textos y estilos para el onboarding estándar.
- Restaura los mínimos por ritmo (`LOW`, `CHILL`, `FLOW`, `EVOLVE`) en lugar de exigir tres foundations para todos.
- Mantiene la previsualización de cantidades como presentación visual, sin usarla para decidir las reglas de selección.
- Conserva intacto el redirect de Google corregido en #2271.

## Archivos modificados

- `apps/web/src/onboarding/steps/GameModeStep.tsx`
- `apps/web/src/onboarding/steps/QuickStartTasksStep.tsx`

## Fuera de alcance

No toca:
- Clerk, Google OAuth, `/sso-callback` o redirects
- iOS, Android, Xcode o Capacitor
- API o base de datos
- rutas del onboarding
- dependencias

## Validación manual antes de merge

1. Crear cuenta con Google y confirmar llegada a `/intro-journey2`.
2. Verificar el selector visual segmentado en onboarding2.
3. Confirmar mínimos por ritmo: LOW 1, CHILL 2, FLOW 3, EVOLVE 3.
4. Confirmar que `/onboarding` conserva el selector anterior con ondas.
5. Completar Body, Mind y Soul y verificar navegación, inputs y CTA.

Esta PR se mantiene separada del arreglo de autenticación para reducir el riesgo de regresiones.