### PR TITLE
Fix R2 repair workflow setup

### DIFF
--- a/.github/workflows/marketing-repair-r2-assets.yml
+++ b/.github/workflows/marketing-repair-r2-assets.yml
@@ -14,18 +14,21 @@ permissions:
 jobs:
   repair-r2-assets:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 1
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: npm
+          node-version: 24
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --no-audit --no-fund
 
       - name: Repair approved campaign assets in R2
         env:


### PR DESCRIPTION
The manual R2 repair workflow failed before running the repair script because `actions/setup-node` enabled npm caching from the repository root, where no supported lockfile exists.

This PR:
- switches the workflow to Node 24;
- removes the invalid npm cache configuration;
- installs dependencies using the same root command as the working marketing render workflow;
- keeps the repair script and campaign behavior unchanged.

After merge, rerun **Repair marketing R2 assets** from `main` with `campaign_code=ib_202607`.