### PR TITLE
fix(mobile): align native Step 4 with landing achievement shelf

### DIFF
--- a/apps/web/src/mobile/MobileAppEntry.css
+++ b/apps/web/src/mobile/MobileAppEntry.css
@@ -1,0 +1,42 @@
+/* Native Step 4 uses the landing achievement shelf as its single visual source.
+ * This file only adapts that shared scene to the bounded Capacitor welcome viewport.
+ */
+.native-welcome-visual-shell--step-4 {
+  contain: paint;
+  overflow: hidden;
+}
+
+.native-welcome-visual-shell--step-4 .v3-step-visual,
+.native-welcome-visual-shell--step-4 .v3-method-product-visual,
+.native-welcome-visual-shell--step-4 .v3-method-logros {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: visible;
+}
+
+.native-welcome-visual-shell--step-4 .v3-method-logros__scene {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: min(116%, 530px);
+  margin: 0;
+  transform: translate3d(-50%, var(--native-welcome-visual-y), 0)
+    scale(var(--native-welcome-visual-scale));
+  transform-origin: center top;
+}
+
+/* The shared landing scene owns its internal viewport, track and card clipping.
+ * Keep clipping responsibility at the native shell instead of stacking another
+ * card-sized mask around it.
+ */
+.native-welcome-visual-shell--step-4 .v3-logros-viewport {
+  overflow: hidden;
+}
+
+@media (max-height: 820px) {
+  .native-welcome-visual-shell--step-4 .v3-method-logros__scene {
+    top: 1px;
+  }
+}

--- a/apps/web/src/mobile/MobileAppEntry.tsx
+++ b/apps/web/src/mobile/MobileAppEntry.tsx
@@ -22,22 +22,10 @@ import {
   type MobileAuthMode,
 } from './mobileAuthSession';
 import type { OnboardingProgress } from '../lib/api';
+import './MobileAppEntry.css';
 
 const NATIVE_WELCOME_SLIDE_MS = 5200;
 const NATIVE_LOGROS_SLIDE_MS = 2100;
-
-type NativeLogro = {
-  name: string;
-  pillar: 'body' | 'mind' | 'soul';
-  src: string;
-  trait: string;
-};
-
-const NATIVE_LOGROS: NativeLogro[] = [
-  { name: '2L de agua', pillar: 'body', src: '/sellos/body/sello_body_hydration.png', trait: 'Hidratacion' },
-  { name: 'Ingles', pillar: 'mind', src: '/sellos/mind/sello_mind_focus.png', trait: 'Focus' },
-  { name: 'Llamar familia', pillar: 'soul', src: '/sellos/soul/soul_connection_transparent.png', trait: 'Conexion' },
-];
 
 type MobileEntryCopy = {
   loadingTitle: string;
@@ -85,11 +73,13 @@ function MobileEntryShell({
 
         <main className="flex min-h-0 flex-1 flex-col items-center justify-center py-[clamp(1.5rem,7dvh,4rem)] text-center">
           <div className="w-full space-y-5">
-              <h1 className="text-[clamp(2rem,8vw,2.75rem)] font-semibold leading-[0.98] tracking-normal text-white">
-                {title}
-              </h1>
-              {description ? <p className="mx-auto max-w-[20rem] text-sm leading-6 text-white/62">{description}</p> : null}
-              {children ? <div className="mt-6">{children}</div> : null}
+            <h1 className="text-[clamp(2rem,8vw,2.75rem)] font-semibold leading-[0.98] tracking-normal text-white">
+              {title}
+            </h1>
+            {description ? (
+              <p className="mx-auto max-w-[20rem] text-sm leading-6 text-white/62">{description}</p>
+            ) : null}
+            {children ? <div className="mt-6">{children}</div> : null}
           </div>
         </main>
       </div>
@@ -138,54 +128,9 @@ function MobileEntryError({
   );
 }
 
-function NativeWelcomeLogrosVisual({ language }: { language: 'es' | 'en' }) {
-  const [activeIndex, setActiveIndex] = useState(0);
-  const activeLogro = NATIVE_LOGROS[activeIndex] ?? NATIVE_LOGROS[0];
-  const isSpanish = language === 'es';
-  const pillarLabels = isSpanish
-    ? { body: 'Cuerpo', mind: 'Mente', soul: 'Alma' }
-    : { body: 'Body', mind: 'Mind', soul: 'Soul' };
-
-  useEffect(() => {
-    const interval = window.setInterval(() => {
-      setActiveIndex((current) => (current + 1) % NATIVE_LOGROS.length);
-    }, NATIVE_LOGROS_SLIDE_MS);
-
-    return () => window.clearInterval(interval);
-  }, []);
-
-  return (
-    <div className="native-welcome-logros" aria-label={isSpanish ? 'Vista previa de logros' : 'Achievement preview'}>
-      <div className="native-welcome-logros__tabs" aria-hidden="true">
-        {(['body', 'mind', 'soul'] as const).map((pillar) => (
-          <span className={pillar === activeLogro.pillar ? 'is-active' : ''} key={pillar}>
-            {pillarLabels[pillar]}
-          </span>
-        ))}
-      </div>
-      <article className="native-welcome-logros__card" key={activeLogro.name}>
-        <img src={activeLogro.src} alt="" />
-        <div className="native-welcome-logros__details">
-          <strong>{activeLogro.name}</strong>
-          <p>
-            <span>{activeLogro.trait}</span>
-            <i aria-hidden="true">.</i>
-            <b>{isSpanish ? 'Logrado' : 'Achieved'}</b>
-          </p>
-          <span className="native-welcome-logros__share">{isSpanish ? 'Compartir' : 'Share'}</span>
-        </div>
-      </article>
-    </div>
-  );
-}
-
-function NativeWelcomeCarousel({ language }: { language: 'es' | 'en' }) {
+export function NativeWelcomeCarousel({ language }: { language: 'es' | 'en' }) {
   const slides = LANDING_V3_CONTENT[language].how.steps;
   const [activeIndex, setActiveIndex] = useState(0);
-
-  const handleDotSelect = (index: number) => {
-    setActiveIndex(index);
-  };
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
@@ -203,18 +148,21 @@ function NativeWelcomeCarousel({ language }: { language: 'es' | 'en' }) {
         <span>{activeSlide.badge}</span>
         <h1>{activeSlide.title}</h1>
       </div>
+
       <div
         className={`native-welcome-visual-shell native-welcome-visual-shell--step-${activeIndex + 1} landing landing--v3-conversion`}
         data-theme-mode="dark"
         data-native-step={activeIndex + 1}
         key={`visual-${activeIndex}`}
       >
-        {activeIndex === 3 ? (
-          <NativeWelcomeLogrosVisual language={language} />
-        ) : (
-          <LandingV3MethodVisual index={activeIndex} language={language} nativePreview />
-        )}
+        <LandingV3MethodVisual
+          index={activeIndex}
+          language={language}
+          nativePreview
+          logrosCycleMs={activeIndex === 3 ? NATIVE_LOGROS_SLIDE_MS : undefined}
+        />
       </div>
+
       <div className="native-welcome-carousel-controls" aria-label="Carousel progress" role="tablist">
         {slides.map((slide, index) => (
           <button
@@ -224,7 +172,7 @@ function NativeWelcomeCarousel({ language }: { language: 'es' | 'en' }) {
             aria-label={`${index + 1} / ${slides.length}`}
             aria-selected={index === activeIndex}
             role="tab"
-            onClick={() => handleDotSelect(index)}
+            onClick={() => setActiveIndex(index)}
           >
             {index === activeIndex ? (
               <i
@@ -448,6 +396,7 @@ export function MobileAppEntry() {
     });
   }, [
     dashboardPath,
+    finalRoute,
     isNativeApp,
     isOnboardingComplete,
     nativeAuthMode,
@@ -460,11 +409,7 @@ export function MobileAppEntry() {
   ]);
 
   if (!isLoaded && !hasNativeCallbackSession) {
-    return (
-      <MobileEntryLoading
-        title={entryCopy.loadingTitle}
-      />
-    );
+    return <MobileEntryLoading title={entryCopy.loadingTitle} />;
   }
 
   if (!hasEffectiveSession) {
@@ -483,11 +428,7 @@ export function MobileAppEntry() {
   }
 
   if (backendUser.status !== 'success') {
-    return (
-      <MobileEntryLoading
-        title={entryCopy.loadingTitle}
-      />
-    );
+    return <MobileEntryLoading title={entryCopy.loadingTitle} />;
   }
 
   if (onboarding.status === 'error') {
@@ -504,17 +445,11 @@ export function MobileAppEntry() {
   }
 
   if (onboarding.status !== 'success') {
-    return (
-      <MobileEntryLoading
-        title={entryCopy.loadingTitle}
-      />
-    );
+    return <MobileEntryLoading title={entryCopy.loadingTitle} />;
   }
 
-  if (!isOnboardingComplete) {
-    if (finalRoute === INNERBLOOM2_INTRO_JOURNEY_PATH) {
-      return <Navigate to={INNERBLOOM2_INTRO_JOURNEY_PATH} replace />;
-    }
+  if (!isOnboardingComplete && finalRoute === INNERBLOOM2_INTRO_JOURNEY_PATH) {
+    return <Navigate to={INNERBLOOM2_INTRO_JOURNEY_PATH} replace />;
   }
 
   return <Navigate to={finalRoute} replace />;

--- a/apps/web/src/mobile/__tests__/MobileAppEntry.step4.test.ts
+++ b/apps/web/src/mobile/__tests__/MobileAppEntry.step4.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const entrySource = readFileSync(new URL('../MobileAppEntry.tsx', import.meta.url), 'utf8');
+const entryStyles = readFileSync(new URL('../MobileAppEntry.css', import.meta.url), 'utf8');
+
+describe('native welcome Step 4 architecture', () => {
+  it('renders every native welcome step through the shared landing visual', () => {
+    expect(entrySource).toContain('<LandingV3MethodVisual');
+    expect(entrySource).toContain('index={activeIndex}');
+    expect(entrySource).toContain('nativePreview');
+    expect(entrySource).not.toContain('function NativeWelcomeLogrosVisual');
+    expect(entrySource).not.toContain('NATIVE_LOGROS');
+    expect(entrySource).not.toContain("activeIndex === 3 ? (");
+  });
+
+  it('keeps the landing achievement animation cadence explicit for Step 4', () => {
+    expect(entrySource).toContain('const NATIVE_LOGROS_SLIDE_MS = 2100');
+    expect(entrySource).toContain('logrosCycleMs={activeIndex === 3 ? NATIVE_LOGROS_SLIDE_MS : undefined}');
+  });
+
+  it('centers and scales the shared shelf inside one bounded native shell', () => {
+    expect(entryStyles).toContain('.native-welcome-visual-shell--step-4 .v3-method-logros__scene');
+    expect(entryStyles).toContain('position: absolute');
+    expect(entryStyles).toContain('left: 50%');
+    expect(entryStyles).toContain('scale(var(--native-welcome-visual-scale))');
+    expect(entryStyles).not.toContain('.native-welcome-logros__card');
+  });
+});


### PR DESCRIPTION
## Causa raíz

El welcome nativo no usaba la animación oficial de Step 4. Los pasos 1–3 renderizaban `LandingV3MethodVisual`, pero Step 4 se desviaba a un componente duplicado (`NativeWelcomeLogrosVisual`) con una sola card flex y una jerarquía distinta. Esa card ocupaba todo el alto restante dentro de varios contenedores con clipping, por eso Android e iOS la recortaban de forma distinta.

## Cambio

- elimina la implementación paralela de logros nativa;
- hace que los cuatro pasos pasen por `LandingV3MethodVisual`;
- conserva el ritmo corto de animación de Step 4 mediante `logrosCycleMs`;
- agrega un adaptador CSS acotado al shell nativo para centrar y escalar la escena compartida sin modificar landing desktop;
- no toca Kotlin/Java, Swift, Capacitor, autenticación ni los pasos 1–3;
- mantiene intactos los botones Create account / Google / Log in.

## Limpieza

Se eliminan del runtime nativo:

- `NativeLogro`;
- `NATIVE_LOGROS`;
- `NativeWelcomeLogrosVisual`;
- el intervalo y markup duplicados de Step 4.

El componente de landing queda como única fuente visual y funcional del estante de hábitos.

## Protección contra regresiones

Se agregan tests de arquitectura que verifican que:

1. los cuatro pasos usan `LandingV3MethodVisual`;
2. no vuelve a existir una bifurcación especial para `activeIndex === 3`;
3. no reaparecen `NATIVE_LOGROS` ni `NativeWelcomeLogrosVisual`;
4. la escena compartida queda centrada y escalada dentro de un único shell nativo.

## Validación requerida

- Android Pixel 8 / viewport normal y corto;
- iPhone con notch y dispositivo alto;
- confirmar tabs, cards laterales, flip/desarrollo y contador de landing;
- confirmar que los pasos 1–3 y los tres botones de auth no cambian.