### PR TITLE
Validate R2 media before Metricool CSV export

### DIFF
--- a/apps/api/src/modules/admin/admin.routes.ts
+++ b/apps/api/src/modules/admin/admin.routes.ts
@@ -1,5 +1,8 @@
 import { Router } from 'express';
+import { z } from 'zod';
 import { authMiddleware } from '../../middlewares/auth-middleware.js';
+import { asyncHandler } from '../../lib/async-handler.js';
+import { validateMarketingR2AssetUrls } from '../../services/marketingR2AssetService.js';
 import {
   exportAdminUserLogsCsv,
   getAdminMe,
@@ -57,6 +60,10 @@ import { requireAdmin } from './admin.middleware.js';
 const router = Router();
 const adminRouter = Router();
 
+const marketingMediaValidationBodySchema = z.object({
+  urls: z.array(z.string().trim().url().max(2000)).min(1).max(100),
+});
+
 adminRouter.get('/me', getAdminMe);
 adminRouter.get('/users', getAdminUsers);
 adminRouter.get('/marketing/campaigns', getAdminMarketingCampaigns);
@@ -69,6 +76,14 @@ adminRouter.post('/marketing/analytics/sync', postAdminMarketingAnalyticsSync);
 adminRouter.put('/marketing/analytics/settings', putAdminMarketingAnalyticsSettings);
 adminRouter.get('/marketing/r2/status', getAdminMarketingR2Status);
 adminRouter.post('/marketing/r2/assets', postAdminMarketingR2Assets);
+adminRouter.post('/marketing/r2/validate', asyncHandler(async (req, res) => {
+  const body = marketingMediaValidationBodySchema.parse(req.body ?? {});
+  const assets = await validateMarketingR2AssetUrls(body.urls);
+  res.json({
+    ok: assets.every((asset) => asset.ok),
+    assets,
+  });
+}));
 adminRouter.get('/taskgen/jobs', getTaskgenJobs);
 adminRouter.get('/taskgen/jobs/:jobId/logs', getTaskgenJobLogsHandler);
 adminRouter.post('/taskgen/jobs/:jobId/retry', retryTaskgenJobHandler);

--- a/apps/api/src/services/marketingR2AssetService.ts
+++ b/apps/api/src/services/marketingR2AssetService.ts
@@ -14,6 +14,15 @@ export type MarketingR2UploadedAsset = {
   url: string;
 };
 
+export type MarketingR2AssetValidation = {
+  url: string;
+  ok: boolean;
+  status: number | null;
+  contentType: string | null;
+  contentLength: number | null;
+  reason: string | null;
+};
+
 type R2Config = {
   accountId: string;
   accessKeyId: string;
@@ -77,6 +86,91 @@ export async function uploadMarketingR2Assets(assets: MarketingR2AssetUpload[]) 
   }
 
   return uploaded;
+}
+
+export async function validateMarketingR2AssetUrls(urls: string[]) {
+  const uniqueUrls = [...new Set(urls.map((value) => String(value || '').trim()).filter(Boolean))];
+  if (uniqueUrls.length === 0 || uniqueUrls.length > 100) {
+    throw new HttpError(400, 'invalid_asset_urls', 'Expected 1-100 asset URLs.');
+  }
+
+  const config = getR2Config();
+  const results: MarketingR2AssetValidation[] = [];
+
+  for (let start = 0; start < uniqueUrls.length; start += 8) {
+    const batch = uniqueUrls.slice(start, start + 8);
+    results.push(...await Promise.all(batch.map((url) => validatePublicAssetUrl(url, config.publicBaseUrl))));
+  }
+
+  return results;
+}
+
+async function validatePublicAssetUrl(urlValue: string, expectedBaseUrl: string): Promise<MarketingR2AssetValidation> {
+  let url: URL;
+  try {
+    url = new URL(urlValue);
+  } catch {
+    return invalidValidation(urlValue, 'invalid_url');
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return invalidValidation(urlValue, 'unsupported_protocol');
+  }
+
+  if (expectedBaseUrl && !url.toString().startsWith(`${expectedBaseUrl}/`)) {
+    return invalidValidation(urlValue, 'not_r2_public_url');
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Range: 'bytes=0-1023',
+        Accept: 'image/*',
+        'User-Agent': 'Innerbloom-Metricool-Media-Validator/1.0',
+      },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(15_000),
+    });
+    const contentType = response.headers.get('content-type');
+    const contentLengthHeader = response.headers.get('content-length');
+    const contentLength = contentLengthHeader ? Number(contentLengthHeader) : null;
+    const statusOk = response.status === 200 || response.status === 206;
+    const typeOk = isSupportedImageContentType(contentType ?? undefined);
+    const lengthOk = contentLength === null || (Number.isFinite(contentLength) && contentLength > 0);
+
+    // Consume only the small range response so the connection closes cleanly.
+    await response.arrayBuffer();
+
+    return {
+      url: urlValue,
+      ok: statusOk && typeOk && lengthOk,
+      status: response.status,
+      contentType,
+      contentLength,
+      reason: !statusOk ? `http_${response.status}` : !typeOk ? 'not_an_image' : !lengthOk ? 'empty_asset' : null,
+    };
+  } catch (error) {
+    return {
+      url: urlValue,
+      ok: false,
+      status: null,
+      contentType: null,
+      contentLength: null,
+      reason: error instanceof Error ? error.message : 'asset_fetch_failed',
+    };
+  }
+}
+
+function invalidValidation(url: string, reason: string): MarketingR2AssetValidation {
+  return {
+    url,
+    ok: false,
+    status: null,
+    contentType: null,
+    contentLength: null,
+    reason,
+  };
 }
 
 function getR2Config(): R2Config {

--- a/apps/web/src/lib/marketingMetricoolCsv.ts
+++ b/apps/web/src/lib/marketingMetricoolCsv.ts
@@ -1,6 +1,16 @@
 import type { MarketingPostSeed } from '../content/marketingAdminSeed';
+import { apiAuthorizedFetch } from './api';
 
 const PICTURE_LIMIT = 10;
+
+type MediaValidationResult = {
+  url: string;
+  ok: boolean;
+  status: number | null;
+  contentType: string | null;
+  contentLength: number | null;
+  reason: string | null;
+};
 
 function csvEscape(value: string | number | boolean | null | undefined) {
   const text = String(value ?? '');
@@ -59,18 +69,61 @@ export function buildMetricoolCalendarCsv(posts: MarketingPostSeed[]) {
     return columns.map((column) => row[column]);
   });
 
-  return `${[columns, ...rows].map((row) => row.map(csvEscape).join(',')).join('\n')}\n`;
+  return `\uFEFF${[columns, ...rows].map((row) => row.map(csvEscape).join(',')).join('\n')}\n`;
 }
 
-export function downloadMetricoolCalendarCsv(posts: MarketingPostSeed[]) {
-  const csv = buildMetricoolCalendarCsv(posts);
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = 'metricool-calendar-import.csv';
-  document.body.append(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
+export async function validateMetricoolMedia(posts: MarketingPostSeed[]) {
+  const urls = [...new Set(posts.flatMap((post) => post.assets.map((asset) => asset.url.trim())).filter(Boolean))];
+  if (!urls.length) {
+    return { ok: false, assets: [] as MediaValidationResult[] };
+  }
+
+  const response = await apiAuthorizedFetch('/admin/marketing/r2/validate', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ urls }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Media validation failed with HTTP ${response.status}: ${body}`);
+  }
+
+  return response.json() as Promise<{ ok: boolean; assets: MediaValidationResult[] }>;
+}
+
+export async function downloadMetricoolCalendarCsv(posts: MarketingPostSeed[]) {
+  try {
+    const validation = await validateMetricoolMedia(posts);
+    const invalid = validation.assets.filter((asset) => !asset.ok);
+
+    if (!validation.ok || invalid.length > 0) {
+      const details = invalid
+        .slice(0, 8)
+        .map((asset, index) => `${index + 1}. ${asset.reason || 'invalid media'} · ${asset.url}`)
+        .join('\n');
+      window.alert(
+        `The CSV was not generated because ${invalid.length || 'some'} media URL(s) are not publicly downloadable as images.\n\n${details}\n\nUse Upload R2 again after fixing the public R2 configuration, then retry CSV.`,
+      );
+      return false;
+    }
+
+    const csv = buildMetricoolCalendarCsv(posts);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'metricool-calendar-import.csv';
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+    return true;
+  } catch (error) {
+    window.alert(error instanceof Error ? error.message : 'Unable to validate media before CSV export.');
+    return false;
+  }
 }


### PR DESCRIPTION
## Problema
Metricool importó las filas del CSV, pero varias publicaciones mostraron `No image`. El Admin marcaba un asset como listo únicamente porque su URL comenzaba con el dominio de R2; no verificaba que un servicio externo pudiera descargarla como imagen.

## Cambios
- agrega `POST /admin/marketing/r2/validate`;
- descarga una muestra de cada URL pública desde el backend;
- exige HTTP 200/206, `Content-Type: image/*` y contenido no vacío;
- valida hasta 100 URLs en lotes pequeños;
- el botón CSV valida todos los medios aprobados antes de generar el archivo;
- si alguna URL falla, bloquea el CSV y muestra URL + motivo;
- agrega BOM UTF-8 al CSV para máxima compatibilidad;
- mantiene columnas separadas `Picture Url 1..10` para carruseles.

## Resultado esperado
No se vuelve a generar un CSV que Metricool no pueda descargar. El reporte permite distinguir configuración pública incorrecta, HTTP 403/404, contenido no-image o archivos vacíos.

## Nota
La mejora visual para utilizar screenshots de landing sin carcasa de celular queda fuera de esta PR como siguiente iteración del renderer.