### PR TITLE
feat(mobile): unify native welcome step transitions

### DIFF
--- a/apps/web/src/mobile/MobileAppEntry.css
+++ b/apps/web/src/mobile/MobileAppEntry.css
@@ -3,6 +3,63 @@
  * scenes for the bounded Capacitor viewport used by iOS and Android.
  */
 
+/* Keep the outer native step transition homogeneous while preserving every
+ * landing animation inside the copy and visual scene. The current step enters
+ * from the right, remains still for its reading interval, and exits to the left
+ * during the final part of the native 5.2 second cadence.
+ */
+.native-welcome-copy,
+.native-welcome-visual-shell {
+  animation: native-welcome-step-cycle 5200ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  will-change: opacity, transform;
+}
+
+@keyframes native-welcome-step-cycle {
+  0% {
+    opacity: 0;
+    transform: translate3d(28px, 0, 0);
+  }
+
+  4.25% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+
+  96.9% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate3d(-28px, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .native-welcome-copy,
+  .native-welcome-visual-shell {
+    animation: native-welcome-step-cycle-reduced 5200ms linear both;
+  }
+
+  @keyframes native-welcome-step-cycle-reduced {
+    0%, 1.5% {
+      opacity: 0;
+      transform: none;
+    }
+
+    3%, 97% {
+      opacity: 1;
+      transform: none;
+    }
+
+    100% {
+      opacity: 0;
+      transform: none;
+    }
+  }
+}
+
 /* Step 1: remove the tiny internal "FLOW · Quick Start" label shown below the
  * native "Customize your tasks" phase heading. Keep the task cards and all
  * their internal rise/select animations unchanged.

--- a/apps/web/src/mobile/__tests__/MobileAppEntry.transitions.test.ts
+++ b/apps/web/src/mobile/__tests__/MobileAppEntry.transitions.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const entryStyles = readFileSync(new URL('../MobileAppEntry.css', import.meta.url), 'utf8');
+
+describe('native welcome outer transitions', () => {
+  it('uses the same right-to-left transition for copy and visual scenes', () => {
+    expect(entryStyles).toContain('.native-welcome-copy,');
+    expect(entryStyles).toContain('.native-welcome-visual-shell');
+    expect(entryStyles).toContain('animation: native-welcome-step-cycle 5200ms');
+    expect(entryStyles).toContain('transform: translate3d(28px, 0, 0)');
+    expect(entryStyles).toContain('transform: translate3d(-28px, 0, 0)');
+  });
+
+  it('keeps the step stationary between entry and exit', () => {
+    expect(entryStyles).toContain('4.25%');
+    expect(entryStyles).toContain('96.9%');
+  });
+
+  it('provides a reduced-motion fade without horizontal movement', () => {
+    expect(entryStyles).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(entryStyles).toContain('native-welcome-step-cycle-reduced');
+  });
+});


### PR DESCRIPTION
## Alcance

Transición exterior homogénea para los cuatro steps del welcome nativo compartido por iOS y Android.

No se modifican las animaciones internas de landing, la lógica de cada demo, autenticación, navegación, Swift, Kotlin/Java ni Capacitor.

## Comportamiento

Cada step:

- entra desde la derecha con `translateX(28px → 0)` y fade-in;
- permanece completamente estable durante el tiempo de lectura;
- sale hacia la izquierda con `translateX(0 → -28px)` y fade-out;
- utiliza la misma curva `cubic-bezier(0.22, 1, 0.36, 1)`;
- conserva el ciclo nativo actual de 5.2 segundos.

La transición se aplica en paralelo al copy y a la escena visual, de modo que el step se percibe como una sola unidad. Las animaciones internas —cards, tareas, chips, score, rings, carrusel y flip— continúan funcionando dentro de esa unidad.

## Reduced motion

`prefers-reduced-motion` reemplaza el desplazamiento horizontal por un fade breve, sin movimiento lateral.

## Protección contra regresiones

Se agregan tests que fijan:

1. la dirección derecha → izquierda;
2. el período estable entre entrada y salida;
3. el fallback de reduced motion.

## Mejora posterior fuera de alcance

La segunda fase visual del Step 1 —lista de tareas— sigue pendiente de actualización para reflejar el onboarding actual en landing y nativas. No se toca en esta PR.

## Validación requerida

- iPhone real y Pixel 8;
- observar el ciclo completo Step 1 → 2 → 3 → 4 → 1;
- confirmar que las animaciones internas no cambian;
- confirmar que no hay desplazamientos verticales nuevos ni cambios de tamaño.