### PR TITLE
Fix Railway web build for Capacitor import

### DIFF
--- a/apps/web/src/mobile/capacitorCoreWebShim.ts
+++ b/apps/web/src/mobile/capacitorCoreWebShim.ts
@@ -1,0 +1,30 @@
+type CapacitorPlugin = Record<PropertyKey, unknown>;
+
+type CapacitorGlobal = {
+  Plugins?: Record<string, CapacitorPlugin>;
+};
+
+/**
+ * Browser build shim for @capacitor/core's registerPlugin.
+ *
+ * The public web app never invokes native-only plugins because the platform
+ * guards return false. Returning a lazy proxy keeps module initialization safe
+ * while still delegating to a native plugin if a Capacitor bridge is present.
+ */
+export function registerPlugin<T extends object>(pluginName: string): T {
+  return new Proxy({} as T, {
+    get(_target, property) {
+      return (...args: unknown[]) => {
+        const capacitor = (globalThis as typeof globalThis & { Capacitor?: CapacitorGlobal }).Capacitor;
+        const plugin = capacitor?.Plugins?.[pluginName];
+        const method = plugin?.[property];
+
+        if (typeof method !== 'function') {
+          return Promise.reject(new Error(`${pluginName}.${String(property)} is unavailable on the web platform.`));
+        }
+
+        return method.apply(plugin, args);
+      };
+    },
+  });
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,6 +24,13 @@ export default defineConfig({
     alias: {
       config: fileURLToPath(new URL('./src/config', import.meta.url)),
       'lucide-react': fileURLToPath(new URL('./src/lib/lucide-react.tsx', import.meta.url)),
+      ...(!isNativeBuild
+        ? {
+            '@capacitor/core': fileURLToPath(
+              new URL('./src/mobile/capacitorCoreWebShim.ts', import.meta.url),
+            ),
+          }
+        : {}),
       ...(useMockClerk
         ? {
             '@clerk/clerk-react': fileURLToPath(


### PR DESCRIPTION
## Problema

Railway construye `apps/web` de forma aislada con `npm install && npm run build`. El código web importa `@capacitor/core`, pero esa dependencia pertenece al workspace móvil y no está disponible en el servicio Web, por lo que Vite falla durante el bundle.

## Solución

- agrega un shim browser-safe para `registerPlugin`;
- configura Vite para usar el shim únicamente en builds web;
- mantiene el paquete real `@capacitor/core` en builds nativos (`VITE_BUILD_TARGET=native`);
- no modifica dependencias ni lockfiles;
- no cambia el pipeline de marketing ni los datos importados al Admin.

## Validación esperada

Railway puede volver a ejecutar `npm install && npm run build` en `apps/web` sin intentar resolver `@capacitor/core`. Los builds iOS/Android continúan usando el bridge real.