### PR TITLE
Force Google account chooser after native logout

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useSignIn, useSignUp } from '@clerk/clerk-react';
+import { useClerk, useSignIn, useSignUp } from '@clerk/clerk-react';
 
 export type GoogleOAuthMode = 'sign-in' | 'sign-up';
 
@@ -173,6 +173,7 @@ export function GoogleOAuthButton({
   className = '',
   forceAccountSelection = false,
 }: GoogleOAuthButtonProps) {
+  const clerk = useClerk();
   const { isLoaded: isSignInLoaded, signIn } = useSignIn();
   const { isLoaded: isSignUpLoaded, signUp } = useSignUp();
   const [isRedirecting, setIsRedirecting] = useState(false);
@@ -218,18 +219,30 @@ export function GoogleOAuthButton({
         if (!signUp) {
           throw new Error('Clerk sign-up resource is not ready');
         }
+        clerk.client.resetSignUp();
+        console.info('[auth] starting interactive Google OAuth', {
+          mode,
+          oauthMode,
+          accountSelection: shouldForceAccountSelection ? 'required' : 'default',
+        });
         await signUp.authenticateWithRedirect(redirectOptions);
       } else {
         if (!signIn) {
           throw new Error('Clerk sign-in resource is not ready');
         }
+        clerk.client.resetSignIn();
+        console.info('[auth] starting interactive Google OAuth', {
+          mode,
+          oauthMode,
+          accountSelection: shouldForceAccountSelection ? 'required' : 'default',
+        });
         await signIn.authenticateWithRedirect(redirectOptions);
       }
     } catch (error) {
       console.error(`[auth] Google OAuth redirect failed ${JSON.stringify(describeClerkOAuthError(error))}`);
       setIsRedirecting(false);
     }
-  }, [isLoaded, isRedirecting, mode, oauthMode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
+  }, [clerk.client, isLoaded, isRedirecting, mode, oauthMode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
 
   return (
     <button

--- a/apps/web/src/components/auth/__tests__/GoogleOAuthButton.accountSelection.test.ts
+++ b/apps/web/src/components/auth/__tests__/GoogleOAuthButton.accountSelection.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { buildGoogleOAuthRedirectOptions } from '../GoogleOAuthButton';
+
+describe('Google OAuth account selection', () => {
+  it('forces Google to show the account selector for interactive auth', () => {
+    expect(buildGoogleOAuthRedirectOptions('/after-auth', true)).toEqual({
+      strategy: 'oauth_google',
+      redirectUrl: '/sso-callback',
+      redirectUrlComplete: '/after-auth',
+      oidcPrompt: 'select_account',
+    });
+  });
+
+  it('does not force account selection for non-interactive flows', () => {
+    expect(buildGoogleOAuthRedirectOptions('/after-auth', false)).toEqual({
+      strategy: 'oauth_google',
+      redirectUrl: '/sso-callback',
+      redirectUrlComplete: '/after-auth',
+      oidcPrompt: undefined,
+    });
+  });
+});

--- a/apps/web/src/pages/MobileBrowserAuth.tsx
+++ b/apps/web/src/pages/MobileBrowserAuth.tsx
@@ -387,8 +387,17 @@ export default function MobileBrowserAuthPage() {
     }
 
     googleRedirectStartedRef.current = true;
+    clerk.client.resetSignIn();
+    const freshSignIn = clerk.client.signIn;
     const redirectOptions = buildGoogleOAuthRedirectOptions(handoffUrl, true);
-    void signIn
+    console.info('[mobile-auth-page] starting interactive Google OAuth', {
+      at: Date.now(),
+      mode,
+      provider: 'google',
+      accountSelection: 'required',
+      resetSignInAttempt: true,
+    });
+    void freshSignIn
       .authenticateWithRedirect(redirectOptions)
       .catch((cause) => {
         googleRedirectStartedRef.current = false;
@@ -404,6 +413,7 @@ export default function MobileBrowserAuthPage() {
         );
       });
   }, [
+    clerk.client,
     createdSessionId,
     handoffUrl,
     isLoaded,


### PR DESCRIPTION
Cerrada porque la implementación con `resetSignIn()`/`resetSignUp()` invalidaba el recurso de Clerk antes del redirect y podía dejar Chrome Custom Tab en blanco. Sustituida por una corrección nueva y segura basada en `continueSignIn: false`, `continueSignUp: false` y `oidcPrompt: select_account`, sin resets manuales ni cambios nativos.