### PR TITLE
fix(mobile): sync native copy motion and preserve Step 2 exit

### DIFF
--- a/apps/web/src/mobile/MobileAppEntry.css
+++ b/apps/web/src/mobile/MobileAppEntry.css
@@ -14,6 +14,17 @@
   will-change: opacity, transform;
 }
 
+/* The native eyebrow and headline used to inherit their own landing motion,
+ * which read as a pulse on top of the outer slide. Keep the text internally
+ * still so STEP + headline travel in lockstep with the visual shell.
+ */
+.native-welcome-copy > span,
+.native-welcome-copy > h1 {
+  animation: none !important;
+  opacity: 1 !important;
+  transform: none !important;
+}
+
 @keyframes native-welcome-step-cycle {
   0% {
     opacity: 0;
@@ -80,6 +91,46 @@
 .native-welcome-visual-shell--step-2.landing.landing--v3-conversion
   .ib20-showcase-topline {
   display: none !important;
+}
+
+/* Landing loops the task panel and rows back to opacity: 0 near the end of its
+ * cycle. In native that creates a blank frame before the outer leftward exit.
+ * Run the panel and row entrances once, then hold their final visible state so
+ * the complete Step 2 composition is what exits the viewport.
+ */
+.native-welcome-visual-shell--step-2.landing.landing--v3-conversion
+  .ib20-tasks-panel {
+  animation: native-step-2-panel-enter 460ms cubic-bezier(0.22, 1, 0.36, 1) both !important;
+}
+
+.native-welcome-visual-shell--step-2.landing.landing--v3-conversion
+  .ib20-task-row {
+  animation: native-step-2-row-enter 520ms cubic-bezier(0.22, 1, 0.36, 1) both !important;
+  animation-delay: calc(90ms + var(--delay)) !important;
+}
+
+@keyframes native-step-2-panel-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 10px, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes native-step-2-row-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 18px, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
 }
 
 /* Step 3: keep the detail scene on a stable width so the animated green chip

--- a/apps/web/src/mobile/__tests__/MobileAppEntry.transitions.test.ts
+++ b/apps/web/src/mobile/__tests__/MobileAppEntry.transitions.test.ts
@@ -12,9 +12,23 @@ describe('native welcome outer transitions', () => {
     expect(entryStyles).toContain('transform: translate3d(-28px, 0, 0)');
   });
 
+  it('keeps the native eyebrow and headline internally still', () => {
+    expect(entryStyles).toContain('.native-welcome-copy > span,');
+    expect(entryStyles).toContain('.native-welcome-copy > h1');
+    expect(entryStyles).toContain('animation: none !important');
+    expect(entryStyles).toContain('transform: none !important');
+  });
+
   it('keeps the step stationary between entry and exit', () => {
     expect(entryStyles).toContain('4.25%');
     expect(entryStyles).toContain('96.9%');
+  });
+
+  it('keeps Step 2 rows visible after their one-shot entrance', () => {
+    expect(entryStyles).toContain('native-step-2-panel-enter');
+    expect(entryStyles).toContain('native-step-2-row-enter');
+    expect(entryStyles).toContain('animation-delay: calc(90ms + var(--delay)) !important');
+    expect(entryStyles).toContain('animation: native-step-2-row-enter 520ms');
   });
 
   it('provides a reduced-motion fade without horizontal movement', () => {


### PR DESCRIPTION
## Alcance

Ajuste exclusivo del welcome nativo compartido por iOS y Android.

No se modifican landing web, autenticación, navegación, Swift, Kotlin/Java, Capacitor ni las animaciones internas de los Steps 1, 3 y 4.

## Copy coordinado

- elimina el pulso interno heredado por `STEP X` y el título;
- mantiene eyebrow y headline internamente estáticos;
- deja que la transición exterior derecha → izquierda sea el único movimiento de ese bloque;
- conserva la misma duración y curva del visual para que copy y escena se perciban coordinados.

## Step 2

- reemplaza el loop que devolvía panel y filas a `opacity: 0` antes de la salida;
- conserva una entrada escalonada desde abajo;
- la entrada se ejecuta una sola vez;
- panel y cards mantienen su estado visible durante el tiempo de lectura;
- el Step 2 completo permanece visible cuando sale hacia la izquierda, evitando el frame negro.

## Reduced motion

Se conserva el fallback actual basado en fade sin desplazamiento lateral.

## Protección contra regresiones

Los tests verifican:

1. que eyebrow y headline no ejecuten animaciones internas;
2. que Step 2 use entradas one-shot;
3. que las filas mantengan su estado final visible;
4. que la transición exterior derecha → izquierda y reduced motion permanezcan intactos.

## Validación requerida

- iPhone real y Pixel 8;
- observar varios ciclos completos;
- confirmar que `STEP X + título` no pulsen y acompañen el cambio de escena;
- confirmar que Step 2 sale completo hacia la izquierda sin quedar vacío antes;
- confirmar que Steps 1, 3 y 4 mantienen sus animaciones internas actuales.