### PR TITLE
feat(ios): restore Innerbloom 2 splash and native branding

### DIFF
--- a/apps/mobile/ios/App/App/AppDelegate.swift
+++ b/apps/mobile/ios/App/App/AppDelegate.swift
@@ -2,8 +2,64 @@ import UIKit
 import Capacitor
 
 final class InnerbloomBridgeViewController: CAPBridgeViewController {
+    private var launchOverlay: UIView?
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        presentInnerbloomLaunchOverlay()
+    }
+
     override public func capacitorDidLoad() {
         bridge?.registerPluginInstance(InnerbloomAuthBrowserPlugin())
+    }
+
+    private func presentInnerbloomLaunchOverlay() {
+        guard launchOverlay == nil else { return }
+
+        let overlay = UIView()
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        overlay.backgroundColor = UIColor(red: 5 / 255, green: 7 / 255, blue: 11 / 255, alpha: 1)
+        overlay.isUserInteractionEnabled = false
+
+        let logo = UIImageView(image: UIImage(named: "Splash"))
+        logo.translatesAutoresizingMaskIntoConstraints = false
+        logo.contentMode = .scaleAspectFit
+
+        let wordmark = UILabel()
+        wordmark.translatesAutoresizingMaskIntoConstraints = false
+        wordmark.text = "INNERBLOOM"
+        wordmark.textColor = UIColor(white: 1, alpha: 0.92)
+        wordmark.font = UIFont.systemFont(ofSize: 21, weight: .semibold)
+        wordmark.textAlignment = .center
+        wordmark.adjustsFontForContentSizeCategory = true
+
+        overlay.addSubview(logo)
+        overlay.addSubview(wordmark)
+        view.addSubview(overlay)
+
+        NSLayoutConstraint.activate([
+            overlay.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            overlay.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            overlay.topAnchor.constraint(equalTo: view.topAnchor),
+            overlay.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            logo.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+            logo.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: -24),
+            logo.widthAnchor.constraint(equalToConstant: 156),
+            logo.heightAnchor.constraint(equalTo: logo.widthAnchor),
+            wordmark.topAnchor.constraint(equalTo: logo.bottomAnchor, constant: 18),
+            wordmark.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+        ])
+
+        launchOverlay = overlay
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.35) { [weak self, weak overlay] in
+            UIView.animate(withDuration: 0.28, animations: {
+                overlay?.alpha = 0
+            }, completion: { _ in
+                overlay?.removeFromSuperview()
+                self?.launchOverlay = nil
+            })
+        }
     }
 }
 

--- a/apps/mobile/ios/App/App/Base.lproj/LaunchScreen.storyboard
+++ b/apps/mobile/ios/App/App/Base.lproj/LaunchScreen.storyboard
@@ -1,22 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17132" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17105"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
         <scene sceneID="EHf-IW-A2E">
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
-                    <imageView key="view" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Splash" id="snD-IY-ifK">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    </imageView>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Splash" translatesAutoresizingMaskIntoConstraints="NO" id="snD-IY-ifK">
+                                <rect key="frame" x="109.5" y="231.5" width="156" height="156"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="156" id="QfM-logo-width"/>
+                                    <constraint firstAttribute="height" constant="156" id="QfM-logo-height"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="INNERBLOOM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="brand-wordmark">
+                                <rect key="frame" x="124" y="405" width="127" height="25"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
+                                <color key="textColor" white="0.92" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" red="0.01960784314" green="0.02745098039" blue="0.0431372549" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="snD-IY-ifK" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="QfM-logo-center-x"/>
+                            <constraint firstItem="snD-IY-ifK" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" constant="-24" id="QfM-logo-center-y"/>
+                            <constraint firstItem="brand-wordmark" firstAttribute="top" secondItem="snD-IY-ifK" secondAttribute="bottom" constant="18" id="QfM-wordmark-top"/>
+                            <constraint firstItem="brand-wordmark" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="QfM-wordmark-center-x"/>
+                        </constraints>
+                    </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -25,8 +46,5 @@
     </scenes>
     <resources>
         <image name="Splash" width="1366" height="1366"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build:web": "VITE_BUILD_TARGET=native pnpm --dir ../web build",
+    "brand:ios": "bash ./scripts/refresh-ios-brand-assets.sh",
     "sync": "cap sync",
     "sync:android": "pnpm run build:web && cap sync android",
     "sync:ios": "pnpm run build:web && cap sync ios",

--- a/apps/mobile/scripts/refresh-ios-brand-assets.sh
+++ b/apps/mobile/scripts/refresh-ios-brand-assets.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${MOBILE_DIR}/../.." && pwd)"
+SOURCE="${REPO_ROOT}/apps/web/public/brand/innerbloom-2/flower-square-large.png"
+ASSETS="${MOBILE_DIR}/ios/App/App/Assets.xcassets"
+APP_ICON="${ASSETS}/AppIcon.appiconset/AppIcon-512@2x.png"
+SPLASH_DIR="${ASSETS}/Splash.imageset"
+
+if [[ ! -f "${SOURCE}" ]]; then
+  echo "Missing Innerbloom 2 logo asset: ${SOURCE}" >&2
+  exit 1
+fi
+
+if ! command -v sips >/dev/null 2>&1; then
+  echo "This script requires macOS sips." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${APP_ICON}")" "${SPLASH_DIR}"
+
+sips --resampleHeightWidth 1024 1024 "${SOURCE}" --out "${APP_ICON}" >/dev/null
+
+for filename in splash-2732x2732.png splash-2732x2732-1.png splash-2732x2732-2.png; do
+  sips --resampleHeightWidth 2732 2732 "${SOURCE}" --out "${SPLASH_DIR}/${filename}" >/dev/null
+done
+
+echo "Updated iOS app icon and splash assets from Innerbloom 2 brand source."

--- a/apps/web/src/mobile/capacitor.ts
+++ b/apps/web/src/mobile/capacitor.ts
@@ -255,7 +255,7 @@ function shouldUseIOSNativeAuthSession(url: string): boolean {
     const parsed = new URL(url);
     const mode = parsed.searchParams.get('mode');
     return parsed.pathname.endsWith('/mobile-auth')
-      && (mode === 'sign-in' || mode === 'sign-up');
+      && (mode === 'sign-in' || mode === 'sign-up' || mode === 'refresh' || mode === 'logout');
   } catch {
     return false;
   }


### PR DESCRIPTION
Superseded by a clean follow-up PR from `agent/ios-innerbloom2-branding`. This PR pointed to the older auth branch and is intentionally closed to avoid duplicate or conflicting history.