### PR TITLE
fix(ios): use canonical Innerbloom 2 splash lockup

### DIFF
--- a/apps/mobile/ios/App/App/AppDelegate.swift
+++ b/apps/mobile/ios/App/App/AppDelegate.swift
@@ -21,20 +21,21 @@ final class InnerbloomBridgeViewController: CAPBridgeViewController {
         overlay.backgroundColor = UIColor(red: 5 / 255, green: 7 / 255, blue: 11 / 255, alpha: 1)
         overlay.isUserInteractionEnabled = false
 
+        let glow = UIView()
+        glow.translatesAutoresizingMaskIntoConstraints = false
+        glow.backgroundColor = UIColor(red: 132 / 255, green: 92 / 255, blue: 246 / 255, alpha: 0.14)
+        glow.layer.cornerRadius = 150
+        glow.layer.shadowColor = UIColor(red: 132 / 255, green: 92 / 255, blue: 246 / 255, alpha: 1).cgColor
+        glow.layer.shadowOpacity = 0.36
+        glow.layer.shadowRadius = 72
+        glow.layer.shadowOffset = .zero
+
         let logo = UIImageView(image: UIImage(named: "Splash"))
         logo.translatesAutoresizingMaskIntoConstraints = false
         logo.contentMode = .scaleAspectFit
 
-        let wordmark = UILabel()
-        wordmark.translatesAutoresizingMaskIntoConstraints = false
-        wordmark.text = "INNERBLOOM"
-        wordmark.textColor = UIColor(white: 1, alpha: 0.92)
-        wordmark.font = UIFont.systemFont(ofSize: 21, weight: .semibold)
-        wordmark.textAlignment = .center
-        wordmark.adjustsFontForContentSizeCategory = true
-
+        overlay.addSubview(glow)
         overlay.addSubview(logo)
-        overlay.addSubview(wordmark)
         view.addSubview(overlay)
 
         NSLayoutConstraint.activate([
@@ -42,12 +43,16 @@ final class InnerbloomBridgeViewController: CAPBridgeViewController {
             overlay.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             overlay.topAnchor.constraint(equalTo: view.topAnchor),
             overlay.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            glow.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+            glow.centerYAnchor.constraint(equalTo: overlay.centerYAnchor),
+            glow.widthAnchor.constraint(equalToConstant: 300),
+            glow.heightAnchor.constraint(equalTo: glow.widthAnchor),
+
             logo.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
-            logo.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: -24),
-            logo.widthAnchor.constraint(equalToConstant: 156),
-            logo.heightAnchor.constraint(equalTo: logo.widthAnchor),
-            wordmark.topAnchor.constraint(equalTo: logo.bottomAnchor, constant: 18),
-            wordmark.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+            logo.centerYAnchor.constraint(equalTo: overlay.centerYAnchor),
+            logo.widthAnchor.constraint(lessThanOrEqualTo: overlay.widthAnchor, multiplier: 0.58),
+            logo.heightAnchor.constraint(lessThanOrEqualToConstant: 260),
         ])
 
         launchOverlay = overlay

--- a/apps/mobile/ios/App/App/Base.lproj/LaunchScreen.storyboard
+++ b/apps/mobile/ios/App/App/Base.lproj/LaunchScreen.storyboard
@@ -4,7 +4,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17105"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -15,27 +14,29 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="glw-IB-202">
+                                <rect key="frame" x="37.5" y="183.5" width="300" height="300"/>
+                                <color key="backgroundColor" red="0.5176470588" green="0.3607843137" blue="0.9647058824" alpha="0.12" colorSpace="custom" customColorSpace="sRGB"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <real key="value" value="150"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Splash" translatesAutoresizingMaskIntoConstraints="NO" id="snD-IY-ifK">
-                                <rect key="frame" x="109.5" y="231.5" width="156" height="156"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="156" id="QfM-logo-width"/>
-                                    <constraint firstAttribute="height" constant="156" id="QfM-logo-height"/>
-                                </constraints>
+                                <rect key="frame" x="79" y="203.5" width="217" height="260"/>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="INNERBLOOM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="brand-wordmark">
-                                <rect key="frame" x="124" y="405" width="127" height="25"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
-                                <color key="textColor" white="0.92" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" red="0.01960784314" green="0.02745098039" blue="0.0431372549" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="snD-IY-ifK" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="QfM-logo-center-x"/>
-                            <constraint firstItem="snD-IY-ifK" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" constant="-24" id="QfM-logo-center-y"/>
-                            <constraint firstItem="brand-wordmark" firstAttribute="top" secondItem="snD-IY-ifK" secondAttribute="bottom" constant="18" id="QfM-wordmark-top"/>
-                            <constraint firstItem="brand-wordmark" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="QfM-wordmark-center-x"/>
+                            <constraint firstItem="glw-IB-202" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="glw-x"/>
+                            <constraint firstItem="glw-IB-202" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="glw-y"/>
+                            <constraint firstItem="glw-IB-202" firstAttribute="width" constant="300" id="glw-w"/>
+                            <constraint firstItem="glw-IB-202" firstAttribute="height" constant="300" id="glw-h"/>
+                            <constraint firstItem="snD-IY-ifK" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="logo-x"/>
+                            <constraint firstItem="snD-IY-ifK" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="logo-y"/>
+                            <constraint firstItem="snD-IY-ifK" firstAttribute="width" secondItem="Ze5-6b-2t3" secondAttribute="width" multiplier="0.58" id="logo-w"/>
+                            <constraint firstItem="snD-IY-ifK" firstAttribute="height" constant="260" id="logo-h"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/apps/mobile/scripts/refresh-ios-brand-assets.sh
+++ b/apps/mobile/scripts/refresh-ios-brand-assets.sh
@@ -4,27 +4,25 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MOBILE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${MOBILE_DIR}/../.." && pwd)"
-SOURCE="${REPO_ROOT}/apps/web/public/brand/innerbloom-2/flower-square-large.png"
+
+ICON_SOURCE="${REPO_ROOT}/apps/web/public/brand/innerbloom-2/flower-square-large.png"
+SPLASH_SOURCE="${REPO_ROOT}/apps/web/public/IB-COLOR-LOGO-v2.png"
 ASSETS="${MOBILE_DIR}/ios/App/App/Assets.xcassets"
 APP_ICON="${ASSETS}/AppIcon.appiconset/AppIcon-512@2x.png"
 SPLASH_DIR="${ASSETS}/Splash.imageset"
 
-if [[ ! -f "${SOURCE}" ]]; then
-  echo "Missing Innerbloom 2 logo asset: ${SOURCE}" >&2
-  exit 1
-fi
-
-if ! command -v sips >/dev/null 2>&1; then
-  echo "This script requires macOS sips." >&2
-  exit 1
-fi
+[[ -f "${ICON_SOURCE}" ]] || { echo "Missing ${ICON_SOURCE}" >&2; exit 1; }
+[[ -f "${SPLASH_SOURCE}" ]] || { echo "Missing ${SPLASH_SOURCE}" >&2; exit 1; }
+command -v sips >/dev/null || { echo "macOS sips is required" >&2; exit 1; }
 
 mkdir -p "$(dirname "${APP_ICON}")" "${SPLASH_DIR}"
 
-sips --resampleHeightWidth 1024 1024 "${SOURCE}" --out "${APP_ICON}" >/dev/null
+# Home-screen icon: standalone flower mark.
+sips --resampleHeightWidth 1024 1024 "${ICON_SOURCE}" --out "${APP_ICON}" >/dev/null
 
+# Launch screen: canonical complete Innerbloom lockup. Preserve aspect ratio/transparency.
 for filename in splash-2732x2732.png splash-2732x2732-1.png splash-2732x2732-2.png; do
-  sips --resampleHeightWidth 2732 2732 "${SOURCE}" --out "${SPLASH_DIR}/${filename}" >/dev/null
+  cp "${SPLASH_SOURCE}" "${SPLASH_DIR}/${filename}"
 done
 
-echo "Updated iOS app icon and splash assets from Innerbloom 2 brand source."
+echo "Updated iOS icon from the flower mark and splash from IB-COLOR-LOGO-v2.png."


### PR DESCRIPTION
## Fix
- Uses `apps/web/public/IB-COLOR-LOGO-v2.png` as the splash source.
- Keeps the standalone flower only for the iOS home-screen icon.
- Removes the synthetic `UILabel` wordmark and system font.
- Preserves the real logo aspect ratio and transparency.
- Centers the canonical lockup on the dark launch screen with a subtle violet glow.

## Validation
1. Pull `agent/fix-ios-splash-lockup`.
2. Run `pnpm brand:ios` from `apps/mobile`.
3. Delete the installed app from the iPhone.
4. Clean Build Folder and run from Xcode.

No auth, routing, Android, or web behavior is changed.