### PR TITLE
Improve native session and reminder reliability without changing auth plugin

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -13,6 +13,7 @@ import { PostLoginLanguageProvider } from './i18n/postLoginLanguage';
 import { IOSNativeAuthCallbackBridge } from './mobile/IOSNativeAuthCallbackBridge';
 import { NativeInternalNavigationBridge } from './mobile/NativeInternalNavigationBridge';
 import { NativeMobileBridge } from './mobile/NativeMobileBridge';
+import { NativeReliabilityBridge } from './mobile/NativeReliabilityBridge';
 import { isNativeCapacitorPlatform } from './mobile/capacitor';
 import { RuntimeAuthProvider } from './auth/runtimeAuth';
 
@@ -103,6 +104,7 @@ createRoot(rootElement).render(
             <IOSNativeAuthCallbackBridge />
             <NativeInternalNavigationBridge />
             <NativeMobileBridge />
+            <NativeReliabilityBridge />
             <App />
           </ThemePreferenceProvider>
         </PostLoginLanguageProvider>

--- a/apps/web/src/mobile/NativeReliabilityBridge.tsx
+++ b/apps/web/src/mobile/NativeReliabilityBridge.tsx
@@ -1,0 +1,142 @@
+import { useEffect } from 'react';
+import { getDailyReminderSettings } from '../lib/api';
+import {
+  getCapacitorAppPlugin,
+  isNativeCapacitorPlatform,
+} from './capacitor';
+import { syncNativeDailyReminderNotification } from './localNotifications';
+import {
+  ensureFreshMobileAuthSession,
+  getMobileAuthSession,
+  shouldForceNativeWelcome,
+} from './mobileAuthSession';
+import { writeMobileDebug } from './mobileDebug';
+
+const NATIVE_SESSION_REFRESH_WINDOW_MS = 15 * 60 * 1000;
+const NATIVE_RELIABILITY_COOLDOWN_MS = 30_000;
+
+let maintenancePromise: Promise<void> | null = null;
+let lastMaintenanceStartedAt = 0;
+
+export function shouldRefreshNativeSession(
+  expiresAt: number | null | undefined,
+  now = Date.now(),
+): boolean {
+  if (typeof expiresAt !== 'number') {
+    return false;
+  }
+
+  return expiresAt - now <= NATIVE_SESSION_REFRESH_WINDOW_MS;
+}
+
+async function runNativeReliabilityMaintenance(reason: string): Promise<void> {
+  if (!isNativeCapacitorPlatform() || shouldForceNativeWelcome()) {
+    return;
+  }
+
+  const session = getMobileAuthSession();
+  if (!session?.token) {
+    return;
+  }
+
+  const now = Date.now();
+  if (maintenancePromise) {
+    return maintenancePromise;
+  }
+
+  if (now - lastMaintenanceStartedAt < NATIVE_RELIABILITY_COOLDOWN_MS) {
+    return;
+  }
+
+  lastMaintenanceStartedAt = now;
+  maintenancePromise = (async () => {
+    writeMobileDebug('native-reliability:start', {
+      reason,
+      expiresAt: session.expiresAt,
+      shouldRefresh: shouldRefreshNativeSession(session.expiresAt, now),
+      at: now,
+    });
+
+    try {
+      if (shouldRefreshNativeSession(session.expiresAt, now)) {
+        await ensureFreshMobileAuthSession({
+          reason: `native-reliability:${reason}`,
+          minValidityMs: NATIVE_SESSION_REFRESH_WINDOW_MS,
+        });
+      }
+    } catch (error) {
+      console.warn('[native-reliability] session refresh failed without clearing local session', {
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      writeMobileDebug('native-reliability:session-refresh-failed', {
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+        at: Date.now(),
+      });
+    }
+
+    try {
+      const latestSession = getMobileAuthSession();
+      if (!latestSession?.token || shouldForceNativeWelcome()) {
+        return;
+      }
+
+      const reminder = await getDailyReminderSettings('notification');
+      await syncNativeDailyReminderNotification(reminder);
+      writeMobileDebug('native-reliability:reminder-resynced', {
+        reason,
+        at: Date.now(),
+      });
+    } catch (error) {
+      console.warn('[native-reliability] reminder resync failed without cancelling the existing schedule', {
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      writeMobileDebug('native-reliability:reminder-resync-failed', {
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+        at: Date.now(),
+      });
+    }
+  })().finally(() => {
+    maintenancePromise = null;
+  });
+
+  return maintenancePromise;
+}
+
+export function NativeReliabilityBridge() {
+  useEffect(() => {
+    if (!isNativeCapacitorPlatform()) {
+      return;
+    }
+
+    void runNativeReliabilityMaintenance('mount');
+
+    const app = getCapacitorAppPlugin();
+    let appStateHandle: Awaited<ReturnType<NonNullable<typeof app>['addListener']>> | null = null;
+
+    if (app) {
+      void Promise.resolve(app.addListener('appStateChange', ({ isActive }) => {
+        if (isActive) {
+          void runNativeReliabilityMaintenance('app-active');
+        }
+      })).then((handle) => {
+        appStateHandle = handle;
+      });
+    }
+
+    const handleOnline = () => {
+      void runNativeReliabilityMaintenance('online');
+    };
+    window.addEventListener('online', handleOnline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      void appStateHandle?.remove();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/mobile/__tests__/NativeReliabilityBridge.test.ts
+++ b/apps/web/src/mobile/__tests__/NativeReliabilityBridge.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRefreshNativeSession } from '../NativeReliabilityBridge';
+
+describe('shouldRefreshNativeSession', () => {
+  const now = Date.UTC(2026, 6, 25, 12, 0, 0);
+
+  it('refreshes an expired native token', () => {
+    expect(shouldRefreshNativeSession(now - 1, now)).toBe(true);
+  });
+
+  it('refreshes before the token enters the expiry race window', () => {
+    expect(shouldRefreshNativeSession(now + 10 * 60 * 1000, now)).toBe(true);
+  });
+
+  it('keeps a healthy token without opening the auth surface', () => {
+    expect(shouldRefreshNativeSession(now + 30 * 60 * 1000, now)).toBe(false);
+  });
+
+  it('does not force refresh when the token has no expiry metadata', () => {
+    expect(shouldRefreshNativeSession(null, now)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Objetivo

Mejorar la confiabilidad de sesión y del recordatorio diario en Android/iOS sin reemplazar ni modificar el plugin nativo de autenticación existente.

## Qué cambia

- Agrega `NativeReliabilityBridge`, montado junto a los bridges nativos existentes.
- Reutiliza exactamente `ensureFreshMobileAuthSession()` y el callback actual de Clerk/Capacitor.
- Anticipa la renovación cuando al JWT le quedan 15 minutos o menos, reduciendo la carrera de expiración durante una llamada API.
- Ejecuta mantenimiento en tres momentos seguros: arranque, regreso al foreground y recuperación de conexión.
- Vuelve a consultar y sincronizar el recordatorio local diario en esos momentos para reparar programaciones perdidas.
- Evita ejecuciones concurrentes y aplica un cooldown de 30 segundos.
- Registra fallos de renovación o resincronización sin borrar la sesión local ni cancelar deliberadamente el recordatorio existente.
- Añade pruebas unitarias para la ventana de renovación anticipada.

## Qué NO cambia

- No modifica el plugin nativo de login.
- No cambia el registro del plugin en iOS o Android.
- No cambia Google OAuth.
- No cambia los esquemas `innerbloom://`, callbacks ni rutas posteriores al login.
- No cambia el flujo de logout.
- No incorpora todavía Push Notifications, Firebase ni APNs; eso corresponde a la fase 2.

## Causa que mitiga

La app conservaba un JWT móvil persistido, pero normalmente intentaba renovarlo casi al momento exacto de vencimiento o después de un `401`. Esto dejaba una ventana frágil, especialmente al volver a abrir la app después de varias horas. En paralelo, la notificación local solo se resincronizaba cuando cambiaba el estado React de sesión, no necesariamente al volver del background o recuperar red.

## Impacto esperado

- Menos cierres de sesión provocados por llegar tarde a la renovación.
- Recuperación automática al volver a abrir la aplicación.
- Mayor probabilidad de que el recordatorio local quede nuevamente programado después de background, suspensión o pérdida de conexión.
- Ningún cambio visible en la experiencia de login que hoy funciona.

## Validación

- Pruebas unitarias agregadas para token expirado, token próximo a vencer, token saludable y token sin metadata de expiración.
- Se requiere ejecutar en CI o checkout local:
  - `pnpm --dir apps/web typecheck`
  - `pnpm --dir apps/web test --run`
  - `pnpm --dir apps/web build`
- QA manual requerido en Android e iOS: login por email, Google OAuth, reapertura, foreground/background, recuperación de red, logout y notificación de prueba.

## Nota de alcance

Esta PR es deliberadamente conservadora. No migra autenticación ni reemplaza infraestructura. Si las pruebas confirman que todavía existe un borrado prematuro después de un `401` no recuperable, ese manejo se ajustará en una PR separada y pequeña, sin tocar el plugin nativo.