### PR TITLE
fix(auth): unify Google OAuth across web, Android and iOS

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -6,6 +6,7 @@ export type GoogleOAuthMode = 'sign-in' | 'sign-up';
 type GoogleOAuthButtonProps = {
   language: 'es' | 'en';
   mode: GoogleOAuthMode;
+  oauthMode?: GoogleOAuthMode;
   redirectUrlComplete: string;
   className?: string;
   forceAccountSelection?: boolean;
@@ -72,6 +73,7 @@ export function readOAuthRedirectIntent(): OAuthRedirectIntent | null {
 export function GoogleOAuthButton({
   language,
   mode,
+  oauthMode = 'sign-in',
   redirectUrlComplete,
   className = '',
   forceAccountSelection = false,
@@ -81,7 +83,7 @@ export function GoogleOAuthButton({
   const { isLoaded: isSignUpLoaded, signUp } = useSignUp();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
-  const isLoaded = mode === 'sign-up' ? isSignUpLoaded : isSignInLoaded;
+  const isLoaded = oauthMode === 'sign-up' ? isSignUpLoaded : isSignInLoaded;
   const isDisabled = !isLoaded || isRedirecting;
   const shouldForceAccountSelection = forceAccountSelection || mode === 'sign-up';
 
@@ -114,7 +116,7 @@ export function GoogleOAuthButton({
     persistOAuthRedirectIntent({ mode, redirectUrlComplete, createdAt: Date.now() });
 
     try {
-      if (mode === 'sign-up') {
+      if (oauthMode === 'sign-up') {
         if (!signUp) {
           throw new Error('Clerk sign-up resource is not ready');
         }
@@ -143,7 +145,7 @@ export function GoogleOAuthButton({
       console.error('[auth] Google OAuth redirect failed', error);
       setIsRedirecting(false);
     }
-  }, [allowCrossModeCompletion, isLoaded, isRedirecting, mode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
+  }, [allowCrossModeCompletion, isLoaded, isRedirecting, mode, oauthMode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
 
   return (
     <button

--- a/apps/web/src/mobile/capacitor.ts
+++ b/apps/web/src/mobile/capacitor.ts
@@ -246,7 +246,7 @@ export function buildNativeAppUrl(host: string): string {
   return `${CAPACITOR_APP_SCHEME}://${CAPACITOR_APP_HOST}/${host}`;
 }
 
-function shouldUseEphemeralIOSGoogleAuth(url: string): boolean {
+function shouldUseIOSNativeAuthSession(url: string): boolean {
   if (getCapacitorPlatform() !== 'ios') {
     return false;
   }
@@ -255,7 +255,6 @@ function shouldUseEphemeralIOSGoogleAuth(url: string): boolean {
     const parsed = new URL(url);
     const mode = parsed.searchParams.get('mode');
     return parsed.pathname.endsWith('/mobile-auth')
-      && parsed.searchParams.get('provider') === 'google'
       && parsed.searchParams.get('fresh') === '1'
       && (mode === 'sign-in' || mode === 'sign-up');
   } catch {
@@ -268,19 +267,33 @@ function dispatchNativeAuthCallback(url: string): void {
     return;
   }
 
-  window.dispatchEvent(new CustomEvent(NATIVE_AUTH_CALLBACK_EVENT, { detail: { url } }));
+  const event = new CustomEvent(NATIVE_AUTH_CALLBACK_EVENT, {
+    detail: { url },
+    cancelable: true,
+  });
+  const wasNotCancelled = window.dispatchEvent(event);
+
+  // The iOS auth plugin resolves inside the WebView rather than through
+  // Capacitor's appUrlOpen event. Older web bundles did not subscribe to the
+  // custom event, so fall back to the registered app scheme and let the
+  // existing appUrlOpen bridge consume the same normalized callback.
+  if (wasNotCancelled) {
+    window.setTimeout(() => {
+      window.location.assign(url);
+    }, 0);
+  }
 }
 
 export async function openUrlInCapacitorBrowser(url: string): Promise<void> {
-  if (shouldUseEphemeralIOSGoogleAuth(url)) {
+  if (shouldUseIOSNativeAuthSession(url)) {
     const authBrowser = getInnerbloomAuthBrowserPlugin();
     if (!authBrowser) {
-      console.error('[mobile-auth] InnerbloomAuthBrowser unavailable for fresh iOS Google auth', {
+      console.error('[mobile-auth] InnerbloomAuthBrowser unavailable for fresh iOS auth', {
         url,
         platform: getCapacitorPlatform(),
         hasCapacitor: Boolean(getCapacitorGlobal()),
       });
-      throw new Error('InnerbloomAuthBrowser is unavailable for fresh iOS Google auth.');
+      throw new Error('InnerbloomAuthBrowser is unavailable for fresh iOS auth.');
     }
 
     const startedAt = Date.now();
@@ -360,12 +373,8 @@ export function shouldOpenExternalUrl(url: string): boolean {
   }
 
   try {
-    const parsed = new URL(url, window.location.href);
-    if (!/^https?:$/i.test(parsed.protocol)) {
-      return false;
-    }
-
-    return parsed.origin !== window.location.origin;
+    const parsed = new URL(url, typeof window !== 'undefined' ? window.location.href : undefined);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
   } catch {
     return false;
   }

--- a/apps/web/src/mobile/capacitor.ts
+++ b/apps/web/src/mobile/capacitor.ts
@@ -255,7 +255,6 @@ function shouldUseIOSNativeAuthSession(url: string): boolean {
     const parsed = new URL(url);
     const mode = parsed.searchParams.get('mode');
     return parsed.pathname.endsWith('/mobile-auth')
-      && parsed.searchParams.get('fresh') === '1'
       && (mode === 'sign-in' || mode === 'sign-up');
   } catch {
     return false;
@@ -273,10 +272,6 @@ function dispatchNativeAuthCallback(url: string): void {
   });
   const wasNotCancelled = window.dispatchEvent(event);
 
-  // The iOS auth plugin resolves inside the WebView rather than through
-  // Capacitor's appUrlOpen event. Older web bundles did not subscribe to the
-  // custom event, so fall back to the registered app scheme and let the
-  // existing appUrlOpen bridge consume the same normalized callback.
   if (wasNotCancelled) {
     window.setTimeout(() => {
       window.location.assign(url);
@@ -288,12 +283,12 @@ export async function openUrlInCapacitorBrowser(url: string): Promise<void> {
   if (shouldUseIOSNativeAuthSession(url)) {
     const authBrowser = getInnerbloomAuthBrowserPlugin();
     if (!authBrowser) {
-      console.error('[mobile-auth] InnerbloomAuthBrowser unavailable for fresh iOS auth', {
+      console.error('[mobile-auth] InnerbloomAuthBrowser unavailable for iOS auth', {
         url,
         platform: getCapacitorPlatform(),
         hasCapacitor: Boolean(getCapacitorGlobal()),
       });
-      throw new Error('InnerbloomAuthBrowser is unavailable for fresh iOS auth.');
+      throw new Error('InnerbloomAuthBrowser is unavailable for iOS auth.');
     }
 
     const startedAt = Date.now();


### PR DESCRIPTION
## Objetivo

Corregir el flujo de autenticación de Clerk/Google para que respete los tres canales de entrada sin modificar la UX del onboarding:

- Web browser: Clerk mantiene el redirect dentro de la web.
- Android: Capacitor Browser vuelve mediante el deep link y `appUrlOpen`.
- iOS: `ASWebAuthenticationSession` devuelve el callback al esquema nativo y lo reinyecta en el bridge existente.

## Cambios

### Google OAuth
- Separa el modo visual (`Crear cuenta` / `Iniciar sesión`) del recurso de Clerk usado para OAuth.
- Google usa por defecto el recurso `signIn` de Clerk incluso cuando la intención visual es `sign-up`.
- Se conserva la intención original en sessionStorage, por lo que una cuenta creada desde onboarding continúa hacia onboarding2.
- Restaura compatibilidad con `oauthMode="sign-in"`, que ya estaba siendo utilizado por `MobileBrowserAuth`.

### iOS
- Todo flujo `/mobile-auth?mode=sign-in|sign-up` usa `InnerbloomAuthBrowser` en iOS, no solamente el caso que llevaba `provider=google&fresh=1`.
- Esto cubre tanto Google como email/Clerk dentro de la sesión segura de iOS.
- Cuando el plugin devuelve `innerbloom://...`, primero emite el evento web existente y, si nadie lo consume, usa el esquema registrado como fallback para activar el `appUrlOpen` ya manejado por `NativeMobileBridge`.

### Android y web
- Android conserva el flujo actual con Capacitor Browser y deep link.
- Web conserva el redirect SPA de Clerk; no interviene ningún bridge nativo.

## Casos a revisar antes de mergear

- [ ] Web desktop: crear cuenta con Google → onboarding2.
- [ ] Web responsive/mobile: crear cuenta con Google → onboarding2.
- [ ] Web: iniciar sesión con Google → destino esperado.
- [ ] Android: Google sign-up y sign-in vuelven a la app.
- [ ] Android: email sign-up y sign-in vuelven a la app.
- [ ] iOS: Google sign-up y sign-in vuelven a la app.
- [ ] iOS: email sign-up y sign-in vuelven a la app.
- [ ] Usuario Google ya existente entrando desde “Crear cuenta” no queda bloqueado.

## Alcance

No cambia archivos Swift, Gradle, Xcode ni configuración de Clerk/Google Console. El cambio está limitado a la capa web de autenticación y al adaptador Capacitor existente.