### PR TITLE
Fix oversized marketing asset URLs on save

### DIFF
--- a/apps/web/src/lib/marketingCampaigns.ts
+++ b/apps/web/src/lib/marketingCampaigns.ts
@@ -69,6 +69,8 @@ export type MarketingPostUpdate = Partial<Pick<
   | 'scheduledAt'
 >>;
 
+const MAX_PERSISTED_ASSET_URL_LENGTH = 2000;
+
 export async function fetchMarketingCampaigns() {
   const response = await apiAuthorizedFetch('/admin/marketing/campaigns', {
     headers: {
@@ -96,7 +98,7 @@ export async function updateMarketingCampaignPost(
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(sanitizeMarketingPostUpdate(payload)),
     },
   );
 
@@ -106,4 +108,37 @@ export async function updateMarketingCampaignPost(
   }
 
   return response.json() as Promise<{ ok: boolean; post: MarketingPostRecord }>;
+}
+
+function sanitizeMarketingPostUpdate(payload: MarketingPostUpdate): MarketingPostUpdate {
+  if (!payload.assetUrls) {
+    return payload;
+  }
+
+  return {
+    ...payload,
+    assetUrls: payload.assetUrls.map((asset) => ({
+      ...asset,
+      url: persistableAssetUrl(asset.url),
+      previewUrl: persistableAssetUrl(asset.previewUrl),
+      sourceUrl: persistableAssetUrl(asset.sourceUrl),
+    })),
+  };
+}
+
+function persistableAssetUrl(value: string | undefined) {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  if (/^(data|blob):/i.test(normalized)) {
+    return undefined;
+  }
+
+  if (normalized.length > MAX_PERSISTED_ASSET_URL_LENGTH) {
+    return undefined;
+  }
+
+  return normalized;
 }


### PR DESCRIPTION
## Problema
El Admin podía aprobar un post, pero `Save` fallaba con HTTP 400 porque reenviaba previews inline (`data:image/...;base64,...`) dentro de `assetUrls`. Esas cadenas superaban el límite de 2000 caracteres del API.

## Solución
- sanitiza `assetUrls` en la capa común de `updateMarketingCampaignPost`;
- elimina del payload URLs `data:` y `blob:`;
- elimina cualquier URL mayor a 2000 caracteres;
- conserva URLs HTTP/HTTPS y R2 válidas;
- protege tanto la pantalla nueva como futuras llamadas desde otros componentes.

## Resultado esperado
Guardar caption, fecha, horario, hipótesis o tracking ya no falla por previews inline. La imagen sigue visible en el estado local del Admin y las URLs definitivas se persisten después de `Upload R2`.