### PR TITLE
Block 3: batch marketing review changes and simplify CSV workflow

### DIFF
--- a/apps/api/src/modules/admin/admin.routes.ts
+++ b/apps/api/src/modules/admin/admin.routes.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { authMiddleware } from '../../middlewares/auth-middleware.js';
 import { asyncHandler } from '../../lib/async-handler.js';
 import { validateMarketingR2AssetUrls } from '../../services/marketingR2AssetService.js';
+import { updateMarketingCampaignPostsBulk } from '../../services/marketingCampaignBulkUpdateService.js';
 import {
   exportAdminUserLogsCsv,
   getAdminMe,
@@ -55,6 +56,7 @@ import {
   postAdminMarketingR2Assets,
   putAdminMarketingAnalyticsSettings,
 } from './admin.handlers.js';
+import { marketingPostUpdateBodySchema } from './admin.schemas.js';
 import { requireAdmin } from './admin.middleware.js';
 
 const router = Router();
@@ -64,10 +66,23 @@ const marketingMediaValidationBodySchema = z.object({
   urls: z.array(z.string().trim().url().max(2000)).min(1).max(100),
 });
 
+const marketingCampaignBulkSaveSchema = z.object({
+  updates: z.array(z.object({
+    postCode: z.string().trim().min(1).max(120),
+    changes: marketingPostUpdateBodySchema,
+  })).min(1).max(100),
+});
+
 adminRouter.get('/me', getAdminMe);
 adminRouter.get('/users', getAdminUsers);
 adminRouter.get('/marketing/campaigns', getAdminMarketingCampaigns);
 adminRouter.patch('/marketing/campaigns/:campaignCode/posts/:postCode', patchAdminMarketingPost);
+adminRouter.post('/marketing/campaigns/:campaignCode/posts/bulk-save', asyncHandler(async (req, res) => {
+  const campaignCode = z.string().trim().min(1).max(120).parse(req.params.campaignCode);
+  const body = marketingCampaignBulkSaveSchema.parse(req.body ?? {});
+  const posts = await updateMarketingCampaignPostsBulk(campaignCode, body.updates);
+  res.json({ ok: true, posts });
+}));
 adminRouter.post('/marketing/agents/cmo/context', postAdminMarketingCmoContext);
 adminRouter.get('/marketing/agents/cmo/context/status', getAdminMarketingCmoContextStatus);
 adminRouter.get('/marketing/analytics/status', getAdminMarketingAnalyticsStatus);
@@ -79,10 +94,7 @@ adminRouter.post('/marketing/r2/assets', postAdminMarketingR2Assets);
 adminRouter.post('/marketing/r2/validate', asyncHandler(async (req, res) => {
   const body = marketingMediaValidationBodySchema.parse(req.body ?? {});
   const assets = await validateMarketingR2AssetUrls(body.urls);
-  res.json({
-    ok: assets.every((asset) => asset.ok),
-    assets,
-  });
+  res.json({ ok: assets.every((asset) => asset.ok), assets });
 }));
 adminRouter.get('/taskgen/jobs', getTaskgenJobs);
 adminRouter.get('/taskgen/jobs/:jobId/logs', getTaskgenJobLogsHandler);

--- a/apps/api/src/services/marketingCampaignBulkUpdateService.ts
+++ b/apps/api/src/services/marketingCampaignBulkUpdateService.ts
@@ -1,0 +1,110 @@
+import type { PoolClient } from 'pg';
+import { pool } from '../db.js';
+import { HttpError } from '../lib/http-error.js';
+import type { MarketingPostPayload, MarketingPostStatus, MarketingPostUpdateInput } from './marketingCampaignService.js';
+
+export type MarketingCampaignBulkUpdate = {
+  postCode: string;
+  changes: MarketingPostUpdateInput;
+};
+
+export async function updateMarketingCampaignPostsBulk(
+  campaignCode: string,
+  updates: MarketingCampaignBulkUpdate[],
+): Promise<MarketingPostPayload[]> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const posts: MarketingPostPayload[] = [];
+    for (const update of updates) {
+      posts.push(await updateOne(client, campaignCode, update.postCode, update.changes));
+    }
+    await client.query('COMMIT');
+    return posts;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function updateOne(
+  client: PoolClient,
+  campaignCode: string,
+  postCode: string,
+  input: MarketingPostUpdateInput,
+): Promise<MarketingPostPayload> {
+  const existing = await client.query<any>(
+    `SELECT mp.*
+       FROM marketing_posts mp
+       JOIN marketing_campaigns mc ON mc.marketing_campaign_id = mp.marketing_campaign_id
+      WHERE mc.campaign_code = $1 AND mp.post_code = $2
+      LIMIT 1`,
+    [campaignCode, postCode],
+  );
+  const current = existing.rows[0];
+  if (!current) throw new HttpError(404, 'marketing_post_not_found', `Marketing post ${postCode} not found.`);
+
+  const nextStatus = (input.status ?? current.status) as MarketingPostStatus;
+  const now = new Date();
+  const approvedAt = nextStatus === 'approved' && current.status !== 'approved' ? now : current.approved_at;
+  const rejectedAt = nextStatus === 'rejected' && current.status !== 'rejected' ? now : current.rejected_at;
+
+  const result = await client.query<any>(
+    `UPDATE marketing_posts
+        SET status = $3, hook = $4, caption = $5, hypothesis = $6, target_metric = $7,
+            tracking_url = $8, asset_urls = $9::jsonb, agent_notes = $10, decision_note = $11,
+            rejection_reason = $12, scheduled_at = $13, approved_at = $14, rejected_at = $15,
+            updated_at = now()
+      WHERE marketing_post_id = $1 AND post_code = $2
+      RETURNING *`,
+    [
+      current.marketing_post_id,
+      postCode,
+      nextStatus,
+      input.hook ?? current.hook,
+      input.caption ?? current.caption,
+      input.hypothesis ?? current.hypothesis,
+      input.targetMetric ?? current.target_metric,
+      input.trackingUrl ?? current.tracking_url,
+      JSON.stringify(input.assetUrls ?? normalizeAssets(current.asset_urls)),
+      input.agentNotes ?? current.agent_notes,
+      input.decisionNote ?? current.decision_note,
+      input.rejectionReason ?? current.rejection_reason,
+      input.scheduledAt === undefined ? current.scheduled_at : input.scheduledAt,
+      approvedAt,
+      rejectedAt,
+    ],
+  );
+  return mapRow(result.rows[0]);
+}
+
+function normalizeAssets(value: unknown) {
+  return Array.isArray(value) ? value : [];
+}
+
+function mapRow(row: any): MarketingPostPayload {
+  const iso = (value: unknown) => value ? new Date(value as string | number | Date).toISOString() : null;
+  return {
+    postCode: row.post_code,
+    platform: row.platform,
+    format: row.format,
+    status: row.status,
+    hook: row.hook ?? '',
+    caption: row.caption ?? '',
+    hypothesis: row.hypothesis ?? '',
+    targetMetric: row.target_metric ?? '',
+    trackingUrl: row.tracking_url ?? '',
+    assetUrls: normalizeAssets(row.asset_urls),
+    agentNotes: row.agent_notes ?? '',
+    decisionNote: row.decision_note ?? '',
+    rejectionReason: row.rejection_reason ?? '',
+    scheduledAt: iso(row.scheduled_at),
+    approvedAt: iso(row.approved_at),
+    rejectedAt: iso(row.rejected_at),
+    publishedAt: iso(row.published_at),
+    measuredAt: iso(row.measured_at),
+    updatedAt: iso(row.updated_at) ?? new Date().toISOString(),
+  };
+}

--- a/apps/api/src/services/marketingCampaignBulkUpdateService.ts
+++ b/apps/api/src/services/marketingCampaignBulkUpdateService.ts
@@ -1,11 +1,39 @@
 import type { PoolClient } from 'pg';
 import { pool } from '../db.js';
 import { HttpError } from '../lib/http-error.js';
-import type { MarketingPostPayload, MarketingPostStatus, MarketingPostUpdateInput } from './marketingCampaignService.js';
+import type {
+  MarketingAssetPayload,
+  MarketingPostPayload,
+  MarketingPostStatus,
+  MarketingPostUpdateInput,
+} from './marketingCampaignService.js';
 
 export type MarketingCampaignBulkUpdate = {
   postCode: string;
   changes: MarketingPostUpdateInput;
+};
+
+type MarketingPostRow = {
+  marketing_post_id: string;
+  post_code: string;
+  platform: string;
+  format: string;
+  status: MarketingPostStatus;
+  hook: string | null;
+  caption: string | null;
+  hypothesis: string | null;
+  target_metric: string | null;
+  tracking_url: string | null;
+  asset_urls: unknown;
+  agent_notes: string | null;
+  decision_note: string | null;
+  rejection_reason: string | null;
+  scheduled_at: string | Date | null;
+  approved_at: string | Date | null;
+  rejected_at: string | Date | null;
+  published_at: string | Date | null;
+  measured_at: string | Date | null;
+  updated_at: string | Date | null;
 };
 
 export async function updateMarketingCampaignPostsBulk(
@@ -35,7 +63,7 @@ async function updateOne(
   postCode: string,
   input: MarketingPostUpdateInput,
 ): Promise<MarketingPostPayload> {
-  const existing = await client.query<any>(
+  const existing = await client.query<MarketingPostRow>(
     `SELECT mp.*
        FROM marketing_posts mp
        JOIN marketing_campaigns mc ON mc.marketing_campaign_id = mp.marketing_campaign_id
@@ -46,12 +74,12 @@ async function updateOne(
   const current = existing.rows[0];
   if (!current) throw new HttpError(404, 'marketing_post_not_found', `Marketing post ${postCode} not found.`);
 
-  const nextStatus = (input.status ?? current.status) as MarketingPostStatus;
+  const nextStatus = input.status ?? current.status;
   const now = new Date();
   const approvedAt = nextStatus === 'approved' && current.status !== 'approved' ? now : current.approved_at;
   const rejectedAt = nextStatus === 'rejected' && current.status !== 'rejected' ? now : current.rejected_at;
 
-  const result = await client.query<any>(
+  const result = await client.query<MarketingPostRow>(
     `UPDATE marketing_posts
         SET status = $3, hook = $4, caption = $5, hypothesis = $6, target_metric = $7,
             tracking_url = $8, asset_urls = $9::jsonb, agent_notes = $10, decision_note = $11,
@@ -80,12 +108,12 @@ async function updateOne(
   return mapRow(result.rows[0]);
 }
 
-function normalizeAssets(value: unknown) {
-  return Array.isArray(value) ? value : [];
+function normalizeAssets(value: unknown): MarketingAssetPayload[] {
+  return Array.isArray(value) ? value as MarketingAssetPayload[] : [];
 }
 
-function mapRow(row: any): MarketingPostPayload {
-  const iso = (value: unknown) => value ? new Date(value as string | number | Date).toISOString() : null;
+function mapRow(row: MarketingPostRow): MarketingPostPayload {
+  const iso = (value: string | Date | null) => value ? new Date(value).toISOString() : null;
   return {
     postCode: row.post_code,
     platform: row.platform,

--- a/apps/web/src/lib/marketingCampaigns.ts
+++ b/apps/web/src/lib/marketingCampaigns.ts
@@ -72,49 +72,54 @@ export type MarketingPostUpdate = Partial<Pick<
 const MAX_PERSISTED_ASSET_URL_LENGTH = 2000;
 
 export async function fetchMarketingCampaigns() {
-  const response = await apiAuthorizedFetch('/admin/marketing/campaigns', {
-    headers: {
-      Accept: 'application/json',
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Marketing campaigns request failed with HTTP ${response.status}`);
-  }
-
+  const response = await apiAuthorizedFetch('/admin/marketing/campaigns', { headers: { Accept: 'application/json' } });
+  if (!response.ok) throw new Error(`Marketing campaigns request failed with HTTP ${response.status}`);
   return response.json() as Promise<{ ok: boolean; campaigns: MarketingCampaignRecord[] }>;
 }
 
-export async function updateMarketingCampaignPost(
-  campaignCode: string,
-  postCode: string,
-  payload: MarketingPostUpdate,
-) {
+export async function updateMarketingCampaignPost(campaignCode: string, postCode: string, payload: MarketingPostUpdate) {
   const response = await apiAuthorizedFetch(
     `/admin/marketing/campaigns/${encodeURIComponent(campaignCode)}/posts/${encodeURIComponent(postCode)}`,
     {
       method: 'PATCH',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
       body: JSON.stringify(sanitizeMarketingPostUpdate(payload)),
     },
   );
-
   if (!response.ok) {
     const body = await response.text();
     throw new Error(`Marketing post update failed with HTTP ${response.status}: ${body}`);
   }
-
   return response.json() as Promise<{ ok: boolean; post: MarketingPostRecord }>;
 }
 
-function sanitizeMarketingPostUpdate(payload: MarketingPostUpdate): MarketingPostUpdate {
-  if (!payload.assetUrls) {
-    return payload;
+export async function saveMarketingCampaignBulk(
+  campaignCode: string,
+  updates: Array<{ postCode: string; changes: MarketingPostUpdate }>,
+) {
+  if (!updates.length) return { ok: true, posts: [] as MarketingPostRecord[] };
+  const response = await apiAuthorizedFetch(
+    `/admin/marketing/campaigns/${encodeURIComponent(campaignCode)}/posts/bulk-save`,
+    {
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        updates: updates.map((item) => ({
+          postCode: item.postCode,
+          changes: sanitizeMarketingPostUpdate(item.changes),
+        })),
+      }),
+    },
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Marketing campaign bulk save failed with HTTP ${response.status}: ${body}`);
   }
+  return response.json() as Promise<{ ok: boolean; posts: MarketingPostRecord[] }>;
+}
 
+function sanitizeMarketingPostUpdate(payload: MarketingPostUpdate): MarketingPostUpdate {
+  if (!payload.assetUrls) return payload;
   return {
     ...payload,
     assetUrls: payload.assetUrls.map((asset) => ({
@@ -128,17 +133,6 @@ function sanitizeMarketingPostUpdate(payload: MarketingPostUpdate): MarketingPos
 
 function persistableAssetUrl(value: string | undefined) {
   const normalized = value?.trim();
-  if (!normalized) {
-    return undefined;
-  }
-
-  if (/^(data|blob):/i.test(normalized)) {
-    return undefined;
-  }
-
-  if (normalized.length > MAX_PERSISTED_ASSET_URL_LENGTH) {
-    return undefined;
-  }
-
+  if (!normalized || /^(data|blob):/i.test(normalized) || normalized.length > MAX_PERSISTED_ASSET_URL_LENGTH) return undefined;
   return normalized;
 }

--- a/apps/web/src/lib/marketingR2Assets.ts
+++ b/apps/web/src/lib/marketingR2Assets.ts
@@ -17,142 +17,85 @@ export type UploadedMarketingAsset = {
   url: string;
 };
 
-type UploadAssetInput = {
-  asset: MarketingAsset;
-  campaignCode: string;
-  postId: string;
-};
-
-type UploadMarketingAssetsResponse = {
+export type MarketingMediaValidation = {
+  url: string;
   ok: boolean;
-  assets: UploadedMarketingAsset[];
-};
-
-type PreparedMarketingAsset = {
-  key: string;
-  sourceUrl?: string;
-  contentBase64?: string;
+  status?: number;
   contentType?: string;
+  reason?: string;
 };
 
-export function buildMarketingAssetKey({
-  campaignCode,
-  postId,
-  file,
-}: {
-  campaignCode: string;
-  postId: string;
-  file: string;
-}) {
+type UploadAssetInput = { asset: MarketingAsset; campaignCode: string; postId: string };
+type UploadMarketingAssetsResponse = { ok: boolean; assets: UploadedMarketingAsset[] };
+type PreparedMarketingAsset = { key: string; sourceUrl?: string; contentBase64?: string; contentType?: string };
+
+export function buildMarketingAssetKey({ campaignCode, postId, file }: { campaignCode: string; postId: string; file: string }) {
   const safeCampaign = toSafeSegment(campaignCode);
   const safePost = toSafeSegment(postId);
   const safeFile = file.split('/').pop() ?? file;
-
   return `campaigns/${safeCampaign}/${safePost}/${safeFile}`;
 }
 
 export async function fetchMarketingR2Status() {
-  const response = await apiAuthorizedFetch('/admin/marketing/r2/status', {
-    headers: {
-      Accept: 'application/json',
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`R2 status request failed with HTTP ${response.status}`);
-  }
-
+  const response = await apiAuthorizedFetch('/admin/marketing/r2/status', { headers: { Accept: 'application/json' } });
+  if (!response.ok) throw new Error(`R2 status request failed with HTTP ${response.status}`);
   return response.json() as Promise<MarketingR2Status>;
 }
 
-export async function uploadMarketingAssetsToR2(inputs: UploadAssetInput[]) {
-  if (inputs.length === 0) {
-    return { ok: true, assets: [] } satisfies UploadMarketingAssetsResponse;
+export async function validateMarketingMedia(urls: string[]) {
+  const response = await apiAuthorizedFetch('/admin/marketing/r2/validate', {
+    method: 'POST',
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    body: JSON.stringify({ urls }),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Media validation failed with HTTP ${response.status}: ${body}`);
   }
+  return response.json() as Promise<{ ok: boolean; assets: MarketingMediaValidation[] }>;
+}
 
+export async function uploadMarketingAssetsToR2(inputs: UploadAssetInput[]) {
+  if (inputs.length === 0) return { ok: true, assets: [] } satisfies UploadMarketingAssetsResponse;
   const uploadedAssets: UploadedMarketingAsset[] = [];
-
-  // The API intentionally accepts at most ten assets per request. Prepare and
-  // upload one batch at a time so a complete campaign (including carousels)
-  // does not create one enormous browser payload or exceed the API limit.
   for (let start = 0; start < inputs.length; start += R2_UPLOAD_BATCH_SIZE) {
     const batchInputs = inputs.slice(start, start + R2_UPLOAD_BATCH_SIZE);
     const assets = await Promise.all(batchInputs.map(prepareMarketingAsset));
     const batchNumber = Math.floor(start / R2_UPLOAD_BATCH_SIZE) + 1;
     const batchCount = Math.ceil(inputs.length / R2_UPLOAD_BATCH_SIZE);
-
     const response = await apiAuthorizedFetch('/admin/marketing/r2/assets', {
       method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
       body: JSON.stringify({ assets }),
     });
-
     if (!response.ok) {
       const body = await response.text();
-      throw new Error(
-        `R2 upload batch ${batchNumber}/${batchCount} failed with HTTP ${response.status}: ${body}`,
-      );
+      throw new Error(`R2 upload batch ${batchNumber}/${batchCount} failed with HTTP ${response.status}: ${body}`);
     }
-
     const result = await response.json() as UploadMarketingAssetsResponse;
     uploadedAssets.push(...result.assets);
   }
-
-  return {
-    ok: true,
-    assets: uploadedAssets,
-  } satisfies UploadMarketingAssetsResponse;
+  return { ok: true, assets: uploadedAssets } satisfies UploadMarketingAssetsResponse;
 }
 
 export function isMarketingAssetStoredOnR2(assetUrl: string, publicBaseUrl: string | null | undefined) {
   const normalizedBaseUrl = String(publicBaseUrl ?? '').trim().replace(/\/+$/, '');
-  if (!normalizedBaseUrl) {
-    return false;
-  }
-
-  return assetUrl.trim().startsWith(`${normalizedBaseUrl}/`);
+  return Boolean(normalizedBaseUrl && assetUrl.trim().startsWith(`${normalizedBaseUrl}/`));
 }
 
 async function prepareMarketingAsset({ asset, campaignCode, postId }: UploadAssetInput): Promise<PreparedMarketingAsset> {
-  const basePayload = {
-    key: buildMarketingAssetKey({
-      campaignCode,
-      postId,
-      file: asset.file,
-    }),
-  };
-
+  const basePayload = { key: buildMarketingAssetKey({ campaignCode, postId, file: asset.file }) };
   const sourceUrl = asset.sourceUrl || asset.url;
-
-  if (/^https?:\/\//i.test(sourceUrl)) {
-    return {
-      ...basePayload,
-      sourceUrl,
-    };
-  }
-
+  if (/^https?:\/\//i.test(sourceUrl)) return { ...basePayload, sourceUrl };
   const fetchedAsset = await fetchAssetAsBase64(sourceUrl);
-  return {
-    ...basePayload,
-    contentBase64: fetchedAsset.contentBase64,
-    contentType: fetchedAsset.contentType,
-  };
+  return { ...basePayload, contentBase64: fetchedAsset.contentBase64, contentType: fetchedAsset.contentType };
 }
 
 async function fetchAssetAsBase64(url: string) {
   const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Asset fetch failed with HTTP ${response.status}: ${url}`);
-  }
-
+  if (!response.ok) throw new Error(`Asset fetch failed with HTTP ${response.status}: ${url}`);
   const blob = await response.blob();
-  const contentType = blob.type || 'application/octet-stream';
-  const contentBase64 = await blobToBase64(blob);
-
-  return { contentBase64, contentType };
+  return { contentBase64: await blobToBase64(blob), contentType: blob.type || 'application/octet-stream' };
 }
 
 function blobToBase64(blob: Blob) {
@@ -168,9 +111,5 @@ function blobToBase64(blob: Blob) {
 }
 
 function toSafeSegment(value: string) {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]+/g, '-')
-    .replace(/^-+|-+$/g, '') || 'default';
+  return value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'default';
 }

--- a/apps/web/src/pages/admin2/MarketingPageV2.tsx
+++ b/apps/web/src/pages/admin2/MarketingPageV2.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState, type ChangeEvent } from 'react';
-import { Check, ChevronDown, ChevronUp, FileDown, ImagePlus, Pencil, RefreshCcwDot, RotateCcw, Save, Trash2, UploadCloud, X } from '../../lib/lucide-react';
-import { fetchMarketingCampaigns, updateMarketingCampaignPost, type MarketingAssetRecord, type MarketingCampaignRecord, type MarketingPostRecord } from '../../lib/marketingCampaigns';
+import { Check, ChevronDown, ChevronUp, FileDown, ImagePlus, Pencil, Save, Trash2, X } from '../../lib/lucide-react';
+import { fetchMarketingCampaigns, saveMarketingCampaignBulk, type MarketingAssetRecord, type MarketingCampaignRecord, type MarketingPostRecord } from '../../lib/marketingCampaigns';
 import { downloadMetricoolCalendarCsv } from '../../lib/marketingMetricoolCsv';
-import { buildMarketingAssetKey, fetchMarketingR2Status, isMarketingAssetStoredOnR2, uploadMarketingAssetsToR2, type MarketingR2Status } from '../../lib/marketingR2Assets';
+import { fetchMarketingR2Status, uploadMarketingAssetsToR2, validateMarketingMedia, type MarketingR2Status } from '../../lib/marketingR2Assets';
 import { fetchMarketingAnalyticsInsights, syncMarketingAnalytics, type MarketingAnalyticsInsights } from '../../lib/marketingAnalytics';
 import type { MarketingAsset, MarketingPostSeed } from '../../content/marketingAdminSeed';
 
@@ -19,24 +19,23 @@ export function MarketingPageV2() {
   const [posts, setPosts] = useState<EditablePost[]>([]);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [drafts, setDrafts] = useState<Record<string, EditablePost>>({});
+  const [dirtyIds, setDirtyIds] = useState<Set<string>>(() => new Set());
   const [loading, setLoading] = useState(true);
-  const [savingId, setSavingId] = useState<string | null>(null);
-  const [statusBusyId, setStatusBusyId] = useState<string | null>(null);
+  const [savingAll, setSavingAll] = useState(false);
+  const [exportingCsv, setExportingCsv] = useState(false);
   const [uploadingAssetId, setUploadingAssetId] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [r2Status, setR2Status] = useState<MarketingR2Status | null>(null);
-  const [uploading, setUploading] = useState(false);
   const [analytics, setAnalytics] = useState<MarketingAnalyticsInsights | null>(null);
   const [syncing, setSyncing] = useState(false);
 
-  const selectedCampaign = useMemo(() => campaigns.find((campaign) => campaign.campaignCode === selectedCampaignCode) ?? campaigns[0] ?? null, [campaigns, selectedCampaignCode]);
+  const selectedCampaign = useMemo(
+    () => campaigns.find((campaign) => campaign.campaignCode === selectedCampaignCode) ?? campaigns[0] ?? null,
+    [campaigns, selectedCampaignCode],
+  );
   const approvedPosts = useMemo(() => posts.filter((post) => post.status === 'approved'), [posts]);
   const needsReviewCount = useMemo(() => posts.filter((post) => post.status === 'needs_review').length, [posts]);
-  const approvedAssetCount = approvedPosts.reduce((sum, post) => sum + post.assets.length, 0);
-  const r2ReadyCount = approvedPosts.reduce((sum, post) => sum + post.assets.filter((asset) => isMarketingAssetStoredOnR2(asset.url, r2Status?.publicBaseUrl)).length, 0);
-  const csvReady = approvedPosts.length > 0 && approvedAssetCount > 0 && approvedAssetCount === r2ReadyCount;
 
   useEffect(() => { void loadCampaigns(); void loadSecondaryData(); }, []);
   useEffect(() => {
@@ -44,7 +43,7 @@ export function MarketingPageV2() {
     setPosts(selectedCampaign.posts.map(mapPost));
     setExpandedIds(new Set());
     setEditingId(null);
-    setDrafts({});
+    setDirtyIds(new Set());
   }, [selectedCampaignCode]);
 
   async function loadCampaigns() {
@@ -68,84 +67,52 @@ export function MarketingPageV2() {
     if (analyticsResult.status === 'fulfilled') setAnalytics(analyticsResult.value);
   }
 
-  function beginEdit(post: EditablePost) {
-    setDrafts((current) => ({ ...current, [post.id]: clonePost(post) }));
-    setEditingId(post.id);
-    setExpandedIds((current) => new Set(current).add(post.id));
-    setMessage(null);
-    setError(null);
+  function markDirty(postId: string) {
+    setDirtyIds((current) => new Set(current).add(postId));
   }
 
-  function cancelEdit(postId: string) {
-    setDrafts((current) => { const next = { ...current }; delete next[postId]; return next; });
-    setEditingId(null);
+  function updatePost(postId: string, updater: (post: EditablePost) => EditablePost) {
+    setPosts((current) => current.map((post) => post.id === postId ? updater(post) : post));
+    markDirty(postId);
     setMessage(null);
     setError(null);
-  }
-
-  function updateDraft(postId: string, updater: (post: EditablePost) => EditablePost) {
-    setDrafts((current) => {
-      const source = current[postId] ?? posts.find((post) => post.id === postId);
-      return source ? { ...current, [postId]: updater(source) } : current;
-    });
   }
 
   function removeAsset(postId: string, assetIndex: number) {
-    const source = drafts[postId] ?? posts.find((post) => post.id === postId);
-    if (!source) return;
-    if (source.assets.length <= 1) {
-      setError('A post must keep at least one image. Add the replacement first, then remove the old image.');
+    const post = posts.find((item) => item.id === postId);
+    if (!post) return;
+    if (post.assets.length <= 1) {
+      setError('A post must keep at least one image. Add the replacement first.');
       return;
     }
-    updateDraft(postId, (post) => ({ ...post, assets: post.assets.filter((_, index) => index !== assetIndex) }));
-    setMessage('Image removed from the draft. Press Save to confirm the carousel change.');
-    setError(null);
+    updatePost(postId, (item) => ({ ...item, assets: item.assets.filter((_, index) => index !== assetIndex) }));
   }
 
   async function addAsset(postId: string, file: File) {
-    const source = drafts[postId] ?? posts.find((post) => post.id === postId);
-    if (!source || !selectedCampaign) return;
-    if (!r2Status?.configured) {
-      setError('R2 must be configured before adding a new image.');
-      return;
-    }
-    if (!file.type.startsWith('image/')) {
-      setError('Choose an image file.');
-      return;
-    }
-    if (file.size > MAX_UPLOAD_BYTES) {
-      setError('The image is larger than 12 MB.');
-      return;
-    }
-    if (source.assets.length >= MAX_CAROUSEL_ASSETS) {
-      setError('Instagram carousels support a maximum of 10 images.');
-      return;
-    }
+    const post = posts.find((item) => item.id === postId);
+    if (!post || !selectedCampaign) return;
+    if (!r2Status?.configured) return setError('R2 must be configured before adding an image.');
+    if (!file.type.startsWith('image/')) return setError('Choose a PNG, JPEG or WebP image.');
+    if (file.size > MAX_UPLOAD_BYTES) return setError('The image is larger than 12 MB.');
+    if (post.assets.length >= MAX_CAROUSEL_ASSETS) return setError('Instagram carousels support a maximum of 10 images.');
 
     const objectUrl = URL.createObjectURL(file);
     const fileName = `${postId}-manual-${Date.now()}-${safeFileName(file.name)}`;
-    const temporaryAsset: MarketingAsset = {
-      file: fileName,
-      title: file.name.replace(/\.[^.]+$/, ''),
-      url: objectUrl,
-      previewUrl: objectUrl,
-    };
-
     setUploadingAssetId(postId);
     setError(null);
-    setMessage(null);
     try {
-      const result = await uploadMarketingAssetsToR2([{ asset: temporaryAsset, campaignCode: selectedCampaign.campaignCode, postId }]);
+      const result = await uploadMarketingAssetsToR2([{
+        asset: { file: fileName, title: file.name.replace(/\.[^.]+$/, ''), url: objectUrl, previewUrl: objectUrl },
+        campaignCode: selectedCampaign.campaignCode,
+        postId,
+      }]);
       const uploaded = result.assets[0];
       if (!uploaded) throw new Error('R2 did not return the uploaded image.');
-      const storedAsset: MarketingAsset = {
-        file: fileName,
-        title: temporaryAsset.title,
-        url: uploaded.url,
-        previewUrl: uploaded.url,
-      };
-      updateDraft(postId, (post) => ({ ...post, assets: [...post.assets, storedAsset] }));
-      setMessage(`${file.name} was uploaded to R2 and added to the draft. Press Save to confirm.`);
+      updatePost(postId, (item) => ({
+        ...item,
+        assets: [...item.assets, { file: fileName, title: file.name.replace(/\.[^.]+$/, ''), url: uploaded.url, previewUrl: uploaded.url }],
+      }));
+      setMessage('Image uploaded to R2. Save campaign to persist the new carousel.');
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : 'Unable to add image.');
     } finally {
@@ -154,44 +121,55 @@ export function MarketingPageV2() {
     }
   }
 
-  async function savePost(postId: string) {
-    const draft = drafts[postId];
-    if (!draft || !selectedCampaign) return;
-    setSavingId(postId);
-    setMessage(null);
+  async function persistPendingChanges() {
+    if (!selectedCampaign || dirtyIds.size === 0) return;
+    const changedPosts = posts.filter((post) => dirtyIds.has(post.id));
+    const result = await saveMarketingCampaignBulk(
+      selectedCampaign.campaignCode,
+      changedPosts.map((post) => ({ postCode: post.id, changes: toApiUpdate(post) })),
+    );
+    const savedByCode = new Map(result.posts.map((post) => [post.postCode, post]));
+    setCampaigns((current) => current.map((campaign) => campaign.campaignCode !== selectedCampaign.campaignCode ? campaign : {
+      ...campaign,
+      posts: campaign.posts.map((post) => savedByCode.get(post.postCode) ?? post),
+    }));
+    setDirtyIds(new Set());
+  }
+
+  async function saveCampaign() {
+    if (!dirtyIds.size) return setMessage('There are no pending changes.');
+    setSavingAll(true);
     setError(null);
     try {
-      await updateMarketingCampaignPost(selectedCampaign.campaignCode, postId, toApiUpdate(draft));
-      setPosts((current) => current.map((post) => post.id === postId ? clonePost(draft) : post));
-      setCampaigns((current) => current.map((campaign) => campaign.campaignCode === selectedCampaign.campaignCode ? { ...campaign, posts: campaign.posts.map((post) => post.postCode === postId ? mergeApiPost(post, draft) : post) } : campaign));
-      setDrafts((current) => ({ ...current, [postId]: clonePost(draft) }));
-      setMessage(`Saved ${postId}. Editing remains open.`);
+      const count = dirtyIds.size;
+      await persistPendingChanges();
+      setMessage(`Saved ${count} changed post${count === 1 ? '' : 's'} in one transaction.`);
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : 'Unable to save post.');
+      setError(cause instanceof Error ? cause.message : 'Unable to save campaign changes.');
     } finally {
-      setSavingId(null);
+      setSavingAll(false);
     }
   }
 
-  async function changeStatus(postId: string, status: EditablePost['status']) {
-    const currentPost = drafts[postId] ?? posts.find((post) => post.id === postId);
-    if (!currentPost || !selectedCampaign) return;
-    const previousStatus = currentPost.status;
-    const nextPost = { ...currentPost, status };
-    if (drafts[postId]) setDrafts((current) => ({ ...current, [postId]: nextPost }));
-    setPosts((current) => current.map((post) => post.id === postId ? { ...post, status } : post));
-    setStatusBusyId(postId);
+  async function exportCsv() {
+    if (!approvedPosts.length) return setError('Approve at least one post before exporting.');
+    setExportingCsv(true);
     setError(null);
     setMessage(null);
     try {
-      await updateMarketingCampaignPost(selectedCampaign.campaignCode, postId, { status });
-      setMessage(`${postId} marked ${statusLabels[status]}.`);
+      await persistPendingChanges();
+      const urls = approvedPosts.flatMap((post) => post.assets.map((asset) => asset.url)).filter(Boolean);
+      const validation = await validateMarketingMedia(urls);
+      const failures = validation.assets.filter((asset) => !asset.ok);
+      if (failures.length) {
+        throw new Error(`${failures.length} image${failures.length === 1 ? '' : 's'} failed public validation. Fix them before exporting.`);
+      }
+      downloadMetricoolCalendarCsv(approvedPosts);
+      setMessage(`Saved campaign, validated ${urls.length} images and generated the Metricool CSV.`);
     } catch (cause) {
-      if (drafts[postId]) setDrafts((current) => ({ ...current, [postId]: { ...nextPost, status: previousStatus } }));
-      setPosts((current) => current.map((post) => post.id === postId ? { ...post, status: previousStatus } : post));
-      setError(cause instanceof Error ? cause.message : 'Unable to update status.');
+      setError(cause instanceof Error ? cause.message : 'CSV export failed.');
     } finally {
-      setStatusBusyId(null);
+      setExportingCsv(false);
     }
   }
 
@@ -203,37 +181,10 @@ export function MarketingPageV2() {
     });
   }
 
-  async function uploadApproved() {
-    if (!selectedCampaign || !r2Status?.configured) return;
-    const inputs = approvedPosts.flatMap((post) => post.assets.filter((asset) => !isMarketingAssetStoredOnR2(asset.url, r2Status.publicBaseUrl)).map((asset) => ({ asset, campaignCode: selectedCampaign.campaignCode, postId: post.id })));
-    if (!inputs.length) { setMessage('All approved assets are already on R2.'); return; }
-    setUploading(true);
-    setError(null);
-    try {
-      const result = await uploadMarketingAssetsToR2(inputs);
-      const uploaded = new Map(result.assets.map((asset) => [asset.key, asset.url]));
-      const nextPosts = posts.map((post) => ({ ...post, assets: post.assets.map((asset) => {
-        const key = buildMarketingAssetKey({ campaignCode: selectedCampaign.campaignCode, postId: post.id, file: asset.file });
-        return uploaded.has(key) ? { ...asset, url: uploaded.get(key)!, previewUrl: uploaded.get(key)! } : asset;
-      }) }));
-      setPosts(nextPosts);
-      for (const post of nextPosts.filter((candidate) => candidate.status === 'approved')) await updateMarketingCampaignPost(selectedCampaign.campaignCode, post.id, toApiUpdate(post));
-      setMessage(`Uploaded ${result.assets.length} assets to R2.`);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : 'R2 upload failed.');
-    } finally {
-      setUploading(false);
-    }
-  }
-
   async function syncAnalytics() {
     setSyncing(true);
-    try {
-      await syncMarketingAnalytics();
-      setAnalytics(await fetchMarketingAnalyticsInsights());
-    } finally {
-      setSyncing(false);
-    }
+    try { await syncMarketingAnalytics(); setAnalytics(await fetchMarketingAnalyticsInsights()); }
+    finally { setSyncing(false); }
   }
 
   return <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 pb-16">
@@ -241,8 +192,8 @@ export function MarketingPageV2() {
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div><p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--admin-muted)]">Marketing operations</p><h2 className="mt-1 text-2xl font-semibold">Campaign review</h2></div>
         <div className="flex items-center gap-2">
-          <button className="admin2-btn admin2-btn--ghost inline-flex items-center gap-2" onClick={() => void loadCampaigns()} disabled={loading}><RefreshCcwDot className={loading ? 'animate-spin' : ''} size={16}/>{loading ? 'Loading' : 'Refresh'}</button>
-          <select value={selectedCampaignCode} onChange={(event) => setSelectedCampaignCode(event.target.value)} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-sm">{campaigns.map((campaign) => <option key={campaign.campaignCode} value={campaign.campaignCode}>{campaign.campaignCode}</option>)}</select>
+          <button className="admin2-btn admin2-btn--ghost" onClick={() => void loadCampaigns()} disabled={loading || dirtyIds.size > 0}>{loading ? <Spinner size="sm"/> : 'Refresh'}</button>
+          <select value={selectedCampaignCode} onChange={(event) => setSelectedCampaignCode(event.target.value)} disabled={dirtyIds.size > 0} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-sm">{campaigns.map((campaign) => <option key={campaign.campaignCode} value={campaign.campaignCode}>{campaign.campaignCode}</option>)}</select>
         </div>
       </div>
       <div className="mt-5 flex gap-2 border-b border-[color:var(--admin-border)]"><TabButton active={tab === 'posts'} onClick={() => setTab('posts')}>Posts & approval</TabButton><TabButton active={tab === 'insights'} onClick={() => setTab('insights')}>Insights & infrastructure</TabButton></div>
@@ -252,56 +203,56 @@ export function MarketingPageV2() {
 
     {loading ? <LoadingPanel/> : tab === 'posts' ? <>
       <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-        <Stat label="Posts" value={posts.length}/><Stat label="Approved" value={approvedPosts.length}/><Stat label="Needs review" value={needsReviewCount}/><Stat label="R2 assets" value={`${r2ReadyCount}/${approvedAssetCount}`}/>
-        <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4"><button className="admin2-btn admin2-btn--secondary inline-flex items-center gap-2" disabled={!r2Status?.configured || !approvedPosts.length || uploading} onClick={uploadApproved}>{uploading ? <RotateCcw className="animate-spin" size={16}/> : <UploadCloud size={16}/>} {uploading ? 'Uploading' : 'Upload R2'}</button><button className="admin2-btn admin2-btn--primary inline-flex items-center gap-2" disabled={!csvReady} onClick={() => downloadMetricoolCalendarCsv(approvedPosts)}><FileDown size={16}/>CSV</button></div>
+        <Stat label="Posts" value={posts.length}/><Stat label="Approved" value={approvedPosts.length}/><Stat label="Needs review" value={needsReviewCount}/><Stat label="Unsaved changes" value={dirtyIds.size}/>
+        <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4">
+          <button className="admin2-btn admin2-btn--secondary inline-flex items-center gap-2" disabled={!dirtyIds.size || savingAll || exportingCsv} onClick={() => void saveCampaign()}>{savingAll ? <Spinner size="sm"/> : <Save size={16}/>}Save campaign</button>
+          <button className="admin2-btn admin2-btn--primary inline-flex items-center gap-2" disabled={!approvedPosts.length || savingAll || exportingCsv} onClick={() => void exportCsv()}>{exportingCsv ? <Spinner size="sm"/> : <FileDown size={16}/>} {exportingCsv ? 'Checking media' : 'Export CSV'}</button>
+        </div>
       </section>
-      <section className="flex flex-col gap-4">{posts.map((post) => {
-        const editing = editingId === post.id;
-        const displayPost = editing ? drafts[post.id] ?? post : post;
-        return <ReviewCard key={post.id} post={displayPost} expanded={expandedIds.has(post.id)} editing={editing} saving={savingId === post.id} statusBusy={statusBusyId === post.id} uploadingAsset={uploadingAssetId === post.id} onToggle={() => toggleExpanded(post.id)} onEdit={() => beginEdit(post)} onCancel={() => cancelEdit(post.id)} onSave={() => void savePost(post.id)} onChange={(updater) => updateDraft(post.id, updater)} onStatus={(status) => void changeStatus(post.id, status)} onRemoveAsset={(index) => removeAsset(post.id, index)} onAddAsset={(file) => void addAsset(post.id, file)}/>;
-      })}</section>
+      <section className="flex flex-col gap-4">{posts.map((post) => <ReviewCard
+        key={post.id}
+        post={post}
+        expanded={expandedIds.has(post.id)}
+        editing={editingId === post.id}
+        dirty={dirtyIds.has(post.id)}
+        uploadingAsset={uploadingAssetId === post.id}
+        onToggle={() => toggleExpanded(post.id)}
+        onEdit={() => { setEditingId(post.id); setExpandedIds((current) => new Set(current).add(post.id)); }}
+        onDone={() => setEditingId(null)}
+        onChange={(updater) => updatePost(post.id, updater)}
+        onStatus={(status) => updatePost(post.id, (item) => ({ ...item, status }))}
+        onRemoveAsset={(index) => removeAsset(post.id, index)}
+        onAddAsset={(file) => void addAsset(post.id, file)}
+      />)}</section>
     </> : <InsightsPanel analytics={analytics} r2Status={r2Status} syncing={syncing} onSync={() => void syncAnalytics()} campaign={selectedCampaign}/>} 
   </div>;
 }
 
-function ReviewCard({ post, expanded, editing, saving, statusBusy, uploadingAsset, onToggle, onEdit, onCancel, onSave, onChange, onStatus, onRemoveAsset, onAddAsset }: { post: EditablePost; expanded: boolean; editing: boolean; saving: boolean; statusBusy: boolean; uploadingAsset: boolean; onToggle: () => void; onEdit: () => void; onCancel: () => void; onSave: () => void; onChange: (updater: (post: EditablePost) => EditablePost) => void; onStatus: (status: EditablePost['status']) => void; onRemoveAsset: (index: number) => void; onAddAsset: (file: File) => void; }) {
+function ReviewCard({ post, expanded, editing, dirty, uploadingAsset, onToggle, onEdit, onDone, onChange, onStatus, onRemoveAsset, onAddAsset }: { post: EditablePost; expanded: boolean; editing: boolean; dirty: boolean; uploadingAsset: boolean; onToggle: () => void; onEdit: () => void; onDone: () => void; onChange: (updater: (post: EditablePost) => EditablePost) => void; onStatus: (status: EditablePost['status']) => void; onRemoveAsset: (index: number) => void; onAddAsset: (file: File) => void; }) {
   const field = <K extends keyof EditablePost>(key: K, value: EditablePost[K]) => onChange((current) => ({ ...current, [key]: value }));
-  function handleFile(event: ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
-    event.target.value = '';
-    if (file) onAddAsset(file);
-  }
-
-  return <article className={`overflow-hidden rounded-2xl border bg-[color:var(--admin-surface)] transition ${post.status === 'approved' ? 'border-emerald-500/45 shadow-[0_0_0_1px_rgba(16,185,129,.08)]' : 'border-[color:var(--admin-border)]'}`}>
+  function handleFile(event: ChangeEvent<HTMLInputElement>) { const file = event.target.files?.[0]; event.target.value = ''; if (file) onAddAsset(file); }
+  return <article className={`overflow-hidden rounded-2xl border bg-[color:var(--admin-surface)] transition ${post.status === 'approved' ? 'border-emerald-500/45' : 'border-[color:var(--admin-border)]'}`}>
     <div className="flex flex-wrap items-center justify-between gap-3 bg-[color:var(--admin-surface-muted)] p-4">
       <div className="min-w-0 flex-1"><p className="text-sm font-semibold">{post.scheduledDate} {post.scheduledTime.slice(0,5)} · {post.platform}/{post.format}</p><p className="truncate text-sm text-[color:var(--admin-muted)]">{post.assets[0]?.title ?? post.id}</p></div>
-      <div className="flex items-center gap-2"><span className={`rounded-full border px-3 py-1 text-xs font-semibold transition ${statusBusy ? 'animate-pulse' : ''} ${statusClass(post.status)}`}>{statusBusy ? 'Updating…' : statusLabels[post.status]}</span>{editing ? <><button className="admin2-btn admin2-btn--primary inline-flex items-center gap-2" onClick={onSave} disabled={saving || uploadingAsset}>{saving ? <RotateCcw className="animate-spin" size={16}/> : <Save size={16}/>} {saving ? 'Saving' : 'Save'}</button><button className="admin2-btn admin2-btn--ghost" onClick={onCancel} disabled={saving || uploadingAsset}><X size={16}/></button></> : <button className="admin2-btn admin2-btn--ghost" onClick={onEdit}><Pencil size={16}/></button>}<button className="admin2-btn admin2-btn--ghost" onClick={onToggle}>{expanded ? <ChevronUp size={18}/> : <ChevronDown size={18}/>}</button></div>
+      <div className="flex items-center gap-2">{dirty ? <span className="rounded-full border border-blue-400/30 bg-blue-400/10 px-2 py-1 text-xs text-blue-200">Unsaved</span> : null}<span className={`rounded-full border px-3 py-1 text-xs font-semibold ${statusClass(post.status)}`}>{statusLabels[post.status]}</span>{editing ? <button className="admin2-btn admin2-btn--primary" onClick={onDone}><Check size={16}/>Done</button> : <button className="admin2-btn admin2-btn--ghost" onClick={onEdit}><Pencil size={16}/></button>}<button className="admin2-btn admin2-btn--ghost" onClick={onToggle}>{expanded ? <ChevronUp size={18}/> : <ChevronDown size={18}/>}</button></div>
     </div>
     {expanded ? <div className="space-y-5 p-4">
-      <div className="flex flex-wrap items-center justify-between gap-3"><div><p className="text-sm font-semibold">Carousel assets</p><p className="text-xs text-[color:var(--admin-muted)]">{post.assets.length}/{MAX_CAROUSEL_ASSETS} images · changes are confirmed with Save</p></div>{editing ? <label className={`admin2-btn admin2-btn--secondary inline-flex cursor-pointer items-center gap-2 ${uploadingAsset ? 'pointer-events-none opacity-60' : ''}`}>{uploadingAsset ? <RotateCcw className="animate-spin" size={16}/> : <ImagePlus size={16}/>} {uploadingAsset ? 'Uploading image' : 'Add image'}<input type="file" accept="image/png,image/jpeg,image/webp" className="sr-only" onChange={handleFile} disabled={uploadingAsset || post.assets.length >= MAX_CAROUSEL_ASSETS}/></label> : null}</div>
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">{post.assets.map((asset, index) => <figure key={`${asset.file}-${index}`} className="group relative overflow-hidden rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)]"><img src={asset.previewUrl || asset.url} alt={asset.title} className="aspect-square w-full object-cover"/>{editing ? <button type="button" title="Remove image" aria-label={`Remove ${asset.file}`} onClick={() => onRemoveAsset(index)} className="absolute right-2 top-2 inline-flex h-9 w-9 items-center justify-center rounded-full border border-red-300/30 bg-black/70 text-red-200 opacity-90 backdrop-blur transition hover:scale-105 hover:bg-red-500 hover:text-white"><Trash2 size={17}/></button> : null}<figcaption className="flex items-center justify-between gap-2 p-3 text-xs text-[color:var(--admin-muted)]"><span className="truncate">{asset.file}</span><span>{index + 1}/{post.assets.length}</span></figcaption></figure>)}</div>
-      <div className="grid gap-4 lg:grid-cols-[1.2fr_.8fr]"><label><span className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">Caption</span><textarea disabled={!editing} value={post.caption} onChange={(event) => field('caption', event.target.value)} rows={12} className="mt-2 w-full rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 text-sm disabled:opacity-80"/></label><div className="space-y-3"><div className="grid gap-2 sm:grid-cols-2"><input disabled={!editing} type="date" value={post.scheduledDate} onChange={(event) => field('scheduledDate', event.target.value)} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2"/><input disabled={!editing} type="time" value={post.scheduledTime.slice(0,5)} onChange={(event) => field('scheduledTime', `${event.target.value}:00`)} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2"/></div><label className="block"><span className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">Tracking URL</span><input disabled={!editing} value={post.trackingUrl} onChange={(event) => field('trackingUrl', event.target.value)} className="mt-2 w-full rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-xs"/></label><label className="block"><span className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">Hypothesis</span><textarea disabled={!editing} value={post.hypothesis} onChange={(event) => field('hypothesis', event.target.value)} rows={3} className="mt-2 w-full rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 text-sm"/></label></div></div>
-      <div className="flex flex-wrap gap-2 border-t border-[color:var(--admin-border)] pt-4"><button className="admin2-btn admin2-btn--secondary inline-flex items-center gap-2" disabled={statusBusy} onClick={() => onStatus('approved')}>{statusBusy ? <RotateCcw className="animate-spin" size={16}/> : <Check size={16}/>} {statusBusy ? 'Approving' : post.status === 'approved' ? 'Approved' : 'Approve'}</button><button className="admin2-btn admin2-btn--ghost" disabled={statusBusy} onClick={() => onStatus('needs_review')}>Needs review</button><button className="admin2-btn admin2-btn--ghost" disabled={statusBusy} onClick={() => onStatus('draft')}>Draft</button></div>
+      <div className="flex flex-wrap items-center justify-between gap-3"><div><p className="text-sm font-semibold">Carousel assets</p><p className="text-xs text-[color:var(--admin-muted)]">{post.assets.length}/{MAX_CAROUSEL_ASSETS} images</p></div>{editing ? <label className={`admin2-btn admin2-btn--secondary inline-flex cursor-pointer items-center gap-2 ${uploadingAsset ? 'pointer-events-none opacity-60' : ''}`}>{uploadingAsset ? <Spinner size="sm"/> : <ImagePlus size={16}/>} {uploadingAsset ? 'Uploading' : 'Add image'}<input type="file" accept="image/png,image/jpeg,image/webp" className="sr-only" onChange={handleFile} disabled={uploadingAsset || post.assets.length >= MAX_CAROUSEL_ASSETS}/></label> : null}</div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">{post.assets.map((asset, index) => <figure key={`${asset.file}-${index}`} className="group relative overflow-hidden rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)]"><img src={asset.previewUrl || asset.url} alt={asset.title} className="aspect-square w-full object-cover"/>{editing ? <button type="button" aria-label={`Remove ${asset.file}`} onClick={() => onRemoveAsset(index)} className="absolute right-2 top-2 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/70 text-red-200 hover:bg-red-500 hover:text-white"><Trash2 size={17}/></button> : null}<figcaption className="flex items-center justify-between gap-2 p-3 text-xs text-[color:var(--admin-muted)]"><span className="truncate">{asset.file}</span><span>{index + 1}/{post.assets.length}</span></figcaption></figure>)}</div>
+      <div className="grid gap-4 lg:grid-cols-[1.2fr_.8fr]"><label><span className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">Caption</span><textarea disabled={!editing} value={post.caption} onChange={(event) => field('caption', event.target.value)} rows={12} className="mt-2 w-full rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 text-sm disabled:opacity-80"/></label><div className="space-y-3"><div className="grid gap-2 sm:grid-cols-2"><input disabled={!editing} type="date" value={post.scheduledDate} onChange={(event) => field('scheduledDate', event.target.value)} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2"/><input disabled={!editing} type="time" value={post.scheduledTime.slice(0,5)} onChange={(event) => field('scheduledTime', `${event.target.value}:00`)} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2"/></div><input disabled={!editing} value={post.trackingUrl} onChange={(event) => field('trackingUrl', event.target.value)} className="w-full rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-xs"/><textarea disabled={!editing} value={post.hypothesis} onChange={(event) => field('hypothesis', event.target.value)} rows={3} className="w-full rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-3 text-sm"/></div></div>
+      <div className="flex flex-wrap gap-2 border-t border-[color:var(--admin-border)] pt-4"><button className="admin2-btn admin2-btn--secondary" onClick={() => onStatus('approved')}>Approve</button><button className="admin2-btn admin2-btn--ghost" onClick={() => onStatus('needs_review')}>Needs review</button><button className="admin2-btn admin2-btn--ghost" onClick={() => onStatus('draft')}>Draft</button></div>
     </div> : null}
   </article>;
 }
 
-function LoadingPanel() {
-  return <div className="flex min-h-[360px] items-center justify-center rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)]"><div className="flex flex-col items-center gap-3 text-center"><RotateCcw className="animate-spin text-[color:var(--admin-accent)]" size={30}/><div><p className="font-semibold">Loading campaign posts</p><p className="mt-1 text-sm text-[color:var(--admin-muted)]">Preparing images, statuses and review data…</p></div></div></div>;
-}
-
-function InsightsPanel({ analytics, r2Status, syncing, onSync, campaign }: { analytics: MarketingAnalyticsInsights | null; r2Status: MarketingR2Status | null; syncing: boolean; onSync: () => void; campaign: MarketingCampaignRecord | null; }) {
-  const totals = analytics?.summary?.totals;
-  return <div className="grid gap-4 lg:grid-cols-[1.2fr_.8fr]"><section className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5"><div className="flex items-center justify-between"><h3 className="text-lg font-semibold">Marketing insights</h3><button className="admin2-btn admin2-btn--secondary inline-flex items-center gap-2" disabled={syncing || !analytics?.configured} onClick={onSync}>{syncing ? <RotateCcw className="animate-spin" size={16}/> : <RefreshCcwDot size={16}/>} {syncing ? 'Syncing' : 'Sync data'}</button></div><div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3"><Stat label="Active users" value={totals?.activeUsers ?? 0}/><Stat label="Sessions" value={totals?.sessions ?? 0}/><Stat label="Page views" value={totals?.pageViews ?? 0}/><Stat label="Search clicks" value={totals?.searchClicks ?? 0}/><Stat label="Search impressions" value={totals?.searchImpressions ?? 0}/><Stat label="Registered users" value={analytics?.registeredUsers?.total ?? 0}/></div>{analytics?.summary?.highlights?.length ? <div className="mt-4 space-y-2">{analytics.summary.highlights.map((item) => <p key={item} className="rounded-xl bg-[color:var(--admin-surface-muted)] p-3 text-sm">{item}</p>)}</div> : null}</section><section className="space-y-4"><div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5"><h3 className="font-semibold">Infrastructure</h3><p className="mt-3 text-sm text-[color:var(--admin-muted)]">R2: {r2Status?.configured ? `Ready · ${r2Status.bucket}` : 'Pending'}</p><p className="mt-2 text-sm text-[color:var(--admin-muted)]">Analytics: {analytics?.configured ? 'Ready' : 'Pending'}</p></div><div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5"><h3 className="font-semibold">Campaign resources</h3><p className="mt-3 break-all text-sm text-[color:var(--admin-muted)]">{campaign?.campaignCode}</p></div></section></div>;
-}
-
+function Spinner({ size = 'md' }: { size?: 'sm' | 'md' }) { return <span aria-hidden="true" className={`${size === 'sm' ? 'h-4 w-4 border-2' : 'h-8 w-8 border-[3px]'} inline-block animate-spin rounded-full border-current border-r-transparent`}/>; }
+function LoadingPanel() { return <div className="flex min-h-[360px] items-center justify-center rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)]"><div className="flex flex-col items-center gap-3 text-center"><Spinner/><div><p className="font-semibold">Loading campaign posts</p><p className="mt-1 text-sm text-[color:var(--admin-muted)]">Preparing images and review data…</p></div></div></div>; }
+function InsightsPanel({ analytics, r2Status, syncing, onSync, campaign }: { analytics: MarketingAnalyticsInsights | null; r2Status: MarketingR2Status | null; syncing: boolean; onSync: () => void; campaign: MarketingCampaignRecord | null; }) { const totals = analytics?.summary?.totals; return <div className="grid gap-4 lg:grid-cols-[1.2fr_.8fr]"><section className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5"><div className="flex items-center justify-between"><h3 className="text-lg font-semibold">Marketing insights</h3><button className="admin2-btn admin2-btn--secondary inline-flex items-center gap-2" disabled={syncing || !analytics?.configured} onClick={onSync}>{syncing ? <Spinner size="sm"/> : null}{syncing ? 'Syncing' : 'Sync data'}</button></div><div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3"><Stat label="Active users" value={totals?.activeUsers ?? 0}/><Stat label="Sessions" value={totals?.sessions ?? 0}/><Stat label="Page views" value={totals?.pageViews ?? 0}/><Stat label="Search clicks" value={totals?.searchClicks ?? 0}/><Stat label="Search impressions" value={totals?.searchImpressions ?? 0}/><Stat label="Registered users" value={analytics?.registeredUsers?.total ?? 0}/></div></section><section className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5"><h3 className="font-semibold">Infrastructure</h3><p className="mt-3 text-sm text-[color:var(--admin-muted)]">R2: {r2Status?.configured ? `Ready · ${r2Status.bucket}` : 'Pending'}</p><p className="mt-2 text-sm text-[color:var(--admin-muted)]">Campaign: {campaign?.campaignCode}</p></section></div>; }
 function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: string }) { return <button type="button" onClick={onClick} className={`border-b-2 px-4 py-3 text-sm font-semibold ${active ? 'border-[color:var(--admin-accent)] text-[color:var(--admin-text)]' : 'border-transparent text-[color:var(--admin-muted)]'}`}>{children}</button>; }
 function Stat({ label, value }: { label: string; value: string | number }) { return <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4"><p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">{label}</p><p className="mt-2 text-2xl font-semibold">{value}</p></div>; }
 function statusClass(status: EditablePost['status']) { return status === 'approved' ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300' : status === 'needs_review' ? 'border-amber-500/40 bg-amber-500/10 text-amber-300' : 'border-[color:var(--admin-border)] text-[color:var(--admin-muted)]'; }
-function clonePost(post: EditablePost): EditablePost { return { ...post, assets: post.assets.map((asset) => ({ ...asset })) }; }
 function mapAsset(asset: MarketingAssetRecord): MarketingAsset { return { file: asset.file, title: asset.title, url: asset.url ?? '', previewUrl: asset.previewUrl ?? asset.url ?? '', sourceUrl: asset.sourceUrl }; }
-function mapPost(post: MarketingPostRecord): EditablePost { const [date = '', rawTime = '19:30:00'] = (post.scheduledAt ?? '').split('T'); const time = rawTime.slice(0,8) || '19:30:00'; return { id: post.postCode, number: post.postCode.replace(/^post_?/, '').padStart(3, '0'), platform: 'instagram', format: post.format === 'carousel' ? 'carousel' : 'static', status: post.status === 'approved' || post.status === 'draft' ? post.status : 'needs_review', scheduledDate: date, scheduledTime: time, hypothesis: post.hypothesis, metric: post.targetMetric, caption: post.caption, trackingUrl: post.trackingUrl, assets: post.assetUrls.map(mapAsset) }; }
-function toApiUpdate(post: EditablePost) { return { status: post.status, caption: post.caption, hypothesis: post.hypothesis, targetMetric: post.metric, trackingUrl: post.trackingUrl, scheduledAt: post.scheduledDate ? `${post.scheduledDate}T${post.scheduledTime.length === 5 ? `${post.scheduledTime}:00` : post.scheduledTime}+02:00` : null, assetUrls: post.assets.map((asset) => { const url = persistableUrl(asset.url); const previewUrl = persistableUrl(asset.previewUrl); const sourceUrl = persistableUrl(asset.sourceUrl); return { file: asset.file, title: asset.title, ...(url ? { url } : {}), ...(previewUrl ? { previewUrl } : {}), ...(sourceUrl ? { sourceUrl } : {}), selected: true }; }) }; }
-function mergeApiPost(post: MarketingPostRecord, draft: EditablePost): MarketingPostRecord { const update = toApiUpdate(draft); return { ...post, status: draft.status, caption: draft.caption, hypothesis: draft.hypothesis, targetMetric: draft.metric, trackingUrl: draft.trackingUrl, scheduledAt: update.scheduledAt, assetUrls: update.assetUrls }; }
+function mapPost(post: MarketingPostRecord): EditablePost { const [date = '', rawTime = '19:30:00'] = (post.scheduledAt ?? '').split('T'); return { id: post.postCode, number: post.postCode.replace(/^post_?/, '').padStart(3, '0'), platform: 'instagram', format: post.format === 'carousel' ? 'carousel' : 'static', status: post.status === 'approved' || post.status === 'draft' ? post.status : 'needs_review', scheduledDate: date, scheduledTime: rawTime.slice(0,8) || '19:30:00', hypothesis: post.hypothesis, metric: post.targetMetric, caption: post.caption, trackingUrl: post.trackingUrl, assets: post.assetUrls.map(mapAsset) }; }
+function toApiUpdate(post: EditablePost) { return { status: post.status, caption: post.caption, hypothesis: post.hypothesis, targetMetric: post.metric, trackingUrl: post.trackingUrl, scheduledAt: post.scheduledDate ? `${post.scheduledDate}T${post.scheduledTime.length === 5 ? `${post.scheduledTime}:00` : post.scheduledTime}+02:00` : null, assetUrls: post.assets.map((asset) => ({ file: asset.file, title: asset.title, ...(persistableUrl(asset.url) ? { url: persistableUrl(asset.url) } : {}), ...(persistableUrl(asset.previewUrl) ? { previewUrl: persistableUrl(asset.previewUrl) } : {}), ...(persistableUrl(asset.sourceUrl) ? { sourceUrl: persistableUrl(asset.sourceUrl) } : {}), selected: true })) }; }
 function persistableUrl(value: string | undefined) { const normalized = String(value ?? '').trim(); return /^https?:\/\//i.test(normalized) && normalized.length <= 2000 ? normalized : undefined; }
 function safeFileName(value: string) { return value.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'image.png'; }


### PR DESCRIPTION
## Objetivo
Cerrar el nuevo flujo R2 → Neon → Admin reduciendo botones y evitando una llamada a Neon por cada edición o aprobación.

## Cambios de UX
- elimina el botón general **Upload R2**;
- las imágenes generadas por GitHub Actions ya llegan verificadas desde R2;
- **Add image** sigue subiendo inmediatamente únicamente archivos manuales, para poder previsualizarlos sin perderlos;
- reemplaza los iconos de flecha giratoria por un spinner circular moderno;
- muestra un contador de cambios pendientes y un chip `Unsaved` por post;
- bloquea cambiar de campaña o refrescar mientras haya cambios pendientes.

## Persistencia
- editar copy, fecha, horario, estado o slides modifica solo el estado local del navegador;
- aprobar, marcar draft o needs_review no llama inmediatamente a Neon;
- **Save campaign** guarda todos los posts modificados mediante una sola petición;
- el backend aplica todos los cambios dentro de una sola transacción PostgreSQL;
- si falla un post, se hace rollback completo y la campaña no queda parcialmente guardada.

## Export CSV
El botón **Export CSV** ejecuta en este orden:
1. guarda todos los cambios pendientes en una sola transacción;
2. valida públicamente todas las imágenes de los posts aprobados;
3. exige HTTP válido y contenido de imagen mediante el validador existente;
4. descarga el CSV únicamente si todas pasan.

## Compatibilidad
- no modifica renderer, layouts, campaña de julio ni el workflow de generación;
- conserva el endpoint PATCH individual para compatibilidad con otras pantallas;
- agrega un endpoint bulk específico para el nuevo Admin;
- no elimina objetos de R2 cuando se quita una slide: solo elimina su referencia del post.

## Prueba posterior
Después del merge se debe ejecutar una campaña de prueba separada con un código nuevo y 1–2 posts. No reutilizar `ib_202607`.