### PR TITLE
fix(auth): restore Google OAuth without regressing native session flows

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -17,6 +17,8 @@ type GoogleOAuthButtonProps = {
   redirectUrlComplete: string;
   className?: string;
   forceAccountSelection?: boolean;
+  /** @deprecated Cross-mode continuation is intentionally ignored because Clerk rejects it for this OAuth flow. */
+  allowCrossModeCompletion?: boolean;
 };
 
 const SSO_CALLBACK_PATH = '/sso-callback';

--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -3,6 +3,13 @@ import { useSignIn, useSignUp } from '@clerk/clerk-react';
 
 export type GoogleOAuthMode = 'sign-in' | 'sign-up';
 
+export type GoogleOAuthRedirectOptions = {
+  strategy: 'oauth_google';
+  redirectUrl: string;
+  redirectUrlComplete: string;
+  oidcPrompt?: 'select_account';
+};
+
 type GoogleOAuthButtonProps = {
   language: 'es' | 'en';
   mode: GoogleOAuthMode;
@@ -10,7 +17,6 @@ type GoogleOAuthButtonProps = {
   redirectUrlComplete: string;
   className?: string;
   forceAccountSelection?: boolean;
-  allowCrossModeCompletion?: boolean;
 };
 
 const SSO_CALLBACK_PATH = '/sso-callback';
@@ -22,6 +28,48 @@ export type OAuthRedirectIntent = {
   redirectUrlComplete: string;
   createdAt: number;
 };
+
+export function buildGoogleOAuthRedirectOptions(
+  redirectUrlComplete: string,
+  forceAccountSelection: boolean,
+): GoogleOAuthRedirectOptions {
+  return {
+    strategy: 'oauth_google',
+    redirectUrl: SSO_CALLBACK_PATH,
+    redirectUrlComplete,
+    oidcPrompt: forceAccountSelection ? 'select_account' : undefined,
+  };
+}
+
+export function describeClerkOAuthError(error: unknown): Record<string, unknown> {
+  const candidate = error && typeof error === 'object'
+    ? error as {
+        name?: unknown;
+        message?: unknown;
+        code?: unknown;
+        errors?: Array<{ code?: unknown; message?: unknown; longMessage?: unknown }>;
+      }
+    : null;
+
+  return {
+    name: error instanceof Error ? error.name : typeof candidate?.name === 'string' ? candidate.name : null,
+    message: error instanceof Error
+      ? error.message
+      : typeof candidate?.message === 'string'
+        ? candidate.message
+        : typeof error === 'string'
+          ? error
+          : String(error),
+    code: typeof candidate?.code === 'string' ? candidate.code : null,
+    errors: Array.isArray(candidate?.errors)
+      ? candidate.errors.map((item) => ({
+          code: typeof item?.code === 'string' ? item.code : null,
+          message: typeof item?.message === 'string' ? item.message : null,
+          longMessage: typeof item?.longMessage === 'string' ? item.longMessage : null,
+        }))
+      : [],
+  };
+}
 
 function persistOAuthRedirectIntent(intent: OAuthRedirectIntent) {
   if (typeof window === 'undefined') {
@@ -77,7 +125,6 @@ export function GoogleOAuthButton({
   redirectUrlComplete,
   className = '',
   forceAccountSelection = false,
-  allowCrossModeCompletion = false,
 }: GoogleOAuthButtonProps) {
   const { isLoaded: isSignInLoaded, signIn } = useSignIn();
   const { isLoaded: isSignUpLoaded, signUp } = useSignUp();
@@ -114,38 +161,28 @@ export function GoogleOAuthButton({
 
     setIsRedirecting(true);
     persistOAuthRedirectIntent({ mode, redirectUrlComplete, createdAt: Date.now() });
+    const redirectOptions = buildGoogleOAuthRedirectOptions(
+      redirectUrlComplete,
+      shouldForceAccountSelection,
+    );
 
     try {
       if (oauthMode === 'sign-up') {
         if (!signUp) {
           throw new Error('Clerk sign-up resource is not ready');
         }
-        await signUp.authenticateWithRedirect({
-          strategy: 'oauth_google',
-          redirectUrl: SSO_CALLBACK_PATH,
-          redirectUrlComplete,
-          continueSignIn: allowCrossModeCompletion,
-          continueSignUp: allowCrossModeCompletion,
-          oidcPrompt: shouldForceAccountSelection ? 'select_account' : undefined,
-        });
+        await signUp.authenticateWithRedirect(redirectOptions);
       } else {
         if (!signIn) {
           throw new Error('Clerk sign-in resource is not ready');
         }
-        await signIn.authenticateWithRedirect({
-          strategy: 'oauth_google',
-          redirectUrl: SSO_CALLBACK_PATH,
-          redirectUrlComplete,
-          continueSignIn: allowCrossModeCompletion,
-          continueSignUp: allowCrossModeCompletion,
-          oidcPrompt: shouldForceAccountSelection ? 'select_account' : undefined,
-        });
+        await signIn.authenticateWithRedirect(redirectOptions);
       }
     } catch (error) {
-      console.error('[auth] Google OAuth redirect failed', error);
+      console.error(`[auth] Google OAuth redirect failed ${JSON.stringify(describeClerkOAuthError(error))}`);
       setIsRedirecting(false);
     }
-  }, [allowCrossModeCompletion, isLoaded, isRedirecting, mode, oauthMode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
+  }, [isLoaded, isRedirecting, mode, oauthMode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
 
   return (
     <button

--- a/apps/web/src/components/auth/__tests__/GoogleOAuthButton.test.ts
+++ b/apps/web/src/components/auth/__tests__/GoogleOAuthButton.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildGoogleOAuthRedirectOptions,
+  describeClerkOAuthError,
+} from '../GoogleOAuthButton';
+
+describe('Google OAuth redirect contract', () => {
+  it('starts a fresh Clerk OAuth attempt without cross-mode continuation flags', () => {
+    const options = buildGoogleOAuthRedirectOptions(
+      'https://innerbloomjourney.org/mobile-auth?mode=sign-up&handoff=1',
+      true,
+    );
+
+    expect(options).toEqual({
+      strategy: 'oauth_google',
+      redirectUrl: '/sso-callback',
+      redirectUrlComplete: 'https://innerbloomjourney.org/mobile-auth?mode=sign-up&handoff=1',
+      oidcPrompt: 'select_account',
+    });
+    expect(options).not.toHaveProperty('continueSignIn');
+    expect(options).not.toHaveProperty('continueSignUp');
+  });
+
+  it('keeps account selection optional for flows that do not request it', () => {
+    const options = buildGoogleOAuthRedirectOptions('/innerbloom2/dashboard', false);
+
+    expect(options.oidcPrompt).toBeUndefined();
+    expect(options.redirectUrlComplete).toBe('/innerbloom2/dashboard');
+  });
+
+  it('serializes Clerk errors into Logcat-readable fields', () => {
+    const details = describeClerkOAuthError({
+      code: 'oauth_error',
+      message: 'transferable not supported yet',
+      errors: [{
+        code: 'form_identifier_exists',
+        message: 'Account already exists',
+        longMessage: 'Use the existing sign-in flow.',
+      }],
+    });
+
+    expect(details).toEqual({
+      name: null,
+      message: 'transferable not supported yet',
+      code: 'oauth_error',
+      errors: [{
+        code: 'form_identifier_exists',
+        message: 'Account already exists',
+        longMessage: 'Use the existing sign-in flow.',
+      }],
+    });
+  });
+});

--- a/apps/web/src/pages/MobileBrowserAuth.tsx
+++ b/apps/web/src/pages/MobileBrowserAuth.tsx
@@ -2,7 +2,11 @@ import { SignIn, SignUp, useAuth, useClerk, useSession, useSignIn, useSignUp, us
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { GoogleOAuthButton } from '../components/auth/GoogleOAuthButton';
+import {
+  GoogleOAuthButton,
+  buildGoogleOAuthRedirectOptions,
+  describeClerkOAuthError,
+} from '../components/auth/GoogleOAuthButton';
 import { AuthLayout } from '../components/layout/AuthLayout';
 import { CLERK_TOKEN_TEMPLATE } from '../config/auth';
 import { buildLocalizedAuthPath, resolveAuthLanguage, type AuthLanguage } from '../lib/authLanguage';
@@ -375,33 +379,24 @@ export default function MobileBrowserAuthPage() {
       return;
     }
 
-    // Google OAuth uses Clerk's sign-in resource for both entry intents. Clerk
-    // creates a user when needed and reliably completes existing Google users
-    // through this resource. The URL still carries mode=sign-up, so the native
-    // callback goes to the V2 onboarding rather than the dashboard.
+    // Google OAuth uses Clerk's sign-in resource for both entry intents. The URL
+    // still carries mode=sign-up when account creation should return to onboarding2.
     const resourceReady = signInLoaded && signIn;
     if (!isLoaded || !resourceReady) {
       return;
     }
 
     googleRedirectStartedRef.current = true;
-    const resource = signIn;
-    void resource
-      ?.authenticateWithRedirect({
-        strategy: 'oauth_google',
-        redirectUrl: '/sso-callback',
-        redirectUrlComplete: handoffUrl,
-        continueSignIn: true,
-        continueSignUp: true,
-        oidcPrompt: 'select_account',
-      })
+    const redirectOptions = buildGoogleOAuthRedirectOptions(handoffUrl, true);
+    void signIn
+      .authenticateWithRedirect(redirectOptions)
       .catch((cause) => {
         googleRedirectStartedRef.current = false;
-        console.error('[mobile-auth-page] google-oauth-start-failed', {
+        console.error(`[mobile-auth-page] google-oauth-start-failed ${JSON.stringify({
           at: Date.now(),
           mode,
-          error: cause instanceof Error ? cause.message : String(cause),
-        });
+          ...describeClerkOAuthError(cause),
+        })}`);
         setError(
           language === 'en'
             ? 'We could not start Google sign-in. Please try again.'
@@ -419,7 +414,6 @@ export default function MobileBrowserAuthPage() {
     shouldResetBrowserSession,
     signIn,
     signInLoaded,
-    signUp,
     isResettingBrowserSession,
   ]);
 
@@ -669,7 +663,6 @@ export default function MobileBrowserAuthPage() {
               oauthMode="sign-in"
               redirectUrlComplete={handoffUrl}
               forceAccountSelection
-              allowCrossModeCompletion
             />
             <div className={AUTH_DIVIDER_CLASS}>
               <span className="h-px flex-1 bg-white/12" aria-hidden />


### PR DESCRIPTION
## Investigación integral

El plugin nativo de Android **sí abre correctamente** `/mobile-auth` y entrega el control mediante `appUrlOpen`. Los logs muestran que el fallo sucede después, dentro de Clerk, antes de que Google llegue a abrirse.

La causa se confirmó en dos rutas distintas del código:

1. El inicio directo con Google desde la app ejecutaba `signIn.authenticateWithRedirect()` con:
   - `continueSignIn: true`
   - `continueSignUp: true`
2. El botón compartido `GoogleOAuthButton` repetía esas mismas opciones cuando `allowCrossModeCompletion` estaba activo.

Esas opciones piden a Clerk continuar recursos cruzados ya existentes. El repositorio ya tuvo esta misma regresión anteriormente: el flujo fallaba antes de Google con `transferable not supported yet`, y una hotfix restauró el comportamiento estable. Las opciones fueron reintroducidas después durante la unificación móvil.

## Solución

- Google OAuth sigue comenzando siempre desde el recurso `signIn`, tanto para intención visual de login como de creación de cuenta.
- La intención de destino se mantiene de forma separada mediante:
  - `mode=sign-in|sign-up`;
  - `redirect_path`;
  - `redirectUrlComplete` / `handoffUrl`.
- Se eliminan de la llamada real a Clerk:
  - `continueSignIn`;
  - `continueSignUp`.
- Se conserva `oidcPrompt: select_account` para que Android permita elegir cuenta.
- Se mantiene temporalmente la prop `allowCrossModeCompletion` como compatibilidad de tipos, pero se ignora deliberadamente para no reactivar la regresión.
- Los errores de Clerk ahora se serializan en JSON legible por Logcat, incluyendo `name`, `message`, `code` y `errors`.

## Protección contra regresiones

Se agregan tests que verifican que:

- las opciones de OAuth no contienen `continueSignIn` ni `continueSignUp`;
- `redirectUrlComplete` se conserva intacto;
- el selector de cuenta se conserva;
- los errores de Clerk quedan legibles en Logcat.

## Scope deliberadamente preservado

Esta PR no modifica:

- `InnerbloomAuthBrowserPlugin.java`;
- callback/deep links `innerbloom://`;
- navegación interna de Capacitor corregida en #2288;
- refresh del token nativo;
- logout;
- delete account;
- iOS;
- notificaciones.

## Matriz de validación requerida

1. Android: login Google con usuario existente → Dashboard.
2. Android: crear cuenta Google con usuario nuevo → onboarding2.
3. Android: intención crear cuenta con Google ya existente → onboarding2 según la intención solicitada.
4. Android: selector de cuentas visible.
5. Android: Dashboard → DQuest → Tasks → Achievements sin abrir Chrome.
6. Android: esperar 2–3 minutos y repetir navegación para validar refresh.
7. Android: logout y segundo login.
8. Android: delete account.
9. Web desktop: login y sign-up Google.
10. iOS: smoke test de login/logout sin cambios funcionales esperados.

No se realizó merge automático. La PR queda en Draft para revisión y prueba.