### PR TITLE
Marketing: Drive → render → Admin approval bridge

### DIFF
--- a/.github/workflows/marketing-render-campaign.yml
+++ b/.github/workflows/marketing-render-campaign.yml
@@ -1,0 +1,95 @@
+name: Render campaign and send it to Admin
+
+on:
+  workflow_dispatch:
+    inputs:
+      period_key:
+        description: Target campaign period in YYYY-MM format
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: marketing-render-${{ inputs.period_key }}
+  cancel-in-progress: false
+
+jobs:
+  render-and-import:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      GOOGLE_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 }}
+      MARKETING_DRIVE_STAGING_FOLDER_ID: ${{ secrets.MARKETING_DRIVE_STAGING_FOLDER_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: automation/marketing-cycle-${{ inputs.period_key }}
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Check configuration
+        run: |
+          set -euo pipefail
+          for key in DATABASE_URL GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 MARKETING_DRIVE_STAGING_FOLDER_ID; do
+            if [[ -z "${!key:-}" ]]; then
+              echo "Missing required GitHub secret: ${key}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Validate creative contract
+        run: node scripts/marketing/validate-creative-direction.mjs marketing/agent-outputs/${{ inputs.period_key }}/campaign.json
+
+      - name: Stage approved source assets from Drive
+        run: >-
+          npm -w @innerbloom/api exec tsx scripts/stage-marketing-drive-assets.ts
+          ../../marketing/agent-outputs/${{ inputs.period_key }}/campaign.json
+          ../../marketing/asset-registry/innerbloom-drive-assets-v1.json
+          ../../marketing/generated/${{ inputs.period_key }}/source-assets
+
+      - name: Render deterministic campaign PNGs
+        run: >-
+          node scripts/marketing/render-campaign-v2.mjs
+          marketing/agent-outputs/${{ inputs.period_key }}/campaign.json
+          --asset-dir marketing/generated/${{ inputs.period_key }}/source-assets
+          --out marketing/generated/${{ inputs.period_key }}/rendered
+
+      - name: Upload review PNGs to Drive staging
+        run: >-
+          npm -w @innerbloom/api exec tsx scripts/upload-marketing-rendered-assets.ts
+          ../../marketing/generated/${{ inputs.period_key }}/rendered
+          ../../marketing/generated/${{ inputs.period_key }}/drive-staging-manifest.json
+
+      - name: Import campaign into Admin review
+        run: >-
+          npm -w @innerbloom/api exec tsx scripts/import-marketing-campaign.ts
+          ../../marketing/agent-outputs/${{ inputs.period_key }}/campaign.json
+          ../../marketing/generated/${{ inputs.period_key }}/drive-staging-manifest.json
+
+      - name: Keep output as a build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: innerbloom-marketing-${{ inputs.period_key }}
+          path: marketing/generated/${{ inputs.period_key }}
+          retention-days: 30
+
+      - name: Report next step
+        run: |
+          {
+            echo "## Campaign ready for human review"
+            echo "- Period: ${{ inputs.period_key }}"
+            echo "- Result: rendered PNGs are in Drive staging and imported to Admin."
+            echo "- Next: open Admin > Marketing, approve or reject each post."
+            echo "- After approval: use Upload approved assets to R2, then Download Metricool CSV."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/Docs/marketing/CREATIVE_RENDERER_WORKFLOW.md
+++ b/Docs/marketing/CREATIVE_RENDERER_WORKFLOW.md
@@ -1,0 +1,51 @@
+# Innerbloom Creative Rendering Workflow
+
+## What this adds
+
+The campaign remains a single file:
+
+`marketing/agent-outputs/<YYYY-MM>/campaign.json`
+
+The Head of Content creates the campaign, its copy, truthful product anchors and source assets. The Creative Director then adds `creative_direction` to every image job inside that same file. No second campaign plan exists.
+
+The renderer reads only the completed campaign and staged approved assets. It has no creative discretion.
+
+## Monthly sequence
+
+1. GitHub Action exports CMO context.
+2. CMO and Head of Content create the monthly `campaign.json`.
+3. Creative Director enriches every image job with `creative_direction`.
+4. Deterministic Drive staging downloads the approved real assets by registered asset key.
+5. `npm run marketing:render-v2 -- <campaign.json> --asset-dir <staged-assets> --out <generated-assets>` produces PNGs.
+6. Generated assets are imported into Admin Marketing for human approval.
+7. Approved assets upload to R2 and code produces the Metricool CSV.
+8. The CSV is imported in Metricool. API publishing is a later optional replacement.
+
+## The Creative Director may decide
+
+- a reusable creative family;
+- light or dark mode;
+- front, angled, layered or close-cropped device treatment;
+- exact registered assets;
+- visual focal instruction;
+- whether a non-UI generated supporting visual is necessary;
+- acceptance criteria.
+
+## The Creative Director may never decide
+
+- visible text;
+- logo or wordmark recreation;
+- fake product UI;
+- files, folders, Drive, R2, Metricool or Admin actions;
+- campaign strategy, captions, schedules, CTA destinations or analytics.
+
+## Brand and truth rules
+
+- Render the canonical Innerbloom flower and wordmark using the established landing brand implementation.
+- Sora is the headline / wordmark family and Manrope is body copy, matching the web product's font setup.
+- Screenshots are real proof. They can be placed inside a deterministic phone shell, transformed in perspective or layered with other real screens; the UI itself is never generated.
+- Supporting image generation is allowed only for non-UI atmosphere or objects. It cannot contain visible copy, logo, phone UI or fake device screens.
+
+## Current boundary
+
+The v2 renderer is ready to consume a completed visual contract. A deterministic Drive-staging step and the Admin/R2 import step still need to be connected before a full monthly batch can run unattended.

--- a/Docs/marketing/DRIVE_TO_ADMIN_WORKFLOW.md
+++ b/Docs/marketing/DRIVE_TO_ADMIN_WORKFLOW.md
@@ -1,0 +1,44 @@
+# Operación mensual de renders de marketing
+
+Este flujo separa pensamiento de mecánica:
+
+1. **CMO / Head of Content / Creative Director**: producen o enriquecen `campaign.json`. Es el único tramo que usa criterio.
+2. **GitHub Action `Render campaign and send it to Admin`**: código determinista. Descarga los assets aprobados, renderiza los PNG, los sube a Drive y crea los posts en el Admin.
+3. **Humano en Admin**: aprueba o rechaza cada post.
+4. **Admin**: al pulsar **Upload approved assets to R2**, sube los aprobados. Cuando todos estén en R2, **Download Metricool CSV** genera el CSV para importar.
+
+## Configuración de Drive (una sola vez)
+
+El workflow requiere estos secretos de GitHub:
+
+| Secreto | Qué contiene |
+| --- | --- |
+| `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64` | El JSON de la cuenta de servicio de Google, codificado en base64. |
+| `MARKETING_DRIVE_STAGING_FOLDER_ID` | ID de la carpeta de Drive donde se guardarán los PNGs de revisión. |
+| `DATABASE_URL` | Ya se usa para crear los posts dentro del Admin. |
+
+Permisos que debe recibir la cuenta de servicio:
+
+- Comparte la carpeta **Innerbloom Marketing** (la vigente) o los archivos registrados, como **Lector**.
+- Comparte la carpeta de staging de renders como **Editor**.
+
+No hay que mandar la clave privada por chat. La dirección exacta que hay que compartir es `client_email` dentro del JSON de la cuenta de servicio.
+
+## Ejecución mensual
+
+Cuando el Creative Director haya dejado `marketing/agent-outputs/YYYY-MM/campaign.json` con `creative_direction` válido, ejecuta:
+
+- GitHub Actions → **Render campaign and send it to Admin**
+- `period_key`: por ejemplo `2026-07`
+
+La Action falla temprano si falta un secreto, si el contrato creativo no está completo, o si un asset no está en el registro. Nunca improvisa pantallas, logos ni textos.
+
+## Qué entra al Admin
+
+Cada post llega como `needs_review` con:
+
+- copy, hipótesis, métrica y URL de tracking del `campaign.json`;
+- sus PNGs de revisión desde Drive;
+- metadatos de que fue renderizado de forma determinista.
+
+El administrador conserva la decisión final: aprobar, rechazar, subir a R2 y exportar CSV.

--- a/Docs/marketing/DRIVE_TO_ADMIN_WORKFLOW.md
+++ b/Docs/marketing/DRIVE_TO_ADMIN_WORKFLOW.md
@@ -14,7 +14,7 @@ El workflow requiere estos secretos de GitHub:
 | Secreto | Qué contiene |
 | --- | --- |
 | `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64` | El JSON de la cuenta de servicio de Google, codificado en base64. |
-| `MARKETING_DRIVE_STAGING_FOLDER_ID` | ID de la carpeta de Drive donde se guardarán los PNGs de revisión. |
+| `MARKETING_DRIVE_STAGING_FOLDER_ID` | ID de la carpeta de Drive donde se guardarán los PNGs de revisión: `1x1hkC8VZclb6zvCVnNb3mNh7TLk76CWo` (`Generated Marketing Reviews`). |
 | `DATABASE_URL` | Ya se usa para crear los posts dentro del Admin. |
 
 Permisos que debe recibir la cuenta de servicio:

--- a/apps/api/scripts/import-marketing-campaign.ts
+++ b/apps/api/scripts/import-marketing-campaign.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pool, endPool } from '../src/db.js';
+
+type Campaign = {
+  period_key: string;
+  campaign: { campaign_code: string; title: string; objective: string; status: string; strategy_summary: string };
+  posts: Array<Record<string, any>>;
+};
+type StagingManifest = { assets: Array<{ file: string; source_url: string; preview_url: string; web_view_url: string }> };
+
+const [campaignPath, manifestPath] = process.argv.slice(2);
+if (!campaignPath || !manifestPath) {
+  throw new Error('Usage: tsx scripts/import-marketing-campaign.ts <campaign.json> <drive-staging-manifest.json>');
+}
+const campaign = JSON.parse(await fs.readFile(campaignPath, 'utf8')) as Campaign;
+const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8')) as StagingManifest;
+const assetByFile = new Map(manifest.assets.map((asset) => [asset.file, asset]));
+
+try {
+  const campaignResult = await pool.query<{ marketing_campaign_id: string }>(
+    `INSERT INTO marketing_campaigns (period_key, campaign_code, title, objective, status, strategy_summary, source_context)
+     VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb)
+     ON CONFLICT (campaign_code) DO UPDATE SET
+       period_key=EXCLUDED.period_key,title=EXCLUDED.title,objective=EXCLUDED.objective,status=EXCLUDED.status,
+       strategy_summary=EXCLUDED.strategy_summary,source_context=EXCLUDED.source_context,updated_at=now()
+     RETURNING marketing_campaign_id`,
+    [
+      campaign.period_key,
+      campaign.campaign.campaign_code,
+      campaign.campaign.title,
+      campaign.campaign.objective,
+      campaign.campaign.status,
+      campaign.campaign.strategy_summary,
+      JSON.stringify({
+        campaignJsonPath: campaignPath,
+        driveStagingManifestPath: manifestPath,
+        pipeline: {
+          creativeDirection: 'complete',
+          renderedAt: new Date().toISOString(),
+          renderedAssetCount: manifest.assets.length,
+          currentStep: 'review',
+        },
+      }),
+    ],
+  );
+  const campaignId = campaignResult.rows[0].marketing_campaign_id;
+
+  for (const post of campaign.posts) {
+    const postAssets = (post.assets ?? []).map((planned: any) => {
+      const filename = planned.asset_code ? `${planned.asset_code}.png` : planned.filename;
+      const staged = assetByFile.get(filename);
+      if (!staged) throw new Error(`Rendered Drive asset missing for ${post.post_code}: ${filename}`);
+      return {
+        file: filename,
+        title: post.visible_copy_plan?.headline ?? post.hook ?? filename,
+        type: planned.asset_kind ?? post.format,
+        url: staged.source_url,
+        previewUrl: staged.preview_url,
+        sourceUrl: staged.web_view_url,
+        selected: true,
+      };
+    });
+    await pool.query(
+      `INSERT INTO marketing_posts (
+         marketing_campaign_id,post_code,platform,format,status,hook,caption,hypothesis,target_metric,tracking_url,
+         asset_urls,agent_notes,scheduled_at
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12,$13)
+       ON CONFLICT (marketing_campaign_id,post_code) DO UPDATE SET
+         platform=EXCLUDED.platform,format=EXCLUDED.format,status=EXCLUDED.status,hook=EXCLUDED.hook,
+         caption=EXCLUDED.caption,hypothesis=EXCLUDED.hypothesis,target_metric=EXCLUDED.target_metric,
+         tracking_url=EXCLUDED.tracking_url,asset_urls=EXCLUDED.asset_urls,agent_notes=EXCLUDED.agent_notes,
+         scheduled_at=EXCLUDED.scheduled_at,updated_at=now()`,
+      [
+        campaignId, post.post_code, post.platform ?? 'instagram', post.format ?? 'static', 'needs_review',
+        post.hook ?? '', post.caption ?? '', post.hypothesis ?? '', post.primary_metric ?? '',
+        post.tracking_url ?? '', JSON.stringify(postAssets),
+        `Imported deterministically from ${path.basename(campaignPath)}; visual direction was resolved before rendering.`,
+        post.scheduled_at ?? null,
+      ],
+    );
+  }
+  console.log(`Imported ${campaign.posts.length} posts into Admin for ${campaign.campaign.campaign_code}.`);
+} finally {
+  await endPool();
+}

--- a/apps/api/scripts/stage-marketing-drive-assets.ts
+++ b/apps/api/scripts/stage-marketing-drive-assets.ts
@@ -14,7 +14,7 @@ const [campaign, registry] = await Promise.all([
   readJson<{ image_generation?: { jobs?: Job[] } }>(campaignPath),
   readJson<{ assets?: RegistryAsset[] }>(registryPath),
 ]);
-const requiredKeys = new Set<string>(['brand_logo_512']);
+const requiredKeys = new Set<string>(['brand_logo_512', 'brand_logo_full']);
 for (const job of campaign.image_generation?.jobs ?? []) {
   for (const key of job.selected_asset_keys ?? []) requiredKeys.add(key);
 }

--- a/apps/api/scripts/stage-marketing-drive-assets.ts
+++ b/apps/api/scripts/stage-marketing-drive-assets.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { downloadDriveFile } from '../src/services/marketingGoogleDriveService.js';
+
+type RegistryAsset = { asset_key: string; drive_file_id: string; file_name?: string };
+type Job = { selected_asset_keys?: string[] };
+
+const [campaignPath, registryPath, outputDir] = process.argv.slice(2);
+if (!campaignPath || !registryPath || !outputDir) {
+  throw new Error('Usage: tsx scripts/stage-marketing-drive-assets.ts <campaign.json> <asset-registry.json> <output-dir>');
+}
+
+const [campaign, registry] = await Promise.all([
+  readJson<{ image_generation?: { jobs?: Job[] } }>(campaignPath),
+  readJson<{ assets?: RegistryAsset[] }>(registryPath),
+]);
+const requiredKeys = new Set<string>(['brand_logo_512']);
+for (const job of campaign.image_generation?.jobs ?? []) {
+  for (const key of job.selected_asset_keys ?? []) requiredKeys.add(key);
+}
+if (requiredKeys.size === 1) {
+  throw new Error('No creative selected_asset_keys were found. Run the Creative Director before staging.');
+}
+
+const byKey = new Map((registry.assets ?? []).map((asset) => [asset.asset_key, asset]));
+const missing = [...requiredKeys].filter((key) => !byKey.has(key));
+if (missing.length) throw new Error(`Asset registry is missing: ${missing.join(', ')}`);
+
+await fs.mkdir(outputDir, { recursive: true });
+const staged: Array<{ asset_key: string; file: string; drive_file_id: string; content_type: string }> = [];
+for (const key of [...requiredKeys].sort()) {
+  const asset = byKey.get(key)!;
+  const result = await downloadDriveFile(asset.drive_file_id);
+  const extension = extensionFor(asset.file_name ?? key, result.contentType);
+  const file = `${safeName(key)}${extension}`;
+  await fs.writeFile(path.join(outputDir, file), result.bytes);
+  staged.push({ asset_key: key, file, drive_file_id: asset.drive_file_id, content_type: result.contentType });
+  console.log(`staged ${key} -> ${file}`);
+}
+await fs.writeFile(path.join(outputDir, 'manifest.json'), JSON.stringify({ generated_at: new Date().toISOString(), assets: staged }, null, 2));
+
+async function readJson<T>(file: string): Promise<T> {
+  return JSON.parse(await fs.readFile(file, 'utf8')) as T;
+}
+function safeName(value: string) { return value.replace(/[^a-z0-9._-]+/gi, '_'); }
+function extensionFor(file: string, contentType: string) {
+  const fromFile = path.extname(file);
+  if (fromFile) return fromFile;
+  if (contentType.includes('png')) return '.png';
+  if (contentType.includes('jpeg')) return '.jpg';
+  if (contentType.includes('webp')) return '.webp';
+  return '.bin';
+}

--- a/apps/api/scripts/upload-marketing-rendered-assets.ts
+++ b/apps/api/scripts/upload-marketing-rendered-assets.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { uploadDriveImage } from '../src/services/marketingGoogleDriveService.js';
+
+const [renderDir, outputPath] = process.argv.slice(2);
+const folderId = String(process.env.MARKETING_DRIVE_STAGING_FOLDER_ID ?? '').trim();
+if (!renderDir || !outputPath) {
+  throw new Error('Usage: tsx scripts/upload-marketing-rendered-assets.ts <render-dir> <output-manifest.json>');
+}
+if (!folderId) throw new Error('MARKETING_DRIVE_STAGING_FOLDER_ID is required to upload rendered previews.');
+
+const files = (await fs.readdir(renderDir)).filter((file) => /\.png$/i.test(file)).sort();
+if (!files.length) throw new Error(`No PNG files found in ${renderDir}`);
+
+const assets = [];
+for (const file of files) {
+  const bytes = await fs.readFile(path.join(renderDir, file));
+  const uploaded = await uploadDriveImage({
+    name: file,
+    bytes,
+    contentType: 'image/png',
+    parentFolderId: folderId,
+  });
+  assets.push({
+    file,
+    drive_file_id: uploaded.id,
+    source_url: `https://drive.google.com/uc?export=download&id=${uploaded.id}`,
+    preview_url: uploaded.thumbnailLink ?? `https://drive.google.com/thumbnail?id=${uploaded.id}&sz=w1200`,
+    web_view_url: uploaded.webViewLink ?? `https://drive.google.com/file/d/${uploaded.id}/view`,
+  });
+  console.log(`uploaded ${file}`);
+}
+await fs.mkdir(path.dirname(outputPath), { recursive: true });
+await fs.writeFile(outputPath, JSON.stringify({ generated_at: new Date().toISOString(), assets }, null, 2));

--- a/apps/api/src/services/marketingGoogleDriveService.ts
+++ b/apps/api/src/services/marketingGoogleDriveService.ts
@@ -1,0 +1,121 @@
+import { importPKCS8, SignJWT } from 'jose';
+
+type ServiceAccount = {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+};
+
+export type DriveFile = {
+  id: string;
+  name: string;
+  mimeType: string;
+  webViewLink?: string;
+  thumbnailLink?: string;
+};
+
+const DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive';
+
+export async function downloadDriveFile(fileId: string) {
+  const token = await getAccessToken();
+  const response = await fetch(`https://www.googleapis.com/drive/v3/files/${encodeURIComponent(fileId)}?alt=media`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google Drive download failed for ${fileId} (HTTP ${response.status})`);
+  }
+
+  return {
+    bytes: Buffer.from(await response.arrayBuffer()),
+    contentType: response.headers.get('content-type') ?? 'application/octet-stream',
+  };
+}
+
+export async function uploadDriveImage(input: {
+  name: string;
+  bytes: Buffer;
+  contentType: string;
+  parentFolderId: string;
+}): Promise<DriveFile> {
+  const token = await getAccessToken();
+  const boundary = 'innerbloom-drive-upload';
+  const metadata = JSON.stringify({
+    name: input.name,
+    parents: [input.parentFolderId],
+    mimeType: input.contentType,
+  });
+  const body = Buffer.concat([
+    Buffer.from(`--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n--${boundary}\r\nContent-Type: ${input.contentType}\r\n\r\n`),
+    input.bytes,
+    Buffer.from(`\r\n--${boundary}--\r\n`),
+  ]);
+  const response = await fetch(
+    'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,mimeType,webViewLink,thumbnailLink',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': `multipart/related; boundary=${boundary}`,
+      },
+      body,
+      signal: AbortSignal.timeout(60_000),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Google Drive upload failed (HTTP ${response.status}): ${await response.text()}`);
+  }
+
+  return (await response.json()) as DriveFile;
+}
+
+async function getAccessToken() {
+  const raw = String(process.env.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 ?? '').trim();
+  if (!raw) {
+    throw new Error('GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 is required for the Drive staging step.');
+  }
+
+  let serviceAccount: ServiceAccount;
+  try {
+    serviceAccount = JSON.parse(Buffer.from(raw, 'base64').toString('utf8')) as ServiceAccount;
+  } catch {
+    throw new Error('GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 is not valid base64 JSON.');
+  }
+
+  if (!serviceAccount.client_email || !serviceAccount.private_key) {
+    throw new Error('The Google service account must include client_email and private_key.');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const key = await importPKCS8(serviceAccount.private_key, 'RS256');
+  const assertion = await new SignJWT({ scope: DRIVE_SCOPE })
+    .setProtectedHeader({ alg: 'RS256', typ: 'JWT' })
+    .setIssuer(serviceAccount.client_email)
+    .setAudience(serviceAccount.token_uri ?? 'https://oauth2.googleapis.com/token')
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .sign(key);
+
+  const response = await fetch(serviceAccount.token_uri ?? 'https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    }),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google OAuth token request failed (HTTP ${response.status})`);
+  }
+
+  const payload = (await response.json()) as { access_token?: string };
+  if (!payload.access_token) {
+    throw new Error('Google OAuth token response did not include an access token.');
+  }
+
+  return payload.access_token;
+}

--- a/apps/web/src/pages/admin2/MarketingPage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPage.tsx
@@ -773,6 +773,33 @@ export function MarketingPage() {
         ) : null}
       </header>
 
+      <section className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5">
+        <div className="flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--admin-muted)]">Monthly pipeline</p>
+            <h3 className="mt-1 text-lg font-semibold tracking-tight text-[color:var(--admin-text)]">Where this campaign is</h3>
+          </div>
+          <p className="text-xs text-[color:var(--admin-muted)]">{selectedCampaign.periodLabel}</p>
+        </div>
+        <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+          {[
+            { label: '1. Data + strategy', detail: 'Campaign JSON exists', done: true },
+            { label: '2. Creative direction', detail: 'Resolved before rendering', done: posts.length > 0 },
+            { label: '3. Images in Admin', detail: `${posts.reduce((total, post) => total + post.assets.length, 0)} assets ready to review`, done: posts.some((post) => post.assets.length > 0) },
+            { label: '4. Your review', detail: needsReviewCount ? `${needsReviewCount} posts awaiting a decision` : 'Review complete', done: needsReviewCount === 0 },
+            { label: '5. R2 + Metricool', detail: canDownloadApprovedCsv ? 'CSV ready to download' : approvedPosts.length ? 'Upload approved assets to R2' : 'Approve at least one post', done: canDownloadApprovedCsv },
+          ].map((step) => (
+            <div key={step.label} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3">
+              <p className="text-xs font-semibold text-[color:var(--admin-text)]">{step.label}</p>
+              <p className="mt-1 text-xs text-[color:var(--admin-muted)]">{step.detail}</p>
+              <span className={`mt-2 inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold ${step.done ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-200' : 'bg-amber-500/15 text-amber-700 dark:text-amber-200'}`}>
+                {step.done ? 'Ready' : 'Waiting'}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
       <section className="grid gap-4 md:grid-cols-5">
         <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4">
           <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--admin-muted)]">Configured posts</p>

--- a/marketing/renderer/creative-families-v1.json
+++ b/marketing/renderer/creative-families-v1.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "1.0",
+  "canonical_brand": {
+    "logo_asset_key": "brand_logo_512",
+    "wordmark_source": "apps/web landing header and brand font tokens",
+    "wordmark_rule": "Render the established Innerbloom lockup; do not approximate it with arbitrary system typography."
+  },
+  "renderer_rules": [
+    "All visible text is code-rendered from campaign.json.",
+    "All product UI comes from registered real assets.",
+    "Device perspective and layered product depth are deterministic renderer treatments, not generated UI.",
+    "A supporting generated visual may never include readable text, a wordmark, product UI or a fake device."
+  ],
+  "families": [
+    {
+      "key": "product_hero_scene",
+      "device_presentation": "front",
+      "source_assets": {
+        "min": 1,
+        "max": 3
+      },
+      "best_for": [
+        "acquisition",
+        "product promise"
+      ],
+      "description": "Dominant real device with restrained depth from real screens/cards."
+    },
+    {
+      "key": "product_angle",
+      "device_presentation": "angled",
+      "source_assets": {
+        "min": 1,
+        "max": 1
+      },
+      "best_for": [
+        "feature impact",
+        "consideration"
+      ],
+      "description": "Real screenshot within an angled device shell; copy remains clear and separate."
+    },
+    {
+      "key": "product_depth",
+      "device_presentation": "layered_cards",
+      "source_assets": {
+        "min": 2,
+        "max": 3
+      },
+      "best_for": [
+        "system explanation",
+        "feature relationship"
+      ],
+      "description": "Front device plus two truthful secondary panels."
+    },
+    {
+      "key": "module_spotlight",
+      "device_presentation": "front",
+      "source_assets": {
+        "min": 1,
+        "max": 1
+      },
+      "best_for": [
+        "feature explanation"
+      ],
+      "description": "One module, one concise callout, no invented UI."
+    },
+    {
+      "key": "editorial_statement",
+      "device_presentation": "none",
+      "source_assets": {
+        "min": 1,
+        "max": 1
+      },
+      "best_for": [
+        "belief slide",
+        "carousel bridge"
+      ],
+      "description": "Text-led progression with real logo; product appears only if it adds evidence."
+    },
+    {
+      "key": "proof_sequence",
+      "device_presentation": "layered_cards",
+      "source_assets": {
+        "min": 2,
+        "max": 3
+      },
+      "best_for": [
+        "carousel"
+      ],
+      "description": "Hook, reframe, proof, CTA; varies visual treatment across slides."
+    },
+    {
+      "key": "supporting_visual_scene",
+      "device_presentation": "none",
+      "source_assets": {
+        "min": 1,
+        "max": 2
+      },
+      "best_for": [
+        "brand context"
+      ],
+      "description": "Code-composed post with an optional generated non-UI atmospheric layer."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint": "npm --workspace apps/api run lint",
     "test": "npm --workspace apps/api run test",
     "routes:print": "npm --workspace apps/api run routes:print",
-    "marketing:generate": "node scripts/marketing/generate-campaign-assets.mjs"
+    "marketing:generate": "node scripts/marketing/generate-campaign-assets.mjs",
+    "marketing:render-v2": "node scripts/marketing/render-campaign-v2.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.6.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "npm --workspace apps/api run test",
     "routes:print": "npm --workspace apps/api run routes:print",
     "marketing:generate": "node scripts/marketing/generate-campaign-assets.mjs",
-    "marketing:render-v2": "node scripts/marketing/render-campaign-v2.mjs"
+    "marketing:render-v2": "node scripts/marketing/render-campaign-v2.mjs",
+    "marketing:validate-creative": "node scripts/marketing/validate-creative-direction.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.6.2",

--- a/prompts/marketing/agent-system/asset-producer/AGENTS.md
+++ b/prompts/marketing/agent-system/asset-producer/AGENTS.md
@@ -1,81 +1,11 @@
-# Innerbloom Asset Producer Agent
+# Innerbloom Asset Producer (mechanical handoff)
 
-## Purpose
+This file remains for compatibility with earlier monthly workflows.
 
-This agent is the visual-selection stage of the monthly Innerbloom marketing cycle.
+Creative decisions now belong exclusively to:
 
-It runs only after one validated schema-v2 `campaign.json` exists. It makes the small set of decisions that require judgement: which real asset, mode, crop/composition intent, and whether a supporting generated visual is genuinely needed.
+`prompts/marketing/agent-system/creative-director/AGENTS.md`
 
-It does **not** do mechanical work. Code renders layouts, writes files, uploads assets, imports campaign records, uploads approved files to R2, and generates the Metricool CSV.
+The Creative Director amends the same `campaign.json` with `creative_direction`. Once that field exists, the Asset Producer has no creative judgement left: deterministic code resolves assets, fetches/stages sources, composes the final image, stores it, and imports it for review.
 
-## Single authoritative input
-
-Read only:
-
-`marketing/agent-outputs/<YYYY-MM>/campaign.json`
-
-That file is the complete production contract. Do not read `content-context.json`, `cmo-strategy.json`, strategy memory, old campaigns, Drive prompt guides, or a second planning artifact.
-
-Use only the registry references already included by the campaign jobs. Do not guess Drive IDs or filenames.
-
-## Preconditions
-
-Do not execute unless:
-
-- `campaign.json` exists and has `schema_version: "2.0"`;
-- `campaign.status` is `review`;
-- every target post has `status: needs_review`;
-- every visual task is represented in `campaign.image_generation.jobs[]`;
-- each job declares its source assets, mode, composition, acceptance criteria, and expected output.
-
-## Decision rules
-
-For each job, choose exactly one production mode already declared or compatible with the job:
-
-- `reuse_existing_asset`: the approved source is sufficient unchanged;
-- `compose_existing_assets`: code should combine named, real assets;
-- `generate_supporting_visual`: generate only a background, avatar variation, or other non-UI support asset;
-- `blocked`: a required real source is missing or the brief is contradictory.
-
-Priority:
-
-1. reuse a current real product or landing asset;
-2. compose current real assets;
-3. generate a supporting visual only when neither option supports the post.
-
-Never request or create a final social post image from an image model. The final post is rendered by code from real assets, exact copy, exact logo, and a selected layout.
-
-## Allowed decisions
-
-Only update asset-decision fields within the same `campaign.json`:
-
-- `production_mode`;
-- `selected_asset_keys`;
-- `selected_mode`;
-- `layout_key`;
-- `crop_or_focal_instruction`;
-- `supporting_visual_brief` when generation is essential;
-- `acceptance_criteria`;
-- `blocking_reason` when blocked.
-
-Do not rewrite strategy, hook, caption, CTA, schedule, tracking, experiment, product claim, or post status.
-
-## Prohibited actions
-
-- Reading upstream context files after `campaign.json` exists.
-- Creating another asset plan or campaign file.
-- Moving, renaming, downloading, uploading, or storing files.
-- Writing to Neon, Drive, R2, Metricool, or GitHub Actions.
-- Creating a CSV.
-- Approving, rejecting, publishing, or scheduling a post.
-- Inventing UI, screenshots, product data, or a replacement logo.
-- Producing binary images directly.
-
-## Output
-
-Return the amended `campaign.json` only. A separate deterministic code step consumes it and:
-
-1. resolves `asset_key` entries through the registry;
-2. renders the final PNGs;
-3. stores assets in the defined staging path;
-4. imports them into Admin Marketing for human review.
+Do not use an image model to produce an entire final post image. If a supporting visual is marked as required, generate only that non-UI visual layer and hand it to the renderer.

--- a/prompts/marketing/agent-system/creative-director/AGENTS.md
+++ b/prompts/marketing/agent-system/creative-director/AGENTS.md
@@ -1,0 +1,83 @@
+# Innerbloom Creative Director Agent
+
+## Job
+
+You are the only creative-judgement stage between a validated monthly `campaign.json` and the deterministic renderer.
+
+You do not create pixels. You enrich the existing `campaign.json` by adding one `creative_direction` object to every item in `image_generation.jobs[]`.
+
+Your decisions must make each post feel like a premium Innerbloom campaign scene, not a pasted mobile screenshot or a generic SaaS template.
+
+## Input and output
+
+Read only:
+
+`marketing/agent-outputs/<YYYY-MM>/campaign.json`
+
+Return only the same file, amended in place. Do not create a second visual plan, markdown brief, CSV, image file, Drive folder, or storage record.
+
+## What you decide
+
+For each image job, set `creative_direction`:
+
+- `visual_family`: choose the best reusable creative family.
+- `mode`: `light` or `dark`, matched to the selected real product asset.
+- `device_presentation`: no device, front device, angled device, layered product cards, or close crop.
+- `composition_intent`: a concise visual decision that helps the renderer place the proof and copy.
+- `selected_asset_keys`: exact keys from the job's registered `source_assets`; never guess a key.
+- `focal_instruction`: what visual truth must stay visible.
+- `supporting_visual`: use only when a non-UI background or editorial object is genuinely needed.
+- `acceptance_criteria`: three or more testable conditions.
+
+## Creative families
+
+1. `product_hero_scene`
+   - Lead-acquisition hero. One large real device with depth and up to two real product layers behind it.
+   - Use when the product itself proves the promise.
+
+2. `product_angle`
+   - A real screenshot placed inside a deterministic device shell at a restrained three-quarter angle.
+   - Use when a single feature benefits from impact and product desirability.
+
+3. `product_depth`
+   - One front device plus one or two authentic product cards/screens behind it.
+   - Use when the claim is about a connected system, not one isolated feature.
+
+4. `module_spotlight`
+   - A feature crop or contained phone. Use one visible product module and one short explanation.
+   - Use for education and consideration.
+
+5. `editorial_statement`
+   - A belief or tension slide with deliberate negative space. No fake UI.
+   - Use only when text itself advances a carousel or supports a truthful brand claim.
+
+6. `proof_sequence`
+   - Carousel story: hook, reframe, genuine product proof, next action.
+   - No duplicate hero screenshot across every slide.
+
+7. `supporting_visual_scene`
+   - Use only when a generated background or non-UI object makes the idea clearer. The final post remains composed by code.
+
+## Non-negotiable rules
+
+- The canonical Innerbloom logo/wordmark is code-rendered. Never recreate it with an image model or a substitute font.
+- Product UI is always real, exact and readable. Do not invent interface, metrics, controls or data.
+- Generated imagery may supply only background atmosphere or a non-UI editorial object. It may never contain visible copy, logo, product screens or fake devices.
+- The hero must be clear at Instagram grid size: one claim first, product proof second, CTA third.
+- Light: clean, high-contrast, controlled lilac accent. Dark: near-black, restrained violet, no neon fog.
+- Avoid generic wellness, quotes, mystical imagery, fake dashboards, excessive glow, stock-photo feeling and decorative shapes without a narrative role.
+- A device angle is allowed, but it is produced by code using the real screenshot inside the deterministic phone shell.
+- Prefer real product proof over generated visual support.
+- If the supplied assets cannot honestly support the claim, set `status: "blocked"` and name the reason.
+
+## Handoff
+
+The renderer consumes `creative_direction` and does all mechanical work:
+
+1. resolves asset keys;
+2. fetches/stages the approved source bytes;
+3. creates device shells, perspectives, layers, logo, wordmark and exact copy;
+4. renders PNGs;
+5. imports the staging result into Admin Marketing.
+
+You never perform those actions.

--- a/prompts/marketing/agent-system/schemas/head-of-content-output-v2.schema.json
+++ b/prompts/marketing/agent-system/schemas/head-of-content-output-v2.schema.json
@@ -17,10 +17,19 @@
     "source_manifest"
   ],
   "properties": {
-    "schema_version": { "const": "2.0" },
-    "agent": { "const": "innerbloom_head_of_content" },
-    "period_key": { "$ref": "#/$defs/periodKey" },
-    "generated_at": { "type": "string", "format": "date-time" },
+    "schema_version": {
+      "const": "2.0"
+    },
+    "agent": {
+      "const": "innerbloom_head_of_content"
+    },
+    "period_key": {
+      "$ref": "#/$defs/periodKey"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "campaign": {
       "type": "object",
       "additionalProperties": false,
@@ -39,73 +48,208 @@
         "human_review_required"
       ],
       "properties": {
-        "campaign_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
-        "title": { "type": "string", "minLength": 1 },
-        "objective": { "enum": ["new_users", "leads", "activation", "awareness", "retention", "learning"] },
-        "status": { "const": "review" },
-        "strategy_summary": { "type": "string", "minLength": 1 },
-        "language": { "type": "string", "minLength": 1 },
-        "platforms": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
-        "formats": { "type": "array", "minItems": 1, "items": { "enum": ["static", "carousel", "reel", "story", "thread", "short_video"] } },
-        "target_post_count": { "type": "integer", "minimum": 1, "maximum": 100 },
-        "publishing_start_date": { "type": "string", "format": "date" },
-        "publishing_end_date": { "type": "string", "format": "date" },
-        "human_review_required": { "const": true }
+        "campaign_code": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]+$"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "objective": {
+          "enum": [
+            "new_users",
+            "leads",
+            "activation",
+            "awareness",
+            "retention",
+            "learning"
+          ]
+        },
+        "status": {
+          "const": "review"
+        },
+        "strategy_summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "language": {
+          "type": "string",
+          "minLength": 1
+        },
+        "platforms": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "formats": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": [
+              "static",
+              "carousel",
+              "reel",
+              "story",
+              "thread",
+              "short_video"
+            ]
+          }
+        },
+        "target_post_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "publishing_start_date": {
+          "type": "string",
+          "format": "date"
+        },
+        "publishing_end_date": {
+          "type": "string",
+          "format": "date"
+        },
+        "human_review_required": {
+          "const": true
+        }
       }
     },
     "campaign_execution_summary": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["post_count", "static_count", "carousel_count", "image_job_count", "batch_size", "batch_count"],
+      "required": [
+        "post_count",
+        "static_count",
+        "carousel_count",
+        "image_job_count",
+        "batch_size",
+        "batch_count"
+      ],
       "properties": {
-        "post_count": { "type": "integer", "minimum": 1 },
-        "static_count": { "type": "integer", "minimum": 0 },
-        "carousel_count": { "type": "integer", "minimum": 0 },
-        "image_job_count": { "type": "integer", "minimum": 1 },
-        "batch_size": { "type": "integer", "minimum": 1, "maximum": 20 },
-        "batch_count": { "type": "integer", "minimum": 1 },
-        "notes": { "type": "array", "items": { "type": "string" } }
+        "post_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "static_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "carousel_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "image_job_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "batch_size": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20
+        },
+        "batch_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
     "posts": {
       "type": "array",
       "minItems": 1,
-      "items": { "$ref": "#/$defs/post" }
+      "items": {
+        "$ref": "#/$defs/post"
+      }
     },
     "image_generation": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["generator", "batch_size", "staging_root", "jobs"],
+      "required": [
+        "generator",
+        "batch_size",
+        "staging_root",
+        "jobs"
+      ],
       "properties": {
-        "generator": { "const": "native_gpt_image" },
-        "batch_size": { "type": "integer", "minimum": 1, "maximum": 20 },
-        "staging_root": { "type": "string", "minLength": 1 },
+        "generator": {
+          "const": "native_gpt_image"
+        },
+        "batch_size": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20
+        },
+        "staging_root": {
+          "type": "string",
+          "minLength": 1
+        },
         "jobs": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "#/$defs/imageJob" }
+          "items": {
+            "$ref": "#/$defs/imageJob"
+          }
         }
       }
     },
     "campaign_quality_report": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["status", "checks", "warnings", "blockers"],
+      "required": [
+        "status",
+        "checks",
+        "warnings",
+        "blockers"
+      ],
       "properties": {
-        "status": { "enum": ["passed", "passed_with_warnings", "blocked"] },
-        "checks": { "type": "array", "items": { "type": "string" } },
-        "warnings": { "type": "array", "items": { "$ref": "#/$defs/qualityFinding" } },
-        "blockers": { "type": "array", "items": { "$ref": "#/$defs/qualityFinding" } }
+        "status": {
+          "enum": [
+            "passed",
+            "passed_with_warnings",
+            "blocked"
+          ]
+        },
+        "checks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/qualityFinding"
+          }
+        },
+        "blockers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/qualityFinding"
+          }
+        }
       }
     },
     "source_manifest": {
       "type": "array",
       "minItems": 1,
-      "items": { "$ref": "#/$defs/sourceManifestItem" }
+      "items": {
+        "$ref": "#/$defs/sourceManifestItem"
+      }
     }
   },
   "$defs": {
-    "periodKey": { "type": "string", "pattern": "^\\d{4}-\\d{2}$" },
+    "periodKey": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}$"
+    },
     "post": {
       "type": "object",
       "additionalProperties": false,
@@ -134,128 +278,382 @@
         "accessibility"
       ],
       "properties": {
-        "post_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
-        "sequence_number": { "type": "integer", "minimum": 1 },
-        "platform": { "type": "string", "minLength": 1 },
-        "format": { "enum": ["static", "carousel", "reel", "story", "thread", "short_video"] },
-        "status": { "const": "needs_review" },
-        "scheduled_at": { "type": "string", "format": "date-time" },
-        "content_pillar": { "type": "string", "minLength": 1 },
-        "funnel_stage": { "enum": ["awareness", "consideration", "activation", "acquisition", "registration", "registration_intent", "product_usage_explanation"] },
-        "experiment_code": { "type": "string", "minLength": 1 },
-        "audience_tension": { "type": "string", "minLength": 1 },
-        "product_truth_anchor": { "type": "string", "minLength": 1 },
-        "hook": { "type": "string", "minLength": 1 },
-        "caption": { "type": "string", "minLength": 1 },
-        "cta": { "$ref": "#/$defs/cta" },
-        "hypothesis": { "type": "string", "minLength": 1 },
-        "primary_metric": { "type": "string", "minLength": 1 },
-        "tracking_url": { "type": "string", "format": "uri" },
-        "utm": { "$ref": "#/$defs/utm" },
-        "visible_copy_plan": { "$ref": "#/$defs/visibleCopyPlan" },
-        "visual_strategy": { "$ref": "#/$defs/visualStrategy" },
-        "carousel": { "$ref": "#/$defs/carousel" },
+        "post_code": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]+$"
+        },
+        "sequence_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "platform": {
+          "type": "string",
+          "minLength": 1
+        },
+        "format": {
+          "enum": [
+            "static",
+            "carousel",
+            "reel",
+            "story",
+            "thread",
+            "short_video"
+          ]
+        },
+        "status": {
+          "const": "needs_review"
+        },
+        "scheduled_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "content_pillar": {
+          "type": "string",
+          "minLength": 1
+        },
+        "funnel_stage": {
+          "enum": [
+            "awareness",
+            "consideration",
+            "activation",
+            "acquisition",
+            "registration",
+            "registration_intent",
+            "product_usage_explanation"
+          ]
+        },
+        "experiment_code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "audience_tension": {
+          "type": "string",
+          "minLength": 1
+        },
+        "product_truth_anchor": {
+          "type": "string",
+          "minLength": 1
+        },
+        "hook": {
+          "type": "string",
+          "minLength": 1
+        },
+        "caption": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cta": {
+          "$ref": "#/$defs/cta"
+        },
+        "hypothesis": {
+          "type": "string",
+          "minLength": 1
+        },
+        "primary_metric": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tracking_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "utm": {
+          "$ref": "#/$defs/utm"
+        },
+        "visible_copy_plan": {
+          "$ref": "#/$defs/visibleCopyPlan"
+        },
+        "visual_strategy": {
+          "$ref": "#/$defs/visualStrategy"
+        },
+        "carousel": {
+          "$ref": "#/$defs/carousel"
+        },
         "assets": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "#/$defs/postAsset" }
+          "items": {
+            "$ref": "#/$defs/postAsset"
+          }
         },
-        "accessibility": { "$ref": "#/$defs/accessibility" }
+        "accessibility": {
+          "$ref": "#/$defs/accessibility"
+        }
       },
       "allOf": [
         {
-          "if": { "properties": { "format": { "const": "carousel" } }, "required": ["format"] },
-          "then": { "required": ["carousel"] }
+          "if": {
+            "properties": {
+              "format": {
+                "const": "carousel"
+              }
+            },
+            "required": [
+              "format"
+            ]
+          },
+          "then": {
+            "required": [
+              "carousel"
+            ]
+          }
         }
       ]
     },
     "cta": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["label", "destination", "intent", "truthfulness_note"],
+      "required": [
+        "label",
+        "destination",
+        "intent",
+        "truthfulness_note"
+      ],
       "properties": {
-        "label": { "type": "string", "minLength": 1 },
-        "destination": { "type": "string", "format": "uri" },
-        "intent": { "type": "string", "minLength": 1 },
-        "truthfulness_note": { "type": "string", "minLength": 1 }
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "destination": {
+          "type": "string",
+          "format": "uri"
+        },
+        "intent": {
+          "type": "string",
+          "minLength": 1
+        },
+        "truthfulness_note": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "utm": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["utm_source", "utm_medium", "utm_campaign", "utm_content", "ib_post"],
+      "required": [
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_content",
+        "ib_post"
+      ],
       "properties": {
-        "utm_source": { "type": "string", "minLength": 1 },
-        "utm_medium": { "type": "string", "minLength": 1 },
-        "utm_campaign": { "type": "string", "minLength": 1 },
-        "utm_content": { "type": "string", "minLength": 1 },
-        "ib_post": { "type": ["string", "integer"] }
+        "utm_source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "utm_medium": {
+          "type": "string",
+          "minLength": 1
+        },
+        "utm_campaign": {
+          "type": "string",
+          "minLength": 1
+        },
+        "utm_content": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ib_post": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        }
       }
     },
     "visibleCopyPlan": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["headline", "supporting_text"],
+      "required": [
+        "headline",
+        "supporting_text"
+      ],
       "properties": {
-        "headline": { "type": "string", "minLength": 1 },
-        "supporting_text": { "type": "string" },
-        "eyebrow": { "type": "string" },
-        "microcopy": { "type": "array", "items": { "type": "string" } }
+        "headline": {
+          "type": "string",
+          "minLength": 1
+        },
+        "supporting_text": {
+          "type": "string"
+        },
+        "eyebrow": {
+          "type": "string"
+        },
+        "microcopy": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
     "visualStrategy": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["visual_goal", "proof_type", "screenshot_requirement", "composition_archetype", "claim_to_visual_reasoning"],
+      "required": [
+        "visual_goal",
+        "proof_type",
+        "screenshot_requirement",
+        "composition_archetype",
+        "claim_to_visual_reasoning"
+      ],
       "properties": {
-        "visual_goal": { "type": "string", "minLength": 1 },
-        "proof_type": { "enum": ["product_screenshot", "brand_led", "hybrid", "logo_only", "abstract_system"] },
-        "screenshot_requirement": { "enum": ["required", "optional", "not_required", "forbidden"] },
-        "composition_archetype": { "type": "string", "minLength": 1 },
-        "claim_to_visual_reasoning": { "type": "string", "minLength": 1 },
-        "forbidden_uses": { "type": "array", "items": { "type": "string" } }
+        "visual_goal": {
+          "type": "string",
+          "minLength": 1
+        },
+        "proof_type": {
+          "enum": [
+            "product_screenshot",
+            "brand_led",
+            "hybrid",
+            "logo_only",
+            "abstract_system"
+          ]
+        },
+        "screenshot_requirement": {
+          "enum": [
+            "required",
+            "optional",
+            "not_required",
+            "forbidden"
+          ]
+        },
+        "composition_archetype": {
+          "type": "string",
+          "minLength": 1
+        },
+        "claim_to_visual_reasoning": {
+          "type": "string",
+          "minLength": 1
+        },
+        "forbidden_uses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
     "carousel": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["slide_count", "narrative_arc", "slides"],
+      "required": [
+        "slide_count",
+        "narrative_arc",
+        "slides"
+      ],
       "properties": {
-        "slide_count": { "type": "integer", "minimum": 2, "maximum": 20 },
-        "narrative_arc": { "type": "string", "minLength": 1 },
+        "slide_count": {
+          "type": "integer",
+          "minimum": 2,
+          "maximum": 20
+        },
+        "narrative_arc": {
+          "type": "string",
+          "minLength": 1
+        },
         "slides": {
           "type": "array",
           "minItems": 2,
-          "items": { "$ref": "#/$defs/carouselSlide" }
+          "items": {
+            "$ref": "#/$defs/carouselSlide"
+          }
         }
       }
     },
     "carouselSlide": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["slide_number", "narrative_role", "visible_copy", "product_truth_anchor", "visual_proof_requirement", "asset_code", "acceptance_criteria"],
+      "required": [
+        "slide_number",
+        "narrative_role",
+        "visible_copy",
+        "product_truth_anchor",
+        "visual_proof_requirement",
+        "asset_code",
+        "acceptance_criteria"
+      ],
       "properties": {
-        "slide_number": { "type": "integer", "minimum": 1 },
-        "narrative_role": { "type": "string", "minLength": 1 },
-        "visible_copy": { "$ref": "#/$defs/visibleCopyPlan" },
-        "product_truth_anchor": { "type": "string", "minLength": 1 },
-        "visual_proof_requirement": { "type": "string", "minLength": 1 },
-        "asset_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
-        "acceptance_criteria": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+        "slide_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "narrative_role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "visible_copy": {
+          "$ref": "#/$defs/visibleCopyPlan"
+        },
+        "product_truth_anchor": {
+          "type": "string",
+          "minLength": 1
+        },
+        "visual_proof_requirement": {
+          "type": "string",
+          "minLength": 1
+        },
+        "asset_code": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]+$"
+        },
+        "acceptance_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
     "postAsset": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["asset_code", "asset_kind", "production_status", "image_job_required", "alt_text"],
+      "required": [
+        "asset_code",
+        "asset_kind",
+        "production_status",
+        "image_job_required",
+        "alt_text"
+      ],
       "properties": {
-        "asset_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
-        "asset_kind": { "enum": ["static", "carousel_slide", "cover", "story", "reel_cover"] },
-        "slide_number": { "type": "integer", "minimum": 1 },
-        "production_status": { "enum": ["planned", "blocked", "not_required"] },
-        "image_job_required": { "type": "boolean" },
-        "alt_text": { "type": "string", "minLength": 1 },
-        "blocker_reason": { "type": "string" }
+        "asset_code": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]+$"
+        },
+        "asset_kind": {
+          "enum": [
+            "static",
+            "carousel_slide",
+            "cover",
+            "story",
+            "reel_cover"
+          ]
+        },
+        "slide_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "production_status": {
+          "enum": [
+            "planned",
+            "blocked",
+            "not_required"
+          ]
+        },
+        "image_job_required": {
+          "type": "boolean"
+        },
+        "alt_text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "blocker_reason": {
+          "type": "string"
+        }
       }
     },
     "imageJob": {
@@ -285,111 +683,470 @@
         "expected_output"
       ],
       "properties": {
-        "asset_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
-        "post_code": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
-        "asset_kind": { "enum": ["static", "carousel_slide", "cover", "story", "reel_cover"] },
-        "slide_number": { "type": "integer", "minimum": 1 },
-        "batch_number": { "type": "integer", "minimum": 1 },
-        "generation_order": { "type": "integer", "minimum": 1 },
-        "platform": { "type": "string", "minLength": 1 },
-        "format": { "enum": ["static", "carousel", "reel", "story", "thread", "short_video"] },
-        "canvas": { "$ref": "#/$defs/canvas" },
-        "visible_copy": { "$ref": "#/$defs/visibleCopyPlan" },
-        "product_truth_anchor": { "type": "string", "minLength": 1 },
-        "funnel_stage": { "type": "string", "minLength": 1 },
+        "asset_code": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]+$"
+        },
+        "post_code": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]+$"
+        },
+        "asset_kind": {
+          "enum": [
+            "static",
+            "carousel_slide",
+            "cover",
+            "story",
+            "reel_cover"
+          ]
+        },
+        "slide_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "batch_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "generation_order": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "platform": {
+          "type": "string",
+          "minLength": 1
+        },
+        "format": {
+          "enum": [
+            "static",
+            "carousel",
+            "reel",
+            "story",
+            "thread",
+            "short_video"
+          ]
+        },
+        "canvas": {
+          "$ref": "#/$defs/canvas"
+        },
+        "visible_copy": {
+          "$ref": "#/$defs/visibleCopyPlan"
+        },
+        "product_truth_anchor": {
+          "type": "string",
+          "minLength": 1
+        },
+        "funnel_stage": {
+          "type": "string",
+          "minLength": 1
+        },
         "source_assets": {
           "type": "array",
-          "items": { "$ref": "#/$defs/sourceAsset" }
+          "items": {
+            "$ref": "#/$defs/sourceAsset"
+          }
         },
-        "visual_concept": { "type": "string", "minLength": 1 },
-        "composition_spec": { "$ref": "#/$defs/compositionSpec" },
-        "generation_prompt": { "type": "string", "minLength": 200 },
-        "negative_prompt": { "type": "string", "minLength": 80 },
-        "must_show": { "type": "array", "minItems": 1, "items": { "type": "string" } },
-        "must_preserve": { "type": "array", "items": { "type": "string" } },
-        "must_avoid": { "type": "array", "minItems": 1, "items": { "type": "string" } },
-        "acceptance_criteria": { "type": "array", "minItems": 1, "items": { "type": "string" } },
-        "expected_output": { "$ref": "#/$defs/expectedOutput" },
-        "blocker_reason": { "type": "string" }
+        "visual_concept": {
+          "type": "string",
+          "minLength": 1
+        },
+        "composition_spec": {
+          "$ref": "#/$defs/compositionSpec"
+        },
+        "generation_prompt": {
+          "type": "string",
+          "minLength": 200
+        },
+        "negative_prompt": {
+          "type": "string",
+          "minLength": 80
+        },
+        "must_show": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "must_preserve": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "must_avoid": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "acceptance_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "expected_output": {
+          "$ref": "#/$defs/expectedOutput"
+        },
+        "blocker_reason": {
+          "type": "string"
+        },
+        "creative_direction": {
+          "$ref": "#/$defs/creativeDirection"
+        }
       }
     },
     "canvas": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["width", "height", "aspect_ratio", "safe_area"],
+      "required": [
+        "width",
+        "height",
+        "aspect_ratio",
+        "safe_area"
+      ],
       "properties": {
-        "width": { "type": "integer", "minimum": 1 },
-        "height": { "type": "integer", "minimum": 1 },
-        "aspect_ratio": { "type": "string", "minLength": 1 },
-        "safe_area": { "type": "string", "minLength": 1 }
+        "width": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "height": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "aspect_ratio": {
+          "type": "string",
+          "minLength": 1
+        },
+        "safe_area": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "sourceAsset": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["asset_key", "role", "preserve_exact_ui", "allowed_transformations", "claim_supported", "claim_not_supported"],
+      "required": [
+        "asset_key",
+        "role",
+        "preserve_exact_ui",
+        "allowed_transformations",
+        "claim_supported",
+        "claim_not_supported"
+      ],
       "properties": {
-        "asset_key": { "type": "string", "minLength": 1 },
-        "role": { "enum": ["primary_product_proof", "secondary_product_proof", "detail_crop", "background_context", "approved_logo", "do_not_use"] },
-        "preserve_exact_ui": { "type": "boolean" },
-        "allowed_transformations": { "type": "array", "items": { "type": "string" } },
-        "claim_supported": { "type": "string", "minLength": 1 },
-        "claim_not_supported": { "type": "string", "minLength": 1 }
+        "asset_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "enum": [
+            "primary_product_proof",
+            "secondary_product_proof",
+            "detail_crop",
+            "background_context",
+            "approved_logo",
+            "do_not_use"
+          ]
+        },
+        "preserve_exact_ui": {
+          "type": "boolean"
+        },
+        "allowed_transformations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "claim_supported": {
+          "type": "string",
+          "minLength": 1
+        },
+        "claim_not_supported": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "compositionSpec": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["layout", "hierarchy", "screenshot_treatment", "brand_treatment", "mobile_readability_priority"],
+      "required": [
+        "layout",
+        "hierarchy",
+        "screenshot_treatment",
+        "brand_treatment",
+        "mobile_readability_priority"
+      ],
       "properties": {
-        "layout": { "type": "string", "minLength": 1 },
-        "hierarchy": { "type": "string", "minLength": 1 },
-        "screenshot_treatment": { "type": "string", "minLength": 1 },
-        "brand_treatment": { "type": "string", "minLength": 1 },
-        "mobile_readability_priority": { "type": "string", "minLength": 1 }
+        "layout": {
+          "type": "string",
+          "minLength": 1
+        },
+        "hierarchy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "screenshot_treatment": {
+          "type": "string",
+          "minLength": 1
+        },
+        "brand_treatment": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mobile_readability_priority": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "expectedOutput": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["filename", "local_staging_path", "mime_type", "width", "height"],
+      "required": [
+        "filename",
+        "local_staging_path",
+        "mime_type",
+        "width",
+        "height"
+      ],
       "properties": {
-        "filename": { "type": "string", "minLength": 1 },
-        "local_staging_path": { "type": "string", "minLength": 1 },
-        "mime_type": { "enum": ["image/png", "image/jpeg", "image/webp"] },
-        "width": { "type": "integer", "minimum": 1 },
-        "height": { "type": "integer", "minimum": 1 }
+        "filename": {
+          "type": "string",
+          "minLength": 1
+        },
+        "local_staging_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mime_type": {
+          "enum": [
+            "image/png",
+            "image/jpeg",
+            "image/webp"
+          ]
+        },
+        "width": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "height": {
+          "type": "integer",
+          "minimum": 1
+        }
       }
     },
     "accessibility": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["alt_text", "readability_note"],
+      "required": [
+        "alt_text",
+        "readability_note"
+      ],
       "properties": {
-        "alt_text": { "type": "string", "minLength": 1 },
-        "readability_note": { "type": "string", "minLength": 1 }
+        "alt_text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "readability_note": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "qualityFinding": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["code", "message", "affected_items"],
+      "required": [
+        "code",
+        "message",
+        "affected_items"
+      ],
       "properties": {
-        "code": { "type": "string", "minLength": 1 },
-        "message": { "type": "string", "minLength": 1 },
-        "affected_items": { "type": "array", "items": { "type": "string" } }
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "affected_items": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
     "sourceManifestItem": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["source_type", "source_path_or_id"],
+      "required": [
+        "source_type",
+        "source_path_or_id"
+      ],
       "properties": {
-        "source_type": { "type": "string", "minLength": 1 },
-        "source_path_or_id": { "type": "string", "minLength": 1 },
-        "captured_at": { "type": "string" },
-        "checksum": { "type": "string" }
+        "source_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_path_or_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "captured_at": {
+          "type": "string"
+        },
+        "checksum": {
+          "type": "string"
+        }
       }
+    },
+    "creativeDirection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "visual_family",
+        "mode",
+        "device_presentation",
+        "wordmark_treatment",
+        "composition_intent",
+        "selected_asset_keys",
+        "supporting_visual",
+        "acceptance_criteria"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "ready_for_render",
+            "blocked"
+          ]
+        },
+        "visual_family": {
+          "enum": [
+            "product_hero_scene",
+            "product_angle",
+            "product_depth",
+            "module_spotlight",
+            "editorial_statement",
+            "proof_sequence",
+            "supporting_visual_scene"
+          ]
+        },
+        "mode": {
+          "enum": [
+            "light",
+            "dark"
+          ]
+        },
+        "device_presentation": {
+          "enum": [
+            "none",
+            "front",
+            "angled",
+            "layered_cards",
+            "close_crop"
+          ]
+        },
+        "wordmark_treatment": {
+          "const": "canonical_innerbloom_lockup"
+        },
+        "composition_intent": {
+          "type": "string",
+          "minLength": 1
+        },
+        "selected_asset_keys": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "focal_instruction": {
+          "type": "string",
+          "minLength": 1
+        },
+        "supporting_visual": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "required"
+          ],
+          "properties": {
+            "required": {
+              "type": "boolean"
+            },
+            "brief": {
+              "type": "string"
+            },
+            "allowed_role": {
+              "enum": [
+                "background_atmosphere",
+                "non_ui_editorial_object",
+                "none"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "required": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "required"
+                ]
+              },
+              "then": {
+                "required": [
+                  "brief",
+                  "allowed_role"
+                ]
+              }
+            }
+          ]
+        },
+        "acceptance_criteria": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "blocking_reason": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "blocked"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "required": [
+              "blocking_reason"
+            ]
+          }
+        }
+      ]
     }
   }
 }

--- a/scripts/marketing/render-campaign-v2.mjs
+++ b/scripts/marketing/render-campaign-v2.mjs
@@ -55,7 +55,7 @@ const css = `
 :root{--ink:#17151b;--muted:#605b69;--accent:#8b63f6;--lilac:#eee9ff;--line:#e8e3ee}
 .frame{position:relative;width:1080px;height:1080px;overflow:hidden;padding:70px;background:#fbfafc;color:var(--ink)}
 .frame.dark{background:#121116;color:#faf9ff;--ink:#faf9ff;--muted:#c8c2d0;--lilac:#211d2c;--line:#37333f}
-.brand{display:flex;align-items:center;gap:12px;position:relative;z-index:4}.brand img{width:36px;height:36px;object-fit:contain}.brand span{font-family:Sora,sans-serif;font-size:21px;font-weight:700;letter-spacing:.24em}
+.brand{position:relative;z-index:4}.brand img{width:248px;height:44px;object-fit:contain;object-position:left center}
 .eyebrow{margin:48px 0 15px;font-family:Sora,sans-serif;font-size:18px;font-weight:700;letter-spacing:.15em;color:var(--accent);text-transform:uppercase}
 h1{margin:0;font-family:Sora,sans-serif;font-size:68px;line-height:1.02;letter-spacing:-.055em;max-width:590px} .support{margin:26px 0 0;font-size:27px;line-height:1.35;color:var(--muted);max-width:510px}
 .cta{display:inline-flex;margin-top:34px;padding:16px 24px;border-radius:999px;background:var(--accent);color:white;font-size:19px;font-weight:800}.footer{position:absolute;left:70px;right:70px;bottom:58px;padding-top:20px;border-top:1px solid var(--line);font-size:15px;color:var(--muted);letter-spacing:.07em}
@@ -65,7 +65,7 @@ h1{margin:0;font-family:Sora,sans-serif;font-size:68px;line-height:1.02;letter-s
 .spotlight .phone{left:50%;top:300px;width:370px;height:480px;transform:translateX(-50%);border-radius:34px}.spotlight .phone img{border-radius:26px}.spotlight h1{max-width:720px;font-size:60px}.statement h1{max-width:790px;font-size:82px}.statement .logic{display:flex;gap:16px;margin-top:54px}.statement .logic span{padding:16px 22px;border-radius:16px;background:var(--lilac);font-weight:800;color:#55459a}
 `;
 
-function brand(logo) { return '<div class="brand"><img src="'+logo+'" alt=""><span>INNERBLOOM</span></div>'; }
+function brand(logo) { return '<div class="brand"><img src="'+logo+'" alt="Innerbloom"></div>'; }
 function footer(job) { return '<div class="footer">INNERBLOOM · '+esc(job.asset_code)+'</div>'; }
 function copy(job) {
   const c=job.visible_copy || {};
@@ -87,7 +87,7 @@ function html(job, logo, sources) {
 
 async function main() {
   const campaign=JSON.parse(await fs.readFile(campaignPath,"utf8"));
-  const logo=await sourceUri("brand_logo_512");
+  const logo=await sourceUri("brand_logo_full");
   const jobs=campaign.image_generation?.jobs || [];
   if (!jobs.length) throw new Error("campaign.json has no image_generation.jobs");
   await fs.mkdir(outputDir,{recursive:true});

--- a/scripts/marketing/render-campaign-v2.mjs
+++ b/scripts/marketing/render-campaign-v2.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Innerbloom deterministic campaign renderer v2.
+ *
+ * Usage:
+ *   node scripts/marketing/render-campaign-v2.mjs \
+ *     marketing/agent-outputs/2026-07/campaign.json \
+ *     --asset-dir marketing/staging/2026-07 \
+ *     --out marketing/generated/2026-07
+ *
+ * The Creative Director provides creative_direction in the same campaign JSON.
+ * This script makes no creative decisions. It composes exact copy, canonical
+ * Innerbloom branding and registered real assets into final social PNGs.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../..");
+const requireFromWeb = createRequire(path.join(repoRoot, "apps/web/package.json"));
+const { chromium } = requireFromWeb("@playwright/test");
+
+const [campaignArg, ...args] = process.argv.slice(2);
+if (!campaignArg) throw new Error("Usage: render-campaign-v2 <campaign.json> --asset-dir <directory> --out <directory>");
+
+function arg(name, fallback) {
+  const index = args.indexOf(name);
+  return index === -1 ? fallback : args[index + 1];
+}
+const campaignPath = path.resolve(campaignArg);
+const assetDir = path.resolve(arg("--asset-dir", path.join(path.dirname(campaignPath), "staged-assets")));
+const outputDir = path.resolve(arg("--out", path.join(repoRoot, "marketing/generated")));
+const esc = (value) => String(value ?? "").replaceAll("&","&amp;").replaceAll("<","&lt;").replaceAll(">","&gt;").replaceAll('"',"&quot;");
+
+async function dataUri(file) {
+  const bytes = await fs.readFile(file);
+  const ext = path.extname(file).toLowerCase();
+  const mime = ext === ".webp" ? "image/webp" : ext === ".jpg" || ext === ".jpeg" ? "image/jpeg" : "image/png";
+  return "data:" + mime + ";base64," + bytes.toString("base64");
+}
+
+async function sourceUri(assetKey) {
+  for (const ext of [".png", ".webp", ".jpg", ".jpeg"]) {
+    const candidate = path.join(assetDir, assetKey + ext);
+    try { return await dataUri(candidate); } catch {}
+  }
+  throw new Error("Missing staged asset for " + assetKey + ". Run the deterministic Drive staging step first.");
+}
+
+const css = `
+@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Sora:wght@600;700&display=swap");
+*{box-sizing:border-box} body{margin:0;width:1080px;height:1080px;overflow:hidden;font-family:Manrope,system-ui,sans-serif}
+:root{--ink:#17151b;--muted:#605b69;--accent:#8b63f6;--lilac:#eee9ff;--line:#e8e3ee}
+.frame{position:relative;width:1080px;height:1080px;overflow:hidden;padding:70px;background:#fbfafc;color:var(--ink)}
+.frame.dark{background:#121116;color:#faf9ff;--ink:#faf9ff;--muted:#c8c2d0;--lilac:#211d2c;--line:#37333f}
+.brand{display:flex;align-items:center;gap:12px;position:relative;z-index:4}.brand img{width:36px;height:36px;object-fit:contain}.brand span{font-family:Sora,sans-serif;font-size:21px;font-weight:700;letter-spacing:.24em}
+.eyebrow{margin:48px 0 15px;font-family:Sora,sans-serif;font-size:18px;font-weight:700;letter-spacing:.15em;color:var(--accent);text-transform:uppercase}
+h1{margin:0;font-family:Sora,sans-serif;font-size:68px;line-height:1.02;letter-spacing:-.055em;max-width:590px} .support{margin:26px 0 0;font-size:27px;line-height:1.35;color:var(--muted);max-width:510px}
+.cta{display:inline-flex;margin-top:34px;padding:16px 24px;border-radius:999px;background:var(--accent);color:white;font-size:19px;font-weight:800}.footer{position:absolute;left:70px;right:70px;bottom:58px;padding-top:20px;border-top:1px solid var(--line);font-size:15px;color:var(--muted);letter-spacing:.07em}
+.phone{position:absolute;overflow:hidden;border-radius:48px;background:#101016;padding:12px;box-shadow:0 36px 80px rgba(11,8,22,.28),inset 0 0 0 1px rgba(255,255,255,.28)}.phone img{display:block;width:100%;height:100%;object-fit:cover;border-radius:37px}
+.phone.front{right:100px;top:160px;width:340px;height:660px}.phone.angle{right:84px;top:185px;width:365px;height:640px;transform:perspective(1200px) rotateY(-14deg) rotateZ(3deg);transform-origin:center;box-shadow:30px 46px 100px rgba(11,8,22,.32)}
+.depth .phone.primary{right:128px;top:170px;width:330px;height:650px;z-index:3}.depth .back-card{position:absolute;right:335px;top:300px;width:270px;height:410px;overflow:hidden;border-radius:30px;opacity:.74;transform:rotate(-8deg);box-shadow:0 24px 60px rgba(11,8,22,.18)}.depth .back-card img{width:100%;height:100%;object-fit:cover}
+.spotlight .phone{left:50%;top:300px;width:370px;height:480px;transform:translateX(-50%);border-radius:34px}.spotlight .phone img{border-radius:26px}.spotlight h1{max-width:720px;font-size:60px}.statement h1{max-width:790px;font-size:82px}.statement .logic{display:flex;gap:16px;margin-top:54px}.statement .logic span{padding:16px 22px;border-radius:16px;background:var(--lilac);font-weight:800;color:#55459a}
+`;
+
+function brand(logo) { return '<div class="brand"><img src="'+logo+'" alt=""><span>INNERBLOOM</span></div>'; }
+function footer(job) { return '<div class="footer">INNERBLOOM · '+esc(job.asset_code)+'</div>'; }
+function copy(job) {
+  const c=job.visible_copy || {};
+  return '<p class="eyebrow">'+esc(c.eyebrow || "Innerbloom")+'</p><h1>'+esc(c.headline)+'</h1>'+(c.supporting_text?'<p class="support">'+esc(c.supporting_text)+'</p>':"")+(c.microcopy?.[0]?'<span class="cta">'+esc(c.microcopy[0])+'</span>':"");
+}
+function html(job, logo, sources) {
+  const d=job.creative_direction;
+  const mode=d.mode==="dark"?"dark":"";
+  const main=sources[0], second=sources[1];
+  let scene="";
+  if (d.visual_family==="product_angle") scene='<div class="phone angle"><img src="'+main+'" alt=""></div>';
+  else if (d.visual_family==="product_depth" || d.visual_family==="product_hero_scene") scene='<div class="depth"><div class="back-card"><img src="'+(second||main)+'" alt=""></div><div class="phone primary"><img src="'+main+'" alt=""></div></div>';
+  else if (d.visual_family==="module_spotlight") scene='<div class="spotlight"><div class="phone"><img src="'+main+'" alt=""></div></div>';
+  else if (d.visual_family==="editorial_statement") scene='<div class="statement"><div class="logic"><span>Observe</span><span>Adjust</span><span>Continue</span></div></div>';
+  else if (d.visual_family==="proof_sequence") scene='<div class="depth"><div class="back-card"><img src="'+(second||main)+'" alt=""></div><div class="phone primary"><img src="'+main+'" alt=""></div></div>';
+  else scene='<div class="phone front"><img src="'+main+'" alt=""></div>';
+  return '<html><head><style>'+css+'</style></head><body><main class="frame '+mode+'">'+brand(logo)+'<section>'+copy(job)+'</section>'+scene+footer(job)+'</main></body></html>';
+}
+
+async function main() {
+  const campaign=JSON.parse(await fs.readFile(campaignPath,"utf8"));
+  const logo=await sourceUri("brand_logo_512");
+  const jobs=campaign.image_generation?.jobs || [];
+  if (!jobs.length) throw new Error("campaign.json has no image_generation.jobs");
+  await fs.mkdir(outputDir,{recursive:true});
+  const browser=await chromium.launch();
+  const manifest=[];
+  try {
+    const page=await browser.newPage({viewport:{width:1080,height:1080},deviceScaleFactor:1});
+    for (const job of jobs) {
+      const d=job.creative_direction;
+      if (!d) throw new Error(job.asset_code+" is missing creative_direction. Run the Creative Director first.");
+      if (d.status==="blocked") { manifest.push({asset_code:job.asset_code,status:"blocked",reason:d.blocking_reason}); continue; }
+      const sources=await Promise.all(d.selected_asset_keys.map(sourceUri));
+      await page.setContent(html(job,logo,sources),{waitUntil:"networkidle"});
+      const file=path.join(outputDir,job.expected_output?.filename || job.asset_code+".png");
+      await page.screenshot({path:file});
+      manifest.push({asset_code:job.asset_code,status:"rendered",file:path.relative(repoRoot,file),creative_direction:d});
+    }
+  } finally { await browser.close(); }
+  await fs.writeFile(path.join(outputDir,"render-manifest.json"),JSON.stringify(manifest,null,2)+"\n");
+  console.log("Rendered "+manifest.filter(x=>x.status==="rendered").length+" assets to "+path.relative(repoRoot,outputDir));
+}
+main().catch(error=>{console.error(error);process.exit(1);});

--- a/scripts/marketing/validate-creative-direction.mjs
+++ b/scripts/marketing/validate-creative-direction.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Mechanical guard for the Creative Director handoff.
+ * It rejects creative choices that do not use the campaign's already approved
+ * source assets, before any renderer or storage job runs.
+ */
+import fs from "node:fs/promises";
+
+const input = process.argv[2];
+if (!input) throw new Error("Usage: validate-creative-direction <campaign.json>");
+const campaign = JSON.parse(await fs.readFile(input, "utf8"));
+const families = new Set(["product_hero_scene","product_angle","product_depth","module_spotlight","editorial_statement","proof_sequence","supporting_visual_scene"]);
+const modes = new Set(["light","dark"]);
+const errors = [];
+
+for (const job of campaign.image_generation?.jobs || []) {
+  const d = job.creative_direction;
+  if (!d) { errors.push(job.asset_code + ": missing creative_direction"); continue; }
+  if (!families.has(d.visual_family)) errors.push(job.asset_code + ": unknown visual_family");
+  if (!modes.has(d.mode)) errors.push(job.asset_code + ": unknown mode");
+  if (d.wordmark_treatment !== "canonical_innerbloom_lockup") errors.push(job.asset_code + ": must use canonical wordmark");
+  const allowed = new Set((job.source_assets || []).map(asset => asset.asset_key));
+  for (const key of d.selected_asset_keys || []) if (!allowed.has(key)) errors.push(job.asset_code + ": " + key + " is not an approved source asset for this job");
+  if (!Array.isArray(d.acceptance_criteria) || d.acceptance_criteria.length < 3) errors.push(job.asset_code + ": needs at least three acceptance criteria");
+  if (d.supporting_visual?.required === true && !d.supporting_visual.brief) errors.push(job.asset_code + ": supporting visual requires a brief");
+  if (d.status === "blocked" && !d.blocking_reason) errors.push(job.asset_code + ": blocked jobs require a reason");
+}
+if (!campaign.image_generation?.jobs?.length) errors.push("campaign has no image jobs");
+if (errors.length) { console.error(errors.join("\n")); process.exit(1); }
+console.log("Creative direction validation passed for " + campaign.image_generation.jobs.length + " image jobs.");


### PR DESCRIPTION
## What this completes

- deterministic Drive staging of registry-approved visual assets
- deterministic campaign render and Drive review upload workflow
- deterministic import of rendered posts into Admin as `needs_review`
- Admin pipeline visibility, canonical full Innerbloom wordmark, and operational documentation

## Still required before first run

Configure the Drive service-account secret and share the current **Innerbloom Marketing** folder / staging folder with that service account. Then enrich `campaign.json` through the Creative Director so every image job has `creative_direction`.

No merge requested yet; this is a reviewable implementation branch.