### PR TITLE
Fix iOS native auth plugin registration

### DIFF
--- a/apps/mobile/ios/App/App/AppDelegate.swift
+++ b/apps/mobile/ios/App/App/AppDelegate.swift
@@ -1,6 +1,12 @@
 import UIKit
 import Capacitor
 
+final class InnerbloomBridgeViewController: CAPBridgeViewController {
+    override open func capacitorDidLoad() {
+        bridge?.registerPluginInstance(InnerbloomAuthBrowserPlugin())
+    }
+}
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 

--- a/apps/mobile/ios/App/App/Base.lproj/Main.storyboard
+++ b/apps/mobile/ios/App/App/Base.lproj/Main.storyboard
@@ -8,10 +8,10 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
     </dependencies>
     <scenes>
-        <!--Bridge View Controller-->
+        <!--Innerbloom Bridge View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="CAPBridgeViewController" customModule="Capacitor" sceneMemberID="viewController"/>
+                <viewController id="BYZ-38-t0r" customClass="InnerbloomBridgeViewController" customModule="App" customModuleProvider="target" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
         </scene>


### PR DESCRIPTION
## Problema
`InnerbloomAuthBrowserPlugin.swift` estaba incluido en el target de iOS, pero el storyboard seguía instanciando directamente `CAPBridgeViewController`. Por eso JavaScript registraba `InnerbloomAuthBrowser.open() start`, pero la llamada nunca llegaba al plugin nativo.

## Cambio
- Agrega `InnerbloomBridgeViewController`, una subclase de `CAPBridgeViewController`.
- Registra `InnerbloomAuthBrowserPlugin` en `capacitorDidLoad()`.
- Configura `Main.storyboard` para usar `InnerbloomBridgeViewController`.

## Alcance
No modifica splash, iconos, `SceneDelegate`, lógica web, Clerk ni Android.

## Validación local recomendada
1. Actualizar la rama local.
2. `pnpm build` en `apps/web` con Node 20.
3. `pnpm exec cap copy ios` y `pnpm exec cap update ios` en `apps/mobile` con Node 24.
4. Abrir Xcode, limpiar build y ejecutar en el iPhone.
5. Confirmar que el log muestre `To Native -> InnerbloomAuthBrowser open` y que se abra la sesión de autenticación.