### PR TITLE
fix(ios): show clean Innerbloom splash on every open

### DIFF
--- a/apps/mobile/ios/App/App/AppDelegate.swift
+++ b/apps/mobile/ios/App/App/AppDelegate.swift
@@ -6,36 +6,59 @@ final class InnerbloomBridgeViewController: CAPBridgeViewController {
 
     override public func viewDidLoad() {
         super.viewDidLoad()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
         presentInnerbloomLaunchOverlay()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     override public func capacitorDidLoad() {
         bridge?.registerPluginInstance(InnerbloomAuthBrowserPlugin())
     }
 
+    @objc private func applicationDidBecomeActive() {
+        presentInnerbloomLaunchOverlay()
+    }
+
     private func presentInnerbloomLaunchOverlay() {
-        guard launchOverlay == nil else { return }
+        guard launchOverlay == nil, isViewLoaded, view.window != nil else { return }
 
         let overlay = UIView()
         overlay.translatesAutoresizingMaskIntoConstraints = false
         overlay.backgroundColor = UIColor(red: 5 / 255, green: 7 / 255, blue: 11 / 255, alpha: 1)
         overlay.isUserInteractionEnabled = false
 
-        let glow = UIView()
-        glow.translatesAutoresizingMaskIntoConstraints = false
-        glow.backgroundColor = UIColor(red: 132 / 255, green: 92 / 255, blue: 246 / 255, alpha: 0.14)
-        glow.layer.cornerRadius = 150
-        glow.layer.shadowColor = UIColor(red: 132 / 255, green: 92 / 255, blue: 246 / 255, alpha: 1).cgColor
-        glow.layer.shadowOpacity = 0.36
-        glow.layer.shadowRadius = 72
-        glow.layer.shadowOffset = .zero
-
         let logo = UIImageView(image: UIImage(named: "Splash"))
         logo.translatesAutoresizingMaskIntoConstraints = false
         logo.contentMode = .scaleAspectFit
 
-        overlay.addSubview(glow)
-        overlay.addSubview(logo)
+        let wordmark = UILabel()
+        wordmark.translatesAutoresizingMaskIntoConstraints = false
+        wordmark.textAlignment = .center
+        wordmark.numberOfLines = 1
+        wordmark.attributedText = NSAttributedString(
+            string: "INNERBLOOM",
+            attributes: [
+                .font: UIFont(name: "AvenirNext-DemiBold", size: 17) ?? UIFont.systemFont(ofSize: 17, weight: .semibold),
+                .foregroundColor: UIColor(white: 1, alpha: 0.78),
+                .kern: 6.5,
+            ]
+        )
+
+        let lockup = UIStackView(arrangedSubviews: [logo, wordmark])
+        lockup.translatesAutoresizingMaskIntoConstraints = false
+        lockup.axis = .vertical
+        lockup.alignment = .center
+        lockup.spacing = 20
+
+        overlay.addSubview(lockup)
         view.addSubview(overlay)
 
         NSLayoutConstraint.activate([
@@ -44,21 +67,16 @@ final class InnerbloomBridgeViewController: CAPBridgeViewController {
             overlay.topAnchor.constraint(equalTo: view.topAnchor),
             overlay.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-            glow.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
-            glow.centerYAnchor.constraint(equalTo: overlay.centerYAnchor),
-            glow.widthAnchor.constraint(equalToConstant: 300),
-            glow.heightAnchor.constraint(equalTo: glow.widthAnchor),
-
-            logo.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
-            logo.centerYAnchor.constraint(equalTo: overlay.centerYAnchor),
-            logo.widthAnchor.constraint(lessThanOrEqualTo: overlay.widthAnchor, multiplier: 0.58),
-            logo.heightAnchor.constraint(lessThanOrEqualToConstant: 260),
+            lockup.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+            lockup.centerYAnchor.constraint(equalTo: overlay.centerYAnchor),
+            logo.widthAnchor.constraint(equalToConstant: 118),
+            logo.heightAnchor.constraint(equalToConstant: 118),
         ])
 
         launchOverlay = overlay
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.35) { [weak self, weak overlay] in
-            UIView.animate(withDuration: 0.28, animations: {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.25) { [weak self, weak overlay] in
+            UIView.animate(withDuration: 0.24, animations: {
                 overlay?.alpha = 0
             }, completion: { _ in
                 overlay?.removeFromSuperview()

--- a/apps/mobile/ios/App/App/Base.lproj/LaunchScreen.storyboard
+++ b/apps/mobile/ios/App/App/Base.lproj/LaunchScreen.storyboard
@@ -14,29 +14,26 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="glw-IB-202">
-                                <rect key="frame" x="37.5" y="183.5" width="300" height="300"/>
-                                <color key="backgroundColor" red="0.5176470588" green="0.3607843137" blue="0.9647058824" alpha="0.12" colorSpace="custom" customColorSpace="sRGB"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <real key="value" value="150"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Splash" translatesAutoresizingMaskIntoConstraints="NO" id="snD-IY-ifK">
-                                <rect key="frame" x="79" y="203.5" width="217" height="260"/>
+                                <rect key="frame" x="128.5" y="226.5" width="118" height="118"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="118" id="logo-width"/>
+                                    <constraint firstAttribute="height" constant="118" id="logo-height"/>
+                                </constraints>
                             </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="I N N E R B L O O M" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" translatesAutoresizingMaskIntoConstraints="NO" id="brand-wordmark">
+                                <rect key="frame" x="91" y="364.5" width="193" height="22"/>
+                                <fontDescription key="fontDescription" name="AvenirNext-DemiBold" family="Avenir Next" pointSize="15"/>
+                                <color key="textColor" white="0.78" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="0.01960784314" green="0.02745098039" blue="0.0431372549" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="glw-IB-202" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="glw-x"/>
-                            <constraint firstItem="glw-IB-202" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="glw-y"/>
-                            <constraint firstItem="glw-IB-202" firstAttribute="width" constant="300" id="glw-w"/>
-                            <constraint firstItem="glw-IB-202" firstAttribute="height" constant="300" id="glw-h"/>
-                            <constraint firstItem="snD-IY-ifK" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="logo-x"/>
-                            <constraint firstItem="snD-IY-ifK" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="logo-y"/>
-                            <constraint firstItem="snD-IY-ifK" firstAttribute="width" secondItem="Ze5-6b-2t3" secondAttribute="width" multiplier="0.58" id="logo-w"/>
-                            <constraint firstItem="snD-IY-ifK" firstAttribute="height" constant="260" id="logo-h"/>
+                            <constraint firstItem="snD-IY-ifK" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="logo-center-x"/>
+                            <constraint firstItem="snD-IY-ifK" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" constant="-48" id="logo-center-y"/>
+                            <constraint firstItem="brand-wordmark" firstAttribute="top" secondItem="snD-IY-ifK" secondAttribute="bottom" constant="20" id="wordmark-top"/>
+                            <constraint firstItem="brand-wordmark" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="wordmark-center-x"/>
                         </constraints>
                     </view>
                 </viewController>
@@ -46,6 +43,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="Splash" width="1366" height="1366"/>
+        <image name="Splash" width="1024" height="1024"/>
     </resources>
 </document>

--- a/apps/mobile/scripts/refresh-ios-brand-assets.sh
+++ b/apps/mobile/scripts/refresh-ios-brand-assets.sh
@@ -6,7 +6,7 @@ MOBILE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${MOBILE_DIR}/../.." && pwd)"
 
 ICON_SOURCE="${REPO_ROOT}/apps/web/public/brand/innerbloom-2/flower-square-large.png"
-SPLASH_SOURCE="${REPO_ROOT}/apps/web/public/IB-COLOR-LOGO-v2.png"
+SPLASH_SOURCE="${REPO_ROOT}/apps/web/public/brand/innerbloom-2/flower-transparent.png"
 ASSETS="${MOBILE_DIR}/ios/App/App/Assets.xcassets"
 APP_ICON="${ASSETS}/AppIcon.appiconset/AppIcon-512@2x.png"
 SPLASH_DIR="${ASSETS}/Splash.imageset"
@@ -17,12 +17,12 @@ command -v sips >/dev/null || { echo "macOS sips is required" >&2; exit 1; }
 
 mkdir -p "$(dirname "${APP_ICON}")" "${SPLASH_DIR}"
 
-# Home-screen icon: standalone flower mark.
+# Home-screen icon: square source prepared for iOS.
 sips --resampleHeightWidth 1024 1024 "${ICON_SOURCE}" --out "${APP_ICON}" >/dev/null
 
-# Launch screen: canonical complete Innerbloom lockup. Preserve aspect ratio/transparency.
+# Splash flower: transparent mark only. The native layout renders the wordmark separately.
 for filename in splash-2732x2732.png splash-2732x2732-1.png splash-2732x2732-2.png; do
-  cp "${SPLASH_SOURCE}" "${SPLASH_DIR}/${filename}"
+  sips --resampleHeightWidth 1024 1024 "${SPLASH_SOURCE}" --out "${SPLASH_DIR}/${filename}" >/dev/null
 done
 
-echo "Updated iOS icon from the flower mark and splash from IB-COLOR-LOGO-v2.png."
+echo "Updated iOS icon and transparent Innerbloom splash mark."


### PR DESCRIPTION
## Fix
- Removes the circular/solid backdrop behind the flower.
- Uses `apps/web/public/brand/innerbloom-2/flower-transparent.png` for the native splash mark.
- Adds the `INNERBLOOM` wordmark below the flower in both the launch storyboard and runtime overlay.
- Shows the splash on cold launch and every time the app becomes active again, regardless of authentication state.
- Keeps auth, routing, Android, and web behavior unchanged.

## Validation
1. Pull `agent/fix-ios-splash-every-open`.
2. Run `pnpm brand:ios` from `apps/mobile`.
3. Delete the installed app once to refresh cached launch assets.
4. Clean Build Folder and run from Xcode.
5. Verify cold launch, background/foreground, signed-in, and signed-out states.