### PR TITLE
Repair R2 assets from original render artifact

### DIFF
--- a/.github/workflows/marketing-repair-r2-assets.yml
+++ b/.github/workflows/marketing-repair-r2-assets.yml
@@ -7,9 +7,18 @@ on:
         description: Campaign code to repair
         required: true
         default: ib_202607
+      period_key:
+        description: Campaign period used by the original render artifact
+        required: true
+        default: 2026-07
+      artifact_run_id:
+        description: Optional render workflow run ID; leave blank to use the newest matching artifact
+        required: false
+        default: ''
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   repair-r2-assets:
@@ -30,6 +39,40 @@ jobs:
       - name: Install dependencies
         run: npm install --no-audit --no-fund
 
+      - name: Download original campaign render artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PERIOD_KEY: ${{ inputs.period_key }}
+          REQUESTED_RUN_ID: ${{ inputs.artifact_run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p marketing-repair-source
+
+          if [[ -n "${REQUESTED_RUN_ID}" ]]; then
+            run_id="${REQUESTED_RUN_ID}"
+            artifact_name=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
+              --jq ".artifacts[] | select(.expired == false and (.name | startswith(\"innerbloom-marketing-${PERIOD_KEY}-run-\"))) | .name" \
+              | head -n 1)
+          else
+            artifact_row=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" \
+              --jq ".artifacts[] | select(.expired == false and (.name | startswith(\"innerbloom-marketing-${PERIOD_KEY}-run-\"))) | [.created_at, (.workflow_run.id | tostring), .name] | @tsv" \
+              | sort -r | head -n 1)
+            [[ -n "${artifact_row}" ]] || { echo "No unexpired render artifact found for ${PERIOD_KEY}" >&2; exit 1; }
+            IFS=$'\t' read -r _created_at run_id artifact_name <<< "${artifact_row}"
+          fi
+
+          [[ -n "${artifact_name:-}" ]] || { echo "No matching render artifact found in run ${run_id}" >&2; exit 1; }
+          echo "Downloading ${artifact_name} from run ${run_id}"
+          gh run download "${run_id}" --name "${artifact_name}" --dir marketing-repair-source
+
+          image_count=$(find marketing-repair-source -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.webp' \) | wc -l | tr -d ' ')
+          [[ "${image_count}" -gt 0 ]] || { echo "Artifact contained no image files" >&2; exit 1; }
+          echo "Found ${image_count} source images"
+          echo "REPAIR_SOURCE_DIR=marketing-repair-source" >> "${GITHUB_ENV}"
+          echo "REPAIR_ARTIFACT_NAME=${artifact_name}" >> "${GITHUB_ENV}"
+          echo "REPAIR_ARTIFACT_RUN_ID=${run_id}" >> "${GITHUB_ENV}"
+
       - name: Repair approved campaign assets in R2
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
@@ -38,7 +81,7 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
           R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
-        run: node scripts/marketing/repair-r2-campaign-assets.mjs "${{ inputs.campaign_code }}"
+        run: node scripts/marketing/repair-r2-campaign-assets.mjs "${{ inputs.campaign_code }}" "${REPAIR_SOURCE_DIR}"
 
       - name: Summary
         if: always()
@@ -47,7 +90,10 @@ jobs:
             echo '## Marketing R2 repair'
             echo ''
             echo '- Campaign: `${{ inputs.campaign_code }}`'
-            echo '- Rewrites approved campaign assets using recoverable previews stored in Neon.'
-            echo '- Restores canonical object keys and image MIME metadata.'
+            echo '- Source artifact: `${REPAIR_ARTIFACT_NAME:-not downloaded}`'
+            echo '- Source run: `${REPAIR_ARTIFACT_RUN_ID:-unknown}`'
+            echo '- Restores only assets still attached to approved posts in Neon.'
+            echo '- Rewrites canonical R2 object keys with real image bytes and MIME metadata.'
+            echo '- Does not overwrite copy, schedule, status, or carousel selection.'
             echo '- After success, return to Admin and run CSV validation again.'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/marketing/repair-r2-campaign-assets.mjs
+++ b/scripts/marketing/repair-r2-campaign-assets.mjs
@@ -1,8 +1,11 @@
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
 import pg from 'pg';
 
 const { Client } = pg;
 const campaignCode = process.argv[2] || process.env.CAMPAIGN_CODE || 'ib_202607';
+const artifactSourceDir = String(process.argv[3] || process.env.REPAIR_SOURCE_DIR || '').trim();
 
 const required = [
   'DATABASE_URL',
@@ -17,6 +20,11 @@ for (const key of required) {
 }
 
 const publicBaseUrl = String(process.env.R2_PUBLIC_BASE_URL).trim().replace(/\/+$/, '');
+const artifactFiles = artifactSourceDir ? await indexArtifactFiles(artifactSourceDir) : new Map();
+if (artifactSourceDir && artifactFiles.size === 0) {
+  throw new Error(`No PNG/JPEG/WebP files were found in artifact source directory: ${artifactSourceDir}`);
+}
+
 const s3 = new S3Client({
   region: 'auto',
   endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
@@ -43,6 +51,7 @@ try {
 
   let repaired = 0;
   let skipped = 0;
+  let restoredFromArtifact = 0;
   const failures = [];
 
   for (const row of result.rows) {
@@ -53,17 +62,26 @@ try {
       const asset = { ...assets[index] };
       try {
         const fileName = chooseFileName(asset, row.post_code, index);
-        const source = chooseSource(asset);
-        if (!source) throw new Error('No recoverable preview/source was found in Neon');
+        const localFile = artifactFiles.get(fileName.toLowerCase());
+        let image;
 
-        const { bytes, contentType } = await readImage(source);
+        if (localFile) {
+          image = validateImage(await readFile(localFile), mimeFromExtension(fileName));
+          restoredFromArtifact += 1;
+        } else {
+          const source = chooseSource(asset);
+          if (!source) {
+            throw new Error(`File ${fileName} was not found in the render artifact and no recoverable source exists in Neon`);
+          }
+          image = await readImage(source);
+        }
+
         const key = `campaigns/${safeSegment(campaignCode)}/${safeSegment(row.post_code)}/${fileName}`;
-
         await s3.send(new PutObjectCommand({
           Bucket: process.env.R2_BUCKET,
           Key: key,
-          Body: bytes,
-          ContentType: contentType,
+          Body: image.bytes,
+          ContentType: image.contentType,
           CacheControl: 'public, max-age=31536000, immutable',
         }));
 
@@ -90,10 +108,37 @@ try {
     );
   }
 
-  console.log(JSON.stringify({ campaignCode, posts: result.rowCount, repaired, skipped, failures }, null, 2));
+  console.log(JSON.stringify({
+    campaignCode,
+    posts: result.rowCount,
+    artifactSourceDir: artifactSourceDir || null,
+    artifactImagesIndexed: artifactFiles.size,
+    restoredFromArtifact,
+    repaired,
+    skipped,
+    failures,
+  }, null, 2));
   if (failures.length) process.exitCode = 1;
 } finally {
   await db.end();
+}
+
+async function indexArtifactFiles(rootDir) {
+  const files = new Map();
+  async function walk(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (/\.(png|jpe?g|webp)$/i.test(entry.name)) {
+        const key = entry.name.toLowerCase();
+        if (files.has(key)) throw new Error(`Duplicate artifact filename found: ${entry.name}`);
+        files.set(key, fullPath);
+      }
+    }
+  }
+  await walk(rootDir);
+  return files;
 }
 
 function chooseFileName(asset, postCode, index) {
@@ -122,22 +167,19 @@ async function readImage(source) {
   if (value.startsWith('data:')) {
     const match = value.match(/^data:(image\/(?:png|jpeg|jpg|webp));base64,(.+)$/i);
     if (!match) throw new Error('Unsupported data image');
-    const bytes = Buffer.from(match[2], 'base64');
-    return validateImage(bytes, normalizeMime(match[1]));
+    return validateImage(Buffer.from(match[2], 'base64'), normalizeMime(match[1]));
   }
 
   const response = await fetch(value, { redirect: 'follow', signal: AbortSignal.timeout(30_000) });
   if (!response.ok) throw new Error(`Source returned HTTP ${response.status}`);
-  const bytes = Buffer.from(await response.arrayBuffer());
-  return validateImage(bytes, response.headers.get('content-type'));
+  return validateImage(Buffer.from(await response.arrayBuffer()), response.headers.get('content-type'));
 }
 
 function validateImage(bytes, declaredType) {
   if (!bytes.length || bytes.length > 12 * 1024 * 1024) throw new Error(`Invalid image size ${bytes.length}`);
   const detected = detectMime(bytes);
   if (!detected) throw new Error('Content is not PNG, JPEG, or WebP');
-  const declared = normalizeMime(declaredType);
-  return { bytes, contentType: detected || declared };
+  return { bytes, contentType: detected || normalizeMime(declaredType) };
 }
 
 function detectMime(bytes) {
@@ -145,6 +187,14 @@ function detectMime(bytes) {
   if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return 'image/jpeg';
   if (bytes.length >= 12 && bytes.toString('ascii', 0, 4) === 'RIFF' && bytes.toString('ascii', 8, 12) === 'WEBP') return 'image/webp';
   return null;
+}
+
+function mimeFromExtension(fileName) {
+  const extension = path.extname(fileName).toLowerCase();
+  if (extension === '.png') return 'image/png';
+  if (extension === '.jpg' || extension === '.jpeg') return 'image/jpeg';
+  if (extension === '.webp') return 'image/webp';
+  return '';
 }
 
 function normalizeMime(value) {


### PR DESCRIPTION
## Problema
La reparación anterior buscaba previews base64 dentro de Neon, pero Neon ya no conserva los bytes originales: solo mantiene las URLs rotas de R2. Por eso encontró 19 posts aprobados pero reparó 0 assets.

## Solución
- descarga automáticamente el último artifact no vencido del render completo para el período indicado;
- permite opcionalmente fijar un `artifact_run_id` concreto;
- indexa los PNG/JPEG/WebP originales por nombre de archivo;
- usa Neon únicamente para determinar qué assets siguen vinculados a los posts aprobados;
- restaura esos assets en sus keys canónicas de R2 con MIME correcto;
- actualiza únicamente `asset_urls`, sin tocar copy, fechas, estado, orden ni slides eliminadas.

## Ejecución
Después del merge, ejecutar **Repair marketing R2 assets** desde `main` con:
- `campaign_code=ib_202607`
- `period_key=2026-07`
- `artifact_run_id` vacío para elegir automáticamente el artifact más reciente.

Luego volver al Admin y generar el CSV; la validación pública debe confirmar que todas las imágenes son descargables.