### PR TITLE
Force Google account chooser on Clerk-generated OAuth URL

### DIFF
--- a/apps/web/src/components/auth/GoogleOAuthButton.tsx
+++ b/apps/web/src/components/auth/GoogleOAuthButton.tsx
@@ -23,6 +23,26 @@ type GoogleOAuthButtonProps = {
   allowCrossModeCompletion?: boolean;
 };
 
+type ExternalVerification = {
+  externalVerificationRedirectURL?: URL | string | null;
+};
+
+type OAuthAttemptResult = {
+  firstFactorVerification?: ExternalVerification | null;
+  verifications?: {
+    externalAccount?: ExternalVerification | null;
+  } | null;
+};
+
+type LegacyOAuthResource = {
+  create(params: {
+    strategy: 'oauth_google';
+    redirectUrl: string;
+    actionCompleteRedirectUrl: string;
+    oidcPrompt?: 'select_account';
+  }): Promise<OAuthAttemptResult>;
+};
+
 const SSO_CALLBACK_PATH = '/sso-callback';
 export const OAUTH_REDIRECT_INTENT_STORAGE_KEY = 'innerbloom:oauth-redirect-intent';
 const OAUTH_REDIRECT_INTENT_TTL_MS = 10 * 60 * 1000;
@@ -45,6 +65,51 @@ export function buildGoogleOAuthRedirectOptions(
     continueSignIn: false,
     continueSignUp: false,
   };
+}
+
+export function forceGoogleAccountChooserUrl(value: URL | string): string {
+  const url = new URL(value.toString());
+  const hostname = url.hostname.toLowerCase();
+  if (hostname !== 'accounts.google.com') {
+    throw new Error(`Unexpected Google OAuth host: ${hostname || 'missing'}`);
+  }
+
+  url.searchParams.set('prompt', 'select_account');
+  url.searchParams.delete('authuser');
+  return url.toString();
+}
+
+function getExternalVerificationUrl(attempt: OAuthAttemptResult): URL | string | null {
+  return attempt.firstFactorVerification?.externalVerificationRedirectURL
+    ?? attempt.verifications?.externalAccount?.externalVerificationRedirectURL
+    ?? null;
+}
+
+export async function startGoogleOAuthRedirect(
+  resource: LegacyOAuthResource,
+  redirectUrlComplete: string,
+  forceAccountSelection: boolean,
+): Promise<void> {
+  const attempt = await resource.create({
+    strategy: 'oauth_google',
+    redirectUrl: SSO_CALLBACK_PATH,
+    actionCompleteRedirectUrl: redirectUrlComplete,
+    oidcPrompt: forceAccountSelection ? 'select_account' : undefined,
+  });
+  const externalVerificationUrl = getExternalVerificationUrl(attempt);
+  if (!externalVerificationUrl) {
+    throw new Error('Clerk did not return an external Google verification URL');
+  }
+
+  const targetUrl = forceAccountSelection
+    ? forceGoogleAccountChooserUrl(externalVerificationUrl)
+    : externalVerificationUrl.toString();
+
+  console.info('[auth] navigating to Google OAuth', {
+    accountSelection: forceAccountSelection ? 'required' : 'default',
+    hasSelectAccountPrompt: new URL(targetUrl).searchParams.get('prompt') === 'select_account',
+  });
+  window.location.assign(targetUrl);
 }
 
 export function describeClerkOAuthError(error: unknown): Record<string, unknown> {
@@ -212,29 +277,32 @@ export function GoogleOAuthButton({
 
     setIsRedirecting(true);
     persistOAuthRedirectIntent({ mode, redirectUrlComplete, createdAt: Date.now() });
-    const redirectOptions = buildGoogleOAuthRedirectOptions(
-      redirectUrlComplete,
-      shouldForceAccountSelection,
-    );
 
     try {
       console.info('[auth] starting interactive Google OAuth', {
         mode,
         oauthMode,
         accountSelection: shouldForceAccountSelection ? 'required' : 'default',
-        freshClerkAttempt: true,
       });
 
       if (oauthMode === 'sign-up') {
         if (!signUp) {
           throw new Error('Clerk sign-up resource is not ready');
         }
-        await signUp.authenticateWithRedirect(redirectOptions);
+        await startGoogleOAuthRedirect(
+          signUp as unknown as LegacyOAuthResource,
+          redirectUrlComplete,
+          shouldForceAccountSelection,
+        );
       } else {
         if (!signIn) {
           throw new Error('Clerk sign-in resource is not ready');
         }
-        await signIn.authenticateWithRedirect(redirectOptions);
+        await startGoogleOAuthRedirect(
+          signIn as unknown as LegacyOAuthResource,
+          redirectUrlComplete,
+          shouldForceAccountSelection,
+        );
       }
     } catch (error) {
       console.error(`[auth] Google OAuth redirect failed ${JSON.stringify(describeClerkOAuthError(error))}`);

--- a/apps/web/src/components/auth/__tests__/GoogleOAuthButton.accountSelection.test.ts
+++ b/apps/web/src/components/auth/__tests__/GoogleOAuthButton.accountSelection.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { buildGoogleOAuthRedirectOptions } from '../GoogleOAuthButton';
+import {
+  buildGoogleOAuthRedirectOptions,
+  forceGoogleAccountChooserUrl,
+} from '../GoogleOAuthButton';
 
 describe('Google OAuth account selection', () => {
   it('starts a fresh Clerk attempt and forces the Google account selector', () => {
@@ -22,5 +25,24 @@ describe('Google OAuth account selection', () => {
       continueSignIn: false,
       continueSignUp: false,
     });
+  });
+
+  it('forces the chooser on the Clerk-generated Google URL and removes the previous account hint', () => {
+    const result = forceGoogleAccountChooserUrl(
+      'https://accounts.google.com/o/oauth2/auth?client_id=client&state=state&authuser=0&prompt=none',
+    );
+    const url = new URL(result);
+
+    expect(url.hostname).toBe('accounts.google.com');
+    expect(url.searchParams.get('prompt')).toBe('select_account');
+    expect(url.searchParams.has('authuser')).toBe(false);
+    expect(url.searchParams.get('state')).toBe('state');
+    expect(url.searchParams.get('client_id')).toBe('client');
+  });
+
+  it('rejects any external verification URL that is not hosted by Google Accounts', () => {
+    expect(() => forceGoogleAccountChooserUrl('https://example.com/oauth?state=state')).toThrow(
+      'Unexpected Google OAuth host',
+    );
   });
 });

--- a/apps/web/src/pages/MobileBrowserAuth.tsx
+++ b/apps/web/src/pages/MobileBrowserAuth.tsx
@@ -4,8 +4,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   GoogleOAuthButton,
-  buildGoogleOAuthRedirectOptions,
   describeClerkOAuthError,
+  startGoogleOAuthRedirect,
 } from '../components/auth/GoogleOAuthButton';
 import { AuthLayout } from '../components/layout/AuthLayout';
 import { CLERK_TOKEN_TEMPLATE } from '../config/auth';
@@ -387,22 +387,23 @@ export default function MobileBrowserAuthPage() {
     }
 
     googleRedirectStartedRef.current = true;
-    const redirectOptions = buildGoogleOAuthRedirectOptions(handoffUrl, true);
-    void signIn
-      .authenticateWithRedirect(redirectOptions)
-      .catch((cause) => {
-        googleRedirectStartedRef.current = false;
-        console.error(`[mobile-auth-page] google-oauth-start-failed ${JSON.stringify({
-          at: Date.now(),
-          mode,
-          ...describeClerkOAuthError(cause),
-        })}`);
-        setError(
-          language === 'en'
-            ? 'We could not start Google sign-in. Please try again.'
-            : 'No pudimos iniciar sesión con Google. Intentá de nuevo.',
-        );
-      });
+    void startGoogleOAuthRedirect(
+      signIn as unknown as Parameters<typeof startGoogleOAuthRedirect>[0],
+      handoffUrl,
+      true,
+    ).catch((cause) => {
+      googleRedirectStartedRef.current = false;
+      console.error(`[mobile-auth-page] google-oauth-start-failed ${JSON.stringify({
+        at: Date.now(),
+        mode,
+        ...describeClerkOAuthError(cause),
+      })}`);
+      setError(
+        language === 'en'
+          ? 'We could not start Google sign-in. Please try again.'
+          : 'No pudimos iniciar sesión con Google. Intentá de nuevo.',
+      );
+    });
   }, [
     createdSessionId,
     handoffUrl,


### PR DESCRIPTION
## Causa confirmada

DevTools mostró que la URL real generada hacia Google no incluía `prompt=select_account` y Google devolvía `authuser=0&prompt=none`. Por eso se reutilizaba automáticamente la cuenta anterior.

## Corrección

- Clerk sigue creando el intento OAuth y el `state` mediante `signIn.create()` / `signUp.create()`.
- Se obtiene la URL externa generada por Clerk desde `externalVerificationRedirectURL`.
- Antes de navegar, se valida que el host sea exactamente `accounts.google.com`.
- Se fija explícitamente `prompt=select_account`.
- Se elimina `authuser` para no conservar la cuenta anterior como sugerencia.
- Si Clerk no devuelve una URL externa válida o el host no es Google Accounts, el flujo falla cerrado y muestra error.
- Se aplica tanto al botón Google de la página como al acceso Google directo desde Android/iOS.

## Prueba agregada

La prueba reproduce la URL observada en producción con `authuser=0&prompt=none` y verifica que el resultado:

- contiene `prompt=select_account`;
- no contiene `authuser`;
- conserva `state` y `client_id`;
- rechaza hosts externos distintos de `accounts.google.com`.

## Alcance

No modifica Android, iOS, el plugin nativo, callbacks, logout, login por email ni renovación silenciosa.

## Validación después del deploy

1. Railway despliega la web.
2. Google A → logout → tocar Google.
3. Confirmar que aparece el selector.
4. En Network, confirmar que la petición inicial a `accounts.google.com` contiene `prompt=select_account` y no contiene `authuser`.
5. Elegir Google B y confirmar el retorno correcto a la app.