### PR TITLE
fix(android): close auth tab and return to native app

### DIFF
--- a/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
+++ b/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
@@ -1,5 +1,6 @@
 package org.innerbloom.app;
 
+import android.content.Intent;
 import android.net.Uri;
 
 import androidx.browser.customtabs.CustomTabsIntent;
@@ -52,7 +53,15 @@ public class InnerbloomAuthBrowserPlugin extends Plugin {
                         // Account selection is still forced by the web flow with prompt=select_account.
                         .setSendToExternalDefaultHandlerEnabled(true)
                         .build();
-                customTabsIntent.launchUrl(getContext(), uri);
+
+                // Authentication is the only reason this Custom Tab exists. Once the browser
+                // hands an innerbloom:// callback back to MainActivity, Android must discard the
+                // tab instead of leaving the web application visible above the Capacitor app.
+                customTabsIntent.intent.addFlags(
+                        Intent.FLAG_ACTIVITY_NO_HISTORY
+                                | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+                );
+                customTabsIntent.launchUrl(getActivity(), uri);
 
                 // Android returns the final callback through Capacitor's appUrlOpen event.
                 // Resolving here only confirms that the system authentication surface opened.


### PR DESCRIPTION
## Problema confirmado

Después de completar el login, Android sí recibía el callback y la sesión nativa funcionaba, pero el Custom Tab de Chrome quedaba por encima de la aplicación. Por eso Dashboard, DQuest, Tareas y Logros se veían con la barra del navegador y la app parecía una web embebida.

## Causa

`InnerbloomAuthBrowserPlugin` abría el Custom Tab para autenticar, pero ese tab no quedaba marcado como temporal. Aunque `MainActivity` recibía `innerbloom://...`, Chrome podía permanecer visible y continuar mostrando las rutas web autenticadas.

## Corrección

En la implementación Android del contrato compartido `InnerbloomAuthBrowser`:

- conserva la sesión de Clerk para permitir refresh silencioso;
- mantiene la entrega externa de `innerbloom://...` hacia `MainActivity`;
- marca el Custom Tab con `FLAG_ACTIVITY_NO_HISTORY` para que se descarte al volver a la app;
- lo excluye de Recientes;
- lo lanza desde la Activity actual, no desde el contexto genérico.

No se modifica iOS, la web, las rutas V2 ni la lógica de sesión.

## Validación requerida

1. Abrir la app nativa.
2. Login con Google o email.
3. Confirmar que, al terminar, desaparece por completo la barra de Chrome.
4. Navegar por Dashboard, DQuest, Tareas y Logros dentro del WebView nativo.
5. Esperar 2–3 minutos y repetir la navegación para validar refresh de sesión.
6. Logout y segundo login.

No se realizó merge automático.