### PR TITLE
Simplify mobile hero to phone-only animation

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="/landing-problem-open-graphic.css" />
     <link rel="stylesheet" href="/landing-problem-premium-v2.css" />
     <link rel="stylesheet" href="/landing-problem-mobile-fix.css" />
+    <link rel="stylesheet" href="/landing-mobile-hero-phone-only.css" />
     <link rel="stylesheet" href="/store-badges/store-badges.css" />
     <script defer src="/landing-problem-premium-v2.js"></script>
     <script defer src="/store-badges/store-badges.js"></script>

--- a/apps/web/public/landing-mobile-hero-phone-only.css
+++ b/apps/web/public/landing-mobile-hero-phone-only.css
@@ -1,0 +1,49 @@
+/* Mobile-only hero adaptation: keep the animated phone, remove desktop expansion cards. */
+@media (max-width: 767px) {
+  .landing.landing--v3-conversion .hero {
+    min-height: auto !important;
+  }
+
+  .landing.landing--v3-conversion .hero-grid {
+    min-height: 0 !important;
+    padding-bottom: 52px !important;
+  }
+
+  .landing.landing--v3-conversion .hero-media {
+    min-height: 0 !important;
+    height: auto !important;
+    overflow: visible !important;
+    align-items: flex-start !important;
+  }
+
+  /* The rhythm, task-summary and task-detail panels are desktop expansion elements. */
+  .landing.landing--v3-conversion .hero-media [class*="HeroProductScene_sceneLayer"] {
+    display: none !important;
+  }
+
+  .landing.landing--v3-conversion .hero-media [class*="HeroProductScene_scene_"] {
+    display: block !important;
+    width: min(100%, 342px) !important;
+    min-height: 0 !important;
+    height: auto !important;
+    margin: 0 auto !important;
+  }
+
+  .landing.landing--v3-conversion .hero-media [class*="HeroProductScene_phoneLayer"] {
+    position: relative !important;
+    inset: auto !important;
+    width: min(88vw, 342px) !important;
+    margin: 0 auto !important;
+    transform: none !important;
+  }
+
+  /* Do not reserve the desktop animation canvas below the phone. */
+  .landing.landing--v3-conversion .hero-media [class*="HeroProductScene_sceneGlow"] {
+    inset: 8% 3% 4% !important;
+  }
+
+  .landing.landing--v3-conversion .hero + section,
+  .landing.landing--v3-conversion .hero + .truth-problem {
+    margin-top: 0 !important;
+  }
+}


### PR DESCRIPTION
## Changes
- Hides the desktop expansion cards on mobile: emotion chart, task summary, and task detail.
- Keeps the animated phone and its internal dashboard/splash sequence.
- Removes the desktop animation canvas height from the mobile layout.
- Reduces the hero's bottom spacing so the problem section follows immediately after the phone.
- Applies only below 768px; desktop behavior is unchanged.

## Scope
CSS-only mobile landing refinement. No authentication, routing, product logic, or native files were changed.