### PR TITLE
Make campaign-draft.json the strict Head of Content output

### DIFF
--- a/.github/workflows/marketing-campaign-draft-contract.yml
+++ b/.github/workflows/marketing-campaign-draft-contract.yml
@@ -1,0 +1,51 @@
+name: Validate marketing campaign draft contract
+
+on:
+  pull_request:
+    paths:
+      - 'prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json'
+      - 'prompts/marketing/agent-system/head-of-content/AGENTS.md'
+      - 'prompts/marketing/head-of-content-v1.md'
+      - 'apps/api/scripts/validate-marketing-campaign-draft.ts'
+      - 'apps/api/scripts/fixtures/campaign-draft-valid.json'
+      - '.github/workflows/marketing-campaign-draft-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm install --no-audit --no-fund
+      - name: Typecheck API
+        run: npm -w @innerbloom/api run typecheck
+      - name: Validate fixture schema
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-agent-json.ts
+          --schema=prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json
+          --input=apps/api/scripts/fixtures/campaign-draft-valid.json
+      - name: Validate fixture business rules
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts
+          --input=apps/api/scripts/fixtures/campaign-draft-valid.json
+      - name: Prove renderer-owned fields fail closed
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const fs = require('fs');
+          const input = JSON.parse(fs.readFileSync('apps/api/scripts/fixtures/campaign-draft-valid.json', 'utf8'));
+          input.posts[0].visual_strategy.layout_variant = 'forbidden';
+          fs.writeFileSync('/tmp/campaign-draft-invalid.json', JSON.stringify(input));
+          NODE
+          if npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts --input=/tmp/campaign-draft-invalid.json; then
+            echo 'Expected forbidden renderer field validation to fail.' >&2
+            exit 1
+          fi

--- a/Docs/marketing/contracts/campaign-draft-v1.md
+++ b/Docs/marketing/contracts/campaign-draft-v1.md
@@ -1,6 +1,8 @@
 # Campaign Draft Contract v1
 
-**Status:** proposed and frozen for Phase 1; not yet enforced by production schema.
+**Status:** active Head of Content output contract  
+**Schema:** `prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json`  
+**Business validator:** `apps/api/scripts/validate-marketing-campaign-draft.ts`
 
 ## Producer
 
@@ -12,11 +14,35 @@ Innerbloom Head of Content agent.
 
 ## Consumer
 
-Deterministic Creative Director context builder.
+Deterministic Creative Director context builder, to be implemented in the next Phase 3 block.
+
+The renderer, Asset Producer, R2 importer and Admin import must not consume this artifact directly.
 
 ## Purpose
 
 Represent the complete editorial campaign without renderer-specific implementation decisions.
+
+## Inputs
+
+The Head of Content reads:
+
+- validated `marketing/agent-inputs/<YYYY-MM>/content-context.json`;
+- immutable `marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json`;
+- Head of Content input schema;
+- canonical visual system;
+- current product, brand and asset evidence referenced by the source manifest.
+
+The validated content context supplies:
+
+- period, campaign code, timezone, target count and publishing window;
+- validated CMO handoff, source paths and SHA-256 identities;
+- complete CMO output;
+- brand positioning and content rules;
+- product stage, changes, product evidence and approved claims;
+- available asset registry/context;
+- supported platforms and formats;
+- publishing and review constraints;
+- tracking base URL and UTM defaults.
 
 ## Required top-level sections
 
@@ -36,10 +62,10 @@ Represent the complete editorial campaign without renderer-specific implementati
 
 Must include:
 
-- `source_branch`;
-- `content_context_sha256`;
-- `cmo_strategy_sha256`;
-- `head_of_content_contract_version`.
+- exact monthly `source_branch`;
+- canonical content-context path and SHA-256;
+- canonical CMO strategy path and SHA-256;
+- `head_of_content_contract_version: campaign-draft-v1`.
 
 ## Campaign
 
@@ -52,9 +78,10 @@ Must contain:
 - language and platforms;
 - supported editorial formats;
 - target post count;
+- timezone;
 - publishing start and end dates.
 
-It must not contain a human-approval requirement for routine monthly generation.
+No human-approval field belongs in routine monthly output.
 
 ## Posts
 
@@ -63,19 +90,18 @@ Each post must include:
 - unique `post_code` and contiguous `sequence_number`;
 - platform and format;
 - `status: needs_review`;
-- scheduled time;
-- approved content pillar, funnel stage and experiment code;
-- audience tension;
-- product truth anchor;
+- scheduled time inside the campaign window;
+- CMO-approved content pillar, funnel stage and experiment code;
+- audience tension and product truth anchor;
 - hook and caption;
 - CTA;
 - hypothesis and primary metric;
-- tracking URL and UTM values;
+- tracking URL when applicable and complete UTM identity;
 - visible copy plan;
 - semantic visual strategy;
 - accessibility requirements;
-- asset slots;
-- carousel narrative and slide records when applicable.
+- one or more stable asset slots;
+- complete carousel narrative and ordered slides when applicable.
 
 ## Semantic visual strategy
 
@@ -83,10 +109,11 @@ May specify:
 
 - visual communication goal;
 - proof type;
-- product module or evidence needed;
+- semantic product module or evidence needed;
 - whether a screenshot is required, optional or forbidden;
 - informational hierarchy;
 - desired emotional/editorial character;
+- preferred dark/light/either mode;
 - truthful transformation constraints;
 - forbidden uses;
 - acceptance criteria.
@@ -95,49 +122,85 @@ Must not specify:
 
 - exact renderer `layout_variant`;
 - exact registered `selected_asset_keys`;
-- palette enums owned by the renderer;
-- exact device presentation;
-- renderer visual-family enum;
-- art-direction profile;
+- `creative_direction` or `art_direction`;
+- renderer palette, visual-family or device-presentation enums;
+- supporting treatment;
 - generation order or batch number;
 - local staging paths;
+- expected binary output metadata;
 - exact renderer composition fields.
 
 ## Asset slots
 
-Each planned final image or carousel slide must have one stable asset slot with:
+Each expected final visual or carousel slide has one stable slot with:
 
-- `asset_code`;
+- globally unique `asset_code`;
 - owning `post_code`;
 - asset kind;
 - slide number when applicable;
 - semantic purpose;
 - product-evidence requirement;
 - whether existing sources are preferred;
-- whether new binary production may be required;
+- optional semantic source references;
+- whether a new binary may conditionally be required;
 - alt text;
 - acceptance criteria.
 
+A carousel must have exactly one asset slot per slide.
+
 ## Asset requirements
 
-This section records unresolved production needs. It does not claim an asset exists.
+This section records unresolved source-production needs. It does not claim an asset exists.
 
-Allowed requirement kinds:
+Allowed kinds:
 
 - `reuse_existing_source`;
 - `edit_existing_source`;
 - `compose_existing_sources`;
 - `new_source_required`.
 
-A `new_source_required` entry is only a conditional request. It does not trigger or prove successful Asset Producer execution.
+Every requirement must reference existing post and asset-slot codes.
+
+## Validation layers
+
+### Structural schema
+
+```bash
+npx tsx apps/api/scripts/validate-marketing-agent-json.ts \
+  --schema=prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json \
+  --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json
+```
+
+### Cross-field business invariants
+
+```bash
+npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts \
+  --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json
+```
+
+The business validator checks:
+
+- target count and execution summaries;
+- canonical period, campaign code, paths and branch;
+- unique and contiguous post sequencing;
+- publishing-window compliance;
+- post and asset ownership;
+- complete carousel structure;
+- unique tracking identities;
+- unique asset slots;
+- requirement references;
+- absence of renderer-owned fields;
+- successful quality booleans.
 
 ## Invariants
 
 - total posts equals campaign target;
 - tracking identifiers are unique;
 - all dates are within the publishing window;
-- all pillars and experiments come from the CMO strategy;
+- all pillars and experiments come from CMO strategy;
 - every required visual output has a stable asset slot;
 - all carousel slides have ordered narrative roles and visible copy;
+- summaries equal the underlying posts and slots;
 - no renderer-specific decisions are present;
-- no unsupported claim or invented product capability is present.
+- no unsupported claim or invented product capability is present;
+- successful quality checks are all true.

--- a/Docs/marketing/phase-3-head-of-content-campaign-draft.md
+++ b/Docs/marketing/phase-3-head-of-content-campaign-draft.md
@@ -1,0 +1,158 @@
+# Phase 3A — Head of Content to campaign draft
+
+**Status:** implementation proposed in this branch  
+**Scope:** only the Head of Content output boundary. Creative Director context and agent are not implemented here.
+
+## Audited inputs
+
+The active deterministic input is:
+
+`marketing/agent-inputs/<YYYY-MM>/content-context.json`
+
+validated by:
+
+`prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json`
+
+It provides:
+
+1. **Period contract**
+   - period key;
+   - canonical campaign code;
+   - timezone;
+   - target post count;
+   - publishing window.
+2. **Validated CMO handoff**
+   - pipeline authority and timestamp;
+   - original CMO review status;
+   - canonical context and strategy paths;
+   - SHA-256 identities;
+   - complete CMO output.
+3. **Brand context**
+   - objective;
+   - positioning;
+   - content rules;
+   - language;
+   - final human-review policy.
+4. **Product context**
+   - product stage;
+   - known product changes;
+   - product pages and totals;
+   - approved claim source.
+5. **Available assets**
+   - current asset registry and source evidence inherited from CMO context.
+6. **Operational constraints**
+   - supported platforms and editorial formats;
+   - carousel and asset limits;
+   - publishing method and public storage;
+   - calendar and review rules.
+7. **Tracking defaults**
+   - base URL;
+   - UTM source and medium;
+   - campaign code;
+   - additional identifiers.
+8. **Source manifest**
+   - traceable evidence used to construct the context.
+
+The immutable original CMO artifact remains an independent input:
+
+`marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json`
+
+The agent must verify period and strategic consistency. It must not mutate or approve it.
+
+## Problems in the previous output contract
+
+The prior `head-of-content-output-v1.schema.json` was too permissive and mixed responsibilities:
+
+- major nested objects allowed unspecified structures;
+- post visual briefs were not structurally defined;
+- carousel narrative and slide ownership were not guaranteed;
+- provenance and source SHA identities were absent;
+- cross-field counts and tracking uniqueness were not validated;
+- asset ownership and requirement references were not validated;
+- it allowed the Head of Content artifact to be confused with renderer-ready `campaign.json`;
+- it did not prohibit fields later manually added for the renderer.
+
+The successful July `campaign.json` contains renderer-owned enrichment such as exact asset selections, layout variants, creative direction and art direction. Those decisions do not belong to Head of Content.
+
+## New successful output
+
+Canonical path:
+
+`marketing/agent-outputs/<YYYY-MM>/campaign-draft.json`
+
+Structural schema:
+
+`prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json`
+
+Business validator:
+
+`apps/api/scripts/validate-marketing-campaign-draft.ts`
+
+The output is editorially complete and contains:
+
+- source provenance;
+- campaign metadata and publishing window;
+- exact post count and summaries;
+- complete post copy, strategy mapping, hypotheses, metrics and tracking;
+- visible copy plans;
+- semantic visual strategies;
+- accessibility;
+- stable asset slots;
+- complete carousel narratives and slides;
+- conditional asset-source requirements;
+- explicit quality checks and known risks.
+
+## Explicit non-output
+
+The Head of Content must not produce:
+
+- production `campaign.json`;
+- exact registered asset selection;
+- renderer layout variants;
+- creative or art direction objects;
+- renderer visual-family, device, palette or treatment enums;
+- generation ordering, batching or staging paths;
+- binary output metadata;
+- claims that an asset was produced.
+
+## Validation model
+
+A successful output must pass two independent layers.
+
+### JSON Schema
+
+Checks all required sections, field types, enums, ownership shape, carousel conditional structure and absence of undeclared properties.
+
+### Business validator
+
+Checks:
+
+- canonical branch, paths, period and campaign code;
+- exact target post count;
+- unique post codes and contiguous sequence numbers;
+- schedule inside publishing window;
+- campaign/post status;
+- UTM consistency and uniqueness;
+- unique global asset slots and slot ownership;
+- one slot per carousel slide;
+- summary counts against source arrays;
+- valid asset-requirement references;
+- absence of renderer-owned keys anywhere in the document;
+- named quality checks all true.
+
+## Compatibility policy
+
+The existing `head-of-content-output-v1.schema.json` is not deleted in this change because current renderer/Asset Producer history may still reference it. It becomes a legacy production-campaign schema and is no longer authoritative for Head of Content.
+
+No workflow is changed to render `campaign-draft.json`. That would be unsafe. The next Phase 3 block must create the deterministic Creative Director context and later the Creative Director agent that produces the production `campaign.json`.
+
+## Definition of done
+
+This phase is complete when:
+
+- Head of Content instructions reference only `campaign-draft.json`;
+- the strict schema exists;
+- the cross-field validator exists;
+- documentation reflects the ownership boundary;
+- CI confirms TypeScript and schema validity;
+- a representative draft fixture passes both validators before Codex scheduling is enabled.

--- a/apps/api/scripts/fixtures/campaign-draft-valid.json
+++ b/apps/api/scripts/fixtures/campaign-draft-valid.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "1.0",
+  "agent": "innerbloom_head_of_content",
+  "period_key": "2026-08",
+  "generated_at": "2026-07-25T00:00:00Z",
+  "provenance": {
+    "source_branch": "automation/marketing-cycle-2026-08",
+    "content_context_path": "marketing/agent-inputs/2026-08/content-context.json",
+    "content_context_sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "cmo_strategy_path": "marketing/agent-outputs/2026-08/cmo-strategy.json",
+    "cmo_strategy_sha256": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "head_of_content_contract_version": "campaign-draft-v1"
+  },
+  "campaign": {
+    "campaign_code": "ib_202608",
+    "title": "Adaptive rhythm",
+    "objective": "new_users",
+    "status": "review",
+    "strategy_summary": "Explain sustainable adaptive habits without guaranteed outcomes.",
+    "language": "English",
+    "platforms": ["instagram"],
+    "formats": ["static"],
+    "target_post_count": 1,
+    "timezone": "Europe/Madrid",
+    "publishing_start_date": "2026-08-01",
+    "publishing_end_date": "2026-08-31"
+  },
+  "campaign_execution_summary": {
+    "post_count": 1,
+    "format_counts": {"static": 1},
+    "pillar_counts": {"Pain and friction": 1},
+    "funnel_counts": {"awareness": 1},
+    "asset_slot_count": 1,
+    "notes": ["Contract fixture only."]
+  },
+  "posts": [
+    {
+      "post_code": "post_001",
+      "sequence_number": 1,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2026-08-03T10:00:00+02:00",
+      "content_pillar": "Pain and friction",
+      "funnel_stage": "awareness",
+      "experiment_code": "pain_first_hook",
+      "audience_tension": "Rigid systems collapse during real weeks.",
+      "product_truth_anchor": "Innerbloom presents progress against a selected rhythm without guaranteeing outcomes.",
+      "hook": "Your routine should survive a difficult week.",
+      "caption": "A useful system leaves room for real life. Innerbloom explores visible progress and adjustable challenge without pretending every week is identical.",
+      "cta": {
+        "label": "Explore Innerbloom",
+        "intent": "traffic",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "Invitation to explore only; no guaranteed result."
+      },
+      "hypothesis": "A pain-first message will improve qualified landing visits.",
+      "primary_metric": "Landing page sessions",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_202608&utm_content=post_001&ib_post=post_001",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_202608",
+        "utm_content": "post_001",
+        "ib_post": "post_001"
+      },
+      "visible_copy_plan": {
+        "headline": "Your routine should survive a difficult week.",
+        "supporting_text": "Progress can remain visible without requiring perfection."
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate resilience without depicting unsupported automation.",
+        "proof_type": "hybrid",
+        "product_evidence": ["dashboard progress overview"],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": ["headline", "product evidence", "supporting text", "brand"],
+        "editorial_character": ["calm", "clear", "human"],
+        "preferred_mode": "either",
+        "truthful_transformations": ["crop", "reframe", "soft dimming outside focal region"],
+        "forbidden_uses": ["invented UI", "fake metrics", "medical claims"],
+        "acceptance_criteria": ["Headline readable on mobile", "Any product evidence remains factual"]
+      },
+      "accessibility": {
+        "alt_text": "Innerbloom post about routines that adapt to difficult weeks.",
+        "readability_note": "Use high contrast and mobile-readable type."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "asset_post_001",
+          "post_code": "post_001",
+          "asset_kind": "static",
+          "semantic_purpose": "Support the resilience message with truthful product evidence.",
+          "product_evidence_requirement": "Optional current dashboard progress evidence.",
+          "existing_sources_preferred": true,
+          "semantic_source_references": ["dashboard_dark", "dashboard_light"],
+          "new_binary_may_be_required": false,
+          "alt_text": "Innerbloom post about routines that adapt to difficult weeks.",
+          "acceptance_criteria": ["No invented UI", "Copy remains legible"]
+        }
+      ]
+    }
+  ],
+  "asset_requirements": [
+    {
+      "requirement_code": "req_post_001_source",
+      "kind": "reuse_existing_source",
+      "related_asset_codes": ["asset_post_001"],
+      "related_post_codes": ["post_001"],
+      "priority": "medium",
+      "semantic_source_references": ["dashboard_dark", "dashboard_light"],
+      "production_brief": "Select current approved dashboard evidence only if it supports the claim.",
+      "truthfulness_constraints": ["Do not alter product labels or values"],
+      "acceptance_criteria": ["Source is current and approved"]
+    }
+  ],
+  "campaign_quality_report": {
+    "schema_ready": true,
+    "strategy_fidelity": true,
+    "claim_safety": true,
+    "tracking_integrity": true,
+    "calendar_integrity": true,
+    "editorial_diversity": true,
+    "visual_brief_completeness": true,
+    "known_risks": ["Creative direction is intentionally unresolved until the next agent stage."]
+  },
+  "source_manifest": [
+    {
+      "source_type": "repo_file",
+      "source_path_or_id": "marketing/agent-inputs/2026-08/content-context.json"
+    }
+  ]
+}

--- a/apps/api/scripts/validate-marketing-campaign-draft.ts
+++ b/apps/api/scripts/validate-marketing-campaign-draft.ts
@@ -104,7 +104,19 @@ async function main(): Promise<void> {
   };
   walk(draft);
 
-  assert(Object.values(draft.campaign_quality_report).slice(0, 7).every((value) => value === true), 'all campaign quality booleans must be true for a successful draft');
+  const requiredQualityChecks = [
+    'schema_ready',
+    'strategy_fidelity',
+    'claim_safety',
+    'tracking_integrity',
+    'calendar_integrity',
+    'editorial_diversity',
+    'visual_brief_completeness',
+  ];
+  for (const check of requiredQualityChecks) {
+    assert(draft.campaign_quality_report[check] === true, `campaign_quality_report.${check} must be true for a successful draft`);
+  }
+
   console.log(`Validated campaign draft business invariants: ${inputPath}`);
 }
 

--- a/apps/api/scripts/validate-marketing-campaign-draft.ts
+++ b/apps/api/scripts/validate-marketing-campaign-draft.ts
@@ -1,0 +1,114 @@
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+function readArg(name: string): string | null {
+  const prefix = `--${name}=`;
+  return process.argv.slice(2).find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? null;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function countBy<T>(values: T[], key: (value: T) => string): Record<string, number> {
+  return values.reduce<Record<string, number>>((acc, value) => {
+    const name = key(value);
+    acc[name] = (acc[name] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
+function equalCountMaps(actual: Record<string, number>, expected: Record<string, number>): boolean {
+  const keys = new Set([...Object.keys(actual), ...Object.keys(expected)]);
+  return [...keys].every((key) => (actual[key] ?? 0) === (expected[key] ?? 0));
+}
+
+async function main(): Promise<void> {
+  const inputPath = readArg('input');
+  if (!inputPath) throw new Error('Usage: tsx apps/api/scripts/validate-marketing-campaign-draft.ts --input=<campaign-draft.json>');
+
+  const draft = JSON.parse(await readFile(inputPath, 'utf8')) as any;
+  const { campaign, posts, campaign_execution_summary: summary, asset_requirements: requirements, provenance } = draft;
+
+  assert(Array.isArray(posts) && posts.length > 0, 'posts must be a non-empty array');
+  assert(posts.length === campaign.target_post_count, `post count ${posts.length} does not match campaign.target_post_count ${campaign.target_post_count}`);
+  assert(summary.post_count === posts.length, 'campaign_execution_summary.post_count does not match posts length');
+  assert(draft.period_key === campaign.campaign_code.slice(3, 7) + '-' + campaign.campaign_code.slice(7, 9), 'period_key does not match canonical campaign_code ib_YYYYMM');
+  assert(provenance.source_branch === `automation/marketing-cycle-${draft.period_key}`, 'provenance.source_branch does not match period_key');
+  assert(provenance.content_context_path === `marketing/agent-inputs/${draft.period_key}/content-context.json`, 'content_context_path does not match period_key');
+  assert(provenance.cmo_strategy_path === `marketing/agent-outputs/${draft.period_key}/cmo-strategy.json`, 'cmo_strategy_path does not match period_key');
+
+  const postCodes = posts.map((post: any) => post.post_code);
+  assert(new Set(postCodes).size === postCodes.length, 'post_code values must be unique');
+  const sequenceNumbers = posts.map((post: any) => post.sequence_number).sort((a: number, b: number) => a - b);
+  assert(sequenceNumbers.every((value: number, index: number) => value === index + 1), 'sequence_number values must be contiguous from 1');
+
+  const start = Date.parse(`${campaign.publishing_start_date}T00:00:00Z`);
+  const end = Date.parse(`${campaign.publishing_end_date}T23:59:59Z`);
+  for (const post of posts) {
+    const scheduled = Date.parse(post.scheduled_at);
+    assert(scheduled >= start && scheduled <= end, `${post.post_code} scheduled_at is outside the publishing window`);
+    assert(post.status === 'needs_review', `${post.post_code} must remain needs_review`);
+    assert(post.utm.utm_campaign === campaign.campaign_code, `${post.post_code} utm_campaign must equal campaign_code`);
+    assert(post.utm.utm_content === post.post_code, `${post.post_code} utm_content must equal post_code`);
+    assert(post.asset_slots.length >= 1, `${post.post_code} must define at least one asset slot`);
+    for (const slot of post.asset_slots) {
+      assert(slot.post_code === post.post_code, `${slot.asset_code} post_code does not match owner post`);
+    }
+    if (post.format === 'carousel') {
+      assert(post.carousel.slides.length === post.carousel.slide_count, `${post.post_code} carousel slide_count mismatch`);
+      assert(post.asset_slots.length === post.carousel.slide_count, `${post.post_code} carousel must have one asset slot per slide`);
+      const slideNumbers = post.carousel.slides.map((slide: any) => slide.slide_number).sort((a: number, b: number) => a - b);
+      assert(slideNumbers.every((value: number, index: number) => value === index + 1), `${post.post_code} carousel slide numbers must be contiguous`);
+      const slotCodes = new Set(post.asset_slots.map((slot: any) => slot.asset_code));
+      assert(post.carousel.slides.every((slide: any) => slotCodes.has(slide.asset_code)), `${post.post_code} carousel slide references an unknown asset slot`);
+    }
+  }
+
+  const trackingUrls = posts.map((post: any) => post.tracking_url).filter(Boolean);
+  assert(new Set(trackingUrls).size === trackingUrls.length, 'non-null tracking_url values must be unique');
+  const utmContents = posts.map((post: any) => post.utm.utm_content);
+  assert(new Set(utmContents).size === utmContents.length, 'utm_content values must be unique');
+  const ibPosts = posts.map((post: any) => post.utm.ib_post);
+  assert(new Set(ibPosts).size === ibPosts.length, 'ib_post values must be unique');
+
+  const allSlots = posts.flatMap((post: any) => post.asset_slots);
+  const assetCodes = allSlots.map((slot: any) => slot.asset_code);
+  assert(new Set(assetCodes).size === assetCodes.length, 'asset_code values must be globally unique');
+  assert(summary.asset_slot_count === allSlots.length, 'campaign_execution_summary.asset_slot_count does not match asset slots');
+
+  assert(equalCountMaps(summary.format_counts, countBy(posts, (post: any) => post.format)), 'format_counts do not match posts');
+  assert(equalCountMaps(summary.pillar_counts, countBy(posts, (post: any) => post.content_pillar)), 'pillar_counts do not match posts');
+  assert(equalCountMaps(summary.funnel_counts, countBy(posts, (post: any) => post.funnel_stage)), 'funnel_counts do not match posts');
+
+  const postCodeSet = new Set(postCodes);
+  const assetCodeSet = new Set(assetCodes);
+  const requirementCodes = requirements.map((requirement: any) => requirement.requirement_code);
+  assert(new Set(requirementCodes).size === requirementCodes.length, 'requirement_code values must be unique');
+  for (const requirement of requirements) {
+    assert(requirement.related_post_codes.every((code: string) => postCodeSet.has(code)), `${requirement.requirement_code} references an unknown post`);
+    assert(requirement.related_asset_codes.every((code: string) => assetCodeSet.has(code)), `${requirement.requirement_code} references an unknown asset slot`);
+  }
+
+  const forbiddenRendererFields = new Set([
+    'layout_variant', 'selected_asset_keys', 'creative_direction', 'art_direction', 'visual_family',
+    'device_presentation', 'supporting_treatment', 'generation_order', 'batch_number', 'local_staging_path',
+  ]);
+  const walk = (value: unknown, path = '$'): void => {
+    if (Array.isArray(value)) return value.forEach((item, index) => walk(item, `${path}[${index}]`));
+    if (!value || typeof value !== 'object') return;
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      assert(!forbiddenRendererFields.has(key), `renderer-owned field ${key} is forbidden in campaign draft at ${path}`);
+      walk(child, `${path}.${key}`);
+    }
+  };
+  walk(draft);
+
+  assert(Object.values(draft.campaign_quality_report).slice(0, 7).every((value) => value === true), 'all campaign quality booleans must be true for a successful draft');
+  console.log(`Validated campaign draft business invariants: ${inputPath}`);
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : 'Unknown campaign draft validation error');
+  process.exitCode = 1;
+});

--- a/prompts/marketing/agent-system/head-of-content/AGENTS.md
+++ b/prompts/marketing/agent-system/head-of-content/AGENTS.md
@@ -2,203 +2,156 @@
 
 ## Purpose
 
-This agent converts one validated CMO strategy handoff into a complete campaign draft for later creative direction and human review.
+This agent converts one validated CMO strategy handoff into the complete **editorial** campaign draft consumed later by the Creative Director.
 
-It does not redefine strategy, approve content, produce binary assets, upload assets, import records into Neon, upload to R2, publish to Metricool, or modify application code.
+It decides campaign architecture, posts, copy, schedule, tracking, hypotheses, semantic visual intent, accessibility and unresolved source-asset needs. It does not make renderer-owned composition decisions and does not produce the production `campaign.json`.
+
+It does not redefine strategy, approve content, create binary assets, upload files, write to Neon or R2, generate Metricool CSV, publish content, or modify application code.
 
 ## Authoritative files
 
-Role prompt:
-`prompts/marketing/head-of-content-v1.md`
+- Role prompt: `prompts/marketing/head-of-content-v1.md`
+- Input schema: `prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json`
+- Output schema: `prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json`
+- Business validator: `apps/api/scripts/validate-marketing-campaign-draft.ts`
+- Visual system: `prompts/marketing/agent-system/brand/innerbloom-visual-system-v1.json`
+- Input: `marketing/agent-inputs/<YYYY-MM>/content-context.json`
+- Original CMO strategy: `marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json`
+- Successful output: `marketing/agent-outputs/<YYYY-MM>/campaign-draft.json`
+- Failure output: `marketing/agent-outputs/<YYYY-MM>/campaign-draft-failure.json`
 
-Input schema:
-`prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json`
-
-Output schema:
-`prompts/marketing/agent-system/schemas/head-of-content-output-v1.schema.json`
-
-Canonical visual system:
-`prompts/marketing/agent-system/brand/innerbloom-visual-system-v1.json`
-
-Input for period `<YYYY-MM>`:
-`marketing/agent-inputs/<YYYY-MM>/content-context.json`
-
-Original CMO strategy:
-`marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json`
-
-Temporary required output until Phase 3 migrates the filename:
-`marketing/agent-outputs/<YYYY-MM>/campaign.json`
-
-## Handoff authority
-
-The authoritative handoff checkpoint is the strategy wrapper in `content-context.json`:
-
-- `strategy.handoff_status` must equal `validated`;
-- `strategy.handoff_authority` must equal `automated_marketing_pipeline`;
-- `strategy.handoff_recorded_at` must be present;
-- `strategy.cmo_context_checksum` and `strategy.cmo_output_checksum` must be valid SHA-256 references.
-
-The original CMO artifact remains immutable evidence and may contain `review_status: draft` or `review_status: approved`. Do not edit or approve it.
-
-If the handoff wrapper is invalid, stop and write `campaign-failure.json`.
-
-## Preconditions
+## Handoff preconditions
 
 Do not execute unless:
 
-- `content-context.json` exists and validates;
-- the embedded CMO strategy validates;
-- the validated pipeline handoff wrapper is valid;
-- the recorded context and strategy paths match the target period;
-- period, campaign code, dates, tracking, product context, formats, and asset context are present;
-- the canonical visual system can be read.
+- `content-context.json` validates;
+- `strategy.handoff_status` is `validated`;
+- `strategy.handoff_authority` is `automated_marketing_pipeline`;
+- context and strategy paths and SHA-256 values are present;
+- the embedded and original CMO strategy refer to the same period;
+- campaign code, timezone, publishing window, target count, formats, tracking and current asset context are present;
+- the canonical visual system is readable.
+
+The immutable CMO strategy may retain `review_status: draft`. Never edit it. A valid pipeline handoff is sufficient.
 
 ## Required execution
 
-1. Resolve the target period from the pending `content-context.json`.
-2. Read this file, the role prompt, both schemas, the original strategy, and the canonical visual system.
-3. Validate the input before generating content.
-4. Read accessible current brand, product, asset, and repository sources referenced by `source_manifest`.
-5. Build campaign architecture before individual posts.
-6. Generate exactly the requested number of posts.
-7. Preserve CMO objective, audience, narrative, pillars, experiments, restrictions, and measurement plan.
-8. Produce useful but non-prescriptive visual briefs.
-9. Set campaign status to `review` and every post status to `needs_review`.
-10. Validate schema and business rules.
-11. Write the configured campaign draft artifact and stop.
+1. Resolve the target period from `content-context.json`.
+2. Verify the source branch is `automation/marketing-cycle-<YYYY-MM>`.
+3. Read and validate all authoritative inputs.
+4. Preserve the CMO objective, audience, narrative, pillars, experiments, restrictions, approved claims, CTAs and measurement plan.
+5. Design campaign architecture before writing individual posts.
+6. Generate exactly `period.target_post_count` posts.
+7. Give every post a unique editorial function, hypothesis, metric, schedule, tracking identity and stable asset slot.
+8. For carousels, define the complete ordered narrative and one stable asset slot per slide.
+9. Define semantic visual strategy without renderer implementation choices.
+10. Record unresolved source-asset needs under `asset_requirements`; never claim a binary exists.
+11. Calculate truthful execution summaries and quality checks.
+12. Validate with both:
 
-## Strategy fidelity
+```bash
+npx tsx apps/api/scripts/validate-marketing-agent-json.ts \
+  --schema=prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json \
+  --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json
 
-- The validated CMO strategy is the strategic source of truth.
-- Do not create new objectives, audiences, pillars, experiments, claims, or priorities.
-- Every post must map to an approved strategy pillar and experiment.
-- Creative choices may elaborate but not contradict strategy.
-- Do not turn weak evidence into factual claims.
+npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts \
+  --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json
+```
 
-## Content rules
+13. Write only `campaign-draft.json` and stop.
 
-- Every post has one clear campaign function.
-- Hooks are specific and free of false clickbait.
-- Captions develop one central idea using supported product claims.
-- Avoid duplicate messages with superficial wording changes.
-- Follow the strategy funnel distribution.
-- Use only supported CTAs and destinations.
-- Respect the configured language.
+## Output ownership
+
+The Head of Content owns:
+
+- campaign title and editorial strategy summary;
+- supported platforms and formats;
+- post order and schedule;
+- content pillar, funnel stage and experiment mapping;
+- audience tension and product-truth anchor;
+- hook, caption, CTA, hypothesis and primary metric;
+- unique tracking URL and UTM identity;
+- visible copy plan;
+- carousel narrative, roles and slide copy;
+- semantic visual goal and evidence requirement;
+- accessibility;
+- stable asset slots;
+- conditional source-asset requirements;
+- quality and provenance records.
+
+## Renderer-owned fields forbidden in the draft
+
+Never write:
+
+- `layout_variant`;
+- `selected_asset_keys`;
+- `creative_direction`;
+- `art_direction`;
+- renderer `visual_family`;
+- exact `device_presentation`;
+- renderer palette enums or exact composition fields;
+- `supporting_treatment`;
+- generation order or batch number;
+- local staging paths;
+- expected binary output metadata.
+
+Those belong to the Creative Director or deterministic renderer pipeline.
+
+## Content and truth rules
+
+- Do not invent product capabilities, UI states, statistics, testimonials, outcomes or routes.
+- Every post must map to a CMO pillar and experiment.
+- Do not add objectives, audiences or priorities absent from the CMO strategy.
+- Avoid guilt, shame, medical framing, guarantees, fabricated urgency and generic motivational filler.
+- Respect the configured campaign language.
 - Do not use emojis or hashtags unless explicitly authorised.
-- Avoid guilt, shame, medical framing, guaranteed outcomes, fabricated urgency, and generic motivational filler.
-
-## Visual-brief authority boundaries
-
-The Head of Content defines:
-
-- what the post communicates;
-- the visual objective;
-- the product module or evidence that should support it;
-- the desired informational hierarchy;
-- whether dark or light mode is preferable when strategically relevant;
-- accessibility requirements;
-- truthful transformation needs;
-- acceptance criteria.
-
-The Head of Content must not define or override:
-
-- brand palette;
-- typography system;
-- logo recreation or wordmark styling;
-- a new visual identity;
-- exact colours outside semantic product references;
-- a fixed historical template to copy;
-- a campaign-wide repeated layout;
-- one screenshot to reuse as hero across many posts;
-- invented product UI or data.
-
-The canonical visual system is authoritative for colours, typography, logo use, screenshot treatment, composition, and dark/light execution.
-
-## Asset selection rules
-
-Priority order:
-
-1. current approved product or landing screenshots;
-2. current approved logo and brand assets;
-3. editable current assets;
-4. composites from current approved assets;
-5. simple branded compositions;
-6. net-new generation only when current assets cannot satisfy the idea.
-
-Historical campaign assets are not templates. Use exact source identifiers only when the input positively identifies a current approved source.
-
-## Supported asset tasks
-
-- `reuse_existing_asset`;
-- `edit_existing_asset`;
-- `compose_existing_assets`;
-- `generate_new_asset` only when current assets cannot satisfy the brief.
-
-The agent plans production but does not claim a binary has been created. Every future production task must have a matching `asset_generation_queue` item.
-
-## Visual diversity rules
-
-Across the campaign:
-
-- vary featured product modules;
-- do not assign one screenshot as hero to more than two posts unless strategy truly requires it;
-- do not prescribe one repeated layout for all posts;
-- vary composition across carousel slides;
-- use dark and light mode only when supported by current source assets and the canonical system;
-- preserve one coherent visual identity while allowing editorial variety.
+- Campaign status is always `review`; post status is always `needs_review`.
 
 ## Tracking rules
 
-- Every traffic-oriented post requires a unique tracking URL.
-- `utm_campaign` equals the configured campaign code.
+- `utm_campaign` equals `campaign.campaign_code`.
 - `utm_content` equals `post_code`.
-- `ib_post` and tracking URLs are unique.
-- Never invent an unsupported destination route.
-- Non-traffic CTAs may use a null destination but still require a CTA object.
+- `ib_post`, `utm_content` and every non-null `tracking_url` are unique.
+- Traffic CTAs require a supported destination and tracking URL.
+- Non-traffic CTAs may use null destination and null tracking URL, but still require full UTM identity for traceability.
+
+## Asset-slot rules
+
+- Every expected final visual has one globally unique `asset_code`.
+- Every asset slot names its owning `post_code`.
+- A carousel has exactly one asset slot per slide.
+- Slide numbers are contiguous from 1.
+- Asset slots describe semantic purpose and evidence, not exact layout or registered source selection.
+- `new_binary_may_be_required` is a conditional flag, never proof that production occurred.
+- Every `asset_requirement` must reference existing post and asset-slot codes.
+
+## Provenance
+
+The draft must record:
+
+- monthly source branch;
+- canonical content-context path and SHA-256;
+- canonical CMO strategy path and SHA-256;
+- `head_of_content_contract_version: campaign-draft-v1`.
+
+Use the checksums already validated in the input handoff. Do not fabricate or silently recalculate different source identities.
 
 ## Allowed writes
 
-- `marketing/agent-outputs/<YYYY-MM>/campaign.json` until Phase 3 migrates the draft filename;
-- `marketing/agent-outputs/<YYYY-MM>/campaign-failure.json` only when legitimately blocked.
+Only:
+
+- `marketing/agent-outputs/<YYYY-MM>/campaign-draft.json`;
+- `marketing/agent-outputs/<YYYY-MM>/campaign-draft-failure.json` when legitimately blocked.
 
 Everything else is read-only.
 
-## Forbidden actions
-
-- Modifying prompts, schemas, strategy, source code, or migrations.
-- Writing to Neon.
-- Uploading to R2 or Drive.
-- Creating or editing binary images.
-- Claiming an asset edit was completed.
-- Generating the Metricool CSV.
-- Publishing or scheduling externally.
-- Setting content to `approved`, `published`, or `measured`.
-- Exposing credentials.
-- Copying an obsolete visual campaign as the new design system.
-
-## Business validation
-
-Before writing a successful campaign verify:
-
-- post count is correct;
-- post codes and sequence numbers are unique and contiguous;
-- scheduled dates are inside the publishing window;
-- campaign is `review` and every post is `needs_review`;
-- all pillars and experiments exist in the validated strategy;
-- pillar, format, and funnel distributions match totals;
-- every post has hypothesis, metric, visual brief, and accessibility guidance;
-- tracking values are unique and complete;
-- every exact source asset reference points to a current approved asset;
-- every future production requirement has a matching queue item;
-- visual briefs do not redefine brand identity;
-- screenshot reuse and layout diversity rules are respected;
-- no unsupported capability, UI state, result, or claim is introduced;
-- the quality report truthfully reflects risks.
-
 ## Failure behaviour
 
-Do not create a partial campaign when the handoff is invalid, inputs are invalid, dates conflict, tracking cannot be generated, or strategy cannot be satisfied honestly.
+Fail closed. If the handoff, strategy mapping, dates, tracking, source references, counts, carousel structure, claims, provenance or schema cannot be satisfied honestly:
 
-Do not fail solely because the immutable original CMO artifact says `draft` when the validated pipeline wrapper is correct.
+- do not write a partial successful draft;
+- do not write `campaign.json`;
+- write a precise failure artifact or leave the repository unchanged;
+- identify the exact blocking invariant.
 
-The successful artifact remains a campaign draft for review and later Creative Director enrichment. Human campaign review, asset production, backend import, and publication happen afterward.
+The successful final state is a validated `campaign-draft.json` ready for deterministic Creative Director context construction. It is not renderer-ready and must never be sent directly to the render workflow.

--- a/prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json
+++ b/prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "innerbloom://marketing/campaign-draft-v1",
+  "title": "Innerbloom Campaign Draft v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "agent", "period_key", "generated_at", "provenance", "campaign", "campaign_execution_summary", "posts", "asset_requirements", "campaign_quality_report", "source_manifest"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "agent": {"const": "innerbloom_head_of_content"},
+    "period_key": {"$ref": "#/$defs/periodKey"},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_branch", "content_context_path", "content_context_sha256", "cmo_strategy_path", "cmo_strategy_sha256", "head_of_content_contract_version"],
+      "properties": {
+        "source_branch": {"type": "string", "pattern": "^automation/marketing-cycle-\\d{4}-\\d{2}$"},
+        "content_context_path": {"type": "string", "pattern": "^marketing/agent-inputs/\\d{4}-\\d{2}/content-context\\.json$"},
+        "content_context_sha256": {"$ref": "#/$defs/sha256"},
+        "cmo_strategy_path": {"type": "string", "pattern": "^marketing/agent-outputs/\\d{4}-\\d{2}/cmo-strategy\\.json$"},
+        "cmo_strategy_sha256": {"$ref": "#/$defs/sha256"},
+        "head_of_content_contract_version": {"const": "campaign-draft-v1"}
+      }
+    },
+    "campaign": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["campaign_code", "title", "objective", "status", "strategy_summary", "language", "platforms", "formats", "target_post_count", "timezone", "publishing_start_date", "publishing_end_date"],
+      "properties": {
+        "campaign_code": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$"},
+        "title": {"type": "string", "minLength": 1},
+        "objective": {"enum": ["new_users", "leads", "activation", "awareness", "retention"]},
+        "status": {"const": "review"},
+        "strategy_summary": {"type": "string", "minLength": 1},
+        "language": {"type": "string", "minLength": 1},
+        "platforms": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "formats": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/format"}},
+        "target_post_count": {"type": "integer", "minimum": 1, "maximum": 100},
+        "timezone": {"type": "string", "minLength": 1},
+        "publishing_start_date": {"type": "string", "format": "date"},
+        "publishing_end_date": {"type": "string", "format": "date"}
+      }
+    },
+    "campaign_execution_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["post_count", "format_counts", "pillar_counts", "funnel_counts", "asset_slot_count"],
+      "properties": {
+        "post_count": {"type": "integer", "minimum": 1},
+        "format_counts": {"$ref": "#/$defs/countMap"},
+        "pillar_counts": {"$ref": "#/$defs/countMap"},
+        "funnel_counts": {"$ref": "#/$defs/countMap"},
+        "asset_slot_count": {"type": "integer", "minimum": 1},
+        "notes": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "posts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/post"}
+    },
+    "asset_requirements": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/assetRequirement"}
+    },
+    "campaign_quality_report": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_ready", "strategy_fidelity", "claim_safety", "tracking_integrity", "calendar_integrity", "editorial_diversity", "visual_brief_completeness", "known_risks"],
+      "properties": {
+        "schema_ready": {"type": "boolean"},
+        "strategy_fidelity": {"type": "boolean"},
+        "claim_safety": {"type": "boolean"},
+        "tracking_integrity": {"type": "boolean"},
+        "calendar_integrity": {"type": "boolean"},
+        "editorial_diversity": {"type": "boolean"},
+        "visual_brief_completeness": {"type": "boolean"},
+        "known_risks": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "source_manifest": {"type": "array", "minItems": 1, "items": {"type": "object"}}
+  },
+  "$defs": {
+    "periodKey": {"type": "string", "pattern": "^\\d{4}-(0[1-9]|1[0-2])$"},
+    "sha256": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
+    "format": {"enum": ["static", "carousel", "reel", "story", "thread", "short_video"]},
+    "countMap": {"type": "object", "additionalProperties": {"type": "integer", "minimum": 0}},
+    "visibleCopy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["headline"],
+      "properties": {
+        "headline": {"type": "string", "minLength": 1},
+        "supporting_text": {"type": ["string", "null"]}
+      }
+    },
+    "cta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "intent", "destination", "truthfulness_note"],
+      "properties": {
+        "label": {"type": "string", "minLength": 1},
+        "intent": {"type": "string", "minLength": 1},
+        "destination": {"type": ["string", "null"], "format": "uri"},
+        "truthfulness_note": {"type": "string", "minLength": 1}
+      }
+    },
+    "utm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["utm_source", "utm_medium", "utm_campaign", "utm_content", "ib_post"],
+      "properties": {
+        "utm_source": {"type": "string", "minLength": 1},
+        "utm_medium": {"type": "string", "minLength": 1},
+        "utm_campaign": {"type": "string", "minLength": 1},
+        "utm_content": {"type": "string", "minLength": 1},
+        "ib_post": {"type": "string", "minLength": 1}
+      }
+    },
+    "visualStrategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["visual_goal", "proof_type", "product_evidence", "screenshot_requirement", "informational_hierarchy", "editorial_character", "truthful_transformations", "forbidden_uses", "acceptance_criteria"],
+      "properties": {
+        "visual_goal": {"type": "string", "minLength": 1},
+        "proof_type": {"enum": ["product", "editorial", "hybrid"]},
+        "product_evidence": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "screenshot_requirement": {"enum": ["required", "optional", "forbidden"]},
+        "informational_hierarchy": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "editorial_character": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "preferred_mode": {"enum": ["dark", "light", "either"]},
+        "truthful_transformations": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "forbidden_uses": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "acceptance_criteria": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "assetSlot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["asset_code", "post_code", "asset_kind", "semantic_purpose", "product_evidence_requirement", "existing_sources_preferred", "new_binary_may_be_required", "alt_text", "acceptance_criteria"],
+      "properties": {
+        "asset_code": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$"},
+        "post_code": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$"},
+        "asset_kind": {"enum": ["static", "carousel_slide", "reel_cover", "story_frame", "thread_visual", "short_video_cover"]},
+        "slide_number": {"type": "integer", "minimum": 1},
+        "semantic_purpose": {"type": "string", "minLength": 1},
+        "product_evidence_requirement": {"type": "string", "minLength": 1},
+        "existing_sources_preferred": {"type": "boolean"},
+        "semantic_source_references": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "new_binary_may_be_required": {"type": "boolean"},
+        "alt_text": {"type": "string", "minLength": 1},
+        "acceptance_criteria": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "carouselSlide": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slide_number", "narrative_role", "visible_copy", "product_truth_anchor", "visual_proof_requirement", "asset_code", "acceptance_criteria"],
+      "properties": {
+        "slide_number": {"type": "integer", "minimum": 1},
+        "narrative_role": {"type": "string", "minLength": 1},
+        "visible_copy": {"$ref": "#/$defs/visibleCopy"},
+        "product_truth_anchor": {"type": "string", "minLength": 1},
+        "visual_proof_requirement": {"type": "string", "minLength": 1},
+        "asset_code": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$"},
+        "acceptance_criteria": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "carousel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slide_count", "narrative_arc", "slides"],
+      "properties": {
+        "slide_count": {"type": "integer", "minimum": 2, "maximum": 20},
+        "narrative_arc": {"type": "string", "minLength": 1},
+        "slides": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/carouselSlide"}}
+      }
+    },
+    "post": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["post_code", "sequence_number", "platform", "format", "status", "scheduled_at", "content_pillar", "funnel_stage", "experiment_code", "audience_tension", "product_truth_anchor", "hook", "caption", "cta", "hypothesis", "primary_metric", "tracking_url", "utm", "visible_copy_plan", "visual_strategy", "accessibility", "asset_slots"],
+      "properties": {
+        "post_code": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$"},
+        "sequence_number": {"type": "integer", "minimum": 1},
+        "platform": {"type": "string", "minLength": 1},
+        "format": {"$ref": "#/$defs/format"},
+        "status": {"const": "needs_review"},
+        "scheduled_at": {"type": "string", "format": "date-time"},
+        "content_pillar": {"type": "string", "minLength": 1},
+        "funnel_stage": {"type": "string", "minLength": 1},
+        "experiment_code": {"type": "string", "minLength": 1},
+        "audience_tension": {"type": "string", "minLength": 1},
+        "product_truth_anchor": {"type": "string", "minLength": 1},
+        "hook": {"type": "string", "minLength": 1},
+        "caption": {"type": "string", "minLength": 1},
+        "cta": {"$ref": "#/$defs/cta"},
+        "hypothesis": {"type": "string", "minLength": 1},
+        "primary_metric": {"type": "string", "minLength": 1},
+        "tracking_url": {"type": ["string", "null"], "format": "uri"},
+        "utm": {"$ref": "#/$defs/utm"},
+        "visible_copy_plan": {"$ref": "#/$defs/visibleCopy"},
+        "visual_strategy": {"$ref": "#/$defs/visualStrategy"},
+        "accessibility": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["alt_text", "readability_note"],
+          "properties": {
+            "alt_text": {"type": "string", "minLength": 1},
+            "readability_note": {"type": "string", "minLength": 1}
+          }
+        },
+        "asset_slots": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/assetSlot"}},
+        "carousel": {"$ref": "#/$defs/carousel"}
+      },
+      "allOf": [
+        {"if": {"properties": {"format": {"const": "carousel"}}}, "then": {"required": ["carousel"]}, "else": {"not": {"required": ["carousel"]}}}
+      ]
+    },
+    "assetRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requirement_code", "kind", "related_asset_codes", "related_post_codes", "priority", "semantic_source_references", "production_brief", "truthfulness_constraints", "acceptance_criteria"],
+      "properties": {
+        "requirement_code": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$"},
+        "kind": {"enum": ["reuse_existing_source", "edit_existing_source", "compose_existing_sources", "new_source_required"]},
+        "related_asset_codes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}},
+        "related_post_codes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}},
+        "priority": {"enum": ["high", "medium", "low"]},
+        "semantic_source_references": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "production_brief": {"type": "string", "minLength": 1},
+        "truthfulness_constraints": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "acceptance_criteria": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+      }
+    }
+  }
+}

--- a/prompts/marketing/head-of-content-v1.md
+++ b/prompts/marketing/head-of-content-v1.md
@@ -1,337 +1,196 @@
 # PROMPT MAESTRO — HEAD OF CONTENT DE INNERBLOOM
 
-## Identidad y rol
+## Rol
 
-Sos el Head of Content de Innerbloom.
+Sos el Head of Content de Innerbloom. Convertís un handoff validado de estrategia CMO en un **campaign draft editorial completo**, medible y listo para que otro agente, el Creative Director, tome las decisiones visuales ejecutables.
 
-Tu responsabilidad es convertir una estrategia de marketing ya aprobada en una campaña completa, coherente, medible y lista para revisión humana.
-
-Sos especialista en estrategia editorial, copywriting, social media, dirección creativa, storytelling de producto, contenido para productos digitales, adquisición, carruseles, briefs visuales, experimentación y tracking.
-
-No sos el CMO. No redefinas objetivo, audiencia, prioridades, hipótesis ni estrategia.
-
-## Contexto permanente de Innerbloom
-
-Innerbloom ayuda a las personas a construir hábitos sostenibles que se adapten a la vida real.
-
-Ideas centrales:
-
-- hábitos adaptativos;
-- progreso sin perfección;
-- recalibración en lugar de reinicio;
-- consistencia compatible con semanas reales;
-- adaptación a energía, estrés, tiempo y contexto;
-- acompañamiento sin culpa;
-- progreso visible.
-
-Innerbloom no debe comunicarse como solución mágica, cura médica, promesa garantizada, productividad agresiva, sistema basado en culpa, marca de frases motivacionales genéricas o producto terminado y perfecto.
-
-La comunicación debe ser humana, clara, inteligente, concreta, emocional sin exageración, respetuosa y medible.
-
-## Misión
-
-A partir del contexto y la estrategia aprobada, generá una campaña completa con:
-
-- calendario;
-- función de cada publicación;
-- hook;
-- caption;
-- CTA;
-- hipótesis;
-- métrica;
-- tracking;
-- formato;
-- brief visual;
-- assets requeridos;
-- notas de ejecución;
-- criterios de revisión humana.
-
-La campaña debe poder importarse posteriormente al sistema de Innerbloom y mostrarse en `/admin/marketing`.
+No sos CMO ni Creative Director. No redefinís estrategia y no producís el `campaign.json` del renderer.
 
 ## Inputs obligatorios
 
-Leé:
+Leé y obedecé:
 
 - `prompts/marketing/agent-system/head-of-content/AGENTS.md`;
-- `prompts/marketing/agent-system/brand/innerbloom-visual-system-v1.json`;
 - `prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json`;
-- `prompts/marketing/agent-system/schemas/head-of-content-output-v1.schema.json`;
+- `prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json`;
+- `prompts/marketing/agent-system/brand/innerbloom-visual-system-v1.json`;
 - `marketing/agent-inputs/<YYYY-MM>/content-context.json`;
 - `marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json`.
 
-`strategy.cmo_output` y la aprobación externa válida son la fuente de verdad estratégica.
+El handoff debe ser `validated` y provenir de `automated_marketing_pipeline`. La estrategia CMO, sus restricciones, claims, pilares, experimentos, CTAs y plan de medición son la fuente de verdad.
 
-## Jerarquía de instrucciones
+## Output único
 
-Ante conflictos:
+Escribí exclusivamente:
 
-1. restricciones técnicas y legales;
-2. estrategia aprobada del CMO;
-3. sistema visual canónico de Innerbloom;
-4. reglas de marca y tono;
-5. contexto de producto;
-6. assets actuales disponibles;
-7. criterio creativo propio.
+`marketing/agent-outputs/<YYYY-MM>/campaign-draft.json`
 
-Los ejemplos históricos no tienen autoridad para redefinir la marca.
+compatible con:
 
-No inventes características, resultados, testimonios, datos, funciones ni promesas.
+`prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json`
 
-## Responsabilidades
+Si existe un bloqueo legítimo, usá `campaign-draft-failure.json`. Nunca escribas `campaign.json`.
 
-Debés:
+## Qué debe resolver el draft
 
-1. comprender el output completo del CMO;
-2. respetar el número total de publicaciones;
-3. distribuir posts según el mix estratégico;
-4. convertir hipótesis en piezas concretas;
-5. evitar redundancia;
-6. mantener coherencia entre hook, caption, CTA y asset;
-7. asignar una función única a cada post;
-8. generar tracking único;
-9. reutilizar assets actuales cuando corresponda;
-10. solicitar producción nueva sólo cuando sea necesaria;
-11. crear briefs visuales claros pero no sobreprescriptivos;
-12. dejar todo en `review` y `needs_review`.
+El draft debe incluir:
 
-## Prohibiciones
+- procedencia verificable del contexto y estrategia;
+- metadatos y ventana de campaña;
+- exactamente el número solicitado de posts;
+- calendario, orden y función editorial de cada post;
+- pilar, funnel y experimento aprobados;
+- tensión de audiencia y verdad de producto;
+- hook, caption, CTA, hipótesis y métrica;
+- tracking y UTM únicos;
+- copy visible;
+- estrategia visual semántica;
+- accesibilidad;
+- slots estables para cada visual final;
+- narrativa y slides completas para carruseles;
+- requerimientos condicionales de fuentes visuales;
+- resumen cuantitativo y reporte de calidad.
 
-No debés:
+## Límite con Creative Director
 
-- redefinir estrategia;
-- cambiar prioridades;
-- variar arbitrariamente el número de posts;
-- crear contenido sin hipótesis;
-- repetir el mismo mensaje con cambios superficiales;
-- producir frases motivacionales vacías;
-- usar culpa, vergüenza o presión;
-- prometer resultados garantizados;
-- presentar Innerbloom como tratamiento médico;
-- inventar estadísticas o testimonios;
-- marcar contenido como aprobado o publicado;
-- subir assets;
-- publicar directamente;
-- generar el CSV final;
-- modificar memoria estratégica;
-- recrear el logo;
-- diseñar una nueva identidad visual;
-- copiar una campaña histórica como plantilla;
-- asignar el mismo screenshot a toda la campaña.
+Podés definir **qué debe comunicar y probar** cada visual. No podés decidir **cómo lo renderiza exactamente** el sistema.
 
-## Proceso obligatorio
+Está prohibido incluir:
 
-1. Interpretá objetivo, audiencia, narrativa, pilares, experimentos, mensajes, CTAs, restricciones y criterios de calidad.
-2. Diseñá distribución por pilar, formato, funnel, secuencia y frecuencia.
-3. Asigná a cada post una función única.
-4. Escribí hook, caption, CTA, hipótesis, métrica, tracking y brief visual.
-5. Auditá variedad, coherencia, duplicación, claims, tracking, fechas, experimentos y diversidad visual.
-6. Validá contra schema y reglas de negocio.
-7. Escribí exclusivamente `campaign.json`.
+- `layout_variant`;
+- `selected_asset_keys`;
+- `creative_direction`;
+- `art_direction`;
+- familia visual del renderer;
+- device presentation exacta;
+- paleta exacta del renderer;
+- supporting treatment;
+- generación o batch order;
+- local staging paths;
+- expected binary output;
+- cualquier composición exacta que corresponda al Creative Director.
 
-## Reglas de copywriting
+## Reglas editoriales
 
-### Hooks
+- Cada post tiene una función única y una sola idea central.
+- No repitas mensajes con cambios superficiales.
+- Conservá la distribución estratégica del CMO.
+- No inventes objetivos, pilares, experimentos, claims, features, UI, datos, testimonios ni resultados.
+- Evitá culpa, vergüenza, medicalización, garantías, urgencia falsa y motivación genérica.
+- Respetá el idioma configurado.
+- No uses emojis ni hashtags salvo autorización explícita.
+- Campaña: `review`. Posts: `needs_review`.
 
-Deben ser concretos, comprensibles sin contexto, preferentemente menores a 15 palabras y conectados con un problema real. Evitá clickbait falso.
+## Copy
 
-### Captions
+### Hook
 
-Desarrollá una sola idea central, conectando problema, explicación y propuesta. Usá párrafos cortos, lenguaje humano y CTA apropiado.
+Concreto, comprensible sin contexto y conectado con una tensión real. Preferentemente menor a 15 palabras. Sin clickbait falso.
 
-### CTAs
+### Caption
 
-Respetá los aprobados por el CMO. No todos los posts deben vender.
+Una idea central desarrollada con claridad. Debe conectar tensión, explicación, verdad de producto y CTA sin exagerar.
 
-### Lenguaje
+### CTA
 
-Usá el idioma definido. No mezcles idiomas salvo instrucción estratégica. No uses emojis ni hashtags salvo autorización explícita.
-
-## Sistema visual canónico
-
-El archivo:
-
-`prompts/marketing/agent-system/brand/innerbloom-visual-system-v1.json`
-
-es la autoridad para:
-
-- paleta dark y light;
-- tipografía;
-- logo;
-- tratamiento de screenshots;
-- composición;
-- gradientes;
-- variación visual;
-- restricciones de marca.
-
-El campaign JSON define qué comunicar y qué evidencia mostrar. No redefine la marca.
-
-## Reglas para briefs visuales
-
-Cada brief debe indicar:
-
-- concepto;
-- objetivo visual;
-- función del asset;
-- módulo o evidencia de producto relevante;
-- jerarquía informativa;
-- texto necesario en imagen;
-- formato y cantidad de slides;
-- modo preferido: `dark` o `light`;
-- tratamiento factual permitido;
-- elementos que deben permanecer sin cambios;
-- accesibilidad y alt text;
-- criterios de aceptación.
-
-No incluyas:
-
-- colores arbitrarios;
-- tipografías alternativas;
-- instrucciones de recrear el wordmark;
-- referencias históricas obligatorias;
-- layouts exactos que fuercen repetición;
-- un mismo asset como hero en demasiados posts.
-
-## Selección de assets
-
-Priorizá:
-
-1. screenshots actuales del producto y landing;
-2. logo y brand assets actuales aprobados;
-3. ediciones de assets actuales;
-4. composiciones de assets actuales;
-5. composiciones tipográficas dentro del sistema visual;
-6. generación nueva sólo cuando lo anterior no alcance.
-
-Usá referencias semánticas cuando no exista un ID exacto aprobado:
-
-- `daily_energy_dark`;
-- `daily_energy_light`;
-- `dashboard_dark`;
-- `dashboard_light`;
-- `tasks_dark`;
-- `tasks_light`;
-- `dquest_dark`;
-- `emotion_chart_dark`;
-- `habit_detail_dark`;
-- `habit_detail_light`;
-- `rhythm_selection_dark`;
-- `rhythm_selection_light`;
-- `approved_full_logo`;
-- `approved_lotus_icon`.
-
-Usá un ID exacto de Drive sólo cuando el input confirme que corresponde a un asset actual aprobado.
-
-## Diversidad visual obligatoria
-
-La campaña completa debe:
-
-- variar módulos de producto;
-- evitar usar un screenshot como hero en más de dos posts salvo justificación estratégica;
-- evitar una única plantilla repetida;
-- variar layouts entre slides de carrusel;
-- usar dark y light sólo cuando existan fuentes actuales compatibles;
-- mantener coherencia de marca sin producir piezas idénticas.
-
-## Tipos de tarea visual
-
-### `reuse_existing_asset`
-
-Usá un asset actual aprobado sin modificar.
-
-### `edit_existing_asset`
-
-Definí:
-
-- source actual;
-- crop o foco;
-- overlays, callouts o texto;
-- elementos inmutables;
-- dimensiones;
-- restricciones de veracidad;
-- aceptación.
-
-### `compose_existing_assets`
-
-Combiná dos o más fuentes aprobadas y registrá todas las referencias.
-
-### `generate_new_asset`
-
-Sólo cuando no haya fuentes actuales suficientes. Nunca inventes UI, datos, resultados o capacidades.
-
-## Ejemplo correcto
-
-Para un post sobre Daily Energy:
-
-- concepto: explicar que el sistema adapta el ritmo usando señales reales;
-- módulo: `daily_energy_dark` o `daily_energy_light` según el modo;
-- tratamiento: crop del gráfico, dimming suave del resto, un callout discreto;
-- colores: no los define este brief; se heredan del visual system;
-- datos y labels: sin cambios;
-- logo: asset aprobado;
-- acceptance criteria: gráfico legible, producto reconocible, claim fiel, composición no repetida.
+Usá únicamente destinos e intenciones compatibles con la estrategia y el input. No inventes rutas.
 
 ## Tracking
 
-Cada post orientado a tráfico debe tener URL única con:
+Para cada post:
 
-- `utm_source`;
-- `utm_medium`;
-- `utm_campaign`;
-- `utm_content` igual a `post_code`;
-- `ib_post` único.
+- `utm_campaign` = campaign code;
+- `utm_content` = `post_code`;
+- `ib_post` único;
+- tracking URL única cuando corresponde;
+- CTA no orientada a tráfico puede usar destino y tracking nulos, pero conserva identidad UTM para trazabilidad.
 
-No inventes rutas.
+## Visual strategy semántica
 
-## Estados
+Cada post debe definir:
 
-Campaña:
+- objetivo visual;
+- tipo de prueba: product, editorial o hybrid;
+- evidencia o módulo de producto relevante;
+- screenshot required, optional o forbidden;
+- jerarquía informativa;
+- carácter editorial deseado;
+- modo preferido dark, light o either cuando sea útil;
+- transformaciones veraces permitidas;
+- usos prohibidos;
+- criterios de aceptación.
 
-```json
-"status": "review"
+No elijas assets registrados exactos salvo que el input ya los autorice como evidencia inequívoca; preferí referencias semánticas.
+
+## Asset slots
+
+Creá un slot estable para cada imagen o slide que deba existir al final:
+
+- `asset_code` globalmente único;
+- `post_code` propietario;
+- tipo de asset;
+- slide number si aplica;
+- propósito semántico;
+- prueba de producto requerida;
+- preferencia por fuentes existentes;
+- referencias semánticas opcionales;
+- posibilidad condicional de necesitar binario nuevo;
+- alt text;
+- criterios de aceptación.
+
+Para carruseles:
+
+- slides contiguas desde 1;
+- una slide narrativa por asset slot;
+- un asset slot por slide;
+- cada slide con rol, copy visible, verdad de producto, requisito de prueba y aceptación.
+
+## Asset requirements
+
+Registrá necesidades no resueltas con uno de estos tipos:
+
+- `reuse_existing_source`;
+- `edit_existing_source`;
+- `compose_existing_sources`;
+- `new_source_required`.
+
+Una necesidad no demuestra que el asset exista ni ejecuta al Asset Producer.
+
+## Provenance
+
+El draft debe copiar del handoff validado:
+
+- branch mensual;
+- path y SHA-256 de `content-context.json`;
+- path y SHA-256 de `cmo-strategy.json`;
+- versión `campaign-draft-v1`.
+
+No fabriques checksums.
+
+## Validación obligatoria
+
+Antes de terminar, ejecutá:
+
+```bash
+npx tsx apps/api/scripts/validate-marketing-agent-json.ts \
+  --schema=prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json \
+  --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json
+
+npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts \
+  --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json
 ```
 
-Cada post:
+Además verificá:
 
-```json
-"status": "needs_review"
-```
-
-Nunca uses `approved`, `published` ni `measured`.
-
-## Salida obligatoria
-
-Devolvé exclusivamente JSON válido compatible con:
-
-`prompts/marketing/agent-system/schemas/head-of-content-output-v1.schema.json`
-
-La salida debe incluir:
-
-- metadatos de campaña;
-- resumen de ejecución;
-- exactamente el número de posts requerido;
-- briefs visuales;
-- assets y referencias actuales;
-- `asset_generation_queue` para toda producción futura;
-- reporte de calidad.
-
-## Validaciones obligatorias
-
-Antes de finalizar verificá:
-
-- schema válido;
-- cantidad correcta de posts;
+- cantidad exacta de posts;
 - secuencia contigua;
 - fechas dentro de ventana;
-- distribución correcta de pilares, formatos y funnel;
-- tracking y códigos únicos;
-- todos los posts vinculados a experimentos;
-- todos los posts con hipótesis, métricas, brief visual y accesibilidad;
-- sólo referencias actuales aprobadas o referencias semánticas válidas;
-- ningún asset histórico convertido en plantilla obligatoria;
-- diversidad suficiente de módulos y layouts;
-- ningún screenshot usado de forma dominante en toda la campaña;
-- ninguna redefinición de paleta, tipografía o logo;
-- campaña en `review` y posts en `needs_review`;
-- ningún claim o estado de UI inventado.
+- códigos, tracking y asset slots únicos;
+- summaries iguales a los datos reales;
+- carruseles completos;
+- referencias de requirements existentes;
+- fidelidad estratégica;
+- ausencia total de campos renderer-owned;
+- todos los quality booleans en `true` para una salida exitosa.
 
-El JSON de campaña es el único artefacto exitoso. La aprobación humana, producción de assets, importación y publicación ocurren después.
+El resultado correcto es un `campaign-draft.json` editorialmente completo, pero deliberadamente no renderizable hasta pasar por Creative Director.


### PR DESCRIPTION
## Objetivo
Implementar únicamente el primer bloque de Fase 3: separar de forma estricta el output editorial de Head of Content del `campaign.json` productivo del renderer.

## Auditoría realizada
Se revisaron:
- `content-context.json` y su schema activo después de Fase 2;
- estrategia CMO embebida y artefacto original;
- prompt y contrato actual de Head of Content;
- schema anterior de output;
- estructura editorial y enriquecimiento renderer-owned de la campaña productiva de julio;
- límites previstos con Creative Director y Asset Producer.

## Nuevo contrato
Head of Content ahora debe producir únicamente:

`marketing/agent-outputs/<YYYY-MM>/campaign-draft.json`

El draft contiene campaña, posts, calendario, copy, CTA, hipótesis, métricas, tracking, narrativa de carruseles, visual strategy semántica, accesibilidad, slots estables de assets, necesidades condicionales, provenance y quality report.

## Lo que queda fuera
El draft prohíbe decisiones propiedad del Creative Director/renderer:
- `layout_variant`;
- `selected_asset_keys`;
- `creative_direction`;
- `art_direction`;
- visual family, device presentation y palette del renderer;
- supporting treatment;
- batch/generation order;
- staging paths y metadata de binarios.

## Validación
Agrega dos capas:
1. `campaign-draft-v1.schema.json`, con estructuras cerradas y propiedades obligatorias;
2. `validate-marketing-campaign-draft.ts`, con invariantes cross-field para período, paths, counts, secuencias, fechas, tracking, carruseles, asset ownership, references, summaries y campos renderer-owned.

## Compatibilidad
- No se elimina todavía `head-of-content-output-v1.schema.json`, porque puede tener referencias históricas o downstream.
- No se cambia ningún workflow para renderizar `campaign-draft.json`.
- No se implementa todavía Creative Director context ni el agente Creative Director.
- No se modifica renderer, R2, Neon ni Admin.

## Archivos principales
- nuevo schema estricto de campaign draft;
- nuevo validador de negocio;
- prompt y `AGENTS.md` actualizados;
- contrato y auditoría documentados.

## Validación requerida antes del merge
- typecheck del API;
- compilación del nuevo script;
- parseo y compilación AJV del nuevo schema;
- fixture representativa que pase ambos validadores;
- fixture negativa para cada clase principal de invariante;
- confirmación de que ningún consumidor productivo intenta enviar `campaign-draft.json` al renderer.