### PR TITLE
Fix Google OAuth buttons still calling unsupported Clerk resets

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useClerk, useSignIn, useSignUp } from '@clerk/clerk-react';
+import { useSignIn, useSignUp } from '@clerk/clerk-react';
 
 export type GoogleOAuthMode = 'sign-in' | 'sign-up';
 
@@ -177,7 +177,6 @@ export function GoogleOAuthButton({
   className = '',
   forceAccountSelection = false,
 }: GoogleOAuthButtonProps) {
-  const clerk = useClerk();
   const { isLoaded: isSignInLoaded, signIn } = useSignIn();
   const { isLoaded: isSignUpLoaded, signUp } = useSignUp();
   const [isRedirecting, setIsRedirecting] = useState(false);
@@ -230,30 +229,18 @@ export function GoogleOAuthButton({
         if (!signUp) {
           throw new Error('Clerk sign-up resource is not ready');
         }
-        clerk.client.resetSignUp();
-        console.info('[auth] starting interactive Google OAuth', {
-          mode,
-          oauthMode,
-          accountSelection: shouldForceAccountSelection ? 'required' : 'default',
-        });
         await signUp.authenticateWithRedirect(redirectOptions);
       } else {
         if (!signIn) {
           throw new Error('Clerk sign-in resource is not ready');
         }
-        clerk.client.resetSignIn();
-        console.info('[auth] starting interactive Google OAuth', {
-          mode,
-          oauthMode,
-          accountSelection: shouldForceAccountSelection ? 'required' : 'default',
-        });
         await signIn.authenticateWithRedirect(redirectOptions);
       }
     } catch (error) {
       console.error(`[auth] Google OAuth redirect failed ${JSON.stringify(describeClerkOAuthError(error))}`);
       setIsRedirecting(false);
     }
-  }, [clerk.client, isLoaded, isRedirecting, mode, oauthMode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
+  }, [isLoaded, isRedirecting, mode, oauthMode, redirectUrlComplete, shouldForceAccountSelection, signIn, signUp]);
 
   return (
     <button


### PR DESCRIPTION
## Causa confirmada

DevTools mostró que el botón de Google dentro de la página de autenticación todavía ejecutaba métodos inexistentes en la versión instalada de Clerk:

- `clerk.client.resetSignIn()`
- `clerk.client.resetSignUp()`

Esto provocaba `TypeError: ... resetSignIn is not a function` en `GoogleOAuthButton.tsx`.

## Corrección

- Elimina `useClerk()` del componente compartido.
- Elimina `resetSignIn()` y `resetSignUp()`.
- Usa directamente los recursos válidos de `useSignIn()` y `useSignUp()` para llamar `authenticateWithRedirect()`.
- Mantiene `oidcPrompt: 'select_account'`, `continueSignIn: false` y `continueSignUp: false` en las opciones OAuth.
- Elimina logs duplicados y la dependencia `clerk.client` del callback.

## Alcance

Solo modifica `apps/web/src/components/auth/GoogleOAuthButton.tsx`.

No toca Android, iOS, plugins nativos, callbacks, logout, login por email ni refresh silencioso.

## Validación

1. Railway despliega la web tras mergear.
2. Probar `Create account > Sign up with Google`.
3. Probar `Sign in > Log in with Google`.
4. Confirmar que no aparece ningún error `resetSignIn/resetSignUp is not a function`.
5. Confirmar que Google recibe el flujo OAuth y presenta el selector de cuentas.