### PR TITLE
Fix Google account chooser without resetting Clerk resources

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -8,6 +8,8 @@ export type GoogleOAuthRedirectOptions = {
   redirectUrl: string;
   redirectUrlComplete: string;
   oidcPrompt?: 'select_account';
+  continueSignIn?: boolean;
+  continueSignUp?: boolean;
 };
 
 type GoogleOAuthButtonProps = {
@@ -40,6 +42,8 @@ export function buildGoogleOAuthRedirectOptions(
     redirectUrl: SSO_CALLBACK_PATH,
     redirectUrlComplete,
     oidcPrompt: forceAccountSelection ? 'select_account' : undefined,
+    continueSignIn: false,
+    continueSignUp: false,
   };
 }
 
@@ -214,6 +218,13 @@ export function GoogleOAuthButton({
     );
 
     try {
+      console.info('[auth] starting interactive Google OAuth', {
+        mode,
+        oauthMode,
+        accountSelection: shouldForceAccountSelection ? 'required' : 'default',
+        freshClerkAttempt: true,
+      });
+
       if (oauthMode === 'sign-up') {
         if (!signUp) {
           throw new Error('Clerk sign-up resource is not ready');

--- a/apps/web/src/components/auth/__tests__/GoogleOAuthButton.accountSelection.test.ts
+++ b/apps/web/src/components/auth/__tests__/GoogleOAuthButton.accountSelection.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildGoogleOAuthRedirectOptions } from '../GoogleOAuthButton';
+
+describe('Google OAuth account selection', () => {
+  it('starts a fresh Clerk attempt and forces the Google account selector', () => {
+    expect(buildGoogleOAuthRedirectOptions('/after-auth', true)).toEqual({
+      strategy: 'oauth_google',
+      redirectUrl: '/sso-callback',
+      redirectUrlComplete: '/after-auth',
+      oidcPrompt: 'select_account',
+      continueSignIn: false,
+      continueSignUp: false,
+    });
+  });
+
+  it('starts a fresh Clerk attempt without forcing account selection when disabled', () => {
+    expect(buildGoogleOAuthRedirectOptions('/after-auth', false)).toEqual({
+      strategy: 'oauth_google',
+      redirectUrl: '/sso-callback',
+      redirectUrlComplete: '/after-auth',
+      oidcPrompt: undefined,
+      continueSignIn: false,
+      continueSignUp: false,
+    });
+  });
+});


### PR DESCRIPTION
## Objetivo

Restaurar un Google OAuth funcional y mostrar el selector de cuentas después del logout, sin invalidar el recurso de Clerk ni dejar Chrome Custom Tab en blanco.

## Causa confirmada del bloqueo

La implementación anterior ejecutaba `resetSignIn()`/`resetSignUp()` y luego reutilizaba inmediatamente el recurso anterior. Clerk invalida ese intento de forma síncrona, por lo que `authenticateWithRedirect()` podía ejecutarse sobre un recurso obsoleto y la pestaña quedaba detenida en `/mobile-auth`.

## Solución

- Elimina completamente cualquier reset manual del intento de Clerk.
- Mantiene `oidcPrompt: 'select_account'` para que Google muestre el selector.
- Añade `continueSignIn: false` y `continueSignUp: false` a `authenticateWithRedirect()`.
- Clerk crea el nuevo intento OAuth de manera atómica dentro de la misma operación de redirect.
- No toca `MobileBrowserAuth.tsx`, Android, iOS, callbacks ni el plugin nativo.
- Añade pruebas de regresión sobre las opciones exactas entregadas a Clerk.

## Fundamento técnico

La API oficial de Clerk documenta que `authenticateWithRedirect()` acepta `continueSignIn`, `continueSignUp` y `oidcPrompt`. Los flags `false` evitan continuar intentos existentes sin destruir manualmente el recurso que ejecutará el redirect.

## Resultado esperado

1. Login con Google A.
2. Logout de Innerbloom.
3. Pulsar Google nuevamente.
4. La redirección sale correctamente de `/mobile-auth`.
5. Google presenta el selector de cuentas.
6. Se puede elegir Google B.

## Alcance de seguridad

- Sin `resetSignIn()`.
- Sin `resetSignUp()`.
- Sin cambios en Chrome Custom Tabs.
- Sin cambios en `ASWebAuthenticationSession`.
- Sin borrar cookies globales de Google.
- Sin cambios en login por email, logout o refresh silencioso.

## Validación requerida

- CI completa.
- Android: A → logout → selector → B.
- iOS: A → logout → selector → B.
- Confirmar que el navegador nunca queda detenido en `/mobile-auth`.
