### PR TITLE
Enforce campaign draft strategy and product fidelity

### DIFF
--- a/.github/workflows/marketing-campaign-draft-contract.yml
+++ b/.github/workflows/marketing-campaign-draft-contract.yml
@@ -6,8 +6,11 @@ on:
       - 'prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json'
       - 'prompts/marketing/agent-system/head-of-content/AGENTS.md'
       - 'prompts/marketing/head-of-content-v1.md'
+      - 'apps/api/scripts/export-marketing-content-context.ts'
       - 'apps/api/scripts/validate-marketing-campaign-draft.ts'
       - 'apps/api/scripts/fixtures/campaign-draft-valid.json'
+      - 'apps/api/scripts/fixtures/content-context-valid.json'
+      - 'apps/api/scripts/fixtures/cmo-strategy-valid.json'
       - '.github/workflows/marketing-campaign-draft-contract.yml'
   workflow_dispatch:
 
@@ -26,26 +29,67 @@ jobs:
       - run: npm install --no-audit --no-fund
       - name: Typecheck API
         run: npm -w @innerbloom/api run typecheck
-      - name: Validate fixture schema
+      - name: Validate CMO fixture schema
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-agent-json.ts
+          --schema=prompts/marketing/agent-system/schemas/cmo-output-v1.schema.json
+          --input=apps/api/scripts/fixtures/cmo-strategy-valid.json
+      - name: Validate content context fixture schema
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-agent-json.ts
+          --schema=prompts/marketing/agent-system/schemas/head-of-content-input-v1.schema.json
+          --input=apps/api/scripts/fixtures/content-context-valid.json
+      - name: Validate campaign draft fixture schema
         run: >-
           npx tsx apps/api/scripts/validate-marketing-agent-json.ts
           --schema=prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json
           --input=apps/api/scripts/fixtures/campaign-draft-valid.json
-      - name: Validate fixture business rules
+      - name: Validate campaign draft strategy and product fidelity
         run: >-
           npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts
           --input=apps/api/scripts/fixtures/campaign-draft-valid.json
-      - name: Prove renderer-owned fields fail closed
+          --content-context=apps/api/scripts/fixtures/content-context-valid.json
+          --cmo-strategy=apps/api/scripts/fixtures/cmo-strategy-valid.json
+      - name: Prove invalid strategy and product references fail closed
         shell: bash
         run: |
           set -euo pipefail
+          validate_failure() {
+            local file="$1"
+            local expected="$2"
+            if npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts \
+              --input="${file}" \
+              --content-context=apps/api/scripts/fixtures/content-context-valid.json \
+              --cmo-strategy=apps/api/scripts/fixtures/cmo-strategy-valid.json > /tmp/validator.log 2>&1; then
+              echo "Expected ${file} to fail." >&2
+              exit 1
+            fi
+            grep -F "${expected}" /tmp/validator.log
+          }
+
           node - <<'NODE'
           const fs = require('fs');
-          const input = JSON.parse(fs.readFileSync('apps/api/scripts/fixtures/campaign-draft-valid.json', 'utf8'));
-          input.posts[0].visual_strategy.layout_variant = 'forbidden';
-          fs.writeFileSync('/tmp/campaign-draft-invalid.json', JSON.stringify(input));
+          const source = JSON.parse(fs.readFileSync('apps/api/scripts/fixtures/campaign-draft-valid.json', 'utf8'));
+
+          const badPillar = structuredClone(source);
+          badPillar.posts[0].content_pillar = 'invented_pillar';
+          badPillar.campaign_execution_summary.pillar_counts = { invented_pillar: 1 };
+          fs.writeFileSync('/tmp/campaign-draft-bad-pillar.json', JSON.stringify(badPillar));
+
+          const badExperiment = structuredClone(source);
+          badExperiment.posts[0].experiment_code = 'invented_experiment';
+          fs.writeFileSync('/tmp/campaign-draft-bad-experiment.json', JSON.stringify(badExperiment));
+
+          const badProduct = structuredClone(source);
+          badProduct.posts[0].visual_strategy.product_evidence = ['invented_product_capability'];
+          fs.writeFileSync('/tmp/campaign-draft-bad-product.json', JSON.stringify(badProduct));
+
+          const badRenderer = structuredClone(source);
+          badRenderer.posts[0].visual_strategy.layout_variant = 'forbidden';
+          fs.writeFileSync('/tmp/campaign-draft-bad-renderer.json', JSON.stringify(badRenderer));
           NODE
-          if npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts --input=/tmp/campaign-draft-invalid.json; then
-            echo 'Expected forbidden renderer field validation to fail.' >&2
-            exit 1
-          fi
+
+          validate_failure /tmp/campaign-draft-bad-pillar.json 'references unknown CMO pillar'
+          validate_failure /tmp/campaign-draft-bad-experiment.json 'references unknown CMO experiment'
+          validate_failure /tmp/campaign-draft-bad-product.json 'references unknown product truth'
+          validate_failure /tmp/campaign-draft-bad-renderer.json 'renderer-owned field layout_variant is forbidden'

--- a/apps/api/scripts/export-marketing-content-context.ts
+++ b/apps/api/scripts/export-marketing-content-context.ts
@@ -21,6 +21,41 @@ async function loadJson(path: string): Promise<{ raw: string; value: any }> {
   return { raw, value: JSON.parse(raw) };
 }
 
+type ProductTruth = {
+  truth_ref: string;
+  source_type: 'cmo_core_message' | 'cmo_supporting_message' | 'cmo_proof_point' | 'product_change' | 'positioning';
+  text: string;
+};
+
+function buildApprovedProductTruths(context: any, strategy: any): ProductTruth[] {
+  const groups: Array<{ sourceType: ProductTruth['source_type']; prefix: string; values: unknown }> = [
+    { sourceType: 'cmo_core_message', prefix: 'cmo_core_message', values: strategy?.messaging_guidelines?.core_messages },
+    { sourceType: 'cmo_supporting_message', prefix: 'cmo_supporting_message', values: strategy?.messaging_guidelines?.supporting_messages },
+    { sourceType: 'cmo_proof_point', prefix: 'cmo_proof_point', values: strategy?.messaging_guidelines?.proof_points },
+    { sourceType: 'product_change', prefix: 'product_change', values: context?.business_context?.known_product_changes },
+    { sourceType: 'positioning', prefix: 'positioning', values: context?.strategy_memory?.current_positioning },
+  ];
+
+  const seen = new Set<string>();
+  const truths: ProductTruth[] = [];
+  for (const group of groups) {
+    const values = Array.isArray(group.values) ? group.values : [];
+    for (const value of values) {
+      if (typeof value !== 'string' || !value.trim()) continue;
+      const text = value.trim();
+      const normalized = text.toLocaleLowerCase('en').replace(/\s+/g, ' ');
+      if (seen.has(normalized)) continue;
+      seen.add(normalized);
+      truths.push({
+        truth_ref: `${group.prefix}_${truths.filter((item) => item.source_type === group.sourceType).length + 1}`,
+        source_type: group.sourceType,
+        text,
+      });
+    }
+  }
+  return truths;
+}
+
 async function main(): Promise<void> {
   const period = readArg('period');
   const force = hasFlag('force');
@@ -53,6 +88,8 @@ async function main(): Promise<void> {
   const supported = context.operational_constraints?.supported_formats ?? [];
   const formats = supported.map((value: string) => value.includes('carousel') ? 'carousel' : value.includes('static') ? 'static' : value);
   const primaryUrl = context.available_assets?.existing_visuals?.find((asset: any) => asset.label === 'primaryUrl')?.url ?? 'https://innerbloomjourney.org/';
+  const approvedProductTruths = buildApprovedProductTruths(context, strategy);
+  if (approvedProductTruths.length === 0) throw new Error('No approved product truths are available for Head of Content');
   const now = new Date().toISOString();
 
   const output = {
@@ -89,6 +126,7 @@ async function main(): Promise<void> {
       product_pages: context.analytics?.product_pages ?? [],
       product_totals: context.analytics?.product_totals ?? {},
       approved_claim_source: strategy.messaging_guidelines ?? {},
+      approved_product_truths: approvedProductTruths,
     },
     available_assets: context.available_assets ?? {},
     operational_constraints: {
@@ -120,7 +158,7 @@ async function main(): Promise<void> {
   const tempPath = `${outputPath}.tmp`;
   await writeFile(tempPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
   await rename(tempPath, outputPath);
-  console.log(JSON.stringify({ status: 'written', outputPath, period, campaignCode, contextChecksum, strategyChecksum }, null, 2));
+  console.log(JSON.stringify({ status: 'written', outputPath, period, campaignCode, contextChecksum, strategyChecksum, approvedProductTruthCount: approvedProductTruths.length }, null, 2));
 }
 
 main().catch((error: unknown) => {

--- a/apps/api/scripts/fixtures/campaign-draft-valid.json
+++ b/apps/api/scripts/fixtures/campaign-draft-valid.json
@@ -28,7 +28,7 @@
   "campaign_execution_summary": {
     "post_count": 1,
     "format_counts": {"static": 1},
-    "pillar_counts": {"Pain and friction": 1},
+    "pillar_counts": {"pain_and_friction": 1},
     "funnel_counts": {"awareness": 1},
     "asset_slot_count": 1,
     "notes": ["Contract fixture only."]
@@ -41,13 +41,13 @@
       "format": "static",
       "status": "needs_review",
       "scheduled_at": "2026-08-03T10:00:00+02:00",
-      "content_pillar": "Pain and friction",
+      "content_pillar": "pain_and_friction",
       "funnel_stage": "awareness",
       "experiment_code": "pain_first_hook",
       "audience_tension": "Rigid systems collapse during real weeks.",
       "product_truth_anchor": "Innerbloom presents progress against a selected rhythm without guaranteeing outcomes.",
       "hook": "Your routine should survive a difficult week.",
-      "caption": "A useful system leaves room for real life. Innerbloom explores visible progress and adjustable challenge without pretending every week is identical.",
+      "caption": "A useful system leaves room for real life. Innerbloom presents progress against a selected rhythm without pretending every week is identical.",
       "cta": {
         "label": "Explore Innerbloom",
         "intent": "traffic",
@@ -71,7 +71,7 @@
       "visual_strategy": {
         "visual_goal": "Communicate resilience without depicting unsupported automation.",
         "proof_type": "hybrid",
-        "product_evidence": ["dashboard progress overview"],
+        "product_evidence": ["cmo_proof_point_1"],
         "screenshot_requirement": "optional",
         "informational_hierarchy": ["headline", "product evidence", "supporting text", "brand"],
         "editorial_character": ["calm", "clear", "human"],

--- a/apps/api/scripts/fixtures/cmo-strategy-valid.json
+++ b/apps/api/scripts/fixtures/cmo-strategy-valid.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "1.0",
+  "agent": "innerbloom_cmo",
+  "period": "2026-08",
+  "generated_at": "2026-07-25T00:00:00Z",
+  "review_status": "draft",
+  "executive_summary": "Test adaptive habits messaging without promising outcomes.",
+  "input_assessment": {},
+  "previous_period_analysis": {},
+  "learnings": [
+    {
+      "learning": "Pain-first messages deserve a controlled test.",
+      "evidence": ["Previous campaign observation"],
+      "confidence": "moderate_signal",
+      "implication": "Use one pain-first experiment."
+    }
+  ],
+  "strategic_diagnosis": {},
+  "strategy": {
+    "primary_objective": "new_users",
+    "secondary_objectives": [],
+    "priority_audience": {"description": "People whose routines break during difficult weeks."},
+    "core_value_proposition": "Build sustainable habits that can adapt to real life.",
+    "period_narrative": "Progress without perfection.",
+    "strategic_priorities": ["Explain adaptive habits clearly"],
+    "content_pillars": [
+      {
+        "pillar_code": "pain_and_friction",
+        "name": "Pain and friction",
+        "purpose": "Recognise why rigid routines fail.",
+        "audience_problem": "Rigid systems collapse during real weeks.",
+        "message": "A sustainable routine leaves room for real life.",
+        "proof_or_mechanism": "Progress can be viewed against a selected rhythm.",
+        "recommended_formats": ["static"],
+        "recommended_post_count": 1
+      },
+      {
+        "pillar_code": "adaptive_progress",
+        "name": "Adaptive progress",
+        "purpose": "Explain progress without perfection.",
+        "audience_problem": "People interpret interruption as failure.",
+        "message": "Recalibration is more useful than restarting.",
+        "proof_or_mechanism": "Innerbloom supports visible progress.",
+        "recommended_formats": ["static"],
+        "recommended_post_count": 0
+      },
+      {
+        "pillar_code": "product_clarity",
+        "name": "Product clarity",
+        "purpose": "Show truthful product evidence.",
+        "audience_problem": "The product mechanism is not yet obvious.",
+        "message": "Use current product evidence without invented UI.",
+        "proof_or_mechanism": "Current approved screenshots.",
+        "recommended_formats": ["static"],
+        "recommended_post_count": 0
+      }
+    ],
+    "content_mix": {
+      "total_posts": 1,
+      "by_pillar": {"pain_and_friction": 1},
+      "by_format": {"static": 1},
+      "by_funnel_stage": {"awareness": 1, "consideration": 0, "activation": 0}
+    }
+  },
+  "experiments": [
+    {
+      "experiment_code": "pain_first_hook",
+      "name": "Pain-first hook",
+      "hypothesis": "A pain-first message will improve qualified landing visits.",
+      "variable_being_tested": "Opening framing",
+      "control_or_baseline": "Generic product explanation",
+      "target_audience": "People with inconsistent routines",
+      "content_pillars": ["pain_and_friction"],
+      "primary_metric": "Landing page sessions",
+      "secondary_metrics": [],
+      "success_criteria": "More qualified sessions without misleading claims.",
+      "failure_criteria": "No improvement or low-quality traffic.",
+      "minimum_evidence_needed": "One complete campaign period.",
+      "decision_enabled": "Whether to continue pain-first framing."
+    },
+    {
+      "experiment_code": "product_proof",
+      "name": "Product proof",
+      "hypothesis": "Truthful product evidence improves understanding.",
+      "variable_being_tested": "Presence of product evidence",
+      "control_or_baseline": "Editorial-only creative",
+      "target_audience": "Visitors evaluating Innerbloom",
+      "content_pillars": ["product_clarity"],
+      "primary_metric": "Landing page sessions",
+      "secondary_metrics": [],
+      "success_criteria": "Improved qualified engagement.",
+      "failure_criteria": "No measurable improvement.",
+      "minimum_evidence_needed": "One complete campaign period.",
+      "decision_enabled": "Whether to increase product-led content."
+    }
+  ],
+  "messaging_guidelines": {
+    "core_messages": ["Innerbloom helps people build sustainable habits that adapt to real life."],
+    "supporting_messages": ["Progress does not require perfection."],
+    "proof_points": ["Innerbloom presents progress against a selected rhythm."],
+    "approved_ctas": ["Explore Innerbloom"],
+    "messages_to_avoid": ["Never miss a habit again"],
+    "claims_to_avoid": ["Innerbloom automatically optimizes your whole day"],
+    "tone": ["clear", "human"],
+    "language_rules": ["English"]
+  },
+  "visual_direction": {},
+  "head_of_content_brief": {},
+  "measurement_plan": {},
+  "strategy_memory_update": {},
+  "source_manifest": []
+}

--- a/apps/api/scripts/fixtures/content-context-valid.json
+++ b/apps/api/scripts/fixtures/content-context-valid.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1.0",
+  "period": {
+    "period_key": "2026-08",
+    "campaign_code": "ib_202608",
+    "timezone": "Europe/Madrid",
+    "target_post_count": 1,
+    "publishing_start_date": "2026-08-01",
+    "publishing_end_date": "2026-08-31"
+  },
+  "strategy": {
+    "handoff_status": "validated",
+    "handoff_authority": "automated_marketing_pipeline",
+    "handoff_recorded_at": "2026-07-25T00:00:00Z",
+    "original_cmo_review_status": "draft",
+    "cmo_context_path": "marketing/agent-inputs/2026-08/cmo-context.json",
+    "cmo_context_checksum": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "cmo_output_path": "marketing/agent-outputs/2026-08/cmo-strategy.json",
+    "cmo_output_checksum": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "cmo_output": {"period": "2026-08"}
+  },
+  "brand": {
+    "objective": "new_users",
+    "positioning": ["Sustainable habits that adapt to real life."],
+    "content_rules": ["Do not promise guaranteed outcomes."],
+    "language": "English",
+    "human_approval": false
+  },
+  "product_context": {
+    "stage": "early product",
+    "known_product_changes": [],
+    "product_pages": [],
+    "product_totals": {},
+    "approved_claim_source": {},
+    "approved_product_truths": [
+      {
+        "truth_ref": "cmo_proof_point_1",
+        "source_type": "cmo_proof_point",
+        "text": "Innerbloom presents progress against a selected rhythm."
+      }
+    ]
+  },
+  "available_assets": {
+    "product_screenshots": [
+      {"asset_id": "dashboard_dark", "source": "repo", "kind": "product_screenshot", "label": "dashboard_dark"},
+      {"asset_id": "dashboard_light", "source": "repo", "kind": "product_screenshot", "label": "dashboard_light"}
+    ],
+    "brand_assets": [],
+    "reusable_templates": [],
+    "existing_visuals": [],
+    "missing_assets": []
+  },
+  "operational_constraints": {
+    "platforms": ["instagram"],
+    "formats": ["static"],
+    "max_carousel_slides": 10,
+    "max_assets_per_post": 10,
+    "publishing_method": "Metricool CSV after approval",
+    "public_asset_store": "Cloudflare R2",
+    "review_required": true,
+    "calendar_rules": ["Use dates inside the publishing window"]
+  },
+  "tracking": {
+    "base_url": "https://innerbloomjourney.org/",
+    "utm_source": "instagram",
+    "utm_medium": "social",
+    "campaign_code": "ib_202608",
+    "additional_parameters": {"utm_content": "post_code", "ib_post": "sequence_number"}
+  },
+  "source_manifest": [
+    {"source_type": "repo_file", "source_path_or_id": "marketing/agent-inputs/2026-08/cmo-context.json"}
+  ]
+}

--- a/apps/api/scripts/validate-marketing-campaign-draft.ts
+++ b/apps/api/scripts/validate-marketing-campaign-draft.ts
@@ -23,20 +23,100 @@ function equalCountMaps(actual: Record<string, number>, expected: Record<string,
   return [...keys].every((key) => (actual[key] ?? 0) === (expected[key] ?? 0));
 }
 
+function stringValues(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
+}
+
+function normalized(value: string): string {
+  return value.toLocaleLowerCase('en').replace(/[’']/g, "'").replace(/\s+/g, ' ').trim();
+}
+
+function combinedPostCopy(post: any): string {
+  const slideCopy = Array.isArray(post.carousel?.slides)
+    ? post.carousel.slides.flatMap((slide: any) => [slide.visible_copy?.headline, slide.visible_copy?.supporting_text, slide.product_truth_anchor])
+    : [];
+  return [
+    post.hook,
+    post.caption,
+    post.product_truth_anchor,
+    post.visible_copy_plan?.headline,
+    post.visible_copy_plan?.supporting_text,
+    ...slideCopy,
+  ].filter((value): value is string => typeof value === 'string').join(' ');
+}
+
 async function main(): Promise<void> {
   const inputPath = readArg('input');
-  if (!inputPath) throw new Error('Usage: tsx apps/api/scripts/validate-marketing-campaign-draft.ts --input=<campaign-draft.json>');
+  const contentContextPath = readArg('content-context');
+  const cmoStrategyPath = readArg('cmo-strategy');
+  if (!inputPath || !contentContextPath || !cmoStrategyPath) {
+    throw new Error('Usage: tsx apps/api/scripts/validate-marketing-campaign-draft.ts --input=<campaign-draft.json> --content-context=<content-context.json> --cmo-strategy=<cmo-strategy.json>');
+  }
 
-  const draft = JSON.parse(await readFile(inputPath, 'utf8')) as any;
+  const [draft, contentContext, cmoStrategy] = await Promise.all([
+    readFile(inputPath, 'utf8').then((value) => JSON.parse(value) as any),
+    readFile(contentContextPath, 'utf8').then((value) => JSON.parse(value) as any),
+    readFile(cmoStrategyPath, 'utf8').then((value) => JSON.parse(value) as any),
+  ]);
   const { campaign, posts, campaign_execution_summary: summary, asset_requirements: requirements, provenance } = draft;
 
   assert(Array.isArray(posts) && posts.length > 0, 'posts must be a non-empty array');
   assert(posts.length === campaign.target_post_count, `post count ${posts.length} does not match campaign.target_post_count ${campaign.target_post_count}`);
   assert(summary.post_count === posts.length, 'campaign_execution_summary.post_count does not match posts length');
-  assert(draft.period_key === campaign.campaign_code.slice(3, 7) + '-' + campaign.campaign_code.slice(7, 9), 'period_key does not match canonical campaign_code ib_YYYYMM');
+  const campaignCodeMatch = /^ib_(\d{4})(0[1-9]|1[0-2])$/.exec(campaign.campaign_code);
+  assert(campaignCodeMatch, 'campaign.campaign_code must use canonical ib_YYYYMM format');
+  const campaignPeriod = `${campaignCodeMatch[1]}-${campaignCodeMatch[2]}`;
+  assert(draft.period_key === campaignPeriod, 'period_key does not match canonical campaign_code');
   assert(provenance.source_branch === `automation/marketing-cycle-${draft.period_key}`, 'provenance.source_branch does not match period_key');
   assert(provenance.content_context_path === `marketing/agent-inputs/${draft.period_key}/content-context.json`, 'content_context_path does not match period_key');
   assert(provenance.cmo_strategy_path === `marketing/agent-outputs/${draft.period_key}/cmo-strategy.json`, 'cmo_strategy_path does not match period_key');
+
+  assert(contentContext?.period?.period_key === draft.period_key, 'content context period does not match campaign draft');
+  assert(cmoStrategy?.period === draft.period_key, 'CMO strategy period does not match campaign draft');
+  assert(contentContext?.strategy?.cmo_output?.period === cmoStrategy.period, 'embedded CMO strategy period does not match original strategy');
+  assert(contentContext?.period?.campaign_code === campaign.campaign_code, 'campaign_code differs from content context');
+  assert(contentContext?.period?.target_post_count === campaign.target_post_count, 'target_post_count differs from content context');
+  assert(contentContext?.period?.timezone === campaign.timezone, 'campaign timezone differs from content context');
+  assert(contentContext?.period?.publishing_start_date === campaign.publishing_start_date, 'publishing_start_date differs from content context');
+  assert(contentContext?.period?.publishing_end_date === campaign.publishing_end_date, 'publishing_end_date differs from content context');
+  assert(campaign.objective === cmoStrategy?.strategy?.primary_objective, 'campaign objective differs from CMO primary objective');
+
+  const allowedPlatforms = new Set(stringValues(contentContext?.operational_constraints?.platforms));
+  const allowedFormats = new Set(stringValues(contentContext?.operational_constraints?.formats));
+  assert(campaign.platforms.every((value: string) => allowedPlatforms.has(value)), 'campaign contains a platform not allowed by content context');
+  assert(campaign.formats.every((value: string) => allowedFormats.has(value)), 'campaign contains a format not allowed by content context');
+
+  const pillarCodes = new Set(
+    (Array.isArray(cmoStrategy?.strategy?.content_pillars) ? cmoStrategy.strategy.content_pillars : [])
+      .map((pillar: any) => pillar?.pillar_code)
+      .filter((value: unknown): value is string => typeof value === 'string' && value.length > 0),
+  );
+  const experiments = new Map<string, any>(
+    (Array.isArray(cmoStrategy?.experiments) ? cmoStrategy.experiments : [])
+      .filter((experiment: any) => typeof experiment?.experiment_code === 'string')
+      .map((experiment: any) => [experiment.experiment_code, experiment]),
+  );
+  assert(pillarCodes.size > 0, 'CMO strategy has no valid pillar_code values');
+  assert(experiments.size > 0, 'CMO strategy has no valid experiment_code values');
+
+  const approvedTruths = Array.isArray(contentContext?.product_context?.approved_product_truths)
+    ? contentContext.product_context.approved_product_truths
+    : [];
+  const truthRefs = new Set(
+    approvedTruths.map((truth: any) => truth?.truth_ref).filter((value: unknown): value is string => typeof value === 'string' && value.length > 0),
+  );
+  assert(truthRefs.size > 0, 'content context has no approved product truth references');
+
+  const forbiddenClaims = [
+    ...stringValues(cmoStrategy?.messaging_guidelines?.messages_to_avoid),
+    ...stringValues(cmoStrategy?.messaging_guidelines?.claims_to_avoid),
+  ].map(normalized).filter((value) => value.length >= 4);
+  const hardBlockedClaims: Array<{ pattern: RegExp; label: string }> = [
+    { pattern: /\b(guaranteed?|guarantees?|guarantee)\b/i, label: 'guaranteed outcome' },
+    { pattern: /\b(cure|cures|cured|treat|treats|treatment|diagnose|diagnosis)\b/i, label: 'medical claim' },
+    { pattern: /\bfully automatic\b|\bon autopilot\b/i, label: 'unsupported automatic capability' },
+    { pattern: /\bproven results?\b/i, label: 'unsupported proven result' },
+  ];
 
   const postCodes = posts.map((post: any) => post.post_code);
   assert(new Set(postCodes).size === postCodes.length, 'post_code values must be unique');
@@ -49,11 +129,45 @@ async function main(): Promise<void> {
     const scheduled = Date.parse(post.scheduled_at);
     assert(scheduled >= start && scheduled <= end, `${post.post_code} scheduled_at is outside the publishing window`);
     assert(post.status === 'needs_review', `${post.post_code} must remain needs_review`);
+    assert(allowedPlatforms.has(post.platform), `${post.post_code} uses unsupported platform ${post.platform}`);
+    assert(allowedFormats.has(post.format), `${post.post_code} uses unsupported format ${post.format}`);
+    assert(pillarCodes.has(post.content_pillar), `${post.post_code} references unknown CMO pillar ${post.content_pillar}`);
+    const experiment = experiments.get(post.experiment_code);
+    assert(experiment, `${post.post_code} references unknown CMO experiment ${post.experiment_code}`);
+    const experimentPillars = stringValues(experiment.content_pillars);
+    if (experimentPillars.length > 0) {
+      assert(experimentPillars.includes(post.content_pillar), `${post.post_code} maps experiment ${post.experiment_code} to an unsupported pillar`);
+    }
+    if (typeof experiment.primary_metric === 'string' && experiment.primary_metric.trim()) {
+      assert(post.primary_metric === experiment.primary_metric, `${post.post_code} primary_metric differs from experiment ${post.experiment_code}`);
+    }
+
+    const evidenceRefs = stringValues(post.visual_strategy?.product_evidence);
+    assert(evidenceRefs.length > 0, `${post.post_code} must cite at least one approved product truth reference`);
+    for (const truthRef of evidenceRefs) {
+      assert(truthRefs.has(truthRef), `${post.post_code} references unknown product truth ${truthRef}`);
+    }
+
+    const copy = combinedPostCopy(post);
+    const normalizedCopy = normalized(copy);
+    for (const blocked of forbiddenClaims) {
+      assert(!normalizedCopy.includes(blocked), `${post.post_code} contains a CMO-forbidden claim or message: ${blocked}`);
+    }
+    for (const blocked of hardBlockedClaims) {
+      assert(!blocked.pattern.test(copy), `${post.post_code} contains ${blocked.label}`);
+    }
+
     assert(post.utm.utm_campaign === campaign.campaign_code, `${post.post_code} utm_campaign must equal campaign_code`);
     assert(post.utm.utm_content === post.post_code, `${post.post_code} utm_content must equal post_code`);
     assert(post.asset_slots.length >= 1, `${post.post_code} must define at least one asset slot`);
     for (const slot of post.asset_slots) {
       assert(slot.post_code === post.post_code, `${slot.asset_code} post_code does not match owner post`);
+      for (const reference of stringValues(slot.semantic_source_references)) {
+        const knownAssetReference = Object.values(contentContext.available_assets ?? {})
+          .flatMap((values: any) => Array.isArray(values) ? values : [])
+          .some((asset: any) => [asset?.asset_id, asset?.label].includes(reference));
+        assert(knownAssetReference, `${slot.asset_code} references unknown source asset ${reference}`);
+      }
     }
     if (post.format === 'carousel') {
       assert(post.carousel.slides.length === post.carousel.slide_count, `${post.post_code} carousel slide_count mismatch`);
@@ -117,7 +231,7 @@ async function main(): Promise<void> {
     assert(draft.campaign_quality_report[check] === true, `campaign_quality_report.${check} must be true for a successful draft`);
   }
 
-  console.log(`Validated campaign draft business invariants: ${inputPath}`);
+  console.log(`Validated campaign draft strategy and product fidelity: ${inputPath}`);
 }
 
 main().catch((error: unknown) => {

--- a/apps/api/scripts/validate-marketing-campaign-draft.ts
+++ b/apps/api/scripts/validate-marketing-campaign-draft.ts
@@ -1,207 +1,201 @@
 import { readFile } from 'node:fs/promises';
 import process from 'node:process';
 
-function readArg(name: string): string | null {
+const readArg = (name: string): string | null => {
   const prefix = `--${name}=`;
   return process.argv.slice(2).find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? null;
-}
+};
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
 }
 
-function countBy<T>(values: T[], key: (value: T) => string): Record<string, number> {
-  return values.reduce<Record<string, number>>((acc, value) => {
-    const name = key(value);
-    acc[name] = (acc[name] ?? 0) + 1;
-    return acc;
+const strings = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
+
+const normalize = (value: string): string => value.toLocaleLowerCase('en').replace(/[’']/g, "'").replace(/\s+/g, ' ').trim();
+
+function countBy(values: any[], key: string): Record<string, number> {
+  return values.reduce<Record<string, number>>((counts, value) => {
+    const item = String(value[key]);
+    counts[item] = (counts[item] ?? 0) + 1;
+    return counts;
   }, {});
 }
 
-function equalCountMaps(actual: Record<string, number>, expected: Record<string, number>): boolean {
-  const keys = new Set([...Object.keys(actual), ...Object.keys(expected)]);
-  return [...keys].every((key) => (actual[key] ?? 0) === (expected[key] ?? 0));
+function equalCounts(actual: Record<string, number>, expected: Record<string, number>): boolean {
+  return [...new Set([...Object.keys(actual), ...Object.keys(expected)])]
+    .every((key) => (actual[key] ?? 0) === (expected[key] ?? 0));
 }
 
-function stringValues(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
-}
-
-function normalized(value: string): string {
-  return value.toLocaleLowerCase('en').replace(/[’']/g, "'").replace(/\s+/g, ' ').trim();
-}
-
-function combinedPostCopy(post: any): string {
-  const slideCopy = Array.isArray(post.carousel?.slides)
+function postCopy(post: any): string {
+  const slides = Array.isArray(post.carousel?.slides)
     ? post.carousel.slides.flatMap((slide: any) => [slide.visible_copy?.headline, slide.visible_copy?.supporting_text, slide.product_truth_anchor])
     : [];
-  return [
-    post.hook,
-    post.caption,
-    post.product_truth_anchor,
-    post.visible_copy_plan?.headline,
-    post.visible_copy_plan?.supporting_text,
-    ...slideCopy,
-  ].filter((value): value is string => typeof value === 'string').join(' ');
+  return [post.hook, post.caption, post.product_truth_anchor, post.visible_copy_plan?.headline, post.visible_copy_plan?.supporting_text, ...slides]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ');
+}
+
+function knownAssetReferences(context: any): Set<string> {
+  const refs = new Set<string>();
+  for (const collection of Object.values(context?.available_assets ?? {})) {
+    if (!Array.isArray(collection)) continue;
+    for (const asset of collection) {
+      if (!asset || typeof asset !== 'object') continue;
+      for (const value of [(asset as any).asset_id, (asset as any).label]) {
+        if (typeof value === 'string' && value) refs.add(value);
+      }
+    }
+  }
+  return refs;
 }
 
 async function main(): Promise<void> {
   const inputPath = readArg('input');
-  const contentContextPath = readArg('content-context');
-  const cmoStrategyPath = readArg('cmo-strategy');
-  if (!inputPath || !contentContextPath || !cmoStrategyPath) {
+  const contextPath = readArg('content-context');
+  const strategyPath = readArg('cmo-strategy');
+  if (!inputPath || !contextPath || !strategyPath) {
     throw new Error('Usage: tsx apps/api/scripts/validate-marketing-campaign-draft.ts --input=<campaign-draft.json> --content-context=<content-context.json> --cmo-strategy=<cmo-strategy.json>');
   }
 
-  const [draft, contentContext, cmoStrategy] = await Promise.all([
-    readFile(inputPath, 'utf8').then((value) => JSON.parse(value) as any),
-    readFile(contentContextPath, 'utf8').then((value) => JSON.parse(value) as any),
-    readFile(cmoStrategyPath, 'utf8').then((value) => JSON.parse(value) as any),
-  ]);
+  const [draft, context, strategy] = await Promise.all(
+    [inputPath, contextPath, strategyPath].map(async (path) => JSON.parse(await readFile(path, 'utf8')) as any),
+  );
   const { campaign, posts, campaign_execution_summary: summary, asset_requirements: requirements, provenance } = draft;
 
   assert(Array.isArray(posts) && posts.length > 0, 'posts must be a non-empty array');
-  assert(posts.length === campaign.target_post_count, `post count ${posts.length} does not match campaign.target_post_count ${campaign.target_post_count}`);
-  assert(summary.post_count === posts.length, 'campaign_execution_summary.post_count does not match posts length');
-  const campaignCodeMatch = /^ib_(\d{4})(0[1-9]|1[0-2])$/.exec(campaign.campaign_code);
-  assert(campaignCodeMatch, 'campaign.campaign_code must use canonical ib_YYYYMM format');
-  const campaignPeriod = `${campaignCodeMatch[1]}-${campaignCodeMatch[2]}`;
-  assert(draft.period_key === campaignPeriod, 'period_key does not match canonical campaign_code');
-  assert(provenance.source_branch === `automation/marketing-cycle-${draft.period_key}`, 'provenance.source_branch does not match period_key');
-  assert(provenance.content_context_path === `marketing/agent-inputs/${draft.period_key}/content-context.json`, 'content_context_path does not match period_key');
-  assert(provenance.cmo_strategy_path === `marketing/agent-outputs/${draft.period_key}/cmo-strategy.json`, 'cmo_strategy_path does not match period_key');
+  assert(posts.length === campaign.target_post_count, 'post count does not match campaign target');
+  assert(summary.post_count === posts.length, 'execution summary post_count does not match posts');
 
-  assert(contentContext?.period?.period_key === draft.period_key, 'content context period does not match campaign draft');
-  assert(cmoStrategy?.period === draft.period_key, 'CMO strategy period does not match campaign draft');
-  assert(contentContext?.strategy?.cmo_output?.period === cmoStrategy.period, 'embedded CMO strategy period does not match original strategy');
-  assert(contentContext?.period?.campaign_code === campaign.campaign_code, 'campaign_code differs from content context');
-  assert(contentContext?.period?.target_post_count === campaign.target_post_count, 'target_post_count differs from content context');
-  assert(contentContext?.period?.timezone === campaign.timezone, 'campaign timezone differs from content context');
-  assert(contentContext?.period?.publishing_start_date === campaign.publishing_start_date, 'publishing_start_date differs from content context');
-  assert(contentContext?.period?.publishing_end_date === campaign.publishing_end_date, 'publishing_end_date differs from content context');
-  assert(campaign.objective === cmoStrategy?.strategy?.primary_objective, 'campaign objective differs from CMO primary objective');
+  const code = /^ib_(\d{4})(0[1-9]|1[0-2])$/.exec(campaign.campaign_code);
+  assert(code, 'campaign.campaign_code must use ib_YYYYMM');
+  assert(draft.period_key === `${code[1]}-${code[2]}`, 'period_key does not match campaign_code');
+  assert(provenance.source_branch === `automation/marketing-cycle-${draft.period_key}`, 'source_branch does not match period');
+  assert(provenance.content_context_path === `marketing/agent-inputs/${draft.period_key}/content-context.json`, 'content_context_path does not match period');
+  assert(provenance.cmo_strategy_path === `marketing/agent-outputs/${draft.period_key}/cmo-strategy.json`, 'cmo_strategy_path does not match period');
 
-  const allowedPlatforms = new Set(stringValues(contentContext?.operational_constraints?.platforms));
-  const allowedFormats = new Set(stringValues(contentContext?.operational_constraints?.formats));
-  assert(campaign.platforms.every((value: string) => allowedPlatforms.has(value)), 'campaign contains a platform not allowed by content context');
-  assert(campaign.formats.every((value: string) => allowedFormats.has(value)), 'campaign contains a format not allowed by content context');
+  assert(context?.period?.period_key === draft.period_key, 'content context period does not match draft');
+  assert(strategy?.period === draft.period_key, 'CMO strategy period does not match draft');
+  assert(context?.strategy?.cmo_output?.period === strategy.period, 'embedded CMO strategy period differs from original');
+  assert(context.period.campaign_code === campaign.campaign_code, 'campaign_code differs from content context');
+  assert(context.period.target_post_count === campaign.target_post_count, 'target_post_count differs from content context');
+  assert(context.period.timezone === campaign.timezone, 'timezone differs from content context');
+  assert(context.period.publishing_start_date === campaign.publishing_start_date, 'publishing start differs from content context');
+  assert(context.period.publishing_end_date === campaign.publishing_end_date, 'publishing end differs from content context');
+  assert(campaign.objective === strategy?.strategy?.primary_objective, 'campaign objective differs from CMO primary objective');
 
-  const pillarCodes = new Set(
-    (Array.isArray(cmoStrategy?.strategy?.content_pillars) ? cmoStrategy.strategy.content_pillars : [])
-      .map((pillar: any) => pillar?.pillar_code)
-      .filter((value: unknown): value is string => typeof value === 'string' && value.length > 0),
-  );
-  const experiments = new Map<string, any>(
-    (Array.isArray(cmoStrategy?.experiments) ? cmoStrategy.experiments : [])
-      .filter((experiment: any) => typeof experiment?.experiment_code === 'string')
-      .map((experiment: any) => [experiment.experiment_code, experiment]),
-  );
-  assert(pillarCodes.size > 0, 'CMO strategy has no valid pillar_code values');
-  assert(experiments.size > 0, 'CMO strategy has no valid experiment_code values');
+  const platforms = new Set(strings(context?.operational_constraints?.platforms));
+  const formats = new Set(strings(context?.operational_constraints?.formats));
+  assert(campaign.platforms.every((value: string) => platforms.has(value)), 'campaign contains unsupported platform');
+  assert(campaign.formats.every((value: string) => formats.has(value)), 'campaign contains unsupported format');
 
-  const approvedTruths = Array.isArray(contentContext?.product_context?.approved_product_truths)
-    ? contentContext.product_context.approved_product_truths
-    : [];
-  const truthRefs = new Set(
-    approvedTruths.map((truth: any) => truth?.truth_ref).filter((value: unknown): value is string => typeof value === 'string' && value.length > 0),
-  );
+  const pillars = new Set<string>();
+  for (const pillar of Array.isArray(strategy?.strategy?.content_pillars) ? strategy.strategy.content_pillars : []) {
+    if (typeof pillar?.pillar_code === 'string' && pillar.pillar_code) pillars.add(pillar.pillar_code);
+  }
+  const experiments = new Map<string, any>();
+  for (const experiment of Array.isArray(strategy?.experiments) ? strategy.experiments : []) {
+    if (typeof experiment?.experiment_code === 'string' && experiment.experiment_code) {
+      experiments.set(experiment.experiment_code, experiment);
+    }
+  }
+  assert(pillars.size > 0, 'CMO strategy has no pillar codes');
+  assert(experiments.size > 0, 'CMO strategy has no experiment codes');
+
+  const truthRefs = new Set<string>();
+  for (const truth of Array.isArray(context?.product_context?.approved_product_truths) ? context.product_context.approved_product_truths : []) {
+    if (typeof truth?.truth_ref === 'string' && truth.truth_ref) truthRefs.add(truth.truth_ref);
+  }
   assert(truthRefs.size > 0, 'content context has no approved product truth references');
+  const assetRefs = knownAssetReferences(context);
 
   const forbiddenClaims = [
-    ...stringValues(cmoStrategy?.messaging_guidelines?.messages_to_avoid),
-    ...stringValues(cmoStrategy?.messaging_guidelines?.claims_to_avoid),
-  ].map(normalized).filter((value) => value.length >= 4);
-  const hardBlockedClaims: Array<{ pattern: RegExp; label: string }> = [
-    { pattern: /\b(guaranteed?|guarantees?|guarantee)\b/i, label: 'guaranteed outcome' },
-    { pattern: /\b(cure|cures|cured|treat|treats|treatment|diagnose|diagnosis)\b/i, label: 'medical claim' },
-    { pattern: /\bfully automatic\b|\bon autopilot\b/i, label: 'unsupported automatic capability' },
-    { pattern: /\bproven results?\b/i, label: 'unsupported proven result' },
+    ...strings(strategy?.messaging_guidelines?.messages_to_avoid),
+    ...strings(strategy?.messaging_guidelines?.claims_to_avoid),
+  ].map(normalize).filter((value) => value.length >= 4);
+  const hardBlocks: Array<[RegExp, string]> = [
+    [/\b(guaranteed?|guarantees?|guarantee)\b/i, 'guaranteed outcome'],
+    [/\b(cure|cures|cured|treat|treats|treatment|diagnose|diagnosis)\b/i, 'medical claim'],
+    [/\bfully automatic\b|\bon autopilot\b/i, 'unsupported automatic capability'],
+    [/\bproven results?\b/i, 'unsupported proven result'],
   ];
 
   const postCodes = posts.map((post: any) => post.post_code);
   assert(new Set(postCodes).size === postCodes.length, 'post_code values must be unique');
-  const sequenceNumbers = posts.map((post: any) => post.sequence_number).sort((a: number, b: number) => a - b);
-  assert(sequenceNumbers.every((value: number, index: number) => value === index + 1), 'sequence_number values must be contiguous from 1');
-
+  const sequences = posts.map((post: any) => post.sequence_number).sort((a: number, b: number) => a - b);
+  assert(sequences.every((value: number, index: number) => value === index + 1), 'sequence numbers must be contiguous');
   const start = Date.parse(`${campaign.publishing_start_date}T00:00:00Z`);
   const end = Date.parse(`${campaign.publishing_end_date}T23:59:59Z`);
+
   for (const post of posts) {
     const scheduled = Date.parse(post.scheduled_at);
-    assert(scheduled >= start && scheduled <= end, `${post.post_code} scheduled_at is outside the publishing window`);
+    assert(scheduled >= start && scheduled <= end, `${post.post_code} is outside the publishing window`);
     assert(post.status === 'needs_review', `${post.post_code} must remain needs_review`);
-    assert(allowedPlatforms.has(post.platform), `${post.post_code} uses unsupported platform ${post.platform}`);
-    assert(allowedFormats.has(post.format), `${post.post_code} uses unsupported format ${post.format}`);
-    assert(pillarCodes.has(post.content_pillar), `${post.post_code} references unknown CMO pillar ${post.content_pillar}`);
+    assert(platforms.has(post.platform), `${post.post_code} uses unsupported platform ${post.platform}`);
+    assert(formats.has(post.format), `${post.post_code} uses unsupported format ${post.format}`);
+    assert(pillars.has(post.content_pillar), `${post.post_code} references unknown CMO pillar ${post.content_pillar}`);
+
     const experiment = experiments.get(post.experiment_code);
     assert(experiment, `${post.post_code} references unknown CMO experiment ${post.experiment_code}`);
-    const experimentPillars = stringValues(experiment.content_pillars);
+    const experimentPillars = strings(experiment.content_pillars);
     if (experimentPillars.length > 0) {
-      assert(experimentPillars.includes(post.content_pillar), `${post.post_code} maps experiment ${post.experiment_code} to an unsupported pillar`);
+      assert(experimentPillars.includes(post.content_pillar), `${post.post_code} maps its experiment to an unsupported pillar`);
     }
     if (typeof experiment.primary_metric === 'string' && experiment.primary_metric.trim()) {
-      assert(post.primary_metric === experiment.primary_metric, `${post.post_code} primary_metric differs from experiment ${post.experiment_code}`);
+      assert(post.primary_metric === experiment.primary_metric, `${post.post_code} primary metric differs from its experiment`);
     }
 
-    const evidenceRefs = stringValues(post.visual_strategy?.product_evidence);
-    assert(evidenceRefs.length > 0, `${post.post_code} must cite at least one approved product truth reference`);
-    for (const truthRef of evidenceRefs) {
-      assert(truthRefs.has(truthRef), `${post.post_code} references unknown product truth ${truthRef}`);
-    }
+    const evidence = strings(post.visual_strategy?.product_evidence);
+    assert(evidence.length > 0, `${post.post_code} must cite an approved product truth`);
+    for (const ref of evidence) assert(truthRefs.has(ref), `${post.post_code} references unknown product truth ${ref}`);
 
-    const copy = combinedPostCopy(post);
-    const normalizedCopy = normalized(copy);
+    const copy = postCopy(post);
+    const normalizedCopy = normalize(copy);
     for (const blocked of forbiddenClaims) {
-      assert(!normalizedCopy.includes(blocked), `${post.post_code} contains a CMO-forbidden claim or message: ${blocked}`);
+      assert(!normalizedCopy.includes(blocked), `${post.post_code} contains CMO-forbidden message: ${blocked}`);
     }
-    for (const blocked of hardBlockedClaims) {
-      assert(!blocked.pattern.test(copy), `${post.post_code} contains ${blocked.label}`);
-    }
+    for (const [pattern, label] of hardBlocks) assert(!pattern.test(copy), `${post.post_code} contains ${label}`);
 
-    assert(post.utm.utm_campaign === campaign.campaign_code, `${post.post_code} utm_campaign must equal campaign_code`);
-    assert(post.utm.utm_content === post.post_code, `${post.post_code} utm_content must equal post_code`);
-    assert(post.asset_slots.length >= 1, `${post.post_code} must define at least one asset slot`);
+    assert(post.utm.utm_campaign === campaign.campaign_code, `${post.post_code} has invalid utm_campaign`);
+    assert(post.utm.utm_content === post.post_code, `${post.post_code} has invalid utm_content`);
+    assert(Array.isArray(post.asset_slots) && post.asset_slots.length > 0, `${post.post_code} needs at least one asset slot`);
     for (const slot of post.asset_slots) {
-      assert(slot.post_code === post.post_code, `${slot.asset_code} post_code does not match owner post`);
-      for (const reference of stringValues(slot.semantic_source_references)) {
-        const knownAssetReference = Object.values(contentContext.available_assets ?? {})
-          .flatMap((values: any) => Array.isArray(values) ? values : [])
-          .some((asset: any) => [asset?.asset_id, asset?.label].includes(reference));
-        assert(knownAssetReference, `${slot.asset_code} references unknown source asset ${reference}`);
+      assert(slot.post_code === post.post_code, `${slot.asset_code} has wrong owner post`);
+      for (const ref of strings(slot.semantic_source_references)) {
+        assert(assetRefs.has(ref), `${slot.asset_code} references unknown source asset ${ref}`);
       }
     }
     if (post.format === 'carousel') {
-      assert(post.carousel.slides.length === post.carousel.slide_count, `${post.post_code} carousel slide_count mismatch`);
-      assert(post.asset_slots.length === post.carousel.slide_count, `${post.post_code} carousel must have one asset slot per slide`);
+      assert(post.carousel.slides.length === post.carousel.slide_count, `${post.post_code} carousel slide count mismatch`);
+      assert(post.asset_slots.length === post.carousel.slide_count, `${post.post_code} needs one asset slot per slide`);
       const slideNumbers = post.carousel.slides.map((slide: any) => slide.slide_number).sort((a: number, b: number) => a - b);
-      assert(slideNumbers.every((value: number, index: number) => value === index + 1), `${post.post_code} carousel slide numbers must be contiguous`);
+      assert(slideNumbers.every((value: number, index: number) => value === index + 1), `${post.post_code} slide numbers must be contiguous`);
       const slotCodes = new Set(post.asset_slots.map((slot: any) => slot.asset_code));
-      assert(post.carousel.slides.every((slide: any) => slotCodes.has(slide.asset_code)), `${post.post_code} carousel slide references an unknown asset slot`);
+      assert(post.carousel.slides.every((slide: any) => slotCodes.has(slide.asset_code)), `${post.post_code} slide references unknown asset slot`);
     }
   }
 
   const trackingUrls = posts.map((post: any) => post.tracking_url).filter(Boolean);
-  assert(new Set(trackingUrls).size === trackingUrls.length, 'non-null tracking_url values must be unique');
-  const utmContents = posts.map((post: any) => post.utm.utm_content);
-  assert(new Set(utmContents).size === utmContents.length, 'utm_content values must be unique');
-  const ibPosts = posts.map((post: any) => post.utm.ib_post);
-  assert(new Set(ibPosts).size === ibPosts.length, 'ib_post values must be unique');
+  assert(new Set(trackingUrls).size === trackingUrls.length, 'tracking URLs must be unique');
+  assert(new Set(posts.map((post: any) => post.utm.utm_content)).size === posts.length, 'utm_content values must be unique');
+  assert(new Set(posts.map((post: any) => post.utm.ib_post)).size === posts.length, 'ib_post values must be unique');
 
-  const allSlots = posts.flatMap((post: any) => post.asset_slots);
-  const assetCodes = allSlots.map((slot: any) => slot.asset_code);
-  assert(new Set(assetCodes).size === assetCodes.length, 'asset_code values must be globally unique');
-  assert(summary.asset_slot_count === allSlots.length, 'campaign_execution_summary.asset_slot_count does not match asset slots');
+  const slots = posts.flatMap((post: any) => post.asset_slots);
+  const assetCodes = slots.map((slot: any) => slot.asset_code);
+  assert(new Set(assetCodes).size === assetCodes.length, 'asset codes must be globally unique');
+  assert(summary.asset_slot_count === slots.length, 'asset slot summary does not match posts');
+  assert(equalCounts(summary.format_counts, countBy(posts, 'format')), 'format counts do not match posts');
+  assert(equalCounts(summary.pillar_counts, countBy(posts, 'content_pillar')), 'pillar counts do not match posts');
+  assert(equalCounts(summary.funnel_counts, countBy(posts, 'funnel_stage')), 'funnel counts do not match posts');
 
-  assert(equalCountMaps(summary.format_counts, countBy(posts, (post: any) => post.format)), 'format_counts do not match posts');
-  assert(equalCountMaps(summary.pillar_counts, countBy(posts, (post: any) => post.content_pillar)), 'pillar_counts do not match posts');
-  assert(equalCountMaps(summary.funnel_counts, countBy(posts, (post: any) => post.funnel_stage)), 'funnel_counts do not match posts');
-
-  const postCodeSet = new Set(postCodes);
-  const assetCodeSet = new Set(assetCodes);
+  const postSet = new Set(postCodes);
+  const assetSet = new Set(assetCodes);
   const requirementCodes = requirements.map((requirement: any) => requirement.requirement_code);
-  assert(new Set(requirementCodes).size === requirementCodes.length, 'requirement_code values must be unique');
+  assert(new Set(requirementCodes).size === requirementCodes.length, 'requirement codes must be unique');
   for (const requirement of requirements) {
-    assert(requirement.related_post_codes.every((code: string) => postCodeSet.has(code)), `${requirement.requirement_code} references an unknown post`);
-    assert(requirement.related_asset_codes.every((code: string) => assetCodeSet.has(code)), `${requirement.requirement_code} references an unknown asset slot`);
+    assert(requirement.related_post_codes.every((code: string) => postSet.has(code)), `${requirement.requirement_code} references unknown post`);
+    assert(requirement.related_asset_codes.every((code: string) => assetSet.has(code)), `${requirement.requirement_code} references unknown asset slot`);
   }
 
   const forbiddenRendererFields = new Set([
@@ -218,17 +212,8 @@ async function main(): Promise<void> {
   };
   walk(draft);
 
-  const requiredQualityChecks = [
-    'schema_ready',
-    'strategy_fidelity',
-    'claim_safety',
-    'tracking_integrity',
-    'calendar_integrity',
-    'editorial_diversity',
-    'visual_brief_completeness',
-  ];
-  for (const check of requiredQualityChecks) {
-    assert(draft.campaign_quality_report[check] === true, `campaign_quality_report.${check} must be true for a successful draft`);
+  for (const check of ['schema_ready', 'strategy_fidelity', 'claim_safety', 'tracking_integrity', 'calendar_integrity', 'editorial_diversity', 'visual_brief_completeness']) {
+    assert(draft.campaign_quality_report[check] === true, `campaign_quality_report.${check} must be true`);
   }
 
   console.log(`Validated campaign draft strategy and product fidelity: ${inputPath}`);

--- a/prompts/marketing/agent-system/head-of-content/AGENTS.md
+++ b/prompts/marketing/agent-system/head-of-content/AGENTS.md
@@ -30,6 +30,7 @@ Do not execute unless:
 - context and strategy paths and SHA-256 values are present;
 - the embedded and original CMO strategy refer to the same period;
 - campaign code, timezone, publishing window, target count, formats, tracking and current asset context are present;
+- `product_context.approved_product_truths` contains at least one source-backed truth;
 - the canonical visual system is readable.
 
 The immutable CMO strategy may retain `review_status: draft`. Never edit it. A valid pipeline handoff is sufficient.
@@ -39,15 +40,16 @@ The immutable CMO strategy may retain `review_status: draft`. Never edit it. A v
 1. Resolve the target period from `content-context.json`.
 2. Verify the source branch is `automation/marketing-cycle-<YYYY-MM>`.
 3. Read and validate all authoritative inputs.
-4. Preserve the CMO objective, audience, narrative, pillars, experiments, restrictions, approved claims, CTAs and measurement plan.
+4. Preserve the CMO objective, audience, narrative, pillar codes, experiment codes, restrictions, approved claims, CTAs and measurement plan.
 5. Design campaign architecture before writing individual posts.
 6. Generate exactly `period.target_post_count` posts.
 7. Give every post a unique editorial function, hypothesis, metric, schedule, tracking identity and stable asset slot.
-8. For carousels, define the complete ordered narrative and one stable asset slot per slide.
-9. Define semantic visual strategy without renderer implementation choices.
-10. Record unresolved source-asset needs under `asset_requirements`; never claim a binary exists.
-11. Calculate truthful execution summaries and quality checks.
-12. Validate with both:
+8. Cite at least one valid `approved_product_truths[].truth_ref` for every post through `visual_strategy.product_evidence`.
+9. For carousels, define the complete ordered narrative and one stable asset slot per slide.
+10. Define semantic visual strategy without renderer implementation choices.
+11. Record unresolved source-asset needs under `asset_requirements`; never claim a binary exists.
+12. Calculate truthful execution summaries and quality checks.
+13. Validate with both:
 
 ```bash
 npx tsx apps/api/scripts/validate-marketing-agent-json.ts \
@@ -55,10 +57,34 @@ npx tsx apps/api/scripts/validate-marketing-agent-json.ts \
   --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json
 
 npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts \
-  --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json
+  --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json \
+  --content-context=marketing/agent-inputs/<YYYY-MM>/content-context.json \
+  --cmo-strategy=marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json
 ```
 
-13. Write only `campaign-draft.json` and stop.
+14. Write only `campaign-draft.json` and stop.
+
+## Exact strategy mapping
+
+- `content_pillar` must equal an existing `strategy.content_pillars[].pillar_code`.
+- `experiment_code` must equal an existing `experiments[].experiment_code`.
+- When an experiment declares `content_pillars`, the selected pillar must belong to that list.
+- `primary_metric` must equal the selected experiment's primary metric.
+- Objective, period, campaign code, target count, platforms, formats, timezone and publishing window come from the validated inputs and may not be changed.
+- Never create aliases, subpillars, renamed codes or new experiments.
+
+## Product truth mapping
+
+`product_context.approved_product_truths` is the only product-claim catalog for the draft. Each entry contains a stable `truth_ref` and its approved text.
+
+For every post:
+
+- `visual_strategy.product_evidence` must contain one or more exact existing `truth_ref` values;
+- `product_truth_anchor`, hook, caption and visible copy must remain a prudent explanation or paraphrase of those cited truths;
+- if no truth supports an idea, discard the idea or fail closed;
+- do not use a screenshot or asset as evidence of a capability that its source does not show.
+
+Never invent product capabilities, automatic behavior, UI states, statistics, testimonials, outcomes, routes or medical effects. Obey all CMO `messages_to_avoid` and `claims_to_avoid`.
 
 ## Output ownership
 
@@ -67,8 +93,8 @@ The Head of Content owns:
 - campaign title and editorial strategy summary;
 - supported platforms and formats;
 - post order and schedule;
-- content pillar, funnel stage and experiment mapping;
-- audience tension and product-truth anchor;
+- approved content pillar, funnel stage and experiment mapping;
+- audience tension and source-backed product-truth anchor;
 - hook, caption, CTA, hypothesis and primary metric;
 - unique tracking URL and UTM identity;
 - visible copy plan;
@@ -97,10 +123,8 @@ Never write:
 
 Those belong to the Creative Director or deterministic renderer pipeline.
 
-## Content and truth rules
+## Content rules
 
-- Do not invent product capabilities, UI states, statistics, testimonials, outcomes or routes.
-- Every post must map to a CMO pillar and experiment.
 - Do not add objectives, audiences or priorities absent from the CMO strategy.
 - Avoid guilt, shame, medical framing, guarantees, fabricated urgency and generic motivational filler.
 - Respect the configured campaign language.
@@ -122,6 +146,7 @@ Those belong to the Creative Director or deterministic renderer pipeline.
 - A carousel has exactly one asset slot per slide.
 - Slide numbers are contiguous from 1.
 - Asset slots describe semantic purpose and evidence, not exact layout or registered source selection.
+- Every non-empty `semantic_source_references` value must identify an asset present in `available_assets`.
 - `new_binary_may_be_required` is a conditional flag, never proof that production occurred.
 - Every `asset_requirement` must reference existing post and asset-slot codes.
 
@@ -147,7 +172,7 @@ Everything else is read-only.
 
 ## Failure behaviour
 
-Fail closed. If the handoff, strategy mapping, dates, tracking, source references, counts, carousel structure, claims, provenance or schema cannot be satisfied honestly:
+Fail closed. If the handoff, strategy mapping, product-truth mapping, dates, tracking, source references, counts, carousel structure, claims, provenance or schema cannot be satisfied honestly:
 
 - do not write a partial successful draft;
 - do not write `campaign.json`;

--- a/prompts/marketing/head-of-content-v1.md
+++ b/prompts/marketing/head-of-content-v1.md
@@ -51,6 +51,36 @@ El draft debe incluir:
 - requerimientos condicionales de fuentes visuales;
 - resumen cuantitativo y reporte de calidad.
 
+## Fidelidad estratégica obligatoria
+
+Usá exclusivamente:
+
+- `strategy.content_pillars[].pillar_code` para `content_pillar`;
+- `experiments[].experiment_code` para `experiment_code`;
+- el `primary_metric` del experimento seleccionado;
+- el objetivo, plataformas, formatos, cantidad y ventana entregados en `content-context.json`.
+
+No uses el nombre visible del pilar como código. No inventes códigos parecidos, variantes nuevas, subpilares ni experimentos adicionales.
+
+## Verdad de producto obligatoria
+
+`content-context.json` contiene `product_context.approved_product_truths`. Cada entrada tiene:
+
+- `truth_ref`;
+- `source_type`;
+- `text`.
+
+Para cada post:
+
+1. elegí al menos un `truth_ref` existente;
+2. escribilo exactamente dentro de `visual_strategy.product_evidence`;
+3. redactá `product_truth_anchor`, hook, caption y copy visible únicamente como una explicación o paráfrasis prudente de esas verdades;
+4. si ninguna verdad disponible respalda la idea, descartá la idea o fallá de forma explícita.
+
+`visual_strategy.product_evidence` contiene referencias, no descripciones libres. Nunca inventes un `truth_ref`.
+
+No inventes funciones, automatizaciones, pantallas, datos, resultados, métricas de producto, testimonios o rutas. Obedecé literalmente `messages_to_avoid` y `claims_to_avoid` del CMO. Innerbloom no es una cura, tratamiento médico, sistema de resultados garantizados ni optimizador automático de toda la vida del usuario.
+
 ## Límite con Creative Director
 
 Podés definir **qué debe comunicar y probar** cada visual. No podés decidir **cómo lo renderiza exactamente** el sistema.
@@ -111,7 +141,7 @@ Cada post debe definir:
 
 - objetivo visual;
 - tipo de prueba: product, editorial o hybrid;
-- evidencia o módulo de producto relevante;
+- uno o más `truth_ref` válidos en `product_evidence`;
 - screenshot required, optional o forbidden;
 - jerarquía informativa;
 - carácter editorial deseado;
@@ -120,7 +150,7 @@ Cada post debe definir:
 - usos prohibidos;
 - criterios de aceptación.
 
-No elijas assets registrados exactos salvo que el input ya los autorice como evidencia inequívoca; preferí referencias semánticas.
+No elijas assets registrados exactos salvo que el input ya los autorice como evidencia inequívoca; preferí referencias semánticas que existan en `available_assets`.
 
 ## Asset slots
 
@@ -133,7 +163,7 @@ Creá un slot estable para cada imagen o slide que deba existir al final:
 - propósito semántico;
 - prueba de producto requerida;
 - preferencia por fuentes existentes;
-- referencias semánticas opcionales;
+- referencias semánticas opcionales existentes en el input;
 - posibilidad condicional de necesitar binario nuevo;
 - alt text;
 - criterios de aceptación.
@@ -177,7 +207,9 @@ npx tsx apps/api/scripts/validate-marketing-agent-json.ts \
   --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json
 
 npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts \
-  --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json
+  --input=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json \
+  --content-context=marketing/agent-inputs/<YYYY-MM>/content-context.json \
+  --cmo-strategy=marketing/agent-outputs/<YYYY-MM>/cmo-strategy.json
 ```
 
 Además verificá:
@@ -185,11 +217,13 @@ Además verificá:
 - cantidad exacta de posts;
 - secuencia contigua;
 - fechas dentro de ventana;
+- pilares y experimentos exactamente existentes;
+- evidencia de producto respaldada por `approved_product_truths`;
+- ausencia de claims prohibidos;
 - códigos, tracking y asset slots únicos;
 - summaries iguales a los datos reales;
 - carruseles completos;
 - referencias de requirements existentes;
-- fidelidad estratégica;
 - ausencia total de campos renderer-owned;
 - todos los quality booleans en `true` para una salida exitosa.
 


### PR DESCRIPTION
## Objetivo
Reforzar el bloque Head of Content → `campaign-draft.json` sin agregar complejidad innecesaria: impedir que el draft invente pilares, experimentos, conceptos o capacidades de Innerbloom.

## Cambios principales
- `content-context.json` ahora incluye un catálogo determinístico `product_context.approved_product_truths` construido únicamente desde mensajes, proof points, cambios de producto y posicionamiento ya presentes en los inputs validados;
- cada verdad tiene un `truth_ref` estable que Head of Content debe citar exactamente en `visual_strategy.product_evidence`;
- el validador ahora recibe `campaign-draft.json`, `content-context.json` y `cmo-strategy.json`;
- valida período, campaign code, objetivo, cantidad, timezone, ventana, plataformas y formatos contra los inputs;
- exige que cada `content_pillar` sea un `strategy.content_pillars[].pillar_code` real;
- exige que cada `experiment_code` exista y que su pilar y métrica sean compatibles;
- rechaza referencias de producto inexistentes, assets no registrados y mensajes/claims prohibidos;
- mantiene la prohibición de campos renderer-owned.

## Pruebas fail-closed
CI incluye fixtures reales y demuestra que fallan:
- pilar inventado;
- experimento inventado;
- capacidad o referencia de producto inventada;
- campo propiedad del renderer.

## Alcance deliberado
- no implementa Creative Director;
- no modifica renderer, R2, Neon ni Admin;
- no agrega scoring editorial ni análisis semántico complejo;
- no cambia el formato general de `campaign-draft.json`.

## Flujo resultante
`cmo-strategy.json` + `content-context.json` → Head of Content → `campaign-draft.json` → validación estricta de fidelidad.

## Antes de mergear
Debe quedar verde `Validate marketing campaign draft contract`, incluido typecheck, schemas, fixture válida y las cuatro pruebas negativas.