### PR TITLE
feat(android): unified auth attempt (superseded by corrective PR)

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -54,6 +54,7 @@ repositories {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation "androidx.browser:browser:$androidxBrowserVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
     implementation project(':capacitor-android')

--- a/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
+++ b/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
@@ -1,0 +1,69 @@
+package org.innerbloom.app;
+
+import android.net.Uri;
+
+import androidx.browser.customtabs.CustomTabsIntent;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.util.Locale;
+
+@CapacitorPlugin(name = "InnerbloomAuthBrowser")
+public class InnerbloomAuthBrowserPlugin extends Plugin {
+    @PluginMethod
+    public void open(PluginCall call) {
+        String urlString = call.getString("url");
+        if (urlString == null || urlString.trim().isEmpty()) {
+            call.reject("Must provide a valid URL to open", "AUTH_INVALID_URL");
+            return;
+        }
+
+        Uri uri;
+        try {
+            uri = Uri.parse(urlString.trim());
+        } catch (Exception error) {
+            call.reject("Must provide a valid URL to open", "AUTH_INVALID_URL", error);
+            return;
+        }
+
+        String scheme = uri.getScheme();
+        if (scheme == null) {
+            call.reject("Authentication URL must use HTTP or HTTPS", "AUTH_INVALID_URL_SCHEME");
+            return;
+        }
+
+        String normalizedScheme = scheme.toLowerCase(Locale.US);
+        if (!"http".equals(normalizedScheme) && !"https".equals(normalizedScheme)) {
+            call.reject("Authentication URL must use HTTP or HTTPS", "AUTH_INVALID_URL_SCHEME");
+            return;
+        }
+
+        getActivity().runOnUiThread(() -> {
+            try {
+                CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder()
+                        .setShowTitle(false)
+                        .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+                        .build();
+                customTabsIntent.intent.setPackage(resolveCustomTabsPackage());
+                customTabsIntent.launchUrl(getContext(), uri);
+
+                // Android returns the final callback through Capacitor's appUrlOpen event.
+                // Resolving here only confirms that the system authentication surface opened.
+                JSObject result = new JSObject();
+                result.put("handoff", "appUrlOpen");
+                call.resolve(result);
+            } catch (Exception error) {
+                call.reject("Unable to start authentication session", "AUTH_START_FAILED", error);
+            }
+        });
+    }
+
+    private String resolveCustomTabsPackage() {
+        String packageName = CustomTabsIntent.getPackageName(getContext(), null);
+        return packageName != null ? packageName : getContext().getPackageName();
+    }
+}

--- a/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
+++ b/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
@@ -48,7 +48,6 @@ public class InnerbloomAuthBrowserPlugin extends Plugin {
                         .setShowTitle(false)
                         .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
                         .build();
-                customTabsIntent.intent.setPackage(resolveCustomTabsPackage());
                 customTabsIntent.launchUrl(getContext(), uri);
 
                 // Android returns the final callback through Capacitor's appUrlOpen event.
@@ -60,10 +59,5 @@ public class InnerbloomAuthBrowserPlugin extends Plugin {
                 call.reject("Unable to start authentication session", "AUTH_START_FAILED", error);
             }
         });
-    }
-
-    private String resolveCustomTabsPackage() {
-        String packageName = CustomTabsIntent.getPackageName(getContext(), null);
-        return packageName != null ? packageName : getContext().getPackageName();
     }
 }

--- a/apps/mobile/android/app/src/main/java/org/innerbloom/app/MainActivity.java
+++ b/apps/mobile/android/app/src/main/java/org/innerbloom/app/MainActivity.java
@@ -14,6 +14,7 @@ import com.getcapacitor.BridgeActivity;
 public class MainActivity extends BridgeActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        registerPlugin(InnerbloomAuthBrowserPlugin.class);
         super.onCreate(savedInstanceState);
 
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);

--- a/apps/mobile/android/variables.gradle
+++ b/apps/mobile/android/variables.gradle
@@ -4,6 +4,7 @@ ext {
     targetSdkVersion = 36
     androidxActivityVersion = '1.11.0'
     androidxAppCompatVersion = '1.7.1'
+    androidxBrowserVersion = '1.10.0'
     androidxCoordinatorLayoutVersion = '1.3.0'
     androidxCoreVersion = '1.17.0'
     androidxFragmentVersion = '1.8.9'

--- a/apps/web/src/mobile/capacitor.ts
+++ b/apps/web/src/mobile/capacitor.ts
@@ -115,6 +115,9 @@ export const CAPACITOR_KEYBOARD_STYLE_DARK = 'DARK' as const;
 export const CAPACITOR_KEYBOARD_RESIZE_NATIVE = 'native' as const;
 export const NATIVE_AUTH_CALLBACK_EVENT = 'innerbloom:native-auth-callback';
 
+const NATIVE_AUTH_LOGOUT_REMINDER_PRESERVE_KEY = 'innerbloom.mobile.auth.logout-reminder-preserve.v1';
+const NATIVE_AUTH_LOGOUT_REMINDER_PRESERVE_TTL_MS = 5_000;
+
 function buildNativeCallbackPrefixes(): string[] {
   return [
     `${CAPACITOR_APP_SCHEME}://${CAPACITOR_APP_HOST}/${CAPACITOR_CALLBACK_HOST}`,
@@ -246,19 +249,48 @@ export function buildNativeAppUrl(host: string): string {
   return `${CAPACITOR_APP_SCHEME}://${CAPACITOR_APP_HOST}/${host}`;
 }
 
-function shouldUseIOSNativeAuthSession(url: string): boolean {
-  if (getCapacitorPlatform() !== 'ios') {
+type NativeAuthMode = 'sign-in' | 'sign-up' | 'refresh' | 'logout';
+
+function resolveNativeAuthMode(url: string): NativeAuthMode | null {
+  try {
+    const parsed = new URL(url);
+    if (!parsed.pathname.endsWith('/mobile-auth')) {
+      return null;
+    }
+
+    const mode = parsed.searchParams.get('mode');
+    return mode === 'sign-in' || mode === 'sign-up' || mode === 'refresh' || mode === 'logout'
+      ? mode
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function shouldUseNativeAuthPlugin(url: string): boolean {
+  const platform = getCapacitorPlatform();
+  return (platform === 'ios' || platform === 'android') && resolveNativeAuthMode(url) !== null;
+}
+
+function markNativeLogoutReminderPreservation(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.sessionStorage.setItem(NATIVE_AUTH_LOGOUT_REMINDER_PRESERVE_KEY, String(Date.now()));
+}
+
+export function consumeNativeLogoutReminderPreservation(): boolean {
+  if (typeof window === 'undefined') {
     return false;
   }
 
-  try {
-    const parsed = new URL(url);
-    const mode = parsed.searchParams.get('mode');
-    return parsed.pathname.endsWith('/mobile-auth')
-      && (mode === 'sign-in' || mode === 'sign-up' || mode === 'refresh' || mode === 'logout');
-  } catch {
-    return false;
-  }
+  const raw = window.sessionStorage.getItem(NATIVE_AUTH_LOGOUT_REMINDER_PRESERVE_KEY);
+  window.sessionStorage.removeItem(NATIVE_AUTH_LOGOUT_REMINDER_PRESERVE_KEY);
+  const startedAt = Number(raw);
+  return Number.isFinite(startedAt)
+    && startedAt > 0
+    && Date.now() - startedAt <= NATIVE_AUTH_LOGOUT_REMINDER_PRESERVE_TTL_MS;
 }
 
 function dispatchNativeAuthCallback(url: string): void {
@@ -280,34 +312,43 @@ function dispatchNativeAuthCallback(url: string): void {
 }
 
 export async function openUrlInCapacitorBrowser(url: string): Promise<void> {
-  if (shouldUseIOSNativeAuthSession(url)) {
+  const nativeAuthMode = resolveNativeAuthMode(url);
+  if (nativeAuthMode === 'logout') {
+    markNativeLogoutReminderPreservation();
+  }
+
+  if (shouldUseNativeAuthPlugin(url)) {
+    const platform = getCapacitorPlatform();
     const authBrowser = getInnerbloomAuthBrowserPlugin();
     if (!authBrowser) {
-      console.error('[mobile-auth] InnerbloomAuthBrowser unavailable for iOS auth', {
+      console.error('[mobile-auth] InnerbloomAuthBrowser unavailable for native auth', {
         url,
-        platform: getCapacitorPlatform(),
+        platform,
         hasCapacitor: Boolean(getCapacitorGlobal()),
       });
-      throw new Error('InnerbloomAuthBrowser is unavailable for iOS auth.');
-    }
+      if (platform === 'ios') {
+        throw new Error('InnerbloomAuthBrowser is unavailable for iOS auth.');
+      }
+    } else {
+      const startedAt = Date.now();
+      console.info('[mobile-auth] InnerbloomAuthBrowser.open() start', { url, platform, startedAt });
+      const result = await authBrowser.open({
+        url,
+        callbackScheme: CAPACITOR_APP_SCHEME,
+        prefersEphemeralWebBrowserSession: true,
+      });
+      console.info('[mobile-auth] InnerbloomAuthBrowser.open() end', {
+        url,
+        platform,
+        callbackUrl: result?.url ?? null,
+        finishedAt: Date.now(),
+      });
 
-    const startedAt = Date.now();
-    console.info('[mobile-auth] InnerbloomAuthBrowser.open() start', { url, startedAt });
-    const result = await authBrowser.open({
-      url,
-      callbackScheme: CAPACITOR_APP_SCHEME,
-      prefersEphemeralWebBrowserSession: true,
-    });
-    console.info('[mobile-auth] InnerbloomAuthBrowser.open() end', {
-      url,
-      callbackUrl: result?.url ?? null,
-      finishedAt: Date.now(),
-    });
-
-    if (result?.url) {
-      dispatchNativeAuthCallback(result.url);
+      if (result?.url) {
+        dispatchNativeAuthCallback(result.url);
+      }
+      return;
     }
-    return;
   }
 
   const browser = getCapacitorBrowserPlugin();

--- a/apps/web/src/mobile/localNotifications.ts
+++ b/apps/web/src/mobile/localNotifications.ts
@@ -3,7 +3,11 @@ import { resolvePostLoginTranslation } from '../i18n/post-login';
 import { type PostLoginLanguage, POSTLOGIN_LANGUAGE_STORAGE_KEY, detectDeviceLanguage } from '../i18n/postLoginLanguage';
 import { AUTH_LANGUAGE_STORAGE_KEY } from '../lib/authLanguage';
 import { INNERBLOOM2_DAILY_QUEST_PATH } from '../config/auth';
-import { getCapacitorLocalNotificationsPlugin, isNativeCapacitorPlatform } from './capacitor';
+import {
+  consumeNativeLogoutReminderPreservation,
+  getCapacitorLocalNotificationsPlugin,
+  isNativeCapacitorPlatform,
+} from './capacitor';
 import { writeMobileDebug } from './mobileDebug';
 
 const DAILY_REMINDER_NOTIFICATION_CHANNEL_ID = 'daily-quest-reminders';
@@ -18,6 +22,7 @@ type DailyReminderNotificationPermissionResult = {
 };
 
 const ONBOARDING_LANGUAGE_STORAGE_KEY = 'innerbloom.onboarding.language';
+let isReminderSyncInProgress = false;
 
 function normalizeLanguage(raw: string | null | undefined): PostLoginLanguage | null {
   if (!raw) {
@@ -144,11 +149,7 @@ export async function ensureNativeDailyReminderNotificationPermissions(options?:
   return { granted: true, exactAlarm: null };
 }
 
-export async function cancelNativeDailyReminderNotification(): Promise<void> {
-  if (!isNativeCapacitorPlatform()) {
-    return;
-  }
-
+async function performNativeDailyReminderCancellation(): Promise<void> {
   const plugin = getCapacitorLocalNotificationsPlugin();
   if (!plugin) {
     logNativeReminder('cancel-plugin-missing');
@@ -160,6 +161,34 @@ export async function cancelNativeDailyReminderNotification(): Promise<void> {
   logNativeReminder('cancel-scheduled', {
     ids: notifications.map((notification) => notification.id),
   });
+}
+
+export async function cancelNativeDailyReminderNotification(): Promise<void> {
+  if (!isNativeCapacitorPlatform()) {
+    return;
+  }
+
+  if (isReminderSyncInProgress || typeof window === 'undefined') {
+    await performNativeDailyReminderCancellation();
+    return;
+  }
+
+  // Logout currently asks for cancellation before opening the auth surface. Defer
+  // one task so the unified auth adapter can mark that lifecycle as "preserve".
+  // Account deletion does not open logout auth, so its cancellation still runs.
+  logNativeReminder('cancel-deferred-for-lifecycle-check');
+  window.setTimeout(() => {
+    if (consumeNativeLogoutReminderPreservation()) {
+      logNativeReminder('cancel-skipped-for-logout');
+      return;
+    }
+
+    void performNativeDailyReminderCancellation().catch((error) => {
+      logNativeReminder('cancel-failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }, 0);
 }
 
 export async function sendNativeDailyReminderTestNotification(): Promise<void> {
@@ -236,86 +265,91 @@ export async function syncNativeDailyReminderNotification(
     return;
   }
 
-  if (!isReminderEnabled(reminder)) {
-    logNativeReminder('sync-reminder-disabled', {
+  isReminderSyncInProgress = true;
+  try {
+    if (!isReminderEnabled(reminder)) {
+      logNativeReminder('sync-reminder-disabled', {
+        status: reminder?.status ?? null,
+        enabled: reminder?.enabled ?? null,
+      });
+      await cancelNativeDailyReminderNotification();
+      return;
+    }
+
+    const permissions = options?.requestPermissions
+      ? await ensureNativeDailyReminderNotificationPermissions()
+      : await plugin.checkPermissions().then((result) => ({ granted: result.display === 'granted' }));
+
+    if (!permissions.granted) {
+      logNativeReminder('sync-permission-denied', { requestPermissions: options?.requestPermissions === true });
+      await cancelNativeDailyReminderNotification();
+      if (options?.requestPermissions) {
+        throw new Error(tNotification('dailyQuest.mobile.permissionRequired'));
+      }
+      return;
+    }
+
+    const { hour, minute, second } = normalizeLocalTimeParts(reminder?.local_time ?? reminder?.localTime ?? '09:00:00');
+    const exactAlarm = await plugin.checkExactNotificationSetting?.().catch((error) => {
+      logNativeReminder('sync-exact-alarm-check-failed', { error: error instanceof Error ? error.message : String(error) });
+      return null;
+    });
+    if (exactAlarm) {
+      logNativeReminder('sync-exact-alarm-check', { exactAlarm: exactAlarm.exact_alarm });
+    }
+    await plugin.createChannel?.({
+      id: DAILY_REMINDER_NOTIFICATION_CHANNEL_ID,
+      name: 'Daily Quest reminders',
+      description: 'Daily reminders to open your Daily Quest.',
+      importance: 4,
+      visibility: 1,
+      lights: true,
+      vibration: true,
+    }).catch((error) => {
+      logNativeReminder('sync-channel-create-failed', { error: error instanceof Error ? error.message : String(error) });
+    });
+
+    logNativeReminder('sync-schedule-start', {
+      id: DAILY_REMINDER_NOTIFICATION_ID,
+      hour,
+      minute,
+      second,
       status: reminder?.status ?? null,
       enabled: reminder?.enabled ?? null,
+      channel: reminder?.channel ?? null,
     });
+
     await cancelNativeDailyReminderNotification();
-    return;
-  }
-
-  const permissions = options?.requestPermissions
-    ? await ensureNativeDailyReminderNotificationPermissions()
-    : await plugin.checkPermissions().then((result) => ({ granted: result.display === 'granted' }));
-
-  if (!permissions.granted) {
-    logNativeReminder('sync-permission-denied', { requestPermissions: options?.requestPermissions === true });
-    await cancelNativeDailyReminderNotification();
-    if (options?.requestPermissions) {
-      throw new Error(tNotification('dailyQuest.mobile.permissionRequired'));
-    }
-    return;
-  }
-
-  const { hour, minute, second } = normalizeLocalTimeParts(reminder?.local_time ?? reminder?.localTime ?? '09:00:00');
-  const exactAlarm = await plugin.checkExactNotificationSetting?.().catch((error) => {
-    logNativeReminder('sync-exact-alarm-check-failed', { error: error instanceof Error ? error.message : String(error) });
-    return null;
-  });
-  if (exactAlarm) {
-    logNativeReminder('sync-exact-alarm-check', { exactAlarm: exactAlarm.exact_alarm });
-  }
-  await plugin.createChannel?.({
-    id: DAILY_REMINDER_NOTIFICATION_CHANNEL_ID,
-    name: 'Daily Quest reminders',
-    description: 'Daily reminders to open your Daily Quest.',
-    importance: 4,
-    visibility: 1,
-    lights: true,
-    vibration: true,
-  }).catch((error) => {
-    logNativeReminder('sync-channel-create-failed', { error: error instanceof Error ? error.message : String(error) });
-  });
-
-  logNativeReminder('sync-schedule-start', {
-    id: DAILY_REMINDER_NOTIFICATION_ID,
-    hour,
-    minute,
-    second,
-    status: reminder?.status ?? null,
-    enabled: reminder?.enabled ?? null,
-    channel: reminder?.channel ?? null,
-  });
-
-  await cancelNativeDailyReminderNotification();
-  await plugin.schedule({
-    notifications: [
-      {
-        id: DAILY_REMINDER_NOTIFICATION_ID,
-        title: tNotification('dailyQuest.mobile.notification.title'),
-        body: tNotification('dailyQuest.mobile.notification.body'),
-        channelId: DAILY_REMINDER_NOTIFICATION_CHANNEL_ID,
-        smallIcon: 'ic_stat_innerbloom',
-        iconColor: '#A855F7',
-        schedule: {
-          on: { hour, minute, second },
-          allowWhileIdle: true,
+    await plugin.schedule({
+      notifications: [
+        {
+          id: DAILY_REMINDER_NOTIFICATION_ID,
+          title: tNotification('dailyQuest.mobile.notification.title'),
+          body: tNotification('dailyQuest.mobile.notification.body'),
+          channelId: DAILY_REMINDER_NOTIFICATION_CHANNEL_ID,
+          smallIcon: 'ic_stat_innerbloom',
+          iconColor: '#A855F7',
+          schedule: {
+            on: { hour, minute, second },
+            allowWhileIdle: true,
+          },
+          extra: {
+            targetPath: DAILY_REMINDER_NOTIFICATION_TARGET_PATH,
+            kind: 'daily-reminder',
+          },
         },
-        extra: {
-          targetPath: DAILY_REMINDER_NOTIFICATION_TARGET_PATH,
-          kind: 'daily-reminder',
-        },
-      },
-    ],
-  });
-  const pending = await plugin.getPending?.().catch((error) => {
-    logNativeReminder('sync-pending-check-failed', { error: error instanceof Error ? error.message : String(error) });
-    return null;
-  });
-  logNativeReminder('sync-scheduled', {
-    id: DAILY_REMINDER_NOTIFICATION_ID,
-    pendingCount: pending?.notifications?.length ?? null,
-    pendingIds: pending?.notifications?.map((notification) => notification.id).filter(Boolean) ?? null,
-  });
+      ],
+    });
+    const pending = await plugin.getPending?.().catch((error) => {
+      logNativeReminder('sync-pending-check-failed', { error: error instanceof Error ? error.message : String(error) });
+      return null;
+    });
+    logNativeReminder('sync-scheduled', {
+      id: DAILY_REMINDER_NOTIFICATION_ID,
+      pendingCount: pending?.notifications?.length ?? null,
+      pendingIds: pending?.notifications?.map((notification) => notification.id).filter(Boolean) ?? null,
+    });
+  } finally {
+    isReminderSyncInProgress = false;
+  }
 }


### PR DESCRIPTION
## Objetivo

Unificar la superficie de autenticación nativa para que iOS y Android utilicen el mismo contrato de Capacitor (`InnerbloomAuthBrowser`) sin modificar la implementación nativa de iOS.

## Estado posterior a validación

La PR fue mergeada, pero la validación en Android detectó dos regresiones:
- logout termina en `ERR_UNKNOWN_URL_SCHEME` al navegar a `innerbloom://localhost/signed-out` dentro del Custom Tab;
- Google reutiliza la cuenta anterior sin mostrar el selector.

La corrección está siendo preparada en una PR posterior basada en `main`, habilitando navegación del Custom Tab hacia el handler externo de deep links y navegación efímera sin cookies compartidas.

## Resultado de validación

Compila e instala, pero este flujo Android quedó reemplazado por la corrección posterior.