### PR TITLE
Fix inconsistent App Store and Google Play badge sizing

### DIFF
--- a/apps/web/public/store-badges/store-badges.css
+++ b/apps/web/public/store-badges/store-badges.css
@@ -47,13 +47,16 @@
   object-fit: contain;
 }
 
+/* Google Play's official PNG includes more transparent/internal padding than
+   Apple's badge. These language-specific scales equalize the visible badge
+   height while preserving the same 160x48 (145x44 on mobile) layout box. */
 .ib-store-badge--google-play .ib-store-badge-image {
-  transform: scale(1.16);
+  transform: scale(1.21);
   transform-origin: center;
 }
 
 .ib-store-badges[data-language="en"] .ib-store-badge--google-play .ib-store-badge-image {
-  transform: scale(1.29);
+  transform: scale(1.31);
 }
 
 .ib-store-badge-coming-soon {


### PR DESCRIPTION
## Summary
- equalizes the visible height of the Google Play badge against the App Store badge
- keeps both badges inside the same existing 160×48 desktop and 145×44 mobile layout boxes
- applies calibrated scaling for Spanish and English assets because the official PNGs have different internal padding

## Change
- Spanish Google Play scale: `1.16` → `1.21`
- English Google Play scale: `1.29` → `1.31`

This fixes the visual mismatch shown in the landing hero without changing spacing, links, responsive behavior, or the App Store coming-soon state.