### PR TITLE
Automate validated CMO strategy handoff to Head of Content

### DIFF
--- a/.github/workflows/marketing-content-context.yml
+++ b/.github/workflows/marketing-content-context.yml
@@ -1,17 +1,17 @@
 name: Generate Head of Content context
 
 on:
+  push:
+    branches:
+      - "automation/marketing-cycle-*"
+    paths:
+      - "marketing/agent-outputs/*/cmo-strategy.json"
   workflow_dispatch:
     inputs:
       period_key:
-        description: Approved CMO strategy period in YYYY-MM format
+        description: CMO strategy period in YYYY-MM format
         required: true
         type: string
-      approve_strategy:
-        description: I reviewed and approve the CMO strategy for campaign development
-        required: true
-        default: false
-        type: boolean
       force:
         description: Rebuild content-context.json when it already exists
         required: false
@@ -22,7 +22,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: marketing-content-context-${{ github.event.inputs.period_key }}
+  group: marketing-content-context-${{ github.ref_name }}-${{ github.event.inputs.period_key || github.sha }}
   cancel-in-progress: false
 
 jobs:
@@ -41,47 +41,77 @@ jobs:
         with:
           node-version: 24
 
-      - name: Validate approval and period
+      - name: Resolve and validate period
         id: period
         shell: bash
         env:
-          PERIOD_KEY: ${{ github.event.inputs.period_key }}
-          APPROVED: ${{ github.event.inputs.approve_strategy }}
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_SHA: ${{ github.sha }}
+          PUSH_BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            period_key="${MANUAL_PERIOD_KEY}"
+          else
+            mapfile -t strategy_paths < <(
+              git diff --name-only "${PUSH_BEFORE}" "${PUSH_SHA}" -- \
+                'marketing/agent-outputs/*/cmo-strategy.json' \
+              | grep -E '^marketing/agent-outputs/[0-9]{4}-(0[1-9]|1[0-2])/cmo-strategy\.json$' \
+              | sort -u
+            )
+            if [[ "${#strategy_paths[@]}" -ne 1 ]]; then
+              echo "Expected exactly one changed monthly cmo-strategy.json; found ${#strategy_paths[@]}." >&2
+              printf '%s\n' "${strategy_paths[@]:-}" >&2
+              exit 1
+            fi
+            period_key="$(sed -E 's#^marketing/agent-outputs/([^/]+)/cmo-strategy\.json$#\1#' <<< "${strategy_paths[0]}")"
+            expected_branch="automation/marketing-cycle-${period_key}"
+            if [[ "${PUSH_BRANCH}" != "${expected_branch}" ]]; then
+              echo "Strategy period ${period_key} does not match branch ${PUSH_BRANCH}." >&2
+              exit 1
+            fi
+          fi
+
           node -e '
             const value = process.argv[1];
             const match = /^(\d{4})-(\d{2})$/.exec(value);
             if (!match || Number(match[2]) < 1 || Number(match[2]) > 12) process.exit(1);
-          ' "${PERIOD_KEY}"
-          if [[ "${APPROVED}" != "true" ]]; then
-            echo "Strategy approval must be confirmed." >&2
-            exit 1
-          fi
-          echo "branch=automation/marketing-cycle-${PERIOD_KEY}" >> "${GITHUB_OUTPUT}"
-          echo "output_path=marketing/agent-inputs/${PERIOD_KEY}/content-context.json" >> "${GITHUB_OUTPUT}"
+          ' "${period_key}"
+
+          echo "period_key=${period_key}" >> "${GITHUB_OUTPUT}"
+          echo "branch=automation/marketing-cycle-${period_key}" >> "${GITHUB_OUTPUT}"
+          echo "output_path=marketing/agent-inputs/${period_key}/content-context.json" >> "${GITHUB_OUTPUT}"
 
       - name: Check out monthly marketing branch
         shell: bash
         env:
+          EVENT_NAME: ${{ github.event_name }}
           CYCLE_BRANCH: ${{ steps.period.outputs.branch }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin main --prune
-          if ! git ls-remote --exit-code --heads origin "${CYCLE_BRANCH}" >/dev/null 2>&1; then
-            echo "Monthly branch ${CYCLE_BRANCH} does not exist." >&2
-            exit 1
-          fi
-          git fetch origin "${CYCLE_BRANCH}:${CYCLE_BRANCH}"
-          git checkout "${CYCLE_BRANCH}"
-          git merge --no-edit origin/main
 
-      - name: Verify approved strategy inputs
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            git fetch origin main --prune
+            if ! git ls-remote --exit-code --heads origin "${CYCLE_BRANCH}" >/dev/null 2>&1; then
+              echo "Monthly branch ${CYCLE_BRANCH} does not exist." >&2
+              exit 1
+            fi
+            git fetch origin "${CYCLE_BRANCH}:${CYCLE_BRANCH}"
+            git checkout "${CYCLE_BRANCH}"
+            git merge --no-edit origin/main
+          else
+            git checkout -B "${CYCLE_BRANCH}" "${GITHUB_SHA}"
+          fi
+
+      - name: Verify strategy inputs
         shell: bash
         env:
-          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
         run: |
           set -euo pipefail
           test -s "marketing/agent-inputs/${PERIOD_KEY}/cmo-context.json"
@@ -93,9 +123,17 @@ jobs:
       - name: Typecheck API
         run: npm -w @innerbloom/api run typecheck
 
+      - name: Validate CMO context
+        env:
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-agent-json.ts
+          --schema=prompts/marketing/agent-system/schemas/cmo-input-v1.schema.json
+          --input="marketing/agent-inputs/${PERIOD_KEY}/cmo-context.json"
+
       - name: Validate CMO strategy
         env:
-          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
         run: >-
           npx tsx apps/api/scripts/validate-marketing-agent-json.ts
           --schema=prompts/marketing/agent-system/schemas/cmo-output-v1.schema.json
@@ -104,12 +142,13 @@ jobs:
       - name: Generate Head of Content context
         shell: bash
         env:
-          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
+          EVENT_NAME: ${{ github.event_name }}
           FORCE_INPUT: ${{ github.event.inputs.force }}
         run: |
           set -euo pipefail
-          args=(--period="${PERIOD_KEY}" --approve-strategy)
-          if [[ "${FORCE_INPUT}" == "true" ]]; then args+=(--force); fi
+          args=(--period="${PERIOD_KEY}")
+          if [[ "${EVENT_NAME}" == "push" || "${FORCE_INPUT}" == "true" ]]; then args+=(--force); fi
           npx tsx apps/api/scripts/export-marketing-content-context.ts "${args[@]}"
 
       - name: Validate Head of Content context
@@ -123,7 +162,7 @@ jobs:
       - name: Commit and push monthly branch
         shell: bash
         env:
-          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
           CYCLE_BRANCH: ${{ steps.period.outputs.branch }}
           OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
         run: |
@@ -134,14 +173,14 @@ jobs:
           if git diff --cached --quiet; then
             echo "The validated content context is unchanged."
           else
-            git commit -m "chore(marketing): approve strategy and generate content context for ${PERIOD_KEY}"
+            git commit -m "chore(marketing): generate validated content context for ${PERIOD_KEY}"
+            git push origin "HEAD:${CYCLE_BRANCH}"
           fi
-          git push origin "${CYCLE_BRANCH}"
 
       - name: Upload content context artifact
         uses: actions/upload-artifact@v4
         with:
-          name: marketing-content-context-${{ github.event.inputs.period_key }}
+          name: marketing-content-context-${{ steps.period.outputs.period_key }}
           path: ${{ steps.period.outputs.output_path }}
           if-no-files-found: error
           retention-days: 30
@@ -149,7 +188,7 @@ jobs:
       - name: Report next step
         shell: bash
         env:
-          PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
           CYCLE_BRANCH: ${{ steps.period.outputs.branch }}
           OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
         run: |
@@ -158,7 +197,9 @@ jobs:
             echo "- Period: \`${PERIOD_KEY}\`"
             echo "- Branch: \`${CYCLE_BRANCH}\`"
             echo "- Input: \`${OUTPUT_PATH}\`"
-            echo "- CMO strategy approval: confirmed by workflow dispatch"
-            echo "- Validation: passed"
-            echo "- Next step: run the Head of Content agent on the same branch"
+            echo "- Handoff authority: \`automated_marketing_pipeline\`"
+            echo "- CMO context validation: passed"
+            echo "- CMO strategy validation: passed"
+            echo "- Head of Content input validation: passed"
+            echo "- Next step: the scheduled Head of Content agent may process this input"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/Docs/marketing/content-context-builder.md
+++ b/Docs/marketing/content-context-builder.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The builder converts an approved monthly CMO strategy and its original CMO context into the deterministic input for the Head of Content agent.
+The builder converts a validated monthly CMO strategy and its original CMO context into the deterministic input for the Head of Content agent.
 
 Output:
 
@@ -10,17 +10,19 @@ Output:
 
 It does not execute the Head of Content agent, generate campaign posts, upload assets, write to Neon, or publish content.
 
-## Human approval model
+## Automated handoff model
 
-The CMO strategy remains `review_status: draft` in its source artifact. Human approval is recorded by manually running the `Generate Head of Content context` workflow and checking the approval confirmation input.
+Human approval is not required between the CMO and Head of Content during the routine monthly pipeline.
 
-The generated Head of Content input contains:
+The builder accepts a CMO strategy only after both source artifacts exist, match the same period, and validate against their schemas. The generated Head of Content input records:
 
-- `strategy.review_status: approved`;
+- `strategy.handoff_status: validated`;
+- `strategy.handoff_authority: automated_marketing_pipeline`;
 - the complete original CMO output under `strategy.cmo_output`;
-- a source-manifest entry for the workflow-dispatch approval.
+- SHA-256 checksums for `cmo-context.json` and `cmo-strategy.json`;
+- a source-manifest entry for the automated pipeline handoff.
 
-The source strategy is never modified automatically.
+The immutable source strategy is never rewritten or automatically marked approved. Its original `review_status` is preserved as evidence.
 
 ## CLI
 
@@ -29,7 +31,6 @@ From the repository root:
 ```bash
 npx tsx apps/api/scripts/export-marketing-content-context.ts \
   --period=2026-07 \
-  --approve-strategy \
   --force
 ```
 
@@ -38,7 +39,7 @@ Required inputs:
 - `marketing/agent-inputs/<PERIOD>/cmo-context.json`
 - `marketing/agent-outputs/<PERIOD>/cmo-strategy.json`
 
-The CLI refuses to run without `--approve-strategy`.
+The CLI fails closed when an input is missing, malformed, belongs to another period, or has an ineligible CMO review status.
 
 ## GitHub Actions
 
@@ -46,24 +47,20 @@ Workflow:
 
 `.github/workflows/marketing-content-context.yml`
 
-Manual flow:
+Normal automatic flow:
 
-1. Open **Actions**.
-2. Select **Generate Head of Content context**.
-3. Enter the approved strategy period.
-4. Check the strategy-approval confirmation.
-5. Run the workflow.
+1. Codex commits `marketing/agent-outputs/<PERIOD>/cmo-strategy.json` to `automation/marketing-cycle-<PERIOD>`.
+2. The path-filtered GitHub workflow starts automatically.
+3. It derives the period from the changed path and requires it to match the branch name.
+4. It validates `cmo-context.json` and `cmo-strategy.json`.
+5. It generates and validates `content-context.json`.
+6. It commits and pushes the file to the same monthly branch.
 
-The workflow:
+Manual recovery remains available through `workflow_dispatch` with `period_key` and optional `force`. It does not represent human strategy approval; it only reruns the deterministic handoff.
 
-1. checks out `automation/marketing-cycle-<PERIOD>`;
-2. merges the current `main` into the monthly branch;
-3. validates the CMO strategy;
-4. generates and validates `content-context.json`;
-5. commits and pushes the file to the same monthly branch;
-6. does not open or merge a pull request.
+The workflow does not open or merge a pull request.
 
-The monthly branch is then ready for Codex Head of Content.
+The monthly branch is then ready for the scheduled Codex Head of Content agent.
 
 ## Derived configuration
 
@@ -77,8 +74,11 @@ The monthly branch is then ready for Codex Head of Content.
 
 ## Safety
 
-- The builder does not invent analytics or assets.
+- The builder does not invent analytics, assets, strategy decisions, or approval state.
 - The source strategy and CMO context are read-only.
-- Human approval is mandatory.
+- Both source documents must validate before the handoff.
+- Period and branch identity must agree.
+- Input checksums are recorded for traceability and later idempotency.
 - The output is validated against `head-of-content-input-v1.schema.json` before it is committed.
+- Human review remains mandatory in Admin before publication.
 - No PR to `main` is opened at this stage.

--- a/apps/api/scripts/export-marketing-content-context.ts
+++ b/apps/api/scripts/export-marketing-content-context.ts
@@ -24,8 +24,7 @@ async function loadJson(path: string): Promise<{ raw: string; value: any }> {
 async function main(): Promise<void> {
   const period = readArg('period');
   const force = hasFlag('force');
-  if (!period || !/^\d{4}-(0[1-9]|1[0-2])$/.test(period)) throw new Error('Usage: --period=YYYY-MM --approve-strategy [--force]');
-  if (!hasFlag('approve-strategy')) throw new Error('Explicit human approval is required');
+  if (!period || !/^\d{4}-(0[1-9]|1[0-2])$/.test(period)) throw new Error('Usage: --period=YYYY-MM [--force]');
 
   const root = process.cwd();
   const contextPath = resolve(root, `marketing/agent-inputs/${period}/cmo-context.json`);
@@ -46,8 +45,10 @@ async function main(): Promise<void> {
   ]);
 
   if (context?.period?.current_period !== period || strategy?.period !== period) throw new Error('Period mismatch');
-  if (!['draft', 'approved'].includes(strategy?.review_status)) throw new Error('Strategy is not eligible for approval');
+  if (!['draft', 'approved'].includes(strategy?.review_status)) throw new Error('CMO strategy is not eligible for the validated pipeline handoff');
 
+  const contextChecksum = sha256(contextRaw);
+  const strategyChecksum = sha256(strategyRaw);
   const campaignCode = `ib_${period.replace('-', '')}`;
   const supported = context.operational_constraints?.supported_formats ?? [];
   const formats = supported.map((value: string) => value.includes('carousel') ? 'carousel' : value.includes('static') ? 'static' : value);
@@ -65,11 +66,14 @@ async function main(): Promise<void> {
       publishing_end_date: monthEnd(period),
     },
     strategy: {
-      review_status: 'approved',
-      approval_authority: 'human_workflow_dispatch',
-      approval_recorded_at: now,
+      handoff_status: 'validated',
+      handoff_authority: 'automated_marketing_pipeline',
+      handoff_recorded_at: now,
       original_cmo_review_status: strategy.review_status,
+      cmo_context_path: `marketing/agent-inputs/${period}/cmo-context.json`,
+      cmo_context_checksum: contextChecksum,
       cmo_output_path: `marketing/agent-outputs/${period}/cmo-strategy.json`,
+      cmo_output_checksum: strategyChecksum,
       cmo_output: strategy,
     },
     brand: {
@@ -77,7 +81,7 @@ async function main(): Promise<void> {
       positioning: context.strategy_memory?.current_positioning ?? [],
       content_rules: context.strategy_memory?.content_rules ?? [],
       language: context.strategy_memory?.campaign_defaults?.default_language ?? 'English',
-      human_approval: true,
+      human_approval: false,
     },
     product_context: {
       stage: context.business_context?.product_stage,
@@ -106,9 +110,9 @@ async function main(): Promise<void> {
     },
     source_manifest: [
       ...(Array.isArray(context.source_manifest) ? context.source_manifest : []),
-      { source_type: 'repo_file', source_path_or_id: `marketing/agent-inputs/${period}/cmo-context.json`, captured_at: now, checksum: sha256(contextRaw) },
-      { source_type: 'approved_strategy', source_path_or_id: `marketing/agent-outputs/${period}/cmo-strategy.json`, captured_at: now, checksum: sha256(strategyRaw) },
-      { source_type: 'human_approval', source_path_or_id: 'workflow_dispatch:approve_strategy', captured_at: now, checksum: sha256(`${period}:${campaignCode}:approved`) },
+      { source_type: 'repo_file', source_path_or_id: `marketing/agent-inputs/${period}/cmo-context.json`, captured_at: now, checksum: contextChecksum },
+      { source_type: 'cmo_strategy', source_path_or_id: `marketing/agent-outputs/${period}/cmo-strategy.json`, captured_at: now, checksum: strategyChecksum },
+      { source_type: 'pipeline_handoff', source_path_or_id: 'automated_marketing_pipeline:cmo_to_head_of_content', captured_at: now, checksum: sha256(`${period}:${campaignCode}:${contextChecksum}:${strategyChecksum}`) },
     ],
   };
 
@@ -116,7 +120,7 @@ async function main(): Promise<void> {
   const tempPath = `${outputPath}.tmp`;
   await writeFile(tempPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
   await rename(tempPath, outputPath);
-  console.log(JSON.stringify({ status: 'written', outputPath, period, campaignCode }, null, 2));
+  console.log(JSON.stringify({ status: 'written', outputPath, period, campaignCode, contextChecksum, strategyChecksum }, null, 2));
 }
 
 main().catch((error: unknown) => {

--- a/prompts/marketing/agent-system/head-of-content/AGENTS.md
+++ b/prompts/marketing/agent-system/head-of-content/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This agent converts one human-approved CMO strategy into a complete campaign draft for human review.
+This agent converts one validated CMO strategy handoff into a complete campaign draft for later creative direction and human review.
 
 It does not redefine strategy, approve content, produce binary assets, upload assets, import records into Neon, upload to R2, publish to Metricool, or modify application code.
 
@@ -26,20 +26,21 @@ Input for period `<YYYY-MM>`:
 Original CMO strategy:
 `marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json`
 
-Required output:
+Temporary required output until Phase 3 migrates the filename:
 `marketing/agent-outputs/<YYYY-MM>/campaign.json`
 
-## Approval authority
+## Handoff authority
 
-The authoritative approval checkpoint is the outer strategy wrapper in `content-context.json`:
+The authoritative handoff checkpoint is the strategy wrapper in `content-context.json`:
 
-- `strategy.review_status` must equal `approved`;
-- `strategy.approval_authority` must equal `human_workflow_dispatch`;
-- `strategy.approval_recorded_at` must be present.
+- `strategy.handoff_status` must equal `validated`;
+- `strategy.handoff_authority` must equal `automated_marketing_pipeline`;
+- `strategy.handoff_recorded_at` must be present;
+- `strategy.cmo_context_checksum` and `strategy.cmo_output_checksum` must be valid SHA-256 references.
 
-The original CMO artifact remains immutable evidence and may still contain `review_status: draft`. Do not edit or approve it.
+The original CMO artifact remains immutable evidence and may contain `review_status: draft` or `review_status: approved`. Do not edit or approve it.
 
-If the outer wrapper is invalid, stop and write `campaign-failure.json`.
+If the handoff wrapper is invalid, stop and write `campaign-failure.json`.
 
 ## Preconditions
 
@@ -47,7 +48,8 @@ Do not execute unless:
 
 - `content-context.json` exists and validates;
 - the embedded CMO strategy validates;
-- the outer approval wrapper is valid;
+- the validated pipeline handoff wrapper is valid;
+- the recorded context and strategy paths match the target period;
 - period, campaign code, dates, tracking, product context, formats, and asset context are present;
 - the canonical visual system can be read.
 
@@ -63,13 +65,13 @@ Do not execute unless:
 8. Produce useful but non-prescriptive visual briefs.
 9. Set campaign status to `review` and every post status to `needs_review`.
 10. Validate schema and business rules.
-11. Write `campaign.json` and stop.
+11. Write the configured campaign draft artifact and stop.
 
 ## Strategy fidelity
 
-- The approved CMO strategy is the strategic source of truth.
+- The validated CMO strategy is the strategic source of truth.
 - Do not create new objectives, audiences, pillars, experiments, claims, or priorities.
-- Every post must map to an approved pillar and experiment.
+- Every post must map to an approved strategy pillar and experiment.
 - Creative choices may elaborate but not contradict strategy.
 - Do not turn weak evidence into factual claims.
 
@@ -79,8 +81,8 @@ Do not execute unless:
 - Hooks are specific and free of false clickbait.
 - Captions develop one central idea using supported product claims.
 - Avoid duplicate messages with superficial wording changes.
-- Follow the approved funnel distribution.
-- Use only approved CTAs and destinations.
+- Follow the strategy funnel distribution.
+- Use only supported CTAs and destinations.
 - Respect the configured language.
 - Do not use emojis or hashtags unless explicitly authorised.
 - Avoid guilt, shame, medical framing, guaranteed outcomes, fabricated urgency, and generic motivational filler.
@@ -123,48 +125,16 @@ Priority order:
 5. simple branded compositions;
 6. net-new generation only when current assets cannot satisfy the idea.
 
-Historical campaign assets are not templates. They may be mentioned only as loose references when still compatible with the canonical visual system.
-
-Do not place obsolete campaign asset IDs into `preferred_asset_ids` or `reference_assets` simply because they exist.
-
-Prefer semantic references such as:
-
-- `daily_energy_dark`;
-- `daily_energy_light`;
-- `tasks_dark`;
-- `tasks_light`;
-- `dquest_dark`;
-- `dashboard_dark`;
-- `dashboard_light`;
-- `emotion_chart_dark`;
-- `rhythm_selection_light`;
-- `approved_full_logo`;
-- `approved_lotus_icon`.
-
-Use exact Drive IDs only when the input positively identifies a current approved source.
+Historical campaign assets are not templates. Use exact source identifiers only when the input positively identifies a current approved source.
 
 ## Supported asset tasks
 
-- `reuse_existing_asset`: use an approved current asset unchanged;
-- `edit_existing_asset`: crop, reframe, zoom, resize, highlight, annotate, mask, dim, or add approved branding to one current source;
-- `compose_existing_assets`: combine approved current assets;
-- `generate_new_asset`: create a new visual only when current assets cannot satisfy the brief.
+- `reuse_existing_asset`;
+- `edit_existing_asset`;
+- `compose_existing_assets`;
+- `generate_new_asset` only when current assets cannot satisfy the brief.
 
-For every edited or composite asset include:
-
-- current source reference;
-- task type;
-- focal region;
-- overlays, annotations, or text to add;
-- elements that must remain unchanged;
-- target dimensions and format;
-- truthfulness constraints;
-- accessibility guidance;
-- acceptance criteria.
-
-The agent plans production but does not claim a binary has been created.
-
-Every future production task must have a matching `asset_generation_queue` item.
+The agent plans production but does not claim a binary has been created. Every future production task must have a matching `asset_generation_queue` item.
 
 ## Visual diversity rules
 
@@ -183,13 +153,13 @@ Across the campaign:
 - `utm_campaign` equals the configured campaign code.
 - `utm_content` equals `post_code`.
 - `ib_post` and tracking URLs are unique.
-- Never invent an unapproved destination route.
+- Never invent an unsupported destination route.
 - Non-traffic CTAs may use a null destination but still require a CTA object.
 
 ## Allowed writes
 
-- `marketing/agent-outputs/<YYYY-MM>/campaign.json`
-- `marketing/agent-outputs/<YYYY-MM>/campaign-failure.json` only when legitimately blocked
+- `marketing/agent-outputs/<YYYY-MM>/campaign.json` until Phase 3 migrates the draft filename;
+- `marketing/agent-outputs/<YYYY-MM>/campaign-failure.json` only when legitimately blocked.
 
 Everything else is read-only.
 
@@ -214,7 +184,7 @@ Before writing a successful campaign verify:
 - post codes and sequence numbers are unique and contiguous;
 - scheduled dates are inside the publishing window;
 - campaign is `review` and every post is `needs_review`;
-- all pillars and experiments exist in the approved strategy;
+- all pillars and experiments exist in the validated strategy;
 - pillar, format, and funnel distributions match totals;
 - every post has hypothesis, metric, visual brief, and accessibility guidance;
 - tracking values are unique and complete;
@@ -227,8 +197,8 @@ Before writing a successful campaign verify:
 
 ## Failure behaviour
 
-Do not create a partial campaign when approval is invalid, inputs are invalid, dates conflict, tracking cannot be generated, or strategy cannot be satisfied honestly.
+Do not create a partial campaign when the handoff is invalid, inputs are invalid, dates conflict, tracking cannot be generated, or strategy cannot be satisfied honestly.
 
-Do not fail solely because the immutable original CMO artifact still says `draft` when the outer approval wrapper is valid.
+Do not fail solely because the immutable original CMO artifact says `draft` when the validated pipeline wrapper is correct.
 
-The successful final artifact is `campaign.json`. Human campaign approval, asset production, backend import, and publication happen afterward.
+The successful artifact remains a campaign draft for review and later Creative Director enrichment. Human campaign review, asset production, backend import, and publication happen afterward.

--- a/prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json
+++ b/prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json
@@ -23,13 +23,16 @@
     "strategy": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["review_status", "approval_authority", "approval_recorded_at", "original_cmo_review_status", "cmo_output_path", "cmo_output"],
+      "required": ["handoff_status", "handoff_authority", "handoff_recorded_at", "original_cmo_review_status", "cmo_context_path", "cmo_context_checksum", "cmo_output_path", "cmo_output_checksum", "cmo_output"],
       "properties": {
-        "review_status": {"const": "approved"},
-        "approval_authority": {"const": "human_workflow_dispatch"},
-        "approval_recorded_at": {"type": "string", "format": "date-time"},
+        "handoff_status": {"const": "validated"},
+        "handoff_authority": {"const": "automated_marketing_pipeline"},
+        "handoff_recorded_at": {"type": "string", "format": "date-time"},
         "original_cmo_review_status": {"enum": ["draft", "approved"]},
+        "cmo_context_path": {"type": "string", "minLength": 1},
+        "cmo_context_checksum": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
         "cmo_output_path": {"type": "string", "minLength": 1},
+        "cmo_output_checksum": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
         "cmo_output": {"type": "object"}
       }
     },


### PR DESCRIPTION
## Objetivo
Implementar la Fase 2 del plan de automatización de marketing: eliminar la aprobación humana intermedia entre el agente CMO y el Head of Content, manteniendo validación estricta, trazabilidad y recuperación manual.

## Cambios
- `Generate Head of Content context` se dispara automáticamente cuando Codex guarda `marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json` en la rama mensual correcta;
- deriva el período desde la ruta modificada y exige correspondencia con `automation/marketing-cycle-<YYYY-MM>`;
- conserva `workflow_dispatch` únicamente como recuperación manual, sin checkbox de aprobación;
- valida tanto `cmo-context.json` como `cmo-strategy.json` antes del handoff;
- elimina `--approve-strategy` del builder;
- reemplaza el wrapper de aprobación humana por:
  - `handoff_status: validated`;
  - `handoff_authority: automated_marketing_pipeline`;
  - checksums SHA-256 del contexto y la estrategia;
- preserva el `review_status` original del CMO sin modificar el artefacto fuente;
- actualiza schema, contrato del Head of Content y documentación operativa.

## Seguridad
- falla si falta un input, no valida, el período no coincide o la rama no corresponde;
- no publica ni aprueba posts;
- la primera aprobación humana obligatoria sigue siendo Admin;
- el workflow manual no altera el significado del handoff: solo reejecuta código determinístico;
- no cambia todavía el output del Head of Content a `campaign-draft.json`; eso pertenece a Fase 3.

## Flujo resultante
`cmo-strategy.json` commit → GitHub Action automático → validaciones → `content-context.json` → Head of Content programado.

## Validación pendiente en CI
- parseo del workflow;
- typecheck del API;
- validación de schemas;
- ejecución en una rama mensual de prueba con estrategia válida.