### PR TITLE
fix(android): restore logout callback and Google account picker

### DIFF
--- a/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
+++ b/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
@@ -47,6 +47,8 @@ public class InnerbloomAuthBrowserPlugin extends Plugin {
                 CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder()
                         .setShowTitle(false)
                         .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+                        .setEphemeralBrowsingEnabled(true)
+                        .setSendToExternalDefaultHandlerEnabled(true)
                         .build();
                 customTabsIntent.launchUrl(getContext(), uri);
 


### PR DESCRIPTION
## Problema confirmado en `main`

La PR #2282 fue mergeada en `main`. La validación en Android detectó dos regresiones:

1. El logout terminaba en Chrome con `ERR_UNKNOWN_URL_SCHEME` al navegar a `innerbloom://localhost/signed-out`.
2. Google reutilizaba la sesión/cuenta del navegador sin mostrar el selector de cuentas.

## Causa

El plugin Android abría un Custom Tab estándar que:

- compartía cookies y estado con el navegador;
- no estaba configurado para entregar redirects posteriores al handler externo registrado por la app.

## Corrección

En `InnerbloomAuthBrowserPlugin.java`:

- habilita `setEphemeralBrowsingEnabled(true)` para no compartir cookies ni sesión con Chrome cuando el proveedor lo soporta;
- habilita `setSendToExternalDefaultHandlerEnabled(true)` para que los redirects `innerbloom://...` salgan del Custom Tab y vuelvan a `MainActivity` mediante los intent filters existentes;
- mantiene intacto el plugin iOS y el flujo de notificaciones de #2282.

## Validación requerida antes del merge

- Login con Google muestra selección de cuenta.
- Logout vuelve a la app sin `ERR_UNKNOWN_URL_SCHEME`.
- Segundo login vuelve a mostrar selección de cuenta.
- Login por email sigue funcionando.
- Recordatorio permanece después de logout.

No se realizó merge automático.