### PR TITLE
fix(auth): preserve native OAuth handoff through SSO callback

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -73,13 +73,55 @@ export function describeClerkOAuthError(error: unknown): Record<string, unknown>
   };
 }
 
-function persistOAuthRedirectIntent(intent: OAuthRedirectIntent) {
+export function normalizeOAuthRedirectIntentUrl(
+  redirectUrlComplete: string,
+  currentOrigin = typeof window !== 'undefined' ? window.location.origin : null,
+): string | null {
+  const candidate = redirectUrlComplete.trim();
+  if (!candidate) {
+    return null;
+  }
+
+  if (candidate.startsWith('/') && !candidate.startsWith('//')) {
+    return candidate;
+  }
+
+  if (!currentOrigin) {
+    return null;
+  }
+
+  try {
+    const trustedOrigin = new URL(currentOrigin).origin;
+    const parsed = new URL(candidate);
+    if (
+      (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
+      || parsed.origin !== trustedOrigin
+    ) {
+      return null;
+    }
+
+    return `${parsed.pathname}${parsed.search}${parsed.hash}` || '/';
+  } catch {
+    return null;
+  }
+}
+
+export function persistOAuthRedirectIntent(intent: OAuthRedirectIntent) {
   if (typeof window === 'undefined') {
     return;
   }
 
+  const redirectUrlComplete = normalizeOAuthRedirectIntentUrl(intent.redirectUrlComplete);
+  if (!redirectUrlComplete) {
+    console.warn('[auth] Refused to persist an unsafe OAuth redirect intent');
+    return;
+  }
+
   try {
-    window.sessionStorage.setItem(OAUTH_REDIRECT_INTENT_STORAGE_KEY, JSON.stringify(intent));
+    window.sessionStorage.setItem(OAUTH_REDIRECT_INTENT_STORAGE_KEY, JSON.stringify({
+      ...intent,
+      redirectUrlComplete,
+    }));
   } catch (error) {
     console.warn('[auth] Failed to persist OAuth redirect intent', error);
   }
@@ -97,22 +139,25 @@ export function readOAuthRedirectIntent(): OAuthRedirectIntent | null {
     }
 
     const intent = JSON.parse(rawIntent) as Partial<OAuthRedirectIntent>;
-    const isSafeRedirect =
-      typeof intent.redirectUrlComplete === 'string' &&
-      intent.redirectUrlComplete.startsWith('/') &&
-      !intent.redirectUrlComplete.startsWith('//');
+    const redirectUrlComplete = typeof intent.redirectUrlComplete === 'string'
+      ? normalizeOAuthRedirectIntentUrl(intent.redirectUrlComplete)
+      : null;
     const isValidMode = intent.mode === 'sign-in' || intent.mode === 'sign-up';
     const isRecent =
       typeof intent.createdAt === 'number' &&
       Date.now() - intent.createdAt >= 0 &&
       Date.now() - intent.createdAt <= OAUTH_REDIRECT_INTENT_TTL_MS;
 
-    if (!isSafeRedirect || !isValidMode || !isRecent) {
+    if (!redirectUrlComplete || !isValidMode || !isRecent) {
       window.sessionStorage.removeItem(OAUTH_REDIRECT_INTENT_STORAGE_KEY);
       return null;
     }
 
-    return intent as OAuthRedirectIntent;
+    return {
+      mode: intent.mode,
+      redirectUrlComplete,
+      createdAt: intent.createdAt,
+    };
   } catch (error) {
     console.warn('[auth] Failed to read OAuth redirect intent', error);
     window.sessionStorage.removeItem(OAUTH_REDIRECT_INTENT_STORAGE_KEY);

--- a/apps/web/src/components/auth/__tests__/GoogleOAuthButton.test.ts
+++ b/apps/web/src/components/auth/__tests__/GoogleOAuthButton.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  OAUTH_REDIRECT_INTENT_STORAGE_KEY,
   buildGoogleOAuthRedirectOptions,
   describeClerkOAuthError,
+  normalizeOAuthRedirectIntentUrl,
+  persistOAuthRedirectIntent,
+  readOAuthRedirectIntent,
 } from '../GoogleOAuthButton';
 
 describe('Google OAuth redirect contract', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it('starts a fresh Clerk OAuth attempt without cross-mode continuation flags', () => {
     const options = buildGoogleOAuthRedirectOptions(
       'https://innerbloomjourney.org/mobile-auth?mode=sign-up&handoff=1',
@@ -26,6 +34,66 @@ describe('Google OAuth redirect contract', () => {
 
     expect(options.oidcPrompt).toBeUndefined();
     expect(options.redirectUrlComplete).toBe('/innerbloom2/dashboard');
+  });
+
+  it('normalizes the absolute native handoff into a same-origin callback fallback', () => {
+    const handoffUrl =
+      'https://innerbloomjourney.org/mobile-auth?lang=en&mode=sign-up&redirect_path=%2Fintro-journey2&return_to=innerbloom%3A%2F%2Flocalhost%2Fcallback&handoff=1';
+
+    expect(normalizeOAuthRedirectIntentUrl(handoffUrl, 'https://innerbloomjourney.org')).toBe(
+      '/mobile-auth?lang=en&mode=sign-up&redirect_path=%2Fintro-journey2&return_to=innerbloom%3A%2F%2Flocalhost%2Fcallback&handoff=1',
+    );
+  });
+
+  it('rejects cross-origin and protocol-relative callback fallbacks', () => {
+    expect(normalizeOAuthRedirectIntentUrl(
+      'https://attacker.example/mobile-auth?handoff=1',
+      'https://innerbloomjourney.org',
+    )).toBeNull();
+    expect(normalizeOAuthRedirectIntentUrl(
+      '//attacker.example/mobile-auth?handoff=1',
+      'https://innerbloomjourney.org',
+    )).toBeNull();
+  });
+
+  it('round-trips the Android handoff through sessionStorage for /sso-callback', () => {
+    const createdAt = Date.now();
+    const absoluteHandoffUrl =
+      `${window.location.origin}/mobile-auth?lang=en&mode=sign-up&redirect_path=%2Fintro-journey2&return_to=innerbloom%3A%2F%2Flocalhost%2Fcallback&handoff=1`;
+
+    persistOAuthRedirectIntent({
+      mode: 'sign-up',
+      redirectUrlComplete: absoluteHandoffUrl,
+      createdAt,
+    });
+
+    const persisted = JSON.parse(
+      window.sessionStorage.getItem(OAUTH_REDIRECT_INTENT_STORAGE_KEY) ?? 'null',
+    ) as { redirectUrlComplete?: string } | null;
+    expect(persisted?.redirectUrlComplete).toBe(
+      '/mobile-auth?lang=en&mode=sign-up&redirect_path=%2Fintro-journey2&return_to=innerbloom%3A%2F%2Flocalhost%2Fcallback&handoff=1',
+    );
+    expect(readOAuthRedirectIntent()).toEqual({
+      mode: 'sign-up',
+      redirectUrlComplete:
+        '/mobile-auth?lang=en&mode=sign-up&redirect_path=%2Fintro-journey2&return_to=innerbloom%3A%2F%2Flocalhost%2Fcallback&handoff=1',
+      createdAt,
+    });
+  });
+
+  it('recovers a legacy same-origin absolute intent already stored before the callback', () => {
+    const createdAt = Date.now();
+    window.sessionStorage.setItem(OAUTH_REDIRECT_INTENT_STORAGE_KEY, JSON.stringify({
+      mode: 'sign-in',
+      redirectUrlComplete: `${window.location.origin}/mobile-auth?mode=sign-in&handoff=1`,
+      createdAt,
+    }));
+
+    expect(readOAuthRedirectIntent()).toEqual({
+      mode: 'sign-in',
+      redirectUrlComplete: '/mobile-auth?mode=sign-in&handoff=1',
+      createdAt,
+    });
   });
 
   it('serializes Clerk errors into Logcat-readable fields', () => {


### PR DESCRIPTION
## Contexto

La PR #2290 ya corrigió el ciclo de vida del Custom Tab Android eliminando `FLAG_ACTIVITY_NO_HISTORY`. Este cambio cubre el segundo contrato roto identificado en el flujo compartido de Clerk: el fallback guardado antes de Google no sobrevivía al retorno por `/sso-callback` cuando `redirectUrlComplete` era una URL absoluta del origen de producción.

## Causa

`GoogleOAuthButton` guardaba en `sessionStorage` el handoff nativo completo, por ejemplo:

```text
https://innerbloomjourney.org/mobile-auth?mode=sign-up&redirect_path=%2Fintro-journey2&return_to=innerbloom%3A%2F%2Flocalhost%2Fcallback&handoff=1
```

Pero `readOAuthRedirectIntent()` solo aceptaba valores que comenzaran con `/`. Al llegar a `/sso-callback`, eliminaba la intención absoluta y dejaba a `AuthenticateWithRedirectCallback` sin el fallback necesario para volver a `/mobile-auth?handoff=1` y completar `innerbloom://localhost/callback`.

## Cambio

- normaliza URLs absolutas del mismo origen a `pathname + search + hash` antes de persistirlas;
- acepta y normaliza intents absolutos same-origin que ya estuvieran guardados antes del callback;
- mantiene intacto el `redirectUrlComplete` absoluto enviado a Clerk;
- rechaza URLs cross-origin y protocol-relative;
- conserva `mode`, `redirect_path`, `return_to`, `handoff=1` y el TTL de 10 minutos;
- no modifica Android nativo, iOS, refresh, logout, delete account ni navegación interna.

## Protección contra regresiones

Se agregan pruebas para:

1. normalizar el handoff Android absoluto de producción;
2. rechazar destinos externos;
3. persistir y recuperar el flujo completo mediante `sessionStorage` como lo consume `/sso-callback`;
4. recuperar intents absolutos same-origin creados por versiones anteriores;
5. preservar las pruebas de #2289: sin `continueSignIn`/`continueSignUp`, con selector de cuenta y errores legibles.

## Resultado requerido

- Login Google → selector/cuenta/credenciales → Dashboard.
- Sign-up Google → selector/cuenta/credenciales → Onboarding 2.
- Cuenta existente desde intención de sign-up → Onboarding 2 por la intención de entrada.
- `/sso-callback` no queda sin destino y el flujo termina en `innerbloom://localhost/callback`.

## Validación

La rama parte del `main` posterior a #2290. No se tocó el repositorio local del usuario. La validación definitiva requiere CI y una prueba limpia en Android del round-trip Google completo.