### PR TITLE
fix(mobile): center native Step 4 shelf across iOS and Android

### DIFF
--- a/apps/web/src/mobile/MobileAppEntry.css
+++ b/apps/web/src/mobile/MobileAppEntry.css
@@ -16,13 +16,20 @@
   overflow: visible;
 }
 
+/* Center the unscaled landing scene with physical insets instead of left: 50%.
+ * The global landing adapter also owns `transform`; using left: 50% made the
+ * scene jump right whenever that shared transform won the cascade in a WebView.
+ * Auto inline margins remain stable in both WKWebView and Android WebView even
+ * when the shared translateY/scale transform is applied later.
+ */
 .native-welcome-visual-shell--step-4 .v3-method-logros__scene {
   position: absolute;
+  inset-inline: 0;
   top: 0;
-  left: 50%;
   width: min(116%, 530px);
-  margin: 0;
-  transform: translate3d(-50%, var(--native-welcome-visual-y), 0)
+  max-width: none;
+  margin-inline: auto;
+  transform: translate3d(0, var(--native-welcome-visual-y), 0)
     scale(var(--native-welcome-visual-scale));
   transform-origin: center top;
 }

--- a/apps/web/src/mobile/__tests__/MobileAppEntry.step4.test.ts
+++ b/apps/web/src/mobile/__tests__/MobileAppEntry.step4.test.ts
@@ -19,11 +19,14 @@ describe('native welcome Step 4 architecture', () => {
     expect(entrySource).toContain('logrosCycleMs={activeIndex === 3 ? NATIVE_LOGROS_SLIDE_MS : undefined}');
   });
 
-  it('centers and scales the shared shelf inside one bounded native shell', () => {
+  it('centers and scales the shared shelf without depending on transform cascade order', () => {
     expect(entryStyles).toContain('.native-welcome-visual-shell--step-4 .v3-method-logros__scene');
     expect(entryStyles).toContain('position: absolute');
-    expect(entryStyles).toContain('left: 50%');
+    expect(entryStyles).toContain('inset-inline: 0');
+    expect(entryStyles).toContain('margin-inline: auto');
     expect(entryStyles).toContain('scale(var(--native-welcome-visual-scale))');
+    expect(entryStyles).not.toContain('left: 50%');
+    expect(entryStyles).not.toContain('translate3d(-50%');
     expect(entryStyles).not.toContain('.native-welcome-logros__card');
   });
 });


### PR DESCRIPTION
## Confirmación del problema

El desplazamiento no es específico de Swift ni de iOS. Step 4 se renderiza dentro del mismo componente React/CSS en WKWebView y Android WebView. La diferencia entre plataformas solo cambia cuánto del corrimiento queda visible según el ancho efectivo del viewport.

La regla introducida en #2293 combinaba:

- `left: 50%`;
- `translateX(-50%)` dentro de `transform`;
- una regla global de landing que también define `transform` sobre la misma escena.

Ambos selectores tenían especificidad comparable. Cuando la regla global ganaba el orden de cascada, reemplazaba el `transform` que contenía `translateX(-50%)`, pero conservaba `left: 50%`. El resultado era desplazar toda la escena hacia la derecha. En iOS queda muy expuesto; en Android puede verse parcialmente centrado o recortado de otra manera según el WebView y el viewport.

## Cambio

- elimina la dependencia de `left: 50%` + `translateX(-50%)`;
- centra la caja original con `inset-inline: 0` y `margin-inline: auto`;
- conserva exclusivamente el desplazamiento vertical y la escala;
- mantiene el mismo componente compartido de landing;
- no toca la landing desktop, los pasos 1–3, autenticación, Kotlin/Java, Swift ni Capacitor.

## Por qué funciona en ambas nativas

El centrado ocurre antes del transform y no depende de cuál regla de `transform` gane la cascada. `margin-inline: auto` con ambos insets a cero mantiene la escena centrada en WKWebView y Android WebView.

## Protección contra regresiones

El test comprueba que Step 4:

- usa `inset-inline: 0` y `margin-inline: auto`;
- no vuelve a usar `left: 50%`;
- no vuelve a depender de `translateX(-50%)`;
- conserva la escala compartida y la arquitectura de landing.

## Validación requerida

- iPhone real: título, tabs, card central, laterales y contador centrados;
- Pixel 8: misma validación en viewport normal;
- confirmar que los botones inferiores y Steps 1–3 permanecen intactos.