### PR TITLE
Sanitize R2 credentials during marketing asset repair

### DIFF
--- a/scripts/marketing/repair-r2-campaign-assets.mjs
+++ b/scripts/marketing/repair-r2-campaign-assets.mjs
@@ -19,7 +19,26 @@ for (const key of required) {
   if (!String(process.env[key] || '').trim()) throw new Error(`${key} is required`);
 }
 
-const publicBaseUrl = String(process.env.R2_PUBLIC_BASE_URL).trim().replace(/\/+$/, '');
+function cleanR2Value(key) {
+  return String(process.env[key] || '').replace(/[\r\n\u2028\u2029]+/g, '').trim();
+}
+
+const r2AccountId = cleanR2Value('R2_ACCOUNT_ID');
+const r2AccessKeyId = cleanR2Value('R2_ACCESS_KEY_ID');
+const r2SecretAccessKey = cleanR2Value('R2_SECRET_ACCESS_KEY');
+const r2Bucket = cleanR2Value('R2_BUCKET');
+const publicBaseUrl = cleanR2Value('R2_PUBLIC_BASE_URL').replace(/\/+$/, '');
+
+for (const [name, value] of Object.entries({
+  R2_ACCOUNT_ID: r2AccountId,
+  R2_ACCESS_KEY_ID: r2AccessKeyId,
+  R2_SECRET_ACCESS_KEY: r2SecretAccessKey,
+  R2_BUCKET: r2Bucket,
+  R2_PUBLIC_BASE_URL: publicBaseUrl,
+})) {
+  if (!value) throw new Error(`${name} is empty after removing whitespace and line breaks`);
+}
+
 const artifactFiles = artifactSourceDir ? await indexArtifactFiles(artifactSourceDir) : new Map();
 if (artifactSourceDir && artifactFiles.size === 0) {
   throw new Error(`No PNG/JPEG/WebP files were found in artifact source directory: ${artifactSourceDir}`);
@@ -27,11 +46,11 @@ if (artifactSourceDir && artifactFiles.size === 0) {
 
 const s3 = new S3Client({
   region: 'auto',
-  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  endpoint: `https://${r2AccountId}.r2.cloudflarestorage.com`,
   forcePathStyle: true,
   credentials: {
-    accessKeyId: process.env.R2_ACCESS_KEY_ID,
-    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+    accessKeyId: r2AccessKeyId,
+    secretAccessKey: r2SecretAccessKey,
   },
 });
 
@@ -53,6 +72,7 @@ try {
   let skipped = 0;
   let restoredFromArtifact = 0;
   const failures = [];
+  const warnings = [];
 
   for (const row of result.rows) {
     const assets = Array.isArray(row.asset_urls) ? row.asset_urls : [];
@@ -71,14 +91,17 @@ try {
         } else {
           const source = chooseSource(asset);
           if (!source) {
-            throw new Error(`File ${fileName} was not found in the render artifact and no recoverable source exists in Neon`);
+            warnings.push(`${row.post_code}[${index}]: File ${fileName} was not found in the render artifact and no recoverable source exists in Neon. Re-upload or remove this asset in Admin.`);
+            nextAssets.push(asset);
+            skipped += 1;
+            continue;
           }
           image = await readImage(source);
         }
 
         const key = `campaigns/${safeSegment(campaignCode)}/${safeSegment(row.post_code)}/${fileName}`;
         await s3.send(new PutObjectCommand({
-          Bucket: process.env.R2_BUCKET,
+          Bucket: r2Bucket,
           Key: key,
           Body: image.bytes,
           ContentType: image.contentType,
@@ -116,6 +139,7 @@ try {
     restoredFromArtifact,
     repaired,
     skipped,
+    warnings,
     failures,
   }, null, 2));
   if (failures.length) process.exitCode = 1;


### PR DESCRIPTION
## Problema
La reparación desde el artifact encontró correctamente 52 imágenes y 43 assets restaurables, pero todas las subidas a R2 fallaron con `Invalid character in header content ["authorization"]`. Esto indica saltos de línea o caracteres invisibles en alguno de los secrets copiados a GitHub.

Además existe un único asset manual (`post_001`) agregado después del render completo; ese archivo no está en el artifact ni conserva bytes recuperables en Neon.

## Solución
- limpia CR/LF y espacios externos de las cinco variables de R2 antes de construir el cliente S3;
- usa únicamente los valores sanitizados para endpoint, credenciales, bucket y URL pública;
- restaura los 43 assets presentes en el artifact;
- reporta el asset manual no recuperable como advertencia, sin bloquear toda la reparación;
- mantiene intactos posts, copies, fechas, estados, orden y assets existentes.

## Después del merge
Ejecutar nuevamente **Repair marketing R2 assets** desde `main` con:
- `campaign_code=ib_202607`
- `period_key=2026-07`
- `artifact_run_id` vacío

Después reemplazar o eliminar desde el Admin el único asset manual indicado en la advertencia, guardar, volver a subirlo a R2 y generar el CSV.