### PR TITLE
fix(android): restore Google OAuth Custom Tab lifecycle

### DIFF
--- a/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
+++ b/apps/mobile/android/app/src/main/java/org/innerbloom/app/InnerbloomAuthBrowserPlugin.java
@@ -1,6 +1,5 @@
 package org.innerbloom.app;
 
-import android.content.Intent;
 import android.net.Uri;
 
 import androidx.browser.customtabs.CustomTabsIntent;
@@ -50,17 +49,15 @@ public class InnerbloomAuthBrowserPlugin extends Plugin {
                         .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
                         // Keep the Clerk browser session available so short-lived native callback
                         // tokens can be refreshed without forcing the user through sign-in again.
-                        // Account selection is still forced by the web flow with prompt=select_account.
+                        // Account selection is forced by the web OAuth flow with prompt=select_account.
                         .setSendToExternalDefaultHandlerEnabled(true)
                         .build();
 
-                // Authentication is the only reason this Custom Tab exists. Once the browser
-                // hands an innerbloom:// callback back to MainActivity, Android must discard the
-                // tab instead of leaving the web application visible above the Capacitor app.
-                customTabsIntent.intent.addFlags(
-                        Intent.FLAG_ACTIVITY_NO_HISTORY
-                                | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
-                );
+                // Do not mark the authentication tab NO_HISTORY. Google OAuth temporarily leaves
+                // the tab for account selection, credentials, consent, or two-step verification.
+                // Removing it from history destroys the Clerk redirect chain and leaves a blank tab.
+                // The innerbloom:// callback brings MainActivity back to the foreground, while
+                // internal app navigation remains inside the Capacitor WebView.
                 customTabsIntent.launchUrl(getActivity(), uri);
 
                 // Android returns the final callback through Capacitor's appUrlOpen event.


### PR DESCRIPTION
## Investigación PR #2270 → #2289

El flujo funcional de Android estaba estable antes de la unificación nativa. La regresión se introdujo en dos etapas:

1. **#2282** cambió Android del `Capacitor Browser` existente al nuevo plugin `InnerbloomAuthBrowser` compartido con iOS. Ese cambio abrió una nueva superficie nativa que luego requirió correcciones de callback, cookies y refresh.
2. **#2286** agregó `FLAG_ACTIVITY_NO_HISTORY | FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS` al Custom Tab. Esa fue la causa directa del pantallazo negro actual.

Google OAuth no es una navegación de una sola pantalla: el Custom Tab puede salir temporalmente hacia selector de cuenta, ingreso de credenciales, consentimiento o verificación en dos pasos. Con `NO_HISTORY`, Android puede destruir la pestaña de Clerk al producirse esa transición. Cuando Google intenta regresar, ya no existe una cadena de navegación válida y queda una superficie negra sin callback `innerbloom://`.

Los logs aportados coinciden con ese ciclo: Chrome crea procesos sandbox para iniciar Google, los descarta y nunca aparece ni selector ni callback.

## Por qué #2286 ya no es necesaria

La #2286 intentó resolver que Chrome quedaba visible después del login. La investigación posterior de #2287/#2288 demostró que la barra de Chrome no era el Custom Tab de autenticación retenido: los enlaces internos se estaban clasificando como externos y llamaban a `Browser.open()`.

Ese problema ya está corregido por la navegación interna de Capacitor. Por lo tanto, conservar `NO_HISTORY` ya no aporta una solución y sí rompe OAuth multipaso.

## Cambio

Solo Android nativo:

- elimina `FLAG_ACTIVITY_NO_HISTORY`;
- elimina `FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS`;
- mantiene el lanzamiento desde `getActivity()`;
- mantiene `setSendToExternalDefaultHandlerEnabled(true)` para devolver `innerbloom://` a `MainActivity`;
- mantiene Custom Tab no efímero para refresh silencioso de Clerk;
- mantiene `prompt=select_account` en la capa web;
- no modifica iOS, Clerk web, callback, refresh, logout, delete account, notificaciones ni navegación interna.

## Comportamiento requerido

- **Login Google:** selector/cuenta/credenciales/2FA → Dashboard.
- **Sign-up Google:** selector/cuenta/credenciales/2FA → onboarding2.
- **Email Clerk login:** credenciales/2FA → Dashboard.
- **Email Clerk sign-up:** creación/verificación → onboarding2.

## Matriz de validación Android

1. Login Google con cuenta guardada → selector → Dashboard.
2. Login Google sin cuenta guardada → credenciales y eventual 2FA → Dashboard.
3. Sign-up Google con cuenta nueva → onboarding2.
4. Sign-up Google con cuenta ya existente → onboarding2 por intención de entrada.
5. Sign-up email Clerk → onboarding2.
6. Login email Clerk → Dashboard.
7. Dashboard → DQuest → Tasks → Achievements sin Chrome.
8. Esperar 2–3 minutos y repetir navegación para validar refresh.
9. Logout y segundo login con selector de cuenta.
10. Delete account.

No se realizó merge automático. La PR queda en Draft para prueba en el emulador.