### PR TITLE
fix(ios): complete Innerbloom 2 auth, splash and native branding

### DIFF
--- a/apps/mobile/ios/App/App/AppDelegate.swift
+++ b/apps/mobile/ios/App/App/AppDelegate.swift
@@ -2,7 +2,7 @@ import UIKit
 import Capacitor
 
 final class InnerbloomBridgeViewController: CAPBridgeViewController {
-    override open func capacitorDidLoad() {
+    override public func capacitorDidLoad() {
         bridge?.registerPluginInstance(InnerbloomAuthBrowserPlugin())
     }
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -10,6 +10,7 @@ import { getClerkLocalization } from './lib/clerkLocalization';
 import { ThemePreferenceProvider } from './theme/ThemePreferenceProvider';
 import { applyStoredThemePreference } from './theme/themePreference';
 import { PostLoginLanguageProvider } from './i18n/postLoginLanguage';
+import { IOSNativeAuthCallbackBridge } from './mobile/IOSNativeAuthCallbackBridge';
 import { NativeMobileBridge } from './mobile/NativeMobileBridge';
 import { isNativeCapacitorPlatform } from './mobile/capacitor';
 import { RuntimeAuthProvider } from './auth/runtimeAuth';
@@ -98,6 +99,7 @@ createRoot(rootElement).render(
       <LocalizedClerkProvider>
         <PostLoginLanguageProvider>
           <ThemePreferenceProvider>
+            <IOSNativeAuthCallbackBridge />
             <NativeMobileBridge />
             <App />
           </ThemePreferenceProvider>

--- a/apps/web/src/mobile/IOSNativeAuthCallbackBridge.tsx
+++ b/apps/web/src/mobile/IOSNativeAuthCallbackBridge.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  INNERBLOOM2_DASHBOARD_PATH,
+  INNERBLOOM2_INTRO_JOURNEY_PATH,
+} from '../config/auth';
+import { NATIVE_AUTH_CALLBACK_EVENT, getCapacitorPlatform } from './capacitor';
+import { resolveMobileAuthSessionFromCallback } from './mobileAuthSession';
+import { resolveCallbackTargetPath } from './NativeMobileBridge';
+
+function getCurrentAppPath(): string {
+  const { pathname, search, hash } = window.location;
+  return `${pathname || '/'}${search || ''}${hash || ''}`;
+}
+
+export function IOSNativeAuthCallbackBridge() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (getCapacitorPlatform() !== 'ios') {
+      return;
+    }
+
+    const handleNativeAuthCallback = (event: Event) => {
+      const customEvent = event as CustomEvent<{ url?: unknown }>;
+      const rawUrl = customEvent.detail?.url;
+      const url = typeof rawUrl === 'string' ? rawUrl.trim() : '';
+
+      if (!url) {
+        console.warn('[mobile-auth] iOS callback event ignored: missing url');
+        return;
+      }
+
+      customEvent.preventDefault();
+
+      const resolution = resolveMobileAuthSessionFromCallback(url);
+      if (!resolution) {
+        console.warn('[mobile-auth] iOS callback event ignored: invalid callback', { url });
+        return;
+      }
+
+      const currentPath = getCurrentAppPath();
+      const nextPath = resolution.type === 'session'
+        ? resolveCallbackTargetPath(resolution.session, currentPath)
+        : resolution.type === 'signed-out'
+          ? '/'
+          : INNERBLOOM2_DASHBOARD_PATH;
+
+      const safeNextPath = nextPath === '/intro-journey2'
+        ? INNERBLOOM2_INTRO_JOURNEY_PATH
+        : nextPath;
+
+      console.info('[mobile-auth] iOS callback event consumed', {
+        type: resolution.type,
+        currentPath,
+        nextPath: safeNextPath,
+        at: Date.now(),
+      });
+
+      navigate(safeNextPath, { replace: true });
+    };
+
+    window.addEventListener(NATIVE_AUTH_CALLBACK_EVENT, handleNativeAuthCallback);
+    return () => {
+      window.removeEventListener(NATIVE_AUTH_CALLBACK_EVENT, handleNativeAuthCallback);
+    };
+  }, [navigate]);
+
+  return null;
+}

--- a/apps/web/src/mobile/IOSNativeAuthCallbackBridge.tsx
+++ b/apps/web/src/mobile/IOSNativeAuthCallbackBridge.tsx
@@ -1,9 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import {
-  INNERBLOOM2_DASHBOARD_PATH,
-  INNERBLOOM2_INTRO_JOURNEY_PATH,
-} from '../config/auth';
+import { INNERBLOOM2_DASHBOARD_PATH } from '../config/auth';
 import { NATIVE_AUTH_CALLBACK_EVENT, getCapacitorPlatform } from './capacitor';
 import { resolveMobileAuthSessionFromCallback } from './mobileAuthSession';
 import { resolveCallbackTargetPath } from './NativeMobileBridge';
@@ -46,18 +43,14 @@ export function IOSNativeAuthCallbackBridge() {
           ? '/'
           : INNERBLOOM2_DASHBOARD_PATH;
 
-      const safeNextPath = nextPath === '/intro-journey2'
-        ? INNERBLOOM2_INTRO_JOURNEY_PATH
-        : nextPath;
-
       console.info('[mobile-auth] iOS callback event consumed', {
         type: resolution.type,
         currentPath,
-        nextPath: safeNextPath,
+        nextPath,
         at: Date.now(),
       });
 
-      navigate(safeNextPath, { replace: true });
+      navigate(nextPath, { replace: true });
     };
 
     window.addEventListener(NATIVE_AUTH_CALLBACK_EVENT, handleNativeAuthCallback);


### PR DESCRIPTION
## What this PR fixes

### Native authentication
- Registers the iOS `InnerbloomAuthBrowser` plugin correctly.
- Consumes the native callback inside React Router instead of trying to load `innerbloom://` in the WebView.
- Routes sign-up to `/intro-journey2` and sign-in to `/innerbloom2/dashboard`.
- Uses the native auth session for refresh and logout, preventing the infinite browser screen.

### Splash and iOS branding
- Restores a visible launch overlay while the Capacitor WebView initializes.
- Updates `LaunchScreen.storyboard` to the dark Innerbloom 2 presentation with centered flower and wordmark.
- Adds `pnpm brand:ios`, which generates the native iOS app icon and splash PNGs from the canonical existing asset:
  `apps/web/public/brand/innerbloom-2/flower-square-large.png`.
- The asset generation is deterministic and uses macOS `sips`; no new duplicated source-of-truth image is introduced.

### Delete account
- Reviewed the current Innerbloom 2 delete-account flow. It already calls `deleteCurrentAccount()`, blocks duplicate submissions, shows an error state, and invokes the same now-fixed native sign-out path after deletion. No speculative duplicate implementation was added.

## Physical-device validation already completed
- Native Google login returns to the app.
- Sign-up/login callback is consumed.
- Logout closes the browser session and returns to the native welcome screen.

## Final validation pending
- Run `pnpm brand:ios` once after pulling.
- Clean Build Folder, delete the installed app, and run on the connected iPhone.
- Confirm the new app icon, native splash, login, logout, onboarding route, dashboard route, and delete-account flow.