### PR TITLE
Build the Creative Director context and agent foundation

### DIFF
--- a/.github/workflows/marketing-creative-context.yml
+++ b/.github/workflows/marketing-creative-context.yml
@@ -1,0 +1,151 @@
+name: Generate Creative Director context
+
+on:
+  push:
+    branches:
+      - "automation/marketing-cycle-*"
+    paths:
+      - "marketing/agent-outputs/*/campaign-draft.json"
+  workflow_dispatch:
+    inputs:
+      period_key:
+        description: Campaign draft period in YYYY-MM format
+        required: true
+        type: string
+      force:
+        description: Rebuild creative-context.json when it already exists
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: marketing-creative-context-${{ github.ref_name }}-${{ github.event.inputs.period_key || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  generate-creative-context:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Resolve period and monthly branch
+        id: period
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_PERIOD_KEY: ${{ github.event.inputs.period_key }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_SHA: ${{ github.sha }}
+          PUSH_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            period_key="${MANUAL_PERIOD_KEY}"
+          else
+            mapfile -t paths < <(git diff --name-only "${PUSH_BEFORE}" "${PUSH_SHA}" -- 'marketing/agent-outputs/*/campaign-draft.json' | grep -E '^marketing/agent-outputs/[0-9]{4}-(0[1-9]|1[0-2])/campaign-draft\.json$' | sort -u)
+            if [[ "${#paths[@]}" -ne 1 ]]; then
+              echo "Expected exactly one changed campaign-draft.json; found ${#paths[@]}." >&2
+              exit 1
+            fi
+            period_key="$(sed -E 's#^marketing/agent-outputs/([^/]+)/campaign-draft\.json$#\1#' <<< "${paths[0]}")"
+            [[ "${PUSH_BRANCH}" == "automation/marketing-cycle-${period_key}" ]] || { echo "Period and branch mismatch." >&2; exit 1; }
+          fi
+          [[ "${period_key}" =~ ^[0-9]{4}-(0[1-9]|1[0-2])$ ]] || { echo "Invalid period." >&2; exit 1; }
+          echo "period_key=${period_key}" >> "${GITHUB_OUTPUT}"
+          echo "branch=automation/marketing-cycle-${period_key}" >> "${GITHUB_OUTPUT}"
+          echo "output_path=marketing/agent-inputs/${period_key}/creative-context.json" >> "${GITHUB_OUTPUT}"
+
+      - name: Check out monthly branch
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CYCLE_BRANCH: ${{ steps.period.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            git fetch origin main --prune
+            git ls-remote --exit-code --heads origin "${CYCLE_BRANCH}" >/dev/null
+            git fetch origin "${CYCLE_BRANCH}:${CYCLE_BRANCH}"
+            git checkout "${CYCLE_BRANCH}"
+            git merge --no-edit origin/main
+          else
+            git checkout -B "${CYCLE_BRANCH}" "${GITHUB_SHA}"
+          fi
+
+      - name: Verify required sources
+        env:
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
+        run: |
+          test -s "marketing/agent-outputs/${PERIOD_KEY}/campaign-draft.json"
+          test -s "marketing/agent-outputs/${PERIOD_KEY}/cmo-strategy.json"
+          test -s "marketing/agent-inputs/${PERIOD_KEY}/content-context.json"
+          test -s prompts/marketing/agent-system/brand/innerbloom-visual-system-v1.json
+          test -s marketing/asset-registry/innerbloom-drive-assets-v1.json
+          test -s marketing/layout-references/innerbloom-layout-specifications-v1.json
+
+      - run: npm install --no-audit --no-fund
+      - name: Typecheck API
+        run: npm -w @innerbloom/api run typecheck
+
+      - name: Validate campaign draft fidelity
+        env:
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts
+          --input="marketing/agent-outputs/${PERIOD_KEY}/campaign-draft.json"
+          --content-context="marketing/agent-inputs/${PERIOD_KEY}/content-context.json"
+          --cmo-strategy="marketing/agent-outputs/${PERIOD_KEY}/cmo-strategy.json"
+
+      - name: Generate Creative Director context
+        shell: bash
+        env:
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
+          EVENT_NAME: ${{ github.event_name }}
+          FORCE_INPUT: ${{ github.event.inputs.force }}
+        run: |
+          set -euo pipefail
+          args=(--period="${PERIOD_KEY}")
+          if [[ "${EVENT_NAME}" == "push" || "${FORCE_INPUT}" == "true" ]]; then args+=(--force); fi
+          npx tsx apps/api/scripts/export-marketing-creative-context.ts "${args[@]}"
+
+      - name: Validate Creative Director context
+        env:
+          OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-agent-json.ts
+          --schema=prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json
+          --input="${OUTPUT_PATH}"
+
+      - name: Commit validated creative context
+        shell: bash
+        env:
+          CYCLE_BRANCH: ${{ steps.period.outputs.branch }}
+          OUTPUT_PATH: ${{ steps.period.outputs.output_path }}
+          PERIOD_KEY: ${{ steps.period.outputs.period_key }}
+        run: |
+          set -euo pipefail
+          git add -- "${OUTPUT_PATH}"
+          if git diff --cached --quiet; then
+            echo "Creative context is unchanged."
+          else
+            git commit -m "chore(marketing): generate creative context for ${PERIOD_KEY}"
+            git push origin "HEAD:${CYCLE_BRANCH}"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: marketing-creative-context-${{ steps.period.outputs.period_key }}
+          path: ${{ steps.period.outputs.output_path }}
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/marketing-creative-director-contract.yml
+++ b/.github/workflows/marketing-creative-director-contract.yml
@@ -1,0 +1,61 @@
+name: Validate marketing Creative Director contract
+
+on:
+  pull_request:
+    paths:
+      - 'apps/api/scripts/export-marketing-creative-context.ts'
+      - 'apps/api/scripts/validate-creative-director-preservation.ts'
+      - 'prompts/marketing/creative-director-v1.md'
+      - 'prompts/marketing/agent-system/creative-director/AGENTS.md'
+      - 'prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json'
+      - '.github/workflows/marketing-creative-context.yml'
+      - '.github/workflows/marketing-creative-director-contract.yml'
+      - 'Docs/marketing/contracts/creative-director-v1.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-creative-director-foundation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm install --no-audit --no-fund
+      - name: Typecheck API
+        run: npm -w @innerbloom/api run typecheck
+      - name: Prepare representative monthly fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          period=2026-08
+          mkdir -p "marketing/agent-inputs/${period}" "marketing/agent-outputs/${period}"
+          cp apps/api/scripts/fixtures/content-context-valid.json "marketing/agent-inputs/${period}/content-context.json"
+          cp apps/api/scripts/fixtures/cmo-strategy-valid.json "marketing/agent-outputs/${period}/cmo-strategy.json"
+          cp apps/api/scripts/fixtures/campaign-draft-valid.json "marketing/agent-outputs/${period}/campaign-draft.json"
+      - name: Validate campaign draft before handoff
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-campaign-draft.ts
+          --input=marketing/agent-outputs/2026-08/campaign-draft.json
+          --content-context=marketing/agent-inputs/2026-08/content-context.json
+          --cmo-strategy=marketing/agent-outputs/2026-08/cmo-strategy.json
+      - name: Build Creative Director context
+        run: npx tsx apps/api/scripts/export-marketing-creative-context.ts --period=2026-08 --force
+      - name: Validate Creative Director context schema
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-agent-json.ts
+          --schema=prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json
+          --input=marketing/agent-inputs/2026-08/creative-context.json
+      - name: Prove the context contains executable layouts and current assets
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const context = JSON.parse(fs.readFileSync('marketing/agent-inputs/2026-08/creative-context.json', 'utf8'));
+          if (!context.renderer_capabilities.layouts.some((layout) => layout.status === 'executable')) throw new Error('No executable layout');
+          if (!context.current_assets.assets.length) throw new Error('No current assets');
+          if (context.immutable_editorial_source.period_key !== '2026-08') throw new Error('Draft period missing');
+          NODE

--- a/Docs/marketing/contracts/creative-director-v1.md
+++ b/Docs/marketing/contracts/creative-director-v1.md
@@ -1,12 +1,19 @@
 # Creative Director Contract v1
 
-**Status:** proposed and frozen for Phase 1; agent and schemas are not yet implemented.
+**Status:** implemented foundation; context builder, input schema, agent prompt and preservation validator are active. Codex execution and production pilot remain pending.
 
 ## Classification
 
-Creative Director is an AI reasoning agent.
+Creative Director is an AI reasoning agent. It is not a GitHub Action because it makes non-deterministic creative decisions across the complete campaign. GitHub Actions only assemble its validated context and validate or route its output.
 
-It is not a GitHub Action because it must make non-deterministic creative decisions across the complete campaign. GitHub Actions only assemble its validated context and validate or route its output.
+## Canonical implementation
+
+- Builder: `apps/api/scripts/export-marketing-creative-context.ts`
+- Input schema: `prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json`
+- Prompt: `prompts/marketing/creative-director-v1.md`
+- Agent contract: `prompts/marketing/agent-system/creative-director/AGENTS.md`
+- Handoff workflow: `.github/workflows/marketing-creative-context.yml`
+- Preservation validator: `apps/api/scripts/validate-creative-director-preservation.ts`
 
 ## Input
 
@@ -14,15 +21,14 @@ Canonical path:
 
 `marketing/agent-inputs/<YYYY-MM>/creative-context.json`
 
-The deterministic context builder must include:
+The deterministic context builder includes:
 
-- validated `campaign-draft.json`;
-- validated CMO strategy;
+- validated `campaign-draft.json` as immutable editorial source;
+- validated CMO strategy and approved product truths;
 - current visual system;
-- registered current source assets and metadata;
-- supported renderer layouts, families and treatments;
+- current registered source assets and metadata;
+- supported renderer layouts, device poses and treatments;
 - creative validation thresholds;
-- product-surface compatibility rules;
 - output paths and provenance hashes.
 
 ## Output
@@ -39,11 +45,11 @@ Creative Director must:
 
 1. Preserve campaign strategy, copy, CTA, dates, tracking, hypotheses and post order exactly.
 2. Create one complete renderer job for every asset slot.
-3. Select only registered current assets or explicitly mark a missing-source requirement.
+3. Select only current registered assets or explicitly report a missing-source requirement.
 4. Select renderer-supported layout variants and visual families.
-5. Respect mobile, web and brand surface compatibility.
+5. Respect mobile, web, brand and product-surface compatibility.
 6. Define campaign-wide layout, module, mode and source diversity.
-7. Give each carousel a meaningful slide progression.
+7. Give each carousel a meaningful visual progression.
 8. Produce complete creative directions accepted by the production validator.
 9. Keep campaign status `review` and every post `needs_review`.
 10. Report blocking gaps rather than inventing assets, UI, data or capabilities.
@@ -106,32 +112,34 @@ If a source binary is genuinely missing:
 - allow independent jobs to remain valid;
 - stop before claiming the complete campaign is render-ready.
 
-Asset Producer is therefore conditional, not a mandatory fourth stage.
+Asset Producer is conditional, not a mandatory fourth stage.
 
 ## Validation
 
 A successful output must pass:
 
-- the future production campaign schema;
-- creative-direction validator v3 or its approved successor;
+- `scripts/marketing/validate-creative-direction-v3.mjs`;
+- `apps/api/scripts/validate-creative-director-preservation.ts`;
 - registered asset lookup;
 - layout and source diversity rules;
 - surface compatibility rules;
-- post/slide/job completeness checks;
-- preservation comparison against `campaign-draft.json`.
+- post, slide and job completeness checks.
 
 ## Provenance
 
-The output must record or be paired with:
+The creative context records:
 
-- `source_branch`;
-- `campaign_draft_sha256`;
-- `creative_context_sha256`;
-- visual system version;
-- renderer contract version;
+- source branch;
+- campaign draft SHA-256;
+- CMO strategy and content-context SHA-256;
+- visual system SHA-256;
+- asset registry SHA-256;
+- layout specification SHA-256;
 - Creative Director contract version;
 - generated timestamp.
 
 ## Completion boundary
 
-Successful completion means a validated `campaign.json` that can be passed directly to `Render campaign and send it to Admin` without manual enrichment.
+Foundation completion means the deterministic context and agent contract are ready for Codex configuration.
+
+Agent completion means a validated `campaign.json` that can be passed to a manual `preview_limit: 1` render pilot. Automatic full rendering remains outside this change.

--- a/apps/api/scripts/export-marketing-creative-context.ts
+++ b/apps/api/scripts/export-marketing-creative-context.ts
@@ -1,0 +1,163 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+
+const readArg = (name: string): string | null => {
+  const prefix = `--${name}=`;
+  return process.argv.slice(2).find((value) => value.startsWith(prefix))?.slice(prefix.length) ?? null;
+};
+
+const hasFlag = (name: string): boolean => process.argv.slice(2).includes(`--${name}`);
+const sha256 = (value: string): string => `sha256:${createHash('sha256').update(value).digest('hex')}`;
+
+async function loadJson(path: string): Promise<{ raw: string; value: any }> {
+  const raw = await readFile(path, 'utf8');
+  return { raw, value: JSON.parse(raw) };
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+async function main(): Promise<void> {
+  const period = readArg('period');
+  const force = hasFlag('force');
+  if (!period || !/^\d{4}-(0[1-9]|1[0-2])$/.test(period)) {
+    throw new Error('Usage: --period=YYYY-MM [--force]');
+  }
+
+  const root = process.cwd();
+  const draftPath = resolve(root, `marketing/agent-outputs/${period}/campaign-draft.json`);
+  const strategyPath = resolve(root, `marketing/agent-outputs/${period}/cmo-strategy.json`);
+  const contentContextPath = resolve(root, `marketing/agent-inputs/${period}/content-context.json`);
+  const visualSystemPath = resolve(root, 'prompts/marketing/agent-system/brand/innerbloom-visual-system-v1.json');
+  const assetRegistryPath = resolve(root, 'marketing/asset-registry/innerbloom-drive-assets-v1.json');
+  const layoutSpecPath = resolve(root, 'marketing/layout-references/innerbloom-layout-specifications-v1.json');
+  const outputPath = resolve(root, `marketing/agent-inputs/${period}/creative-context.json`);
+
+  if (!force) {
+    try {
+      await readFile(outputPath, 'utf8');
+      console.log(JSON.stringify({ status: 'already_exists', outputPath }, null, 2));
+      return;
+    } catch {}
+  }
+
+  const [draft, strategy, contentContext, visualSystem, assetRegistry, layoutSpec] = await Promise.all([
+    loadJson(draftPath),
+    loadJson(strategyPath),
+    loadJson(contentContextPath),
+    loadJson(visualSystemPath),
+    loadJson(assetRegistryPath),
+    loadJson(layoutSpecPath),
+  ]);
+
+  assert(draft.value?.period_key === period, 'Campaign draft period mismatch');
+  assert(strategy.value?.period === period, 'CMO strategy period mismatch');
+  assert(contentContext.value?.period?.period_key === period, 'Content context period mismatch');
+  assert(draft.value?.campaign?.status === 'review', 'Campaign draft must remain review');
+  assert(Array.isArray(draft.value?.posts) && draft.value.posts.length === draft.value.campaign.target_post_count, 'Campaign draft post count mismatch');
+
+  const approvedAssets = (Array.isArray(assetRegistry.value?.assets) ? assetRegistry.value.assets : [])
+    .filter((asset: any) => asset?.status === 'approved_current')
+    .map((asset: any) => ({
+      asset_key: asset.asset_key,
+      kind: asset.kind,
+      module: asset.module,
+      mode: asset.mode,
+      surface: asset.surface,
+      composition_profile: asset.composition_profile ?? null,
+      composition_slots: asset.composition_slots ?? null,
+      allowed_operations: asset.allowed_operations ?? [],
+    }));
+
+  const layouts = (Array.isArray(layoutSpec.value?.layouts) ? layoutSpec.value.layouts : []).map((layout: any) => ({
+    layout_key: layout.layout_key,
+    status: layout.status,
+    renderer_layout: layout.renderer_layout,
+    copy_role: layout.copy_role,
+    copy_zone: layout.copy_zone,
+    product_zone: layout.product_zone,
+    device_pose: layout.device_pose,
+    min_mobile_assets: layout.min_mobile_assets ?? 0,
+    max_mobile_assets: layout.max_mobile_assets ?? 0,
+    min_module_assets: layout.min_module_assets ?? 0,
+    allowed_backgrounds: layout.allowed_backgrounds ?? [],
+    required_support_assets: layout.required_support_assets ?? [],
+    fallback_layouts: layout.fallback_layouts ?? [],
+  }));
+
+  assert(approvedAssets.length > 0, 'No approved current assets are available');
+  assert(layouts.some((layout: any) => layout.status === 'executable'), 'No executable renderer layouts are available');
+
+  const generatedAt = new Date().toISOString();
+  const output = {
+    schema_version: '1.0',
+    context_type: 'innerbloom_creative_director_input',
+    period_key: period,
+    generated_at: generatedAt,
+    provenance: {
+      source_branch: `automation/marketing-cycle-${period}`,
+      campaign_draft_path: `marketing/agent-outputs/${period}/campaign-draft.json`,
+      campaign_draft_sha256: sha256(draft.raw),
+      cmo_strategy_path: `marketing/agent-outputs/${period}/cmo-strategy.json`,
+      cmo_strategy_sha256: sha256(strategy.raw),
+      content_context_path: `marketing/agent-inputs/${period}/content-context.json`,
+      content_context_sha256: sha256(contentContext.raw),
+      visual_system_path: 'prompts/marketing/agent-system/brand/innerbloom-visual-system-v1.json',
+      visual_system_sha256: sha256(visualSystem.raw),
+      asset_registry_path: 'marketing/asset-registry/innerbloom-drive-assets-v1.json',
+      asset_registry_sha256: sha256(assetRegistry.raw),
+      layout_spec_path: 'marketing/layout-references/innerbloom-layout-specifications-v1.json',
+      layout_spec_sha256: sha256(layoutSpec.raw),
+      creative_director_contract_version: 'creative-director-v1',
+    },
+    immutable_editorial_source: draft.value,
+    strategic_guardrails: {
+      strategy: strategy.value,
+      approved_product_truths: contentContext.value?.product_context?.approved_product_truths ?? [],
+      approved_claim_source: contentContext.value?.product_context?.approved_claim_source ?? {},
+    },
+    visual_system: visualSystem.value,
+    renderer_capabilities: {
+      policy: layoutSpec.value?.policy ?? {},
+      device_pose_presets: layoutSpec.value?.device_pose_presets ?? {},
+      layouts,
+      output_canvas: { width: 1080, height: 1080, format: 'png' },
+    },
+    current_assets: {
+      registry_name: assetRegistry.value?.registry_name,
+      selection_rules: assetRegistry.value?.selection_rules ?? [],
+      assets: approvedAssets,
+    },
+    production_rules: {
+      output_path: `marketing/agent-outputs/${period}/campaign.json`,
+      failure_path: `marketing/agent-outputs/${period}/creative-director-failure.json`,
+      preserve_editorial_fields: true,
+      registered_assets_only: true,
+      executable_layouts_only: true,
+      allow_experimental_layout_only_with_required_support_assets: true,
+      campaign_status: 'review',
+      post_status: 'needs_review',
+      renderer_validator: 'scripts/marketing/validate-creative-direction-v3.mjs',
+      diversity_rules: {
+        minimum_unique_layouts_full_campaign: 12,
+        minimum_distinct_source_assets_full_campaign: 14,
+        minimum_unique_layouts_per_carousel: 4,
+        maximum_layout_share_percent: 20,
+      },
+    },
+  };
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  const tempPath = `${outputPath}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
+  await rename(tempPath, outputPath);
+  console.log(JSON.stringify({ status: 'written', outputPath, period, approvedAssetCount: approvedAssets.length, layoutCount: layouts.length }, null, 2));
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : 'Unknown creative context export error');
+  process.exitCode = 1;
+});

--- a/apps/api/scripts/validate-creative-director-preservation.ts
+++ b/apps/api/scripts/validate-creative-director-preservation.ts
@@ -1,0 +1,123 @@
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+const readArg = (name: string): string | null => {
+  const prefix = `--${name}=`;
+  return process.argv.slice(2).find((value) => value.startsWith(prefix))?.slice(prefix.length) ?? null;
+};
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const stable = (value: unknown): string => JSON.stringify(value);
+
+function editorialPost(post: any): Record<string, unknown> {
+  return {
+    post_code: post.post_code,
+    sequence_number: post.sequence_number,
+    platform: post.platform,
+    format: post.format,
+    status: post.status,
+    scheduled_at: post.scheduled_at,
+    content_pillar: post.content_pillar,
+    funnel_stage: post.funnel_stage,
+    experiment_code: post.experiment_code,
+    audience_tension: post.audience_tension,
+    product_truth_anchor: post.product_truth_anchor,
+    hook: post.hook,
+    caption: post.caption,
+    cta: post.cta,
+    hypothesis: post.hypothesis,
+    primary_metric: post.primary_metric,
+    tracking_url: post.tracking_url,
+    utm: post.utm,
+    visible_copy_plan: post.visible_copy_plan,
+    accessibility: post.accessibility,
+    carousel: post.carousel,
+  };
+}
+
+function assetCodes(campaign: any): Set<string> {
+  const codes = new Set<string>();
+  for (const post of Array.isArray(campaign?.posts) ? campaign.posts : []) {
+    for (const asset of Array.isArray(post?.assets) ? post.assets : []) {
+      if (typeof asset?.asset_code === 'string') codes.add(asset.asset_code);
+    }
+    for (const slot of Array.isArray(post?.asset_slots) ? post.asset_slots : []) {
+      if (typeof slot?.asset_code === 'string') codes.add(slot.asset_code);
+    }
+  }
+  for (const job of Array.isArray(campaign?.image_jobs) ? campaign.image_jobs : []) {
+    if (typeof job?.asset_code === 'string') codes.add(job.asset_code);
+  }
+  return codes;
+}
+
+async function main(): Promise<void> {
+  const draftPath = readArg('draft');
+  const campaignPath = readArg('campaign');
+  const contextPath = readArg('context');
+  if (!draftPath || !campaignPath || !contextPath) {
+    throw new Error('Usage: tsx apps/api/scripts/validate-creative-director-preservation.ts --draft=<campaign-draft.json> --campaign=<campaign.json> --context=<creative-context.json>');
+  }
+
+  const [draft, campaign, context] = await Promise.all(
+    [draftPath, campaignPath, contextPath].map(async (path) => JSON.parse(await readFile(path, 'utf8')) as any),
+  );
+
+  assert(draft.period_key === campaign.period_key, 'campaign period differs from draft');
+  assert(context.period_key === draft.period_key, 'creative context period differs from draft');
+  assert(campaign.campaign?.status === 'review', 'campaign must remain review');
+
+  const campaignFields = [
+    'campaign_code', 'title', 'objective', 'status', 'strategy_summary', 'language', 'platforms', 'formats',
+    'target_post_count', 'publishing_start_date', 'publishing_end_date',
+  ];
+  for (const field of campaignFields) {
+    assert(stable(campaign.campaign?.[field]) === stable(draft.campaign?.[field]), `campaign.${field} differs from draft`);
+  }
+
+  assert(Array.isArray(campaign.posts), 'campaign posts are missing');
+  assert(campaign.posts.length === draft.posts.length, 'campaign post count differs from draft');
+  const campaignPosts = new Map(campaign.posts.map((post: any) => [post.post_code, post]));
+  for (const draftPost of draft.posts) {
+    const outputPost = campaignPosts.get(draftPost.post_code);
+    assert(outputPost, `campaign is missing ${draftPost.post_code}`);
+    assert(stable(editorialPost(outputPost)) === stable(editorialPost(draftPost)), `${draftPost.post_code} editorial content differs from draft`);
+  }
+
+  const outputAssetCodes = assetCodes(campaign);
+  for (const post of draft.posts) {
+    for (const slot of post.asset_slots) {
+      assert(outputAssetCodes.has(slot.asset_code), `campaign is missing renderer job or asset for ${slot.asset_code}`);
+    }
+  }
+
+  const registeredAssets = new Set(
+    (Array.isArray(context?.current_assets?.assets) ? context.current_assets.assets : [])
+      .map((asset: any) => asset?.asset_key)
+      .filter((value: unknown): value is string => typeof value === 'string'),
+  );
+  const selectedKeys: string[] = [];
+  const walk = (value: unknown): void => {
+    if (Array.isArray(value)) return value.forEach(walk);
+    if (!value || typeof value !== 'object') return;
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (key === 'selected_asset_keys' && Array.isArray(child)) {
+        selectedKeys.push(...child.filter((item): item is string => typeof item === 'string'));
+      }
+      walk(child);
+    }
+  };
+  walk(campaign);
+  assert(selectedKeys.length > 0, 'campaign has no selected_asset_keys');
+  for (const key of selectedKeys) assert(registeredAssets.has(key), `campaign selects unregistered asset ${key}`);
+
+  console.log(`Validated Creative Director preservation and registered assets: ${campaignPath}`);
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : 'Unknown Creative Director preservation error');
+  process.exitCode = 1;
+});

--- a/prompts/marketing/agent-system/creative-director/AGENTS.md
+++ b/prompts/marketing/agent-system/creative-director/AGENTS.md
@@ -1,0 +1,112 @@
+# Innerbloom Creative Director Agent
+
+## Purpose
+
+This agent converts one validated `creative-context.json` into the renderer-ready `campaign.json`.
+
+It owns executable visual decisions. It does not own strategy, editorial copy, scheduling, tracking, product truth, publishing, rendering, storage or Admin import.
+
+## Authoritative files
+
+- Prompt: `prompts/marketing/creative-director-v1.md`
+- Input schema: `prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json`
+- Input: `marketing/agent-inputs/<YYYY-MM>/creative-context.json`
+- Editorial source: `marketing/agent-outputs/<YYYY-MM>/campaign-draft.json`
+- Output: `marketing/agent-outputs/<YYYY-MM>/campaign.json`
+- Failure output: `marketing/agent-outputs/<YYYY-MM>/creative-director-failure.json`
+- Renderer validator: `scripts/marketing/validate-creative-direction-v3.mjs`
+- Preservation validator: `apps/api/scripts/validate-creative-director-preservation.ts`
+
+## Preconditions
+
+Do not execute unless:
+
+- the creative context validates;
+- the embedded draft period and branch match the target period;
+- all provenance paths and SHA-256 values are present;
+- at least one current approved asset exists;
+- at least one executable renderer layout exists;
+- every draft post and asset slot is complete;
+- campaign and posts remain in review states.
+
+## Immutable editorial data
+
+Preserve exactly:
+
+- campaign metadata and publishing window;
+- post count, order and schedule;
+- pillars, funnel and experiments;
+- audience tension and product truth anchor;
+- hooks, captions, CTA, hypotheses and metrics;
+- tracking and UTM values;
+- visible copy and carousel narrative;
+- accessibility;
+- asset codes, slide numbers and ownership.
+
+## Creative ownership
+
+For each asset slot, the agent selects and defines:
+
+- registered source assets;
+- executable layout;
+- visual family;
+- mode and compatible palette;
+- device presentation;
+- composition intent;
+- supporting visual and treatment;
+- focal instruction;
+- screen fit;
+- art direction;
+- acceptance criteria;
+- expected output metadata required by the current renderer contract.
+
+## Asset rules
+
+- Select only keys included in `current_assets.assets`.
+- Respect mode, module, surface and `allowed_operations`.
+- Product evidence must use real registered Innerbloom UI.
+- Never fabricate Drive IDs, URLs, filenames, metrics or UI states.
+- Use registered brand-logo assets rather than recreating the wordmark.
+- An unavailable required asset blocks that job and creates a conditional production requirement.
+
+## Layout rules
+
+- Select only layouts listed in `renderer_capabilities.layouts`.
+- Normal jobs use `status: executable` layouts.
+- Experimental layouts require every declared support asset to be available.
+- Respect asset-count, background and device-pose constraints.
+- Use only declared fallback layouts.
+- Meet campaign diversity thresholds from `production_rules.diversity_rules`.
+
+## Allowed writes
+
+Only:
+
+- `marketing/agent-outputs/<YYYY-MM>/campaign.json`;
+- `marketing/agent-outputs/<YYYY-MM>/creative-director-failure.json` when legitimately blocked.
+
+Everything else is read-only.
+
+## Forbidden actions
+
+- Editing the campaign draft, CMO strategy or context.
+- Changing copy, dates, tracking or editorial mapping.
+- Editing renderer code, schemas, thresholds or canonical visual files.
+- Creating binary assets.
+- Running render, R2 upload, Neon import, Admin operations or Metricool publication.
+- Marking content approved, published or measured.
+
+## Required validation
+
+A successful output must pass:
+
+```bash
+node scripts/marketing/validate-creative-direction-v3.mjs marketing/agent-outputs/<YYYY-MM>/campaign.json
+
+npx tsx apps/api/scripts/validate-creative-director-preservation.ts \
+  --draft=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json \
+  --campaign=marketing/agent-outputs/<YYYY-MM>/campaign.json \
+  --context=marketing/agent-inputs/<YYYY-MM>/creative-context.json
+```
+
+Fail closed. A valid final state is a review-state `campaign.json` ready for a manual pilot render.

--- a/prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json
+++ b/prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "innerbloom://marketing/creative-director-input-v1",
+  "title": "Innerbloom Creative Director Input v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "context_type", "period_key", "generated_at", "provenance", "immutable_editorial_source", "strategic_guardrails", "visual_system", "renderer_capabilities", "current_assets", "production_rules"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "context_type": {"const": "innerbloom_creative_director_input"},
+    "period_key": {"type": "string", "pattern": "^\\d{4}-(0[1-9]|1[0-2])$"},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_branch", "campaign_draft_path", "campaign_draft_sha256", "cmo_strategy_path", "cmo_strategy_sha256", "content_context_path", "content_context_sha256", "visual_system_path", "visual_system_sha256", "asset_registry_path", "asset_registry_sha256", "layout_spec_path", "layout_spec_sha256", "creative_director_contract_version"],
+      "properties": {
+        "source_branch": {"type": "string", "pattern": "^automation/marketing-cycle-\\d{4}-\\d{2}$"},
+        "campaign_draft_path": {"type": "string"},
+        "campaign_draft_sha256": {"$ref": "#/$defs/sha256"},
+        "cmo_strategy_path": {"type": "string"},
+        "cmo_strategy_sha256": {"$ref": "#/$defs/sha256"},
+        "content_context_path": {"type": "string"},
+        "content_context_sha256": {"$ref": "#/$defs/sha256"},
+        "visual_system_path": {"type": "string"},
+        "visual_system_sha256": {"$ref": "#/$defs/sha256"},
+        "asset_registry_path": {"type": "string"},
+        "asset_registry_sha256": {"$ref": "#/$defs/sha256"},
+        "layout_spec_path": {"type": "string"},
+        "layout_spec_sha256": {"$ref": "#/$defs/sha256"},
+        "creative_director_contract_version": {"const": "creative-director-v1"}
+      }
+    },
+    "immutable_editorial_source": {"type": "object"},
+    "strategic_guardrails": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["strategy", "approved_product_truths", "approved_claim_source"],
+      "properties": {
+        "strategy": {"type": "object"},
+        "approved_product_truths": {"type": "array", "minItems": 1, "items": {"type": "object"}},
+        "approved_claim_source": {"type": "object"}
+      }
+    },
+    "visual_system": {"type": "object"},
+    "renderer_capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy", "device_pose_presets", "layouts", "output_canvas"],
+      "properties": {
+        "policy": {"type": "object"},
+        "device_pose_presets": {"type": "object"},
+        "layouts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["layout_key", "status", "renderer_layout", "copy_role", "copy_zone", "product_zone", "device_pose", "min_mobile_assets", "max_mobile_assets", "min_module_assets", "allowed_backgrounds", "required_support_assets", "fallback_layouts"]
+          }
+        },
+        "output_canvas": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["width", "height", "format"],
+          "properties": {
+            "width": {"const": 1080},
+            "height": {"const": 1080},
+            "format": {"const": "png"}
+          }
+        }
+      }
+    },
+    "current_assets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["registry_name", "selection_rules", "assets"],
+      "properties": {
+        "registry_name": {"type": "string"},
+        "selection_rules": {"type": "array", "items": {"type": "string"}},
+        "assets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["asset_key", "kind", "module", "mode", "surface", "composition_profile", "composition_slots", "allowed_operations"],
+            "properties": {
+              "asset_key": {"type": "string", "minLength": 1},
+              "kind": {"type": "string"},
+              "module": {"type": "string"},
+              "mode": {"type": "string"},
+              "surface": {"type": "string"},
+              "composition_profile": {"type": ["string", "null"]},
+              "composition_slots": {"type": ["object", "null"]},
+              "allowed_operations": {"type": "array", "items": {"type": "string"}}
+            }
+          }
+        }
+      }
+    },
+    "production_rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_path", "failure_path", "preserve_editorial_fields", "registered_assets_only", "executable_layouts_only", "allow_experimental_layout_only_with_required_support_assets", "campaign_status", "post_status", "renderer_validator", "diversity_rules"],
+      "properties": {
+        "output_path": {"type": "string"},
+        "failure_path": {"type": "string"},
+        "preserve_editorial_fields": {"const": true},
+        "registered_assets_only": {"const": true},
+        "executable_layouts_only": {"const": true},
+        "allow_experimental_layout_only_with_required_support_assets": {"const": true},
+        "campaign_status": {"const": "review"},
+        "post_status": {"const": "needs_review"},
+        "renderer_validator": {"const": "scripts/marketing/validate-creative-direction-v3.mjs"},
+        "diversity_rules": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["minimum_unique_layouts_full_campaign", "minimum_distinct_source_assets_full_campaign", "minimum_unique_layouts_per_carousel", "maximum_layout_share_percent"],
+          "properties": {
+            "minimum_unique_layouts_full_campaign": {"type": "integer", "minimum": 1},
+            "minimum_distinct_source_assets_full_campaign": {"type": "integer", "minimum": 1},
+            "minimum_unique_layouts_per_carousel": {"type": "integer", "minimum": 1},
+            "maximum_layout_share_percent": {"type": "integer", "minimum": 1, "maximum": 100}
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"}
+  }
+}

--- a/prompts/marketing/creative-director-v1.md
+++ b/prompts/marketing/creative-director-v1.md
@@ -1,0 +1,97 @@
+# PROMPT MAESTRO — CREATIVE DIRECTOR DE INNERBLOOM
+
+## Rol
+
+Sos el Creative Director de Innerbloom. Convertís un `creative-context.json` validado en el `campaign.json` ejecutable que consume el renderer.
+
+No sos CMO ni Head of Content. No cambiás estrategia, copy, fechas, tracking, hipótesis, métricas, pilares, experimentos ni estados editoriales.
+
+## Input obligatorio
+
+Leé:
+
+- `prompts/marketing/agent-system/creative-director/AGENTS.md`;
+- `prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json`;
+- `marketing/agent-inputs/<YYYY-MM>/creative-context.json`;
+- `scripts/marketing/validate-creative-direction-v3.mjs`.
+
+`immutable_editorial_source` es inmutable. El sistema visual, asset registry y layout spec incluidos en el contexto son las únicas fuentes creativas ejecutables.
+
+## Output único
+
+Escribí exclusivamente:
+
+`marketing/agent-outputs/<YYYY-MM>/campaign.json`
+
+Si no existe una combinación veraz y ejecutable de assets y layouts, escribí `creative-director-failure.json`. No inventes assets, IDs, UI, datos, módulos ni capacidades.
+
+## Responsabilidad
+
+Para cada `asset_slot` del draft:
+
+1. creá exactamente un image job con el mismo `asset_code` y post propietario;
+2. preservá copy visible y slide number;
+3. elegí solamente `asset_key` registrados;
+4. elegí solamente layouts ejecutables, o experimentales cuando todos sus support assets requeridos existan;
+5. definí modo, familia visual, device presentation, composición y art direction compatibles con los assets seleccionados;
+6. cumplí diversidad de layouts y fuentes a nivel campaña;
+7. mantené coherencia entre slides sin repetir mecánicamente el mismo layout;
+8. bloqueá jobs sin evidencia suficiente en vez de fabricar una solución.
+
+## Selección de assets
+
+- Seleccioná por `asset_key`, nunca por filename supuesto.
+- Usá assets `approved_current` incluidos en el contexto.
+- Hacé coincidir mode, surface, module y operaciones permitidas.
+- Product claims requieren evidencia real de producto.
+- `module_*` debe acompañar una pantalla padre coherente cuando así lo exija el registry.
+- El logo debe venir de un asset registrado `brand_logo`.
+
+## Selección de layouts
+
+- Usá el `layout_key` y `renderer_layout` presentes en `renderer_capabilities.layouts`.
+- Respetá mínimos y máximos de assets.
+- Respetá backgrounds y support assets requeridos.
+- Aplicá fallback solamente entre layouts declarados.
+- No uses layouts de referencia como verdad de producto.
+
+## Preservación obligatoria
+
+El output debe conservar exactamente del draft:
+
+- campaign code, title, objective, language, platforms, formats y ventana;
+- target post count y status;
+- orden y número de posts;
+- post code, platform, format, status y scheduled_at;
+- pillar, funnel, experiment, audience tension y product truth anchor;
+- hook, caption, CTA, hypothesis, primary metric, tracking y UTM;
+- visible copy, accesibilidad y narrativa de carrusel;
+- asset codes y slide ownership.
+
+## Prohibiciones
+
+No:
+
+- reescribas captions o hooks;
+- agregues posts o slides;
+- conviertas una referencia semántica en un asset inexistente;
+- cambies thresholds de validación;
+- modifiques scripts, schemas o renderer;
+- marques la campaña como aprobada o publicada;
+- ejecutes render, R2, Neon, Admin o Metricool.
+
+## Validación
+
+Antes de terminar ejecutá:
+
+```bash
+node scripts/marketing/validate-creative-direction-v3.mjs \
+  marketing/agent-outputs/<YYYY-MM>/campaign.json
+
+npx tsx apps/api/scripts/validate-creative-director-preservation.ts \
+  --draft=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json \
+  --campaign=marketing/agent-outputs/<YYYY-MM>/campaign.json \
+  --context=marketing/agent-inputs/<YYYY-MM>/creative-context.json
+```
+
+Una salida exitosa pasa ambas validaciones. El resultado queda en `review` y listo para un render piloto manual, no publicado.


### PR DESCRIPTION
## Objetivo
Implementar el siguiente bloque del pipeline: `campaign-draft.json` → contexto determinístico → agente Creative Director → futuro `campaign.json` productivo.

## Qué incluye
- builder `export-marketing-creative-context.ts`;
- schema estricto `creative-director-input-v1.schema.json`;
- workflow automático al recibir un `campaign-draft.json` en la rama mensual;
- prompt y contrato ejecutable del agente Creative Director;
- validador que impide cambiar copy, estrategia, calendario, tracking, carruseles y asset ownership;
- validación de que todos los `selected_asset_keys` estén registrados;
- CI representativo para construir y validar el contexto.

## Fuentes canónicas incluidas
El builder empaqueta y registra SHA-256 de:
- `campaign-draft.json`;
- `cmo-strategy.json`;
- `content-context.json` y verdades de producto aprobadas;
- sistema visual canónico;
- asset registry actual;
- layout specifications y device poses del renderer.

## Límites
- GitHub no toma decisiones creativas: sólo valida y construye el contexto;
- Creative Director no puede alterar ningún dato editorial;
- sólo puede elegir assets actuales registrados y layouts declarados;
- Asset Producer queda condicional para fuentes realmente faltantes;
- no se configura todavía Codex Cloud;
- no se dispara render, R2, Neon ni Admin;
- no se modifica el renderer productivo.

## Conexión implementada
`campaign-draft.json` en `automation/marketing-cycle-YYYY-MM`
→ workflow `Generate Creative Director context`
→ `marketing/agent-inputs/YYYY-MM/creative-context.json`
→ Creative Director escribe `marketing/agent-outputs/YYYY-MM/campaign.json`.

## Antes de mergear
Debe quedar verde `Validate marketing Creative Director contract`, incluido typecheck, validación previa del draft, construcción del contexto, JSON Schema y comprobación de assets/layouts ejecutables.

Después del merge quedará pendiente configurar la automatización Codex del Creative Director y ejecutar un shadow run antes de cualquier render completo.