### PR TITLE
fix(web): add Innerbloom favicon metadata

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,8 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" sizes="any" />
-    <link rel="alternate icon" type="image/png" href="/IB-COLOR-LOGO-v2.png" />
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="stylesheet" href="/landing-method-scroll-fix.css" />
@@ -14,7 +15,6 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Innerbloom" />
-    <link rel="apple-touch-icon" href="/IB-COLOR-LOGO-v2.png" />
     <meta
       name="description"
       content="Obsérvate por primera vez en tercera persona y toma el control de tus acciones y hábitos."


### PR DESCRIPTION
## Cambios
- reemplaza los favicons anteriores por los nuevos PNG de Innerbloom
- agrega tamaños explícitos de 48x48 y 96x96 para buscadores
- actualiza el apple touch icon a 180x180

## Archivos
- `apps/web/index.html`

Los archivos PNG ya existen en `apps/web/public`.