### PR TITLE
fix(auth): render Clerk smart CAPTCHA on SSO callback

### DIFF
--- a/apps/web/src/pages/SsoCallback.tsx
+++ b/apps/web/src/pages/SsoCallback.tsx
@@ -9,12 +9,31 @@ export default function SsoCallbackPage() {
     redirectIntent?.mode === 'sign-up' ? redirectIntent.redirectUrlComplete : undefined;
 
   return (
-    <>
-      <div id="clerk-captcha" className="sr-only" />
-      <AuthenticateWithRedirectCallback
-        signInFallbackRedirectUrl={signInFallbackRedirectUrl}
-        signUpFallbackRedirectUrl={signUpFallbackRedirectUrl}
-      />
-    </>
+    <main className="flex min-h-screen min-h-dvh items-center justify-center bg-black px-5 py-10 text-white">
+      <div className="flex w-full max-w-md flex-col items-center text-center">
+        <span
+          className="h-8 w-8 animate-spin rounded-full border-2 border-white/25 border-t-white"
+          aria-hidden="true"
+        />
+        <p className="mt-4 text-sm leading-6 text-white/75" role="status">
+          Completing secure sign-in…
+        </p>
+
+        {/* Clerk can promote its smart bot check to an interactive Turnstile challenge.
+            This mount must remain visible so a legitimate user can complete that check. */}
+        <div
+          id="clerk-captcha"
+          data-cl-theme="dark"
+          data-cl-size="flexible"
+          data-cl-language="auto"
+          className="mt-6 min-h-[65px] w-full max-w-sm overflow-visible"
+        />
+
+        <AuthenticateWithRedirectCallback
+          signInFallbackRedirectUrl={signInFallbackRedirectUrl}
+          signUpFallbackRedirectUrl={signUpFallbackRedirectUrl}
+        />
+      </div>
+    </main>
   );
 }

--- a/apps/web/src/pages/__tests__/SsoCallback.test.tsx
+++ b/apps/web/src/pages/__tests__/SsoCallback.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redirectCallbackProps = vi.fn();
+const readOAuthRedirectIntent = vi.fn();
+
+vi.mock('@clerk/clerk-react', () => ({
+  AuthenticateWithRedirectCallback: (props: Record<string, unknown>) => {
+    redirectCallbackProps(props);
+    return null;
+  },
+}));
+
+vi.mock('../../components/auth/GoogleOAuthButton', () => ({
+  readOAuthRedirectIntent: () => readOAuthRedirectIntent(),
+}));
+
+import SsoCallbackPage from '../SsoCallback';
+
+describe('SsoCallbackPage', () => {
+  beforeEach(() => {
+    redirectCallbackProps.mockReset();
+    readOAuthRedirectIntent.mockReset();
+  });
+
+  it('keeps the Clerk CAPTCHA mount visible for interactive smart challenges', () => {
+    readOAuthRedirectIntent.mockReturnValue({
+      mode: 'sign-up',
+      redirectUrlComplete: '/mobile-auth?mode=sign-up&handoff=1',
+      createdAt: Date.now(),
+    });
+
+    const { container } = render(<SsoCallbackPage />);
+    const captcha = container.querySelector('#clerk-captcha');
+
+    expect(captcha).not.toBeNull();
+    expect(captcha).not.toHaveClass('sr-only');
+    expect(captcha).toHaveAttribute('data-cl-theme', 'dark');
+    expect(captcha).toHaveAttribute('data-cl-size', 'flexible');
+    expect(screen.getByRole('status')).toHaveTextContent('Completing secure sign-in');
+  });
+
+  it('preserves the native sign-up fallback while Clerk completes the callback', () => {
+    readOAuthRedirectIntent.mockReturnValue({
+      mode: 'sign-up',
+      redirectUrlComplete: '/mobile-auth?mode=sign-up&handoff=1',
+      createdAt: Date.now(),
+    });
+
+    render(<SsoCallbackPage />);
+
+    expect(redirectCallbackProps).toHaveBeenCalledWith(expect.objectContaining({
+      signInFallbackRedirectUrl: undefined,
+      signUpFallbackRedirectUrl: '/mobile-auth?mode=sign-up&handoff=1',
+    }));
+  });
+});


### PR DESCRIPTION
## Causa

El callback OAuth montaba el placeholder de Clerk con `className="sr-only"`. Cuando Clerk resuelve la protección contra bots sin interacción, el flujo continúa. Cuando su CAPTCHA inteligente requiere interacción, el widget se renderiza dentro de ese elemento oculto y el usuario solo ve una pantalla negra.

El 401 del endpoint PAT observado en DevTools es una respuesta esperada del mecanismo de Private Access Tokens y no identifica por sí solo un bloqueo.

## Cambio

- mantiene visible `#clerk-captcha` en la pantalla de callback;
- configura tema oscuro y tamaño flexible;
- muestra un estado de transición mientras Clerk completa el acceso;
- conserva los fallbacks nativos de login y sign-up;
- no modifica Android nativo, iOS ni los deep links.

## Tests

- el mount CAPTCHA existe y no usa `sr-only`;
- conserva sus atributos de configuración;
- el fallback de sign-up sigue llegando al callback de Clerk.

## Resultado esperado

El callback continúa automáticamente cuando no hay interacción y permite completar el CAPTCHA cuando Clerk lo exige, en lugar de quedar en negro.