### PR TITLE
fix(mobile): coordinate native step copy and preserve Step 2 exit

### DIFF
--- a/apps/web/src/mobile/MobileAppEntry.css
+++ b/apps/web/src/mobile/MobileAppEntry.css
@@ -4,14 +4,23 @@
  */
 
 /* Keep the outer native step transition homogeneous while preserving every
- * landing animation inside the copy and visual scene. The current step enters
- * from the right, remains still for its reading interval, and exits to the left
- * during the final part of the native 5.2 second cadence.
+ * landing animation inside the visual scene. Copy and visual share the exact
+ * same cycle, while the copy's own descendants are prevented from adding a
+ * second pulse/transform on top of the native step transition.
  */
 .native-welcome-copy,
 .native-welcome-visual-shell {
   animation: native-welcome-step-cycle 5200ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: 0ms;
+  animation-iteration-count: 1;
   will-change: opacity, transform;
+}
+
+.native-welcome-copy > span,
+.native-welcome-copy > h1 {
+  animation: none !important;
+  opacity: 1 !important;
+  transform: none !important;
 }
 
 @keyframes native-welcome-step-cycle {
@@ -74,12 +83,36 @@
 
 /* Step 2: the native screen already has its own Step heading. Remove the
  * duplicate product topline ("Tareas / Cuerpo") while preserving the table
- * headings, rows, progress rings and all task animation behavior. Match the
- * landing selector specificity so the adapter wins consistently in WebViews.
+ * headings, rows and progress rings.
  */
 .native-welcome-visual-shell--step-2.landing.landing--v3-conversion
   .ib20-showcase-topline {
   display: none !important;
+}
+
+/* Landing's Step 2 loop eventually hides the task rows again. In native, each
+ * row enters once from below, then stays visible so the complete table can
+ * participate in the outer leftward exit instead of leaving a blank stage.
+ */
+.native-welcome-visual-shell--step-2.landing.landing--v3-conversion
+  .ib20-task-row {
+  opacity: 0;
+  transform: translate3d(0, 16px, 0);
+  animation: native-welcome-step-2-row-enter 520ms cubic-bezier(0.22, 1, 0.36, 1) both !important;
+  animation-delay: var(--delay, 0ms) !important;
+  animation-iteration-count: 1 !important;
+}
+
+@keyframes native-welcome-step-2-row-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 16px, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
 }
 
 /* Step 3: keep the detail scene on a stable width so the animated green chip

--- a/apps/web/src/mobile/__tests__/MobileAppEntry.transitions.test.ts
+++ b/apps/web/src/mobile/__tests__/MobileAppEntry.transitions.test.ts
@@ -12,9 +12,26 @@ describe('native welcome outer transitions', () => {
     expect(entryStyles).toContain('transform: translate3d(-28px, 0, 0)');
   });
 
+  it('removes independent pulse animation from the step badge and title', () => {
+    expect(entryStyles).toContain('.native-welcome-copy > span,');
+    expect(entryStyles).toContain('.native-welcome-copy > h1');
+    expect(entryStyles).toContain('animation: none !important');
+    expect(entryStyles).toContain('transform: none !important');
+  });
+
   it('keeps the step stationary between entry and exit', () => {
     expect(entryStyles).toContain('4.25%');
     expect(entryStyles).toContain('96.9%');
+  });
+
+  it('keeps Step 2 rows visible after their one-shot native entrance', () => {
+    expect(entryStyles).toContain(
+      '.native-welcome-visual-shell--step-2.landing.landing--v3-conversion',
+    );
+    expect(entryStyles).toContain('.ib20-task-row');
+    expect(entryStyles).toContain('native-welcome-step-2-row-enter');
+    expect(entryStyles).toContain('animation-iteration-count: 1 !important');
+    expect(entryStyles).toContain('opacity: 1');
   });
 
   it('provides a reduced-motion fade without horizontal movement', () => {


### PR DESCRIPTION
## Alcance

Ajuste exclusivamente para las transiciones del welcome nativo compartido por iOS y Android.

No modifica landing web, autenticación, navegación, Swift, Kotlin/Java ni Capacitor.

## Copy del step

- elimina la animación/pulso independiente de `STEP X` y del título;
- conserva la transición exterior derecha → izquierda ya aprobada;
- fuerza a que badge y título dependan únicamente del mismo ciclo temporal que la escena visual;
- evita transforms y opacidades internas que hagan que el copy parezca entrar o pulsar por separado.

## Step 2

- reemplaza únicamente en nativas el loop que vuelve a ocultar las filas;
- mantiene una entrada escalonada desde abajo;
- cada fila anima una sola vez y queda visible;
- al final, la tabla completa sale hacia la izquierda mediante la transición exterior, sin dejar una pantalla vacía antes del cambio de step.

## Fuera de alcance

- no cambia las animaciones internas de Steps 1, 3 o 4;
- no actualiza todavía la segunda fase visual del Step 1;
- no modifica el contenido ni el layout aprobado.

## Validación requerida

- iPhone real y Pixel 8;
- observar el ciclo completo Step 1 → 2 → 3 → 4 → 1;
- confirmar que `STEP X + título` no pulsan de forma independiente;
- confirmar que Step 2 conserva todas las cards visibles hasta que el bloque completo sale a la izquierda;
- confirmar que no aparece un intervalo negro/vacío antes de Step 3.