### PR TITLE
Fix native Google login crash from unsupported Clerk reset

### DIFF
--- a/apps/web/src/pages/MobileBrowserAuth.tsx
+++ b/apps/web/src/pages/MobileBrowserAuth.tsx
@@ -387,17 +387,8 @@ export default function MobileBrowserAuthPage() {
     }
 
     googleRedirectStartedRef.current = true;
-    clerk.client.resetSignIn();
-    const freshSignIn = clerk.client.signIn;
     const redirectOptions = buildGoogleOAuthRedirectOptions(handoffUrl, true);
-    console.info('[mobile-auth-page] starting interactive Google OAuth', {
-      at: Date.now(),
-      mode,
-      provider: 'google',
-      accountSelection: 'required',
-      resetSignInAttempt: true,
-    });
-    void freshSignIn
+    void signIn
       .authenticateWithRedirect(redirectOptions)
       .catch((cause) => {
         googleRedirectStartedRef.current = false;
@@ -413,7 +404,6 @@ export default function MobileBrowserAuthPage() {
         );
       });
   }, [
-    clerk.client,
     createdSessionId,
     handoffUrl,
     isLoaded,


### PR DESCRIPTION
## Causa confirmada

La consola remota de Chrome mostró:

`Uncaught TypeError: i.client.resetSignIn is not a function`

El fallo ocurría en `MobileBrowserAuth.tsx` antes de iniciar el redirect a Google, dejando el Custom Tab detenido en `/mobile-auth`.

## Corrección

- Elimina `clerk.client.resetSignIn()`.
- Elimina la lectura inmediata de `clerk.client.signIn`.
- Vuelve a usar el recurso `signIn` ya cargado por `useSignIn()` para ejecutar `authenticateWithRedirect()`.
- Elimina la dependencia innecesaria `clerk.client` del efecto.
- Mantiene `buildGoogleOAuthRedirectOptions(...)`, incluido `oidcPrompt: select_account` y los flags configurados allí.

## Alcance

Solo cambia `apps/web/src/pages/MobileBrowserAuth.tsx`.

No modifica Android, iOS, el plugin nativo, callbacks, logout, login por email ni refresh silencioso.

## Validación

1. Desplegar la web tras mergear.
2. Abrir login Google desde Android/iOS.
3. Confirmar que la pestaña sale de `/mobile-auth` y llega a Google.
4. Confirmar que ya no aparece `resetSignIn is not a function` en DevTools.
5. Probar Google A → logout → Google → selector → Google B.
