### PR TITLE
Repair broken marketing assets in R2

### DIFF
--- a/.github/workflows/marketing-repair-r2-assets.yml
+++ b/.github/workflows/marketing-repair-r2-assets.yml
@@ -1,0 +1,50 @@
+name: Repair marketing R2 assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      campaign_code:
+        description: Campaign code to repair
+        required: true
+        default: ib_202607
+
+permissions:
+  contents: read
+
+jobs:
+  repair-r2-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Repair approved campaign assets in R2
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
+        run: node scripts/marketing/repair-r2-campaign-assets.mjs "${{ inputs.campaign_code }}"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo '## Marketing R2 repair'
+            echo ''
+            echo '- Campaign: `${{ inputs.campaign_code }}`'
+            echo '- Rewrites approved campaign assets using recoverable previews stored in Neon.'
+            echo '- Restores canonical object keys and image MIME metadata.'
+            echo '- After success, return to Admin and run CSV validation again.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/marketing/repair-r2-campaign-assets.mjs
+++ b/scripts/marketing/repair-r2-campaign-assets.mjs
@@ -1,0 +1,157 @@
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import pg from 'pg';
+
+const { Client } = pg;
+const campaignCode = process.argv[2] || process.env.CAMPAIGN_CODE || 'ib_202607';
+
+const required = [
+  'DATABASE_URL',
+  'R2_ACCOUNT_ID',
+  'R2_ACCESS_KEY_ID',
+  'R2_SECRET_ACCESS_KEY',
+  'R2_BUCKET',
+  'R2_PUBLIC_BASE_URL',
+];
+for (const key of required) {
+  if (!String(process.env[key] || '').trim()) throw new Error(`${key} is required`);
+}
+
+const publicBaseUrl = String(process.env.R2_PUBLIC_BASE_URL).trim().replace(/\/+$/, '');
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  forcePathStyle: true,
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+  },
+});
+
+const db = new Client({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+await db.connect();
+
+try {
+  const result = await db.query(
+    `SELECT mp.marketing_post_id, mp.post_code, mp.asset_urls
+       FROM marketing_posts mp
+       JOIN marketing_campaigns mc ON mc.marketing_campaign_id = mp.marketing_campaign_id
+      WHERE mc.campaign_code = $1
+        AND mp.status = 'approved'
+      ORDER BY mp.post_code`,
+    [campaignCode],
+  );
+
+  let repaired = 0;
+  let skipped = 0;
+  const failures = [];
+
+  for (const row of result.rows) {
+    const assets = Array.isArray(row.asset_urls) ? row.asset_urls : [];
+    const nextAssets = [];
+
+    for (let index = 0; index < assets.length; index += 1) {
+      const asset = { ...assets[index] };
+      try {
+        const fileName = chooseFileName(asset, row.post_code, index);
+        const source = chooseSource(asset);
+        if (!source) throw new Error('No recoverable preview/source was found in Neon');
+
+        const { bytes, contentType } = await readImage(source);
+        const key = `campaigns/${safeSegment(campaignCode)}/${safeSegment(row.post_code)}/${fileName}`;
+
+        await s3.send(new PutObjectCommand({
+          Bucket: process.env.R2_BUCKET,
+          Key: key,
+          Body: bytes,
+          ContentType: contentType,
+          CacheControl: 'public, max-age=31536000, immutable',
+        }));
+
+        const url = `${publicBaseUrl}/${key}`;
+        nextAssets.push({
+          ...asset,
+          file: fileName,
+          url,
+          previewUrl: url,
+          selected: asset.selected !== false,
+        });
+        repaired += 1;
+        console.log(`repaired ${row.post_code} ${index + 1}/${assets.length}: ${url}`);
+      } catch (error) {
+        failures.push(`${row.post_code}[${index}]: ${error instanceof Error ? error.message : String(error)}`);
+        nextAssets.push(asset);
+        skipped += 1;
+      }
+    }
+
+    await db.query(
+      `UPDATE marketing_posts SET asset_urls = $2::jsonb, updated_at = NOW() WHERE marketing_post_id = $1`,
+      [row.marketing_post_id, JSON.stringify(nextAssets)],
+    );
+  }
+
+  console.log(JSON.stringify({ campaignCode, posts: result.rowCount, repaired, skipped, failures }, null, 2));
+  if (failures.length) process.exitCode = 1;
+} finally {
+  await db.end();
+}
+
+function chooseFileName(asset, postCode, index) {
+  const candidates = [asset.file, filenameFromUrl(asset.url), filenameFromUrl(asset.previewUrl), filenameFromUrl(asset.sourceUrl)];
+  for (const value of candidates) {
+    const name = String(value || '').split('/').pop()?.trim();
+    if (name && !name.startsWith('data:') && /^[a-zA-Z0-9][a-zA-Z0-9._-]*\.(png|jpe?g|webp)$/i.test(name)) {
+      return name;
+    }
+  }
+  return `asset_${safeSegment(postCode)}_${String(index + 1).padStart(2, '0')}.png`;
+}
+
+function filenameFromUrl(value) {
+  try { return new URL(String(value || '')).pathname.split('/').pop() || ''; } catch { return ''; }
+}
+
+function chooseSource(asset) {
+  const values = [asset.previewUrl, asset.sourceUrl, asset.url];
+  return values.find((value) => /^data:image\//i.test(String(value || '')))
+    || values.find((value) => /^https?:\/\//i.test(String(value || '')) && !String(value).startsWith(`${publicBaseUrl}/`));
+}
+
+async function readImage(source) {
+  const value = String(source);
+  if (value.startsWith('data:')) {
+    const match = value.match(/^data:(image\/(?:png|jpeg|jpg|webp));base64,(.+)$/i);
+    if (!match) throw new Error('Unsupported data image');
+    const bytes = Buffer.from(match[2], 'base64');
+    return validateImage(bytes, normalizeMime(match[1]));
+  }
+
+  const response = await fetch(value, { redirect: 'follow', signal: AbortSignal.timeout(30_000) });
+  if (!response.ok) throw new Error(`Source returned HTTP ${response.status}`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  return validateImage(bytes, response.headers.get('content-type'));
+}
+
+function validateImage(bytes, declaredType) {
+  if (!bytes.length || bytes.length > 12 * 1024 * 1024) throw new Error(`Invalid image size ${bytes.length}`);
+  const detected = detectMime(bytes);
+  if (!detected) throw new Error('Content is not PNG, JPEG, or WebP');
+  const declared = normalizeMime(declaredType);
+  return { bytes, contentType: detected || declared };
+}
+
+function detectMime(bytes) {
+  if (bytes.length >= 8 && bytes.subarray(0, 8).equals(Buffer.from([0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a]))) return 'image/png';
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return 'image/jpeg';
+  if (bytes.length >= 12 && bytes.toString('ascii', 0, 4) === 'RIFF' && bytes.toString('ascii', 8, 12) === 'WEBP') return 'image/webp';
+  return null;
+}
+
+function normalizeMime(value) {
+  const type = String(value || '').split(';')[0].trim().toLowerCase();
+  return type === 'image/jpg' ? 'image/jpeg' : type;
+}
+
+function safeSegment(value) {
+  return String(value || '').trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'default';
+}


### PR DESCRIPTION
## Problema
Los assets aprobados figuran con URLs canónicas como `asset_post_002_01.png`, pero los objetos reales no existen bajo esas keys. Durante la primera subida se usaron previews `data:image/...;base64,...` de forma incorrecta, por lo que Metricool no puede descargar las imágenes y R2 responde `NoSuchKey`.

## Solución
- agrega un script de reparación que lee los assets aprobados desde Neon;
- recupera las previews base64 que todavía conserva el Admin;
- detecta PNG/JPEG/WebP por firma binaria;
- reescribe los objetos en R2 con key canónica y `Content-Type` correcto;
- actualiza `asset_urls` en Neon con las URLs públicas reparadas;
- agrega un workflow manual reutilizable para reparar una campaña completa.

## Ejecución
Después del merge, ejecutar **Repair marketing R2 assets** con `campaign_code=ib_202607`. Luego volver al Admin y generar el CSV; la validación pública existente confirmará los medios antes de descargarlo.

No regenera renders, no cambia aprobaciones y no modifica la copy ni el calendario.