### PR TITLE
Align Creative Director output with the production renderer contract

### DIFF
--- a/.github/workflows/marketing-creative-director-contract.yml
+++ b/.github/workflows/marketing-creative-director-contract.yml
@@ -60,12 +60,54 @@ jobs:
           const period = '2026-08';
           const draft = JSON.parse(fs.readFileSync(`marketing/agent-outputs/${period}/campaign-draft.json`, 'utf8'));
           const context = JSON.parse(fs.readFileSync(`marketing/agent-inputs/${period}/creative-context.json`, 'utf8'));
-          const post = draft.posts[0];
-          const slot = post.asset_slots[0];
-          const source = context.current_assets.assets.find((asset) => asset.kind === 'scene_plate' && asset.status === 'approved_current');
-          if (!source) throw new Error('No approved scene asset available for fixture');
-          const rendererLayout = context.renderer_capabilities.layouts.find((layout) => layout.renderer_layout === 'editorial_material_scene');
-          if (!rendererLayout) throw new Error('editorial_material_scene is not declared');
+          const source = context.current_assets.assets.find((asset) => asset.status === 'approved_current' && ['light', 'dark'].includes(asset.mode));
+          if (!source) throw new Error('No approved light/dark asset available for fixture');
+          const rendererLayout = context.renderer_capabilities.layouts.find((layout) => layout.status === 'executable' && layout.renderer_layout === 'storefront_feature_stage');
+          if (!rendererLayout) throw new Error('storefront_feature_stage is not declared as executable');
+
+          const jobs = draft.posts.flatMap((post) => post.asset_slots.map((slot) => {
+            const slide = post.carousel?.slides?.find((item) => item.asset_code === slot.asset_code);
+            return {
+              asset_code: slot.asset_code,
+              post_code: post.post_code,
+              asset_kind: slot.asset_kind,
+              ...(slot.slide_number === undefined ? {} : { slide_number: slot.slide_number }),
+              platform: post.platform,
+              format: post.format,
+              canvas: { width: 1080, height: 1080, aspect_ratio: '1:1', safe_area: 'Keep essential copy and logo inside central 940x940 safe area.' },
+              visible_copy: slide?.visible_copy ?? post.visible_copy_plan,
+              product_truth_anchor: slide?.product_truth_anchor ?? post.product_truth_anchor,
+              funnel_stage: post.funnel_stage,
+              source_assets: [source],
+              expected_output: {
+                filename: `${slot.asset_code}.png`,
+                local_staging_path: `marketing/agent-outputs/${period}/generated-assets/${slot.asset_code}.png`,
+                mime_type: 'image/png', width: 1080, height: 1080
+              },
+              creative_direction: {
+                status: 'ready_for_render',
+                visual_family: 'product_hero_scene',
+                layout_variant: rendererLayout.renderer_layout,
+                mode: source.mode,
+                palette: source.mode === 'dark' ? 'dark' : 'light',
+                device_presentation: 'front',
+                wordmark_treatment: 'canonical_innerbloom_lockup',
+                composition_intent: 'Use one registered source asset with separated copy and product zones.',
+                selected_asset_keys: [source.asset_key],
+                focal_instruction: 'Keep exact visible copy dominant and the registered source legible.',
+                supporting_visual: { required: false },
+                supporting_treatment: 'none',
+                screen_fit: 'contain',
+                acceptance_criteria: [
+                  'Exact visible copy is preserved.',
+                  'Only registered source assets are used.',
+                  'The canonical Innerbloom lockup is present.',
+                  'No invented UI, metrics or product behavior appears.'
+                ]
+              }
+            };
+          }));
+
           const campaign = {
             schema_version: '1.0',
             agent: 'innerbloom_creative_director',
@@ -80,56 +122,7 @@ jobs:
               carousel_minimum_unique_layouts: 1,
               maximum_layout_share: 1
             },
-            image_generation: {
-              jobs: [{
-                asset_code: slot.asset_code,
-                post_code: post.post_code,
-                asset_kind: slot.asset_kind,
-                platform: post.platform,
-                format: post.format,
-                canvas: { width: 1080, height: 1080, aspect_ratio: '1:1', safe_area: 'Keep essential copy and logo inside central 940x940 safe area.' },
-                visible_copy: post.visible_copy_plan,
-                product_truth_anchor: post.product_truth_anchor,
-                funnel_stage: post.funnel_stage,
-                source_assets: [source],
-                expected_output: {
-                  filename: `${slot.asset_code}.png`,
-                  local_staging_path: `marketing/agent-outputs/${period}/generated-assets/${slot.asset_code}.png`,
-                  mime_type: 'image/png', width: 1080, height: 1080
-                },
-                creative_direction: {
-                  status: 'ready_for_render',
-                  visual_family: 'supporting_visual_scene',
-                  layout_variant: rendererLayout.renderer_layout,
-                  mode: source.mode,
-                  palette: source.mode === 'dark' ? 'dark' : 'warm',
-                  device_presentation: 'none',
-                  wordmark_treatment: 'canonical_innerbloom_lockup',
-                  composition_intent: 'Use the registered material scene with separated copy and proof zones.',
-                  selected_asset_keys: [source.asset_key],
-                  focal_instruction: 'Keep the exact headline dominant and the registered scene secondary.',
-                  supporting_visual: { required: true },
-                  supporting_treatment: 'none',
-                  screen_fit: 'contain',
-                  art_direction: {
-                    profile: 'material_editorial_v1',
-                    scene_asset_key: source.asset_key,
-                    copy_zone: source.composition_slots.copy_zone,
-                    product_zone: source.composition_slots.product_zone,
-                    device_grounding: source.composition_slots.device_grounding,
-                    scene_crop: source.composition_slots.scene_crop,
-                    readability_veil: source.composition_slots.readability_veil,
-                    device_angle_deg: 0
-                  },
-                  acceptance_criteria: [
-                    'Exact visible copy is preserved.',
-                    'Only registered source assets are used.',
-                    'The canonical Innerbloom lockup is present.',
-                    'No invented UI, metrics or product behavior appears.'
-                  ]
-                }
-              }]
-            }
+            image_generation: { jobs }
           };
           fs.writeFileSync(`marketing/agent-outputs/${period}/campaign.json`, JSON.stringify(campaign, null, 2));
           NODE

--- a/.github/workflows/marketing-creative-director-contract.yml
+++ b/.github/workflows/marketing-creative-director-contract.yml
@@ -60,8 +60,9 @@ jobs:
           const period = '2026-08';
           const draft = JSON.parse(fs.readFileSync(`marketing/agent-outputs/${period}/campaign-draft.json`, 'utf8'));
           const context = JSON.parse(fs.readFileSync(`marketing/agent-inputs/${period}/creative-context.json`, 'utf8'));
-          const source = context.current_assets.assets.find((asset) => asset.status === 'approved_current' && ['light', 'dark'].includes(asset.mode));
-          if (!source) throw new Error('No approved light/dark asset available for fixture');
+          const source = context.current_assets.assets.find((asset) => asset.status === 'approved_current');
+          if (!source) throw new Error('No approved asset available for fixture');
+          const creativeMode = ['light', 'dark'].includes(source.mode) ? source.mode : 'dark';
           const rendererLayout = context.renderer_capabilities.layouts.find((layout) => layout.status === 'executable' && layout.renderer_layout === 'storefront_feature_stage');
           if (!rendererLayout) throw new Error('storefront_feature_stage is not declared as executable');
 
@@ -88,8 +89,8 @@ jobs:
                 status: 'ready_for_render',
                 visual_family: 'product_hero_scene',
                 layout_variant: rendererLayout.renderer_layout,
-                mode: source.mode,
-                palette: source.mode === 'dark' ? 'dark' : 'light',
+                mode: creativeMode,
+                palette: creativeMode,
                 device_presentation: 'front',
                 wordmark_treatment: 'canonical_innerbloom_lockup',
                 composition_intent: 'Use one registered source asset with separated copy and product zones.',

--- a/.github/workflows/marketing-creative-director-contract.yml
+++ b/.github/workflows/marketing-creative-director-contract.yml
@@ -8,6 +8,7 @@ on:
       - 'prompts/marketing/creative-director-v1.md'
       - 'prompts/marketing/agent-system/creative-director/AGENTS.md'
       - 'prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json'
+      - 'prompts/marketing/agent-system/schemas/creative-director-output-v1.schema.json'
       - '.github/workflows/marketing-creative-context.yml'
       - '.github/workflows/marketing-creative-director-contract.yml'
       - 'Docs/marketing/contracts/creative-director-v1.md'
@@ -50,12 +51,115 @@ jobs:
           npx tsx apps/api/scripts/validate-marketing-agent-json.ts
           --schema=prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json
           --input=marketing/agent-inputs/2026-08/creative-context.json
-      - name: Prove the context contains executable layouts and current assets
+      - name: Build renderer-compatible Creative Director output fixture
+        shell: bash
         run: |
+          set -euo pipefail
           node - <<'NODE'
           const fs = require('fs');
-          const context = JSON.parse(fs.readFileSync('marketing/agent-inputs/2026-08/creative-context.json', 'utf8'));
-          if (!context.renderer_capabilities.layouts.some((layout) => layout.status === 'executable')) throw new Error('No executable layout');
-          if (!context.current_assets.assets.length) throw new Error('No current assets');
-          if (context.immutable_editorial_source.period_key !== '2026-08') throw new Error('Draft period missing');
+          const period = '2026-08';
+          const draft = JSON.parse(fs.readFileSync(`marketing/agent-outputs/${period}/campaign-draft.json`, 'utf8'));
+          const context = JSON.parse(fs.readFileSync(`marketing/agent-inputs/${period}/creative-context.json`, 'utf8'));
+          const post = draft.posts[0];
+          const slot = post.asset_slots[0];
+          const source = context.current_assets.assets.find((asset) => asset.kind === 'scene_plate' && asset.status === 'approved_current');
+          if (!source) throw new Error('No approved scene asset available for fixture');
+          const rendererLayout = context.renderer_capabilities.layouts.find((layout) => layout.renderer_layout === 'editorial_material_scene');
+          if (!rendererLayout) throw new Error('editorial_material_scene is not declared');
+          const campaign = {
+            schema_version: '1.0',
+            agent: 'innerbloom_creative_director',
+            period_key: period,
+            generated_at: '2026-07-25T12:00:00Z',
+            campaign: draft.campaign,
+            posts: draft.posts,
+            validation_profile: {
+              kind: 'derived_test',
+              minimum_unique_layouts: 1,
+              minimum_distinct_assets: 1,
+              carousel_minimum_unique_layouts: 1,
+              maximum_layout_share: 1
+            },
+            image_generation: {
+              jobs: [{
+                asset_code: slot.asset_code,
+                post_code: post.post_code,
+                asset_kind: slot.asset_kind,
+                platform: post.platform,
+                format: post.format,
+                canvas: { width: 1080, height: 1080, aspect_ratio: '1:1', safe_area: 'Keep essential copy and logo inside central 940x940 safe area.' },
+                visible_copy: post.visible_copy_plan,
+                product_truth_anchor: post.product_truth_anchor,
+                funnel_stage: post.funnel_stage,
+                source_assets: [source],
+                expected_output: {
+                  filename: `${slot.asset_code}.png`,
+                  local_staging_path: `marketing/agent-outputs/${period}/generated-assets/${slot.asset_code}.png`,
+                  mime_type: 'image/png', width: 1080, height: 1080
+                },
+                creative_direction: {
+                  status: 'ready_for_render',
+                  visual_family: 'supporting_visual_scene',
+                  layout_variant: rendererLayout.renderer_layout,
+                  mode: source.mode,
+                  palette: source.mode === 'dark' ? 'dark' : 'warm',
+                  device_presentation: 'none',
+                  wordmark_treatment: 'canonical_innerbloom_lockup',
+                  composition_intent: 'Use the registered material scene with separated copy and proof zones.',
+                  selected_asset_keys: [source.asset_key],
+                  focal_instruction: 'Keep the exact headline dominant and the registered scene secondary.',
+                  supporting_visual: { required: true },
+                  supporting_treatment: 'none',
+                  screen_fit: 'contain',
+                  art_direction: {
+                    profile: 'material_editorial_v1',
+                    scene_asset_key: source.asset_key,
+                    copy_zone: source.composition_slots.copy_zone,
+                    product_zone: source.composition_slots.product_zone,
+                    device_grounding: source.composition_slots.device_grounding,
+                    scene_crop: source.composition_slots.scene_crop,
+                    readability_veil: source.composition_slots.readability_veil,
+                    device_angle_deg: 0
+                  },
+                  acceptance_criteria: [
+                    'Exact visible copy is preserved.',
+                    'Only registered source assets are used.',
+                    'The canonical Innerbloom lockup is present.',
+                    'No invented UI, metrics or product behavior appears.'
+                  ]
+                }
+              }]
+            }
+          };
+          fs.writeFileSync(`marketing/agent-outputs/${period}/campaign.json`, JSON.stringify(campaign, null, 2));
           NODE
+      - name: Validate Creative Director output schema
+        run: >-
+          npx tsx apps/api/scripts/validate-marketing-agent-json.ts
+          --schema=prompts/marketing/agent-system/schemas/creative-director-output-v1.schema.json
+          --input=marketing/agent-outputs/2026-08/campaign.json
+      - name: Validate existing renderer creative contract
+        run: node scripts/marketing/validate-creative-direction-v3.mjs marketing/agent-outputs/2026-08/campaign.json
+      - name: Validate exact draft preservation and renderer job ownership
+        run: >-
+          npx tsx apps/api/scripts/validate-creative-director-preservation.ts
+          --draft=marketing/agent-outputs/2026-08/campaign-draft.json
+          --campaign=marketing/agent-outputs/2026-08/campaign.json
+          --context=marketing/agent-inputs/2026-08/creative-context.json
+      - name: Prove legacy image_jobs shape fails closed
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const fs = require('fs');
+          const campaign = JSON.parse(fs.readFileSync('marketing/agent-outputs/2026-08/campaign.json', 'utf8'));
+          campaign.image_jobs = campaign.image_generation.jobs;
+          delete campaign.image_generation;
+          fs.writeFileSync('/tmp/invalid-creative-director-output.json', JSON.stringify(campaign));
+          NODE
+          if npx tsx apps/api/scripts/validate-marketing-agent-json.ts \
+            --schema=prompts/marketing/agent-system/schemas/creative-director-output-v1.schema.json \
+            --input=/tmp/invalid-creative-director-output.json; then
+            echo 'Expected legacy image_jobs output to fail.' >&2
+            exit 1
+          fi

--- a/apps/api/scripts/export-marketing-creative-context.ts
+++ b/apps/api/scripts/export-marketing-creative-context.ts
@@ -67,6 +67,7 @@ async function main(): Promise<void> {
       module: asset.module,
       mode: asset.mode,
       surface: asset.surface,
+      status: asset.status,
       composition_profile: asset.composition_profile ?? null,
       composition_slots: asset.composition_slots ?? null,
       allowed_operations: asset.allowed_operations ?? [],

--- a/apps/api/scripts/validate-creative-director-preservation.ts
+++ b/apps/api/scripts/validate-creative-director-preservation.ts
@@ -11,6 +11,7 @@ function assert(condition: unknown, message: string): asserts condition {
 }
 
 const stable = (value: unknown): string => JSON.stringify(value);
+const strings = (value: unknown): string[] => Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
 
 function editorialPost(post: any): Record<string, unknown> {
   return {
@@ -38,22 +39,6 @@ function editorialPost(post: any): Record<string, unknown> {
   };
 }
 
-function assetCodes(campaign: any): Set<string> {
-  const codes = new Set<string>();
-  for (const post of Array.isArray(campaign?.posts) ? campaign.posts : []) {
-    for (const asset of Array.isArray(post?.assets) ? post.assets : []) {
-      if (typeof asset?.asset_code === 'string') codes.add(asset.asset_code);
-    }
-    for (const slot of Array.isArray(post?.asset_slots) ? post.asset_slots : []) {
-      if (typeof slot?.asset_code === 'string') codes.add(slot.asset_code);
-    }
-  }
-  for (const job of Array.isArray(campaign?.image_jobs) ? campaign.image_jobs : []) {
-    if (typeof job?.asset_code === 'string') codes.add(job.asset_code);
-  }
-  return codes;
-}
-
 async function main(): Promise<void> {
   const draftPath = readArg('draft');
   const campaignPath = readArg('campaign');
@@ -68,11 +53,12 @@ async function main(): Promise<void> {
 
   assert(draft.period_key === campaign.period_key, 'campaign period differs from draft');
   assert(context.period_key === draft.period_key, 'creative context period differs from draft');
+  assert(campaign.agent === 'innerbloom_creative_director', 'campaign agent must be innerbloom_creative_director');
   assert(campaign.campaign?.status === 'review', 'campaign must remain review');
 
   const campaignFields = [
     'campaign_code', 'title', 'objective', 'status', 'strategy_summary', 'language', 'platforms', 'formats',
-    'target_post_count', 'publishing_start_date', 'publishing_end_date',
+    'target_post_count', 'timezone', 'publishing_start_date', 'publishing_end_date',
   ];
   for (const field of campaignFields) {
     assert(stable(campaign.campaign?.[field]) === stable(draft.campaign?.[field]), `campaign.${field} differs from draft`);
@@ -87,34 +73,58 @@ async function main(): Promise<void> {
     assert(stable(editorialPost(outputPost)) === stable(editorialPost(draftPost)), `${draftPost.post_code} editorial content differs from draft`);
   }
 
-  const outputAssetCodes = assetCodes(campaign);
-  for (const post of draft.posts) {
-    for (const slot of post.asset_slots) {
-      assert(outputAssetCodes.has(slot.asset_code), `campaign is missing renderer job or asset for ${slot.asset_code}`);
-    }
+  const jobs = campaign?.image_generation?.jobs;
+  assert(Array.isArray(jobs) && jobs.length > 0, 'campaign.image_generation.jobs must be a non-empty array');
+  const draftSlots = draft.posts.flatMap((post: any) => post.asset_slots.map((slot: any) => ({ ...slot, owner_format: post.format })));
+  assert(jobs.length === draftSlots.length, `campaign must contain exactly one image_generation job per asset slot; expected ${draftSlots.length}, found ${jobs.length}`);
+
+  const jobsByAssetCode = new Map<string, any>();
+  for (const job of jobs) {
+    assert(typeof job.asset_code === 'string' && job.asset_code.length > 0, 'renderer job is missing asset_code');
+    assert(!jobsByAssetCode.has(job.asset_code), `duplicate renderer job for ${job.asset_code}`);
+    jobsByAssetCode.set(job.asset_code, job);
   }
 
-  const registeredAssets = new Set(
+  const registeredAssetMap = new Map<string, any>(
     (Array.isArray(context?.current_assets?.assets) ? context.current_assets.assets : [])
-      .map((asset: any) => asset?.asset_key)
-      .filter((value: unknown): value is string => typeof value === 'string'),
+      .filter((asset: any) => typeof asset?.asset_key === 'string')
+      .map((asset: any) => [asset.asset_key, asset]),
   );
-  const selectedKeys: string[] = [];
-  const walk = (value: unknown): void => {
-    if (Array.isArray(value)) return value.forEach(walk);
-    if (!value || typeof value !== 'object') return;
-    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-      if (key === 'selected_asset_keys' && Array.isArray(child)) {
-        selectedKeys.push(...child.filter((item): item is string => typeof item === 'string'));
-      }
-      walk(child);
-    }
-  };
-  walk(campaign);
-  assert(selectedKeys.length > 0, 'campaign has no selected_asset_keys');
-  for (const key of selectedKeys) assert(registeredAssets.has(key), `campaign selects unregistered asset ${key}`);
+  const rendererLayouts = new Set(
+    (Array.isArray(context?.renderer_capabilities?.layouts) ? context.renderer_capabilities.layouts : [])
+      .map((layout: any) => layout?.renderer_layout)
+      .filter((value: unknown): value is string => typeof value === 'string' && value.length > 0),
+  );
+  assert(registeredAssetMap.size > 0, 'creative context has no registered assets');
+  assert(rendererLayouts.size > 0, 'creative context has no renderer_layout values');
 
-  console.log(`Validated Creative Director preservation and registered assets: ${campaignPath}`);
+  for (const slot of draftSlots) {
+    const job = jobsByAssetCode.get(slot.asset_code);
+    assert(job, `campaign is missing renderer job for ${slot.asset_code}`);
+    assert(job.post_code === slot.post_code, `${slot.asset_code} renderer job owner differs from draft`);
+    assert(job.asset_kind === slot.asset_kind, `${slot.asset_code} asset_kind differs from draft`);
+    if (slot.slide_number !== undefined) assert(job.slide_number === slot.slide_number, `${slot.asset_code} slide_number differs from draft`);
+    assert(job.format === slot.owner_format, `${slot.asset_code} format differs from owning post`);
+    assert(job.expected_output?.filename === `${slot.asset_code}.png`, `${slot.asset_code} expected_output.filename must be canonical`);
+    assert(job.expected_output?.local_staging_path === `marketing/agent-outputs/${draft.period_key}/generated-assets/${slot.asset_code}.png`, `${slot.asset_code} local_staging_path must be canonical`);
+    assert(job.expected_output?.mime_type === 'image/png' && job.expected_output?.width === 1080 && job.expected_output?.height === 1080, `${slot.asset_code} expected output must be 1080x1080 PNG`);
+
+    const direction = job.creative_direction;
+    assert(direction && rendererLayouts.has(direction.layout_variant), `${slot.asset_code} layout_variant must equal a declared renderer_layout`);
+    const sourceAssets = Array.isArray(job.source_assets) ? job.source_assets : [];
+    const sourceKeys = new Set(sourceAssets.map((asset: any) => asset?.asset_key).filter(Boolean));
+    assert(sourceKeys.size > 0, `${slot.asset_code} source_assets must be non-empty`);
+    for (const source of sourceAssets) {
+      const registered = registeredAssetMap.get(source.asset_key);
+      assert(registered, `${slot.asset_code} includes unregistered source asset ${source.asset_key}`);
+      assert(stable(source) === stable(registered), `${slot.asset_code} source asset ${source.asset_key} metadata differs from registry`);
+    }
+    const selectedKeys = strings(direction.selected_asset_keys);
+    assert(selectedKeys.length > 0, `${slot.asset_code} selected_asset_keys must be non-empty`);
+    for (const key of selectedKeys) assert(sourceKeys.has(key), `${slot.asset_code} selects ${key} outside job.source_assets`);
+  }
+
+  console.log(`Validated renderer-ready Creative Director output: ${jobs.length} exact jobs preserved from ${draftPath}`);
 }
 
 main().catch((error: unknown) => {

--- a/prompts/marketing/agent-system/creative-director/AGENTS.md
+++ b/prompts/marketing/agent-system/creative-director/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This agent converts one validated `creative-context.json` into the renderer-ready `campaign.json`.
+This agent converts one validated `creative-context.json` into the renderer-ready `campaign.json` consumed unchanged by `Render campaign and send it to Admin`.
 
 It owns executable visual decisions. It does not own strategy, editorial copy, scheduling, tracking, product truth, publishing, rendering, storage or Admin import.
 
@@ -10,6 +10,7 @@ It owns executable visual decisions. It does not own strategy, editorial copy, s
 
 - Prompt: `prompts/marketing/creative-director-v1.md`
 - Input schema: `prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json`
+- Output schema: `prompts/marketing/agent-system/schemas/creative-director-output-v1.schema.json`
 - Input: `marketing/agent-inputs/<YYYY-MM>/creative-context.json`
 - Editorial source: `marketing/agent-outputs/<YYYY-MM>/campaign-draft.json`
 - Output: `marketing/agent-outputs/<YYYY-MM>/campaign.json`
@@ -25,15 +26,37 @@ Do not execute unless:
 - the embedded draft period and branch match the target period;
 - all provenance paths and SHA-256 values are present;
 - at least one current approved asset exists;
-- at least one executable renderer layout exists;
+- at least one executable `renderer_layout` exists;
 - every draft post and asset slot is complete;
 - campaign and posts remain in review states.
+
+## Required production shape
+
+The only valid renderer job collection is:
+
+```text
+campaign.image_generation.jobs[]
+```
+
+Do not write `campaign.image_jobs` or root-level `jobs`.
+
+There must be exactly one job per draft `asset_slot`, with no missing or extra jobs.
+
+Every job must preserve its slot identity and contain:
+
+- `asset_code`, `post_code`, `asset_kind` and optional `slide_number`;
+- owning post platform and format;
+- 1080x1080 canvas;
+- exact visible copy and product truth;
+- complete registered `source_assets` metadata;
+- canonical `expected_output` metadata;
+- renderer-complete `creative_direction`.
 
 ## Immutable editorial data
 
 Preserve exactly:
 
-- campaign metadata and publishing window;
+- campaign metadata, timezone and publishing window;
 - post count, order and schedule;
 - pillars, funnel and experiments;
 - audience tension and product truth anchor;
@@ -45,7 +68,7 @@ Preserve exactly:
 
 ## Creative ownership
 
-For each asset slot, the agent selects and defines:
+For each asset slot, select and define:
 
 - registered source assets;
 - executable layout;
@@ -63,6 +86,8 @@ For each asset slot, the agent selects and defines:
 ## Asset rules
 
 - Select only keys included in `current_assets.assets`.
+- Copy each selected source asset object exactly from the registry into the job's `source_assets`.
+- Every `selected_asset_keys` value must exist in that same job's `source_assets`.
 - Respect mode, module, surface and `allowed_operations`.
 - Product evidence must use real registered Innerbloom UI.
 - Never fabricate Drive IDs, URLs, filenames, metrics or UI states.
@@ -71,12 +96,25 @@ For each asset slot, the agent selects and defines:
 
 ## Layout rules
 
-- Select only layouts listed in `renderer_capabilities.layouts`.
-- Normal jobs use `status: executable` layouts.
-- Experimental layouts require every declared support asset to be available.
-- Respect asset-count, background and device-pose constraints.
-- Use only declared fallback layouts.
+- `layout_key` is reference/planning metadata.
+- `renderer_layout` is the executable enum.
+- Set `creative_direction.layout_variant` to an exact declared `renderer_layout`.
+- Never substitute `layout_key` unless it is literally identical to `renderer_layout`.
+- Experimental layouts require every declared support asset.
+- Respect asset counts, backgrounds, device poses and declared fallbacks.
 - Meet campaign diversity thresholds from `production_rules.diversity_rules`.
+
+## Canonical expected output
+
+For each slot `<asset_code>`:
+
+```text
+filename: <asset_code>.png
+local_staging_path: marketing/agent-outputs/<YYYY-MM>/generated-assets/<asset_code>.png
+mime_type: image/png
+width: 1080
+height: 1080
+```
 
 ## Allowed writes
 
@@ -91,6 +129,7 @@ Everything else is read-only.
 
 - Editing the campaign draft, CMO strategy or context.
 - Changing copy, dates, tracking or editorial mapping.
+- Adding, dropping or duplicating renderer jobs.
 - Editing renderer code, schemas, thresholds or canonical visual files.
 - Creating binary assets.
 - Running render, R2 upload, Neon import, Admin operations or Metricool publication.
@@ -98,10 +137,15 @@ Everything else is read-only.
 
 ## Required validation
 
-A successful output must pass:
+A successful output must pass all three:
 
 ```bash
-node scripts/marketing/validate-creative-direction-v3.mjs marketing/agent-outputs/<YYYY-MM>/campaign.json
+npx tsx apps/api/scripts/validate-marketing-agent-json.ts \
+  --schema=prompts/marketing/agent-system/schemas/creative-director-output-v1.schema.json \
+  --input=marketing/agent-outputs/<YYYY-MM>/campaign.json
+
+node scripts/marketing/validate-creative-direction-v3.mjs \
+  marketing/agent-outputs/<YYYY-MM>/campaign.json
 
 npx tsx apps/api/scripts/validate-creative-director-preservation.ts \
   --draft=marketing/agent-outputs/<YYYY-MM>/campaign-draft.json \
@@ -109,4 +153,4 @@ npx tsx apps/api/scripts/validate-creative-director-preservation.ts \
   --context=marketing/agent-inputs/<YYYY-MM>/creative-context.json
 ```
 
-Fail closed. A valid final state is a review-state `campaign.json` ready for a manual pilot render.
+Fail closed. A valid final state is a review-state `campaign.json` whose structure and fields are accepted directly by the existing render workflow.

--- a/prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json
+++ b/prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json
@@ -83,13 +83,14 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["asset_key", "kind", "module", "mode", "surface", "composition_profile", "composition_slots", "allowed_operations"],
+            "required": ["asset_key", "kind", "module", "mode", "surface", "status", "composition_profile", "composition_slots", "allowed_operations"],
             "properties": {
               "asset_key": {"type": "string", "minLength": 1},
               "kind": {"type": "string"},
               "module": {"type": "string"},
               "mode": {"type": "string"},
               "surface": {"type": "string"},
+              "status": {"const": "approved_current"},
               "composition_profile": {"type": ["string", "null"]},
               "composition_slots": {"type": ["object", "null"]},
               "allowed_operations": {"type": "array", "items": {"type": "string"}}

--- a/prompts/marketing/agent-system/schemas/creative-director-output-v1.schema.json
+++ b/prompts/marketing/agent-system/schemas/creative-director-output-v1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "innerbloom://marketing/creative-director-output-v1",
+  "title": "Innerbloom Creative Director Output v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schema_version", "agent", "period_key", "generated_at", "campaign", "posts", "image_generation"],
+  "properties": {
+    "schema_version": {"type": "string", "minLength": 1},
+    "agent": {"const": "innerbloom_creative_director"},
+    "period_key": {"type": "string", "pattern": "^\\d{4}-(0[1-9]|1[0-2])$"},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "campaign": {
+      "type": "object",
+      "required": ["campaign_code", "title", "objective", "status", "strategy_summary", "language", "platforms", "formats", "target_post_count", "publishing_start_date", "publishing_end_date"],
+      "properties": {"status": {"const": "review"}}
+    },
+    "posts": {"type": "array", "minItems": 1},
+    "validation_profile": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {"kind": {"enum": ["production", "derived_test"]}}
+    },
+    "image_generation": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["jobs"],
+      "properties": {
+        "jobs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/job"}
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sourceAsset": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["asset_key", "kind", "mode", "surface", "status", "allowed_operations"],
+      "properties": {
+        "asset_key": {"type": "string", "minLength": 1},
+        "status": {"const": "approved_current"},
+        "allowed_operations": {"type": "array", "minItems": 1, "items": {"type": "string"}}
+      }
+    },
+    "creativeDirection": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["status", "visual_family", "layout_variant", "mode", "palette", "wordmark_treatment", "composition_intent", "selected_asset_keys", "focal_instruction", "supporting_visual", "supporting_treatment", "screen_fit", "acceptance_criteria"],
+      "properties": {
+        "status": {"const": "ready_for_render"},
+        "visual_family": {"type": "string", "minLength": 1},
+        "layout_variant": {"type": "string", "minLength": 1},
+        "mode": {"enum": ["light", "dark"]},
+        "palette": {"enum": ["light", "dark", "lilac", "warm", "ink"]},
+        "wordmark_treatment": {"const": "canonical_innerbloom_lockup"},
+        "selected_asset_keys": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "supporting_treatment": {"enum": ["focus_crop", "insight_callout", "metric_badge", "none"]},
+        "screen_fit": {"type": "string", "minLength": 1},
+        "acceptance_criteria": {"type": "array", "minItems": 4, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "job": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["asset_code", "post_code", "asset_kind", "platform", "format", "canvas", "visible_copy", "product_truth_anchor", "source_assets", "expected_output", "creative_direction"],
+      "properties": {
+        "asset_code": {"type": "string", "minLength": 1},
+        "post_code": {"type": "string", "minLength": 1},
+        "slide_number": {"type": "integer", "minimum": 1},
+        "source_assets": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/sourceAsset"}},
+        "expected_output": {
+          "type": "object",
+          "required": ["filename", "local_staging_path", "mime_type", "width", "height"],
+          "properties": {
+            "filename": {"type": "string", "pattern": "\\.png$"},
+            "local_staging_path": {"type": "string", "minLength": 1},
+            "mime_type": {"const": "image/png"},
+            "width": {"const": 1080},
+            "height": {"const": 1080}
+          }
+        },
+        "creative_direction": {"$ref": "#/$defs/creativeDirection"}
+      }
+    }
+  }
+}

--- a/prompts/marketing/creative-director-v1.md
+++ b/prompts/marketing/creative-director-v1.md
@@ -2,16 +2,17 @@
 
 ## Rol
 
-Sos el Creative Director de Innerbloom. Convertís un `creative-context.json` validado en el `campaign.json` ejecutable que consume el renderer.
+Sos el Creative Director de Innerbloom. Convertís un `creative-context.json` validado en el `campaign.json` ejecutable que consume el workflow existente `Render campaign and send it to Admin`.
 
 No sos CMO ni Head of Content. No cambiás estrategia, copy, fechas, tracking, hipótesis, métricas, pilares, experimentos ni estados editoriales.
 
-## Input obligatorio
+## Inputs obligatorios
 
 Leé:
 
 - `prompts/marketing/agent-system/creative-director/AGENTS.md`;
 - `prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json`;
+- `prompts/marketing/agent-system/schemas/creative-director-output-v1.schema.json`;
 - `marketing/agent-inputs/<YYYY-MM>/creative-context.json`;
 - `scripts/marketing/validate-creative-direction-v3.mjs`.
 
@@ -23,25 +24,39 @@ Escribí exclusivamente:
 
 `marketing/agent-outputs/<YYYY-MM>/campaign.json`
 
+La estructura productiva obligatoria es:
+
+```text
+campaign.json
+└── image_generation
+    └── jobs[]
+```
+
+Nunca escribas `image_jobs` ni un array `jobs` en la raíz.
+
 Si no existe una combinación veraz y ejecutable de assets y layouts, escribí `creative-director-failure.json`. No inventes assets, IDs, UI, datos, módulos ni capacidades.
 
-## Responsabilidad
+## Un job exacto por asset slot
 
-Para cada `asset_slot` del draft:
+Para cada `asset_slot` del draft creá exactamente un objeto en `image_generation.jobs` con:
 
-1. creá exactamente un image job con el mismo `asset_code` y post propietario;
-2. preservá copy visible y slide number;
-3. elegí solamente `asset_key` registrados;
-4. elegí solamente layouts ejecutables, o experimentales cuando todos sus support assets requeridos existan;
-5. definí modo, familia visual, device presentation, composición y art direction compatibles con los assets seleccionados;
-6. cumplí diversidad de layouts y fuentes a nivel campaña;
-7. mantené coherencia entre slides sin repetir mecánicamente el mismo layout;
-8. bloqueá jobs sin evidencia suficiente en vez de fabricar una solución.
+- el mismo `asset_code`, `post_code`, `asset_kind` y `slide_number` cuando corresponda;
+- `platform` y `format` del post propietario;
+- canvas 1080x1080 y safe area;
+- copy visible exacta del slot o slide;
+- `product_truth_anchor` y `funnel_stage` preservados;
+- `source_assets` copiados completos y sin modificaciones desde `current_assets.assets`;
+- `expected_output.filename = <asset_code>.png`;
+- `expected_output.local_staging_path = marketing/agent-outputs/<YYYY-MM>/generated-assets/<asset_code>.png`;
+- `expected_output.mime_type = image/png`, width 1080 y height 1080;
+- `creative_direction` completa.
 
 ## Selección de assets
 
 - Seleccioná por `asset_key`, nunca por filename supuesto.
-- Usá assets `approved_current` incluidos en el contexto.
+- Usá únicamente assets `approved_current` incluidos en `current_assets.assets`.
+- Copiá en `source_assets` el objeto registrado completo, sin reescribir metadata.
+- Cada valor de `creative_direction.selected_asset_keys` debe existir dentro del `source_assets` del mismo job.
 - Hacé coincidir mode, surface, module y operaciones permitidas.
 - Product claims requieren evidencia real de producto.
 - `module_*` debe acompañar una pantalla padre coherente cuando así lo exija el registry.
@@ -49,42 +64,56 @@ Para cada `asset_slot` del draft:
 
 ## Selección de layouts
 
-- Usá el `layout_key` y `renderer_layout` presentes en `renderer_capabilities.layouts`.
-- Respetá mínimos y máximos de assets.
-- Respetá backgrounds y support assets requeridos.
-- Aplicá fallback solamente entre layouts declarados.
-- No uses layouts de referencia como verdad de producto.
+Cada entrada del contexto puede tener:
+
+- `layout_key`: identificador de referencia o planificación;
+- `renderer_layout`: enum ejecutable consumido por el renderer.
+
+La asignación obligatoria es:
+
+```text
+creative_direction.layout_variant = renderer_capabilities.layouts[].renderer_layout
+```
+
+Nunca uses `layout_key` como `layout_variant`, salvo que ambos valores sean literalmente iguales.
+
+Respetá mínimos y máximos de assets, backgrounds, support assets, device pose y fallbacks declarados. No uses layouts de referencia como verdad de producto.
 
 ## Preservación obligatoria
 
 El output debe conservar exactamente del draft:
 
-- campaign code, title, objective, language, platforms, formats y ventana;
+- campaign code, title, objective, language, platforms, formats, timezone y ventana;
 - target post count y status;
 - orden y número de posts;
 - post code, platform, format, status y scheduled_at;
 - pillar, funnel, experiment, audience tension y product truth anchor;
 - hook, caption, CTA, hypothesis, primary metric, tracking y UTM;
 - visible copy, accesibilidad y narrativa de carrusel;
-- asset codes y slide ownership.
+- asset codes, slide numbers y ownership.
 
 ## Prohibiciones
 
 No:
 
-- reescribas captions o hooks;
-- agregues posts o slides;
+- reescribas captions, hooks o copy visible;
+- agregues posts, slides o jobs extra;
+- omitas un asset slot;
 - conviertas una referencia semántica en un asset inexistente;
 - cambies thresholds de validación;
 - modifiques scripts, schemas o renderer;
 - marques la campaña como aprobada o publicada;
 - ejecutes render, R2, Neon, Admin o Metricool.
 
-## Validación
+## Validación obligatoria
 
-Antes de terminar ejecutá:
+Antes de terminar ejecutá, en este orden:
 
 ```bash
+npx tsx apps/api/scripts/validate-marketing-agent-json.ts \
+  --schema=prompts/marketing/agent-system/schemas/creative-director-output-v1.schema.json \
+  --input=marketing/agent-outputs/<YYYY-MM>/campaign.json
+
 node scripts/marketing/validate-creative-direction-v3.mjs \
   marketing/agent-outputs/<YYYY-MM>/campaign.json
 
@@ -94,4 +123,4 @@ npx tsx apps/api/scripts/validate-creative-director-preservation.ts \
   --context=marketing/agent-inputs/<YYYY-MM>/creative-context.json
 ```
 
-Una salida exitosa pasa ambas validaciones. El resultado queda en `review` y listo para un render piloto manual, no publicado.
+Una salida exitosa pasa las tres validaciones y queda exactamente en el formato que consume el workflow de render existente.


### PR DESCRIPTION
## Objetivo
Corregir la interfaz entre Creative Director y el workflow existente `Render campaign and send it to Admin`, sin modificar renderer, R2, Neon ni Admin.

## Correcciones
- agrega schema explícito para el `campaign.json` productivo;
- exige la ruta real `campaign.image_generation.jobs[]`;
- prohíbe implícitamente la forma antigua `image_jobs` al requerir `image_generation`;
- corrige el validador de preservación para inspeccionar los jobs que realmente consume el renderer;
- exige exactamente un renderer job por cada `asset_slot` del draft;
- preserva ownership, tipo, slide, formato y output canónico por asset;
- exige que `creative_direction.layout_variant` sea un `renderer_layout` declarado, no el `layout_key` de referencia;
- exige que `source_assets` copie metadata exacta del registry y que `selected_asset_keys` pertenezca al mismo job;
- actualiza prompt y contrato del agente con la estructura exacta del output.

## CI añadido
El check construye un `campaign.json` representativo desde el draft y el creative context y lo valida contra:

1. el nuevo schema de output;
2. `scripts/marketing/validate-creative-direction-v3.mjs`, el validador usado por producción;
3. `validate-creative-director-preservation.ts`;
4. una prueba negativa que demuestra que `image_jobs` falla cerrado.

## Alcance
No se modifica `.github/workflows/marketing-render-campaign.yml` ni ningún script de render, staging, R2, Neon o Admin.

## Resultado esperado
Una salida válida del Creative Director queda en:

`marketing/agent-outputs/<YYYY-MM>/campaign.json`

con `image_generation.jobs[]`, lista para que el workflow existente la consuma sin transformación intermedia.