### PR TITLE
fix(seo): add Innerbloom favicon for search results

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/IB-COLOR-LOGO-v2.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" sizes="any" />
+    <link rel="alternate icon" type="image/png" href="/IB-COLOR-LOGO-v2.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="stylesheet" href="/landing-method-scroll-fix.css" />

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <image width="192" height="192" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdeXxV5b3//9clgZCQkJAQ2EAIYiIoIICgWlRURKttVbfiqLX2Wq3b+qqtbbW21q3VtrbWrVZrq7VW68KrWkVBEEQFRQHZEwIGQghJSEhIAklyzu+Pj/lNZJMcAuT+3k/n4zzP4Xye7/M871f2uRyS5zzPE4ZhGIYxDMOYf+JcugFhmA=="/>
+</svg>

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,3 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
-  <image width="192" height="192" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdeXxV5b3//9clgZCQkJAQ2EAIYiIoIICgWlRURKttVbfiqLX2Wq3b+qqtbbW21q3VtrbWrVZrq7VW68KrWkVBEEQFRQHZEwIGQghJSEhIAklyzu+Pj/lNZJMcAuT+3k/n4zzP4Xye7/M871f2uRyS5zzPE4ZhGIYxDMOYf+JcugFhmA=="/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" role="img" aria-label="Innerbloom">
+  <defs>
+    <linearGradient id="g" x1="25" y1="20" x2="165" y2="172" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#b88cff"/>
+      <stop offset="1" stop-color="#8d5cf6"/>
+    </linearGradient>
+  </defs>
+  <g fill="url(#g)">
+    <path d="M96 18C72 43 61 69 64 99c2 23 14 43 32 63 18-20 30-40 32-63 3-30-8-56-32-81Z"/>
+    <path d="M37 48c2 35 10 64 27 86 8 10 18 18 30 25-9-23-13-45-10-66 2-14 7-27 14-39-18-11-38-17-61-20Z"/>
+    <path d="M155 48c-2 35-10 64-27 86-8 10-18 18-30 25 9-23 13-45 10-66-2-14-7-27-14-39 18-11 38-17 61-20Z"/>
+    <path d="M22 98c9 31 27 55 53 69 9 5 19 7 30 7-20-15-35-31-45-49-7-12-12-25-15-39-8 1-16 5-23 12Z"/>
+    <path d="M170 98c-9 31-27 55-53 69-9 5-19 7-30 7 20-15 35-31 45-49 7-12 12-25 15-39 8 1 16 5 23 12Z"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Cambios
- agrega un favicon SVG dedicado con la marca de Innerbloom
- actualiza `apps/web/index.html` para que Google y Bing usen `/favicon.svg`
- mantiene el PNG actual como fallback

## Resultado esperado
Después del deploy y de que los buscadores vuelvan a rastrear la home, el icono de Innerbloom debería aparecer junto al resultado de búsqueda.