### PR TITLE
fix(mobile): polish native welcome step layouts

### DIFF
--- a/apps/web/src/mobile/MobileAppEntry.css
+++ b/apps/web/src/mobile/MobileAppEntry.css
@@ -1,6 +1,46 @@
-/* Native Step 4 uses the landing achievement shelf as its single visual source.
- * This file only adapts that shared scene to the bounded Capacitor welcome viewport.
+/* Native welcome visual adapters.
+ * Landing remains the single source of truth; this file only tunes the shared
+ * scenes for the bounded Capacitor viewport used by iOS and Android.
  */
+
+/* Step 2: the native screen already has its own Step heading. Remove the
+ * duplicate product topline ("Tareas / Cuerpo") while preserving the table
+ * headings, rows, progress rings and all task animation behavior.
+ */
+.native-welcome-visual-shell--step-2 .ib20-showcase-topline {
+  display: none;
+}
+
+/* Step 3: keep the detail scene on a stable width so the animated green chip
+ * cannot change the intrinsic width of the whole showcase. The task title is
+ * deliberately smaller and single-line in native only.
+ */
+.native-welcome-visual-shell--step-3 .ib20-showcase--detail,
+.native-welcome-visual-shell--step-3 .ib20-detail-shell,
+.native-welcome-visual-shell--step-3 .ib20-habit-dev,
+.native-welcome-visual-shell--step-3 .ib20-habit-body {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.native-welcome-visual-shell--step-3 .ib20-detail-copy,
+.native-welcome-visual-shell--step-3 .ib20-detail-chips {
+  min-width: 0;
+}
+
+.native-welcome-visual-shell--step-3 .ib20-detail-copy h4 {
+  font-size: clamp(1.02rem, 4.6vw, 1.22rem);
+  line-height: 1.08;
+  white-space: nowrap;
+}
+
+.native-welcome-visual-shell--step-3 .ib20-detail-chip--down {
+  max-width: min(11.5rem, 48vw);
+}
+
+/* Step 4 uses the landing achievement shelf as its single visual source. */
 .native-welcome-visual-shell--step-4 {
   contain: paint;
   overflow: hidden;
@@ -17,15 +57,14 @@
 }
 
 /* Center the unscaled landing scene with physical insets instead of left: 50%.
- * The global landing adapter also owns `transform`; using left: 50% made the
- * scene jump right whenever that shared transform won the cascade in a WebView.
  * Auto inline margins remain stable in both WKWebView and Android WebView even
- * when the shared translateY/scale transform is applied later.
+ * when the shared translateY/scale transform is applied later. A small top
+ * offset separates the internal "Habit shelf" label from the native Step copy.
  */
 .native-welcome-visual-shell--step-4 .v3-method-logros__scene {
   position: absolute;
   inset-inline: 0;
-  top: 0;
+  top: 12px;
   width: min(116%, 530px);
   max-width: none;
   margin-inline: auto;
@@ -44,6 +83,6 @@
 
 @media (max-height: 820px) {
   .native-welcome-visual-shell--step-4 .v3-method-logros__scene {
-    top: 1px;
+    top: 8px;
   }
 }

--- a/apps/web/src/mobile/__tests__/MobileAppEntry.visualPolish.test.ts
+++ b/apps/web/src/mobile/__tests__/MobileAppEntry.visualPolish.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const entryStyles = readFileSync(new URL('../MobileAppEntry.css', import.meta.url), 'utf8');
+
+describe('native welcome visual polish', () => {
+  it('removes only the duplicate Step 2 product topline', () => {
+    expect(entryStyles).toContain(
+      '.native-welcome-visual-shell--step-2 .ib20-showcase-topline',
+    );
+    expect(entryStyles).toContain('display: none');
+    expect(entryStyles).not.toContain('.native-welcome-visual-shell--step-2 .ib20-task-head');
+  });
+
+  it('keeps Step 3 stable while the difficulty chip expands', () => {
+    expect(entryStyles).toContain(
+      '.native-welcome-visual-shell--step-3 .ib20-showcase--detail',
+    );
+    expect(entryStyles).toContain(
+      '.native-welcome-visual-shell--step-3 .ib20-habit-body',
+    );
+    expect(entryStyles).toContain('box-sizing: border-box');
+    expect(entryStyles).toContain(
+      '.native-welcome-visual-shell--step-3 .ib20-detail-copy h4',
+    );
+    expect(entryStyles).toContain('white-space: nowrap');
+  });
+
+  it('separates the Step 4 shelf label from the native heading', () => {
+    expect(entryStyles).toContain(
+      '.native-welcome-visual-shell--step-4 .v3-method-logros__scene',
+    );
+    expect(entryStyles).toContain('top: 12px');
+    expect(entryStyles).toContain('top: 8px');
+  });
+});


### PR DESCRIPTION
## Alcance

Ajustes exclusivamente visuales para el welcome nativo compartido por iOS y Android. No se cambian transiciones, temporizadores, autenticación, navegación, Swift, Kotlin/Java ni Capacitor.

## Step 2

- oculta únicamente la topline duplicada `Tareas / Cuerpo`;
- conserva `Tarea / Semanas / Progreso`, filas, rings y animaciones internas.

## Step 3

- reduce el título `Review daily expenses` y lo mantiene en una sola línea;
- fija el ancho de la escena, del detalle y del panel de Habit Development;
- evita que la expansión del chip verde cambie el ancho intrínseco y haga respirar lateralmente toda la composición;
- conserva intacta la animación del chip, la flecha, el score y la ventana activa.

## Step 4

- baja ligeramente la escena del estante para separar `Habit shelf` del título nativo `Grow when you are ready`;
- mantiene el centrado horizontal corregido en #2294.

## Protección contra regresiones

Se agregan tests de arquitectura CSS para verificar que:

1. Step 2 oculta solo la topline duplicada;
2. Step 3 conserva una caja estable y un título single-line;
3. Step 4 mantiene el offset vertical nativo.

## Validación requerida

- iPhone real y Pixel 8;
- Steps 1–4 completos;
- comprobar que el chip de Step 3 abre/cierra sin cambiar el ancho del panel inferior;
- comprobar que las transiciones actuales no cambiaron.