### PR TITLE
fix(android): close auth tab and return to native app

### DIFF
--- a/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
+++ b/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
@@ -1,5 +1,6 @@
 package org.innerbloom.app;
 
+import android.content.Intent;
 import android.net.Uri;
 
 import androidx.browser.customtabs.CustomTabsIntent;
@@ -52,7 +53,13 @@ public class InnerbloomAuthBrowserPlugin extends Plugin {
                         // Account selection is still forced by the web flow with prompt=select_account.
                         .setSendToExternalDefaultHandlerEnabled(true)
                         .build();
-                customTabsIntent.launchUrl(getContext(), uri);
+
+                // The auth tab is a temporary system surface, not the app itself. Launch it from
+                // MainActivity so the deep-link callback returns to the existing Capacitor task,
+                // and keep the tab out of history so authenticated app routes can never remain
+                // visible underneath Chrome's Custom Tab toolbar.
+                customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+                customTabsIntent.launchUrl(getActivity(), uri);
 
                 // Android returns the final callback through Capacitor's appUrlOpen event.
                 // Resolving here only confirms that the system authentication surface opened.


### PR DESCRIPTION
## Problema confirmado

Después de completar login, la autenticación devolvía correctamente el callback pero el Custom Tab de Chrome seguía como superficie visible. Por eso Dashboard, DQuest, Tareas y Logros aparecían debajo de la barra del navegador y la experiencia parecía una web embebida en lugar de la app Capacitor.

## Causa

La implementación Android de `InnerbloomAuthBrowser` lanzaba el Custom Tab con `getContext()`. Eso podía desacoplar la pestaña temporal del task activo de `MainActivity`. Además, el Custom Tab quedaba disponible en el historial y podía seguir ocupando el primer plano después del callback.

## Corrección

- lanza el Custom Tab desde `getActivity()` para asociarlo al task nativo existente;
- agrega `Intent.FLAG_ACTIVITY_NO_HISTORY` para que la superficie de autenticación desaparezca al volver por deep link;
- mantiene `setSendToExternalDefaultHandlerEnabled(true)` para entregar `innerbloom://...` a la app;
- mantiene la sesión web de Clerk para refresh silencioso;
- no modifica iOS, rutas V2, logout, delete account ni la interfaz compartida del plugin.

## Validación requerida

1. Abrir la app nativa.
2. Login con Google o email.
3. Confirmar que, al terminar, desaparece por completo la barra de Chrome.
4. Navegar Dashboard → DQuest → Tareas → Logros dentro del WebView nativo.
5. Confirmar que no queda ninguna pantalla de la app dentro del Custom Tab.
6. Repetir logout y segundo login.

No se realizó merge automático.