### PR TITLE
fix(mobile): keep internal routes inside Capacitor

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,6 +11,7 @@ import { ThemePreferenceProvider } from './theme/ThemePreferenceProvider';
 import { applyStoredThemePreference } from './theme/themePreference';
 import { PostLoginLanguageProvider } from './i18n/postLoginLanguage';
 import { IOSNativeAuthCallbackBridge } from './mobile/IOSNativeAuthCallbackBridge';
+import { NativeInternalNavigationBridge } from './mobile/NativeInternalNavigationBridge';
 import { NativeMobileBridge } from './mobile/NativeMobileBridge';
 import { isNativeCapacitorPlatform } from './mobile/capacitor';
 import { RuntimeAuthProvider } from './auth/runtimeAuth';
@@ -100,6 +101,7 @@ createRoot(rootElement).render(
         <PostLoginLanguageProvider>
           <ThemePreferenceProvider>
             <IOSNativeAuthCallbackBridge />
+            <NativeInternalNavigationBridge />
             <NativeMobileBridge />
             <App />
           </ThemePreferenceProvider>

--- a/apps/web/src/mobile/NativeInternalNavigationBridge.tsx
+++ b/apps/web/src/mobile/NativeInternalNavigationBridge.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { isNativeCapacitorPlatform } from './capacitor';
+
+function isPlainPrimaryClick(event: MouseEvent): boolean {
+  return event.button === 0
+    && !event.altKey
+    && !event.ctrlKey
+    && !event.metaKey
+    && !event.shiftKey;
+}
+
+/**
+ * Capacitor can serve the app from the production HTTPS origin. In that setup,
+ * React Router links resolve to absolute https://innerbloomjourney.org URLs.
+ * The generic external-link bridge used to classify every HTTP(S) URL as
+ * external and opened those routes in a Chrome Custom Tab.
+ *
+ * This bridge claims same-origin links first and routes them through React
+ * Router, while leaving true external links to the existing browser bridge.
+ */
+export function NativeInternalNavigationBridge() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isNativeCapacitorPlatform()) {
+      return;
+    }
+
+    const handleClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || !isPlainPrimaryClick(event)) {
+        return;
+      }
+
+      const element = event.target instanceof Element
+        ? event.target.closest('a[href]')
+        : null;
+      if (!(element instanceof HTMLAnchorElement)) {
+        return;
+      }
+
+      if (element.hasAttribute('download') || element.target === '_blank') {
+        return;
+      }
+
+      let url: URL;
+      try {
+        url = new URL(element.href, window.location.href);
+      } catch {
+        return;
+      }
+
+      if (url.origin !== window.location.origin) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      navigate(`${url.pathname}${url.search}${url.hash}` || '/');
+    };
+
+    document.addEventListener('click', handleClick, true);
+    return () => document.removeEventListener('click', handleClick, true);
+  }, [navigate]);
+
+  return null;
+}


### PR DESCRIPTION
## Bug confirmado leyendo `main`

El problema no era que Android conservara abierto el Custom Tab del login.

La causa real estaba en el bridge genérico de enlaces nativos:

- `shouldOpenExternalUrl()` clasificaba **cualquier URL `http` o `https` como externa**;
- dentro de Capacitor, los `<NavLink>` internos de React Router se resolvían como URLs absolutas del mismo origen (`https://innerbloomjourney.org/innerbloom2/...`);
- el listener global de `NativeMobileBridge` interceptaba esos clics y llamaba a `Browser.open()`;
- por eso Dashboard podía verse dentro del WebView nativo, pero al tocar DQuest, Tareas o Logros se abría Chrome con la barra visible.

## Corrección

Se agrega `NativeInternalNavigationBridge`, montado antes del bridge de enlaces externos:

- intercepta únicamente clics normales sobre enlaces del mismo origen;
- los navega mediante React Router (`navigate()`), dentro del WebView de Capacitor;
- deja enlaces realmente externos, descargas y `_blank` al bridge existente;
- no modifica login, refresh, logout, iOS ni las rutas V2.

## Validación

1. Login y llegada a Dashboard sin barra de Chrome.
2. Tocar DQuest, Dashboard, Tareas y Logros repetidamente.
3. Confirmar que nunca aparece la barra `innerbloomjourney.org`.
4. Abrir un enlace externo real y confirmar que sí abre el navegador.
5. Esperar 2–3 minutos y repetir para validar también el refresh de sesión.

No se realizó merge automático.