### PR TITLE
fix(mobile): refine native welcome copy and Step 3 spacing

### DIFF
--- a/apps/web/src/mobile/MobileAppEntry.css
+++ b/apps/web/src/mobile/MobileAppEntry.css
@@ -3,41 +3,90 @@
  * scenes for the bounded Capacitor viewport used by iOS and Android.
  */
 
+/* Step 1: remove the tiny internal "FLOW · Quick Start" label shown below the
+ * native "Customize your tasks" phase heading. Keep the task cards and all
+ * their internal rise/select animations unchanged.
+ */
+.native-welcome-visual-shell--step-1
+  .v3-quickstart-tasks-preview
+  .quickstart-premium-card
+  > header
+  > p:first-child {
+  display: none !important;
+}
+
 /* Step 2: the native screen already has its own Step heading. Remove the
  * duplicate product topline ("Tareas / Cuerpo") while preserving the table
- * headings, rows, progress rings and all task animation behavior.
+ * headings, rows, progress rings and all task animation behavior. Match the
+ * landing selector specificity so the adapter wins consistently in WebViews.
  */
-.native-welcome-visual-shell--step-2 .ib20-showcase-topline {
-  display: none;
+.native-welcome-visual-shell--step-2.landing.landing--v3-conversion
+  .ib20-showcase-topline {
+  display: none !important;
 }
 
 /* Step 3: keep the detail scene on a stable width so the animated green chip
- * cannot change the intrinsic width of the whole showcase. The task title is
- * deliberately smaller and single-line in native only.
+ * cannot change the intrinsic width of the whole showcase. Remove the trait
+ * chip, reduce the title further, and let Easy + the animated difficulty chip
+ * occupy that freed row without affecting Habit Development below.
  */
-.native-welcome-visual-shell--step-3 .ib20-showcase--detail,
-.native-welcome-visual-shell--step-3 .ib20-detail-shell,
-.native-welcome-visual-shell--step-3 .ib20-habit-dev,
-.native-welcome-visual-shell--step-3 .ib20-habit-body {
-  width: 100%;
-  max-width: 100%;
-  min-width: 0;
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-showcase--detail,
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-detail-shell,
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-detail-head,
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-habit-dev,
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-habit-body {
+  width: 100% !important;
+  max-width: 100% !important;
+  min-width: 0 !important;
   box-sizing: border-box;
 }
 
-.native-welcome-visual-shell--step-3 .ib20-detail-copy,
-.native-welcome-visual-shell--step-3 .ib20-detail-chips {
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-detail-copy {
   min-width: 0;
+  overflow: hidden;
 }
 
-.native-welcome-visual-shell--step-3 .ib20-detail-copy h4 {
-  font-size: clamp(1.02rem, 4.6vw, 1.22rem);
-  line-height: 1.08;
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-detail-copy h4 {
+  max-width: 100%;
+  overflow: hidden;
+  font-size: clamp(0.82rem, 3.7vw, 1rem) !important;
+  line-height: 1.05;
+  letter-spacing: -0.035em;
+  text-overflow: clip;
   white-space: nowrap;
 }
 
-.native-welcome-visual-shell--step-3 .ib20-detail-chip--down {
-  max-width: min(11.5rem, 48vw);
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-detail-chip--trait {
+  display: none !important;
+}
+
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-detail-chips {
+  display: grid;
+  grid-template-columns: auto minmax(0, 11.5rem);
+  justify-content: start;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-detail-chip--difficulty {
+  flex: 0 0 auto;
+}
+
+.native-welcome-visual-shell--step-3.landing.landing--v3-conversion
+  .ib20-detail-chip--down {
+  max-width: 11.5rem;
 }
 
 /* Step 4 uses the landing achievement shelf as its single visual source. */

--- a/apps/web/src/mobile/__tests__/MobileAppEntry.visualPolish.test.ts
+++ b/apps/web/src/mobile/__tests__/MobileAppEntry.visualPolish.test.ts
@@ -4,29 +4,44 @@ import { describe, expect, it } from 'vitest';
 const entryStyles = readFileSync(new URL('../MobileAppEntry.css', import.meta.url), 'utf8');
 
 describe('native welcome visual polish', () => {
-  it('removes only the duplicate Step 2 product topline', () => {
+  it('removes the tiny Step 1 quick-start label without hiding task cards', () => {
     expect(entryStyles).toContain(
-      '.native-welcome-visual-shell--step-2 .ib20-showcase-topline',
+      '.native-welcome-visual-shell--step-1',
     );
-    expect(entryStyles).toContain('display: none');
-    expect(entryStyles).not.toContain('.native-welcome-visual-shell--step-2 .ib20-task-head');
+    expect(entryStyles).toContain(
+      '.quickstart-premium-card',
+    );
+    expect(entryStyles).toContain('> p:first-child');
+    expect(entryStyles).not.toContain(
+      '.native-welcome-visual-shell--step-1 .quickstart-task-row',
+    );
+  });
+
+  it('removes only the duplicate Step 2 product topline with sufficient specificity', () => {
+    expect(entryStyles).toContain(
+      '.native-welcome-visual-shell--step-2.landing.landing--v3-conversion',
+    );
+    expect(entryStyles).toContain('.ib20-showcase-topline');
+    expect(entryStyles).toContain('display: none !important');
+    expect(entryStyles).not.toContain(
+      '.native-welcome-visual-shell--step-2.landing.landing--v3-conversion\n  .ib20-task-head',
+    );
   });
 
   it('keeps Step 3 stable while the difficulty chip expands', () => {
     expect(entryStyles).toContain(
-      '.native-welcome-visual-shell--step-3 .ib20-showcase--detail',
+      '.native-welcome-visual-shell--step-3.landing.landing--v3-conversion',
     );
-    expect(entryStyles).toContain(
-      '.native-welcome-visual-shell--step-3 .ib20-habit-body',
-    );
+    expect(entryStyles).toContain('.ib20-habit-body');
     expect(entryStyles).toContain('box-sizing: border-box');
-    expect(entryStyles).toContain(
-      '.native-welcome-visual-shell--step-3 .ib20-detail-copy h4',
-    );
+    expect(entryStyles).toContain('.ib20-detail-copy h4');
+    expect(entryStyles).toContain('font-size: clamp(0.82rem, 3.7vw, 1rem) !important');
     expect(entryStyles).toContain('white-space: nowrap');
+    expect(entryStyles).toContain('.ib20-detail-chip--trait');
+    expect(entryStyles).toContain('grid-template-columns: auto minmax(0, 11.5rem)');
   });
 
-  it('separates the Step 4 shelf label from the native heading', () => {
+  it('keeps the validated Step 4 spacing unchanged', () => {
     expect(entryStyles).toContain(
       '.native-welcome-visual-shell--step-4 .v3-method-logros__scene',
     );


### PR DESCRIPTION
## Alcance

Ajustes visuales exclusivamente para el welcome nativo compartido por iOS y Android. No se modifican Step 4, transiciones, temporizadores, autenticación, navegación, Swift, Kotlin/Java ni Capacitor.

## Correcciones

### Step 1
- oculta la micro-label interna `FLOW · Quick Start` que aparece debajo de `Customize your tasks`;
- conserva las cards y sus animaciones internas.

### Step 2
- corrige la regla que no estaba ganando la cascada;
- elimina de forma efectiva `Tareas / Cuerpo` solo en nativas;
- conserva `Tarea / Semanas / Progreso` y todo el contenido funcional.

### Step 3
- reduce nuevamente `Review daily expenses` para mantenerlo en una línea;
- elimina el chip `Self-control / Autocontrol`;
- mueve `Easy / Fácil` y el chip animado de dificultad al espacio liberado;
- fija el ancho de la fila y de Habit Development para que la expansión del chip no modifique el ancho de la composición.

## Causa de la regresión anterior

Los overrides de #2295 tenían menor especificidad que las reglas de landing (`.landing.landing--v3-conversion ...`). En consecuencia, algunas reglas nativas —especialmente la de Step 2— quedaban anuladas por la cascada. Esta PR iguala la especificidad y aplica `!important` únicamente a los puntos de ocultación/tamaño que deben prevalecer dentro de Capacitor.

## Validación requerida

- iPhone real y Pixel 8;
- confirmar que Step 2 ya no muestra `Tareas / Cuerpo`;
- confirmar que Step 3 mantiene el mismo ancho con el chip abierto y cerrado;
- confirmar que Step 1 no muestra la micro-label debajo de `Customize your tasks`;
- confirmar que Step 4 permanece exactamente igual.