### PR TITLE
fix(android): keep native auth session alive across app navigation

### DIFF
--- a/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
+++ b/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
@@ -47,7 +47,9 @@ public class InnerbloomAuthBrowserPlugin extends Plugin {
                 CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder()
                         .setShowTitle(false)
                         .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
-                        .setEphemeralBrowsingEnabled(true)
+                        // Keep the Clerk browser session available so short-lived native callback
+                        // tokens can be refreshed without forcing the user through sign-in again.
+                        // Account selection is still forced by the web flow with prompt=select_account.
                         .setSendToExternalDefaultHandlerEnabled(true)
                         .build();
                 customTabsIntent.launchUrl(getContext(), uri);


### PR DESCRIPTION
## Bugs reproducidos en Android

Después de #2283:

- el callback vuelve correctamente a la app;
- logout y delete account funcionan;
- al navegar desde Dashboard a Tareas, DQuest o Logros, la app termina perdiendo la sesión y vuelve al welcome/landing;
- crear cuenta no completa de forma estable el paso hacia onboarding2;
- durante el fallo aparece otra vez la pantalla web de sign-in.

## Causa identificada

La #2283 activó `setEphemeralBrowsingEnabled(true)` en el Custom Tab Android.

El token que la web entrega a la app es un token corto de Clerk. Cuando una pantalla protegida necesita renovarlo, `ensureFreshMobileAuthSession()` vuelve a abrir `/mobile-auth?mode=refresh`.

Como el Custom Tab era efímero, esa nueva ventana no conservaba la sesión Clerk anterior. El refresh terminaba abriendo Sign in, el backend seguía rechazando el token vencido y la app limpiaba la sesión local. Por eso parecía que tocar Tareas, DQuest o Logros hacía logout.

El mismo corte de sesión podía interrumpir el flujo posterior a crear cuenta antes de entrar correctamente en onboarding2.

## Corrección

En la implementación Android del contrato único `InnerbloomAuthBrowser`:

- se mantiene `setSendToExternalDefaultHandlerEnabled(true)` para devolver `innerbloom://...` a la app;
- se elimina el modo efímero del Custom Tab para conservar la sesión web de Clerk y permitir refresh silencioso;
- el selector de cuenta Google sigue controlado por el flujo compartido web mediante `oidcPrompt: 'select_account'` y el reset `fresh=1`;
- no se modifica iOS, las rutas V2 ni la lógica de logout/delete account.

## Validación requerida

1. Crear cuenta con Google → vuelve automáticamente a la app → abre onboarding2.
2. Login existente → Dashboard.
3. Esperar al menos 2–3 minutos.
4. Abrir Tareas, Logros y DQuest sin perder sesión ni ver Sign in.
5. Volver a Dashboard y confirmar que la data permanece.
6. Logout vuelve al welcome.
7. Segundo login Google muestra selector de cuenta.
8. Delete account continúa funcionando.

No se realizó merge automático.