### PR TITLE
Harden the CMO strategy output contract

### DIFF
--- a/.github/workflows/marketing-campaign-draft-contract.yml
+++ b/.github/workflows/marketing-campaign-draft-contract.yml
@@ -3,6 +3,7 @@ name: Validate marketing campaign draft contract
 on:
   pull_request:
     paths:
+      - 'prompts/marketing/agent-system/schemas/cmo-output-v1.schema.json'
       - 'prompts/marketing/agent-system/schemas/campaign-draft-v1.schema.json'
       - 'prompts/marketing/agent-system/head-of-content/AGENTS.md'
       - 'prompts/marketing/head-of-content-v1.md'
@@ -34,6 +35,46 @@ jobs:
           npx tsx apps/api/scripts/validate-marketing-agent-json.ts
           --schema=prompts/marketing/agent-system/schemas/cmo-output-v1.schema.json
           --input=apps/api/scripts/fixtures/cmo-strategy-valid.json
+      - name: Prove incomplete CMO strategies fail closed
+        shell: bash
+        run: |
+          set -euo pipefail
+          schema=prompts/marketing/agent-system/schemas/cmo-output-v1.schema.json
+          source=apps/api/scripts/fixtures/cmo-strategy-valid.json
+
+          expect_schema_failure() {
+            local file="$1"
+            if npx tsx apps/api/scripts/validate-marketing-agent-json.ts --schema="${schema}" --input="${file}"; then
+              echo "Expected ${file} to fail CMO schema validation." >&2
+              exit 1
+            fi
+          }
+
+          node - <<'NODE'
+          const fs = require('fs');
+          const source = JSON.parse(fs.readFileSync('apps/api/scripts/fixtures/cmo-strategy-valid.json', 'utf8'));
+
+          const missingPillarCode = structuredClone(source);
+          delete missingPillarCode.strategy.content_pillars[0].pillar_code;
+          fs.writeFileSync('/tmp/cmo-missing-pillar-code.json', JSON.stringify(missingPillarCode));
+
+          const missingExperimentCode = structuredClone(source);
+          delete missingExperimentCode.experiments[0].experiment_code;
+          fs.writeFileSync('/tmp/cmo-missing-experiment-code.json', JSON.stringify(missingExperimentCode));
+
+          const missingMetric = structuredClone(source);
+          delete missingMetric.experiments[0].primary_metric;
+          fs.writeFileSync('/tmp/cmo-missing-primary-metric.json', JSON.stringify(missingMetric));
+
+          const invalidObjective = structuredClone(source);
+          invalidObjective.strategy.primary_objective = 'Acquire qualified users';
+          fs.writeFileSync('/tmp/cmo-invalid-objective.json', JSON.stringify(invalidObjective));
+          NODE
+
+          expect_schema_failure /tmp/cmo-missing-pillar-code.json
+          expect_schema_failure /tmp/cmo-missing-experiment-code.json
+          expect_schema_failure /tmp/cmo-missing-primary-metric.json
+          expect_schema_failure /tmp/cmo-invalid-objective.json
       - name: Validate content context fixture schema
         run: >-
           npx tsx apps/api/scripts/validate-marketing-agent-json.ts

--- a/prompts/marketing/agent-system/schemas/cmo-output-v1.schema.json
+++ b/prompts/marketing/agent-system/schemas/cmo-output-v1.schema.json
@@ -22,10 +22,10 @@
         "additionalProperties": false,
         "required": ["learning", "evidence", "confidence", "implication"],
         "properties": {
-          "learning": {"type": "string"},
-          "evidence": {"type": "array", "items": {"type": "string"}},
+          "learning": {"type": "string", "minLength": 1},
+          "evidence": {"type": "array", "items": {"type": "string", "minLength": 1}},
           "confidence": {"enum": ["strong_signal", "moderate_signal", "weak_signal", "insufficient_evidence"]},
-          "implication": {"type": "string"}
+          "implication": {"type": "string", "minLength": 1}
         }
       }
     },
@@ -34,17 +34,17 @@
       "type": "object",
       "required": ["primary_objective", "secondary_objectives", "priority_audience", "core_value_proposition", "period_narrative", "strategic_priorities", "content_pillars", "content_mix"],
       "properties": {
-        "primary_objective": {"type": "string", "minLength": 1},
-        "secondary_objectives": {"type": "array", "maxItems": 2, "items": {"type": "string"}},
+        "primary_objective": {"enum": ["new_users", "leads", "activation", "awareness", "retention"]},
+        "secondary_objectives": {"type": "array", "maxItems": 2, "items": {"type": "string", "minLength": 1}},
         "priority_audience": {"type": "object"},
-        "core_value_proposition": {"type": "string"},
-        "period_narrative": {"type": "string"},
-        "strategic_priorities": {"type": "array", "minItems": 1, "maxItems": 3, "items": {"type": "string"}},
-        "content_pillars": {"type": "array", "minItems": 3, "maxItems": 5, "items": {"type": "object"}},
+        "core_value_proposition": {"type": "string", "minLength": 1},
+        "period_narrative": {"type": "string", "minLength": 1},
+        "strategic_priorities": {"type": "array", "minItems": 1, "maxItems": 3, "items": {"type": "string", "minLength": 1}},
+        "content_pillars": {"type": "array", "minItems": 3, "maxItems": 5, "items": {"$ref": "#/$defs/contentPillar"}},
         "content_mix": {"type": "object"}
       }
     },
-    "experiments": {"type": "array", "minItems": 2, "maxItems": 5, "items": {"type": "object"}},
+    "experiments": {"type": "array", "minItems": 2, "maxItems": 5, "items": {"$ref": "#/$defs/experiment"}},
     "messaging_guidelines": {"$ref": "#/$defs/freeObject"},
     "visual_direction": {"$ref": "#/$defs/freeObject"},
     "head_of_content_brief": {"$ref": "#/$defs/freeObject"},
@@ -53,7 +53,41 @@
     "source_manifest": {"type": "array", "items": {"type": "object"}}
   },
   "$defs": {
-    "periodKey": {"type": "string", "pattern": "^\\d{4}-\\d{2}$"},
-    "freeObject": {"type": "object"}
+    "periodKey": {"type": "string", "pattern": "^\\d{4}-(0[1-9]|1[0-2])$"},
+    "freeObject": {"type": "object"},
+    "code": {"type": "string", "pattern": "^[a-z0-9]+(?:_[a-z0-9]+)*$"},
+    "contentPillar": {
+      "type": "object",
+      "required": ["pillar_code", "name", "purpose", "audience_problem", "message", "proof_or_mechanism", "recommended_formats", "recommended_post_count"],
+      "properties": {
+        "pillar_code": {"$ref": "#/$defs/code"},
+        "name": {"type": "string", "minLength": 1},
+        "purpose": {"type": "string", "minLength": 1},
+        "audience_problem": {"type": "string", "minLength": 1},
+        "message": {"type": "string", "minLength": 1},
+        "proof_or_mechanism": {"type": "string", "minLength": 1},
+        "recommended_formats": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["static", "carousel", "reel", "story"]}},
+        "recommended_post_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "experiment": {
+      "type": "object",
+      "required": ["experiment_code", "name", "hypothesis", "variable_being_tested", "control_or_baseline", "target_audience", "content_pillars", "primary_metric", "secondary_metrics", "success_criteria", "failure_criteria", "minimum_evidence_needed", "decision_enabled"],
+      "properties": {
+        "experiment_code": {"$ref": "#/$defs/code"},
+        "name": {"type": "string", "minLength": 1},
+        "hypothesis": {"type": "string", "minLength": 1},
+        "variable_being_tested": {"type": "string", "minLength": 1},
+        "control_or_baseline": {"type": "string", "minLength": 1},
+        "target_audience": {"type": "string", "minLength": 1},
+        "content_pillars": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/code"}},
+        "primary_metric": {"type": "string", "minLength": 1},
+        "secondary_metrics": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "success_criteria": {"type": "string", "minLength": 1},
+        "failure_criteria": {"type": "string", "minLength": 1},
+        "minimum_evidence_needed": {"type": "string", "minLength": 1},
+        "decision_enabled": {"type": "string", "minLength": 1}
+      }
+    }
   }
 }


### PR DESCRIPTION
## Objetivo
Hacer que una estrategia CMO incompleta falle en el límite CMO → Head of Content, en lugar de avanzar y romper el pipeline más tarde.

## Cambios
- endurece `cmo-output-v1.schema.json`;
- limita `strategy.primary_objective` a los códigos que acepta `campaign-draft.json`;
- exige campos semánticos y operativos de cada pilar;
- exige `pillar_code` con formato estable;
- exige campos completos de cada experimento;
- exige `experiment_code`, pilares asociados y `primary_metric`;
- valida el período con mes real `01-12`.

## Pruebas fail-closed
El CI demuestra que fallan estrategias con:
- pilar sin `pillar_code`;
- experimento sin `experiment_code`;
- experimento sin `primary_metric`;
- objetivo narrativo no normalizado.

## Alcance
No modifica builders, agentes, renderer, R2, Neon ni Admin. Mantiene compatibilidad con la fixture CMO válida actual.