### PR TITLE
Add the first Marketing pipeline timeline to Admin

### DIFF
--- a/.github/workflows/marketing-pipeline-admin-contract.yml
+++ b/.github/workflows/marketing-pipeline-admin-contract.yml
@@ -28,8 +28,23 @@ jobs:
       - run: npm install --no-audit --no-fund
       - name: Typecheck API
         run: npm -w @innerbloom/api run typecheck
-      - name: Typecheck web
-        run: npm -w @innerbloom/web run typecheck
+      - name: Typecheck pipeline web modules
+        run: >-
+          npm -w @innerbloom/web exec tsc --
+          --noEmit
+          --jsx react-jsx
+          --target ES2020
+          --module ESNext
+          --moduleResolution Bundler
+          --skipLibCheck
+          src/lib/marketingPipeline.ts
+          src/pages/admin2/MarketingPipelinePage.tsx
+      - name: Verify Admin route registration
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -F "import { MarketingPipelinePage }" apps/web/src/components/admin2/Admin2Shell.tsx
+          grep -F 'path="marketing/pipeline"' apps/web/src/components/admin2/Admin2Shell.tsx
       - name: Validate migration contract
         shell: bash
         run: |

--- a/.github/workflows/marketing-pipeline-admin-contract.yml
+++ b/.github/workflows/marketing-pipeline-admin-contract.yml
@@ -33,7 +33,7 @@ jobs:
           npm -w @innerbloom/web exec tsc --
           --noEmit
           --jsx react-jsx
-          --target ES2020
+          --target ES2022
           --module ESNext
           --moduleResolution Bundler
           --types vite/client

--- a/.github/workflows/marketing-pipeline-admin-contract.yml
+++ b/.github/workflows/marketing-pipeline-admin-contract.yml
@@ -36,6 +36,7 @@ jobs:
           --target ES2020
           --module ESNext
           --moduleResolution Bundler
+          --types vite/client
           --skipLibCheck
           src/lib/marketingPipeline.ts
           src/pages/admin2/MarketingPipelinePage.tsx

--- a/.github/workflows/marketing-pipeline-admin-contract.yml
+++ b/.github/workflows/marketing-pipeline-admin-contract.yml
@@ -44,8 +44,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          grep -F "import { MarketingPipelinePage }" apps/web/src/components/admin2/Admin2Shell.tsx
-          grep -F 'path="marketing/pipeline"' apps/web/src/components/admin2/Admin2Shell.tsx
+          shell_file=apps/web/src/components/admin2/Admin2Shell.tsx
+          grep -F "import { MarketingPipelinePage }" "$shell_file"
+          grep -F "{ to: '/admin/marketing-pipeline', label: 'Marketing Pipeline' }" "$shell_file"
+          grep -F 'path="marketing-pipeline" element={<MarketingPipelinePage />}' "$shell_file"
       - name: Validate migration contract
         shell: bash
         run: |

--- a/.github/workflows/marketing-pipeline-admin-contract.yml
+++ b/.github/workflows/marketing-pipeline-admin-contract.yml
@@ -1,0 +1,42 @@
+name: Validate marketing pipeline Admin foundation
+
+on:
+  pull_request:
+    paths:
+      - 'apps/api/src/db/migrations/202607250001_marketing_pipeline_observability.sql'
+      - 'apps/api/src/services/marketingPipelineService.ts'
+      - 'apps/api/src/modules/admin/admin.routes.ts'
+      - 'apps/web/src/lib/marketingPipeline.ts'
+      - 'apps/web/src/pages/admin2/MarketingPipelinePage.tsx'
+      - 'apps/web/src/components/admin2/Admin2Shell.tsx'
+      - 'Docs/marketing/manual-action-test-plan.md'
+      - '.github/workflows/marketing-pipeline-admin-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm install --no-audit --no-fund
+      - name: Typecheck API
+        run: npm -w @innerbloom/api run typecheck
+      - name: Typecheck web
+        run: npm -w @innerbloom/web run typecheck
+      - name: Validate migration contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          migration=apps/api/src/db/migrations/202607250001_marketing_pipeline_observability.sql
+          grep -F 'CREATE TABLE IF NOT EXISTS marketing_pipeline_runs' "$migration"
+          grep -F 'CREATE TABLE IF NOT EXISTS marketing_pipeline_stages' "$migration"
+          grep -F 'CREATE TABLE IF NOT EXISTS marketing_pipeline_events' "$migration"
+          grep -F "'full_render_admin'" "$migration"
+          grep -F "'failed'" "$migration"

--- a/Docs/marketing/manual-action-test-plan.md
+++ b/Docs/marketing/manual-action-test-plan.md
@@ -1,0 +1,50 @@
+# Isolated manual marketing Action test
+
+## Purpose
+
+Test deterministic GitHub Actions and artifact handoffs without consuming agent tokens, importing a campaign into Admin, or touching the real August cycle.
+
+## Isolation rule
+
+Use the synthetic period `2099-01` and branch:
+
+```text
+automation/marketing-cycle-2099-01
+```
+
+Do not use `2026-08` for infrastructure testing. The synthetic branch can be deleted after the test and cannot collide with the real August campaign.
+
+## Safe test order
+
+1. Run `Generate marketing CMO context` with:
+   - `period_key`: `2099-01`
+   - `force`: `true`
+2. Inspect:
+   - branch `automation/marketing-cycle-2099-01`;
+   - `marketing/agent-inputs/2099-01/cmo-context.json`;
+   - schema validation and Action summary.
+3. Do not run a CMO agent yet. Use a validated fixture only in a later dedicated test PR if the next Action must be exercised without tokens.
+4. Never run `Render campaign and send it to Admin` with `preview_limit: 0` during infrastructure testing.
+5. A renderer test must use `preview_limit: 1` or another positive value. Positive preview limits do not import into Neon/Admin.
+
+## What to verify for every Action
+
+- exact input paths;
+- exact output paths;
+- period in branch, path and JSON agree;
+- schema and business validators pass;
+- a second run with unchanged input creates no unnecessary commit;
+- an invalid input fails before creating a downstream artifact;
+- Action summary names the next expected stage.
+
+## Cleanup
+
+After recording results:
+
+1. preserve workflow URLs and concise findings in the pipeline log;
+2. delete `automation/marketing-cycle-2099-01`;
+3. do not merge synthetic monthly artifacts into `main`.
+
+## Production shadow run
+
+The real `2026-08` branch is reserved for the later end-to-end shadow run with actual CMO, Head of Content and Creative Director executions. It should not be used for preliminary infrastructure experiments.

--- a/apps/api/src/db/migrations/202607250001_marketing_pipeline_observability.sql
+++ b/apps/api/src/db/migrations/202607250001_marketing_pipeline_observability.sql
@@ -1,0 +1,63 @@
+CREATE TABLE IF NOT EXISTS marketing_pipeline_runs (
+  marketing_pipeline_run_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  period_key text NOT NULL CHECK (period_key ~ '^\d{4}-(0[1-9]|1[0-2])$'),
+  branch_name text NOT NULL,
+  status text NOT NULL DEFAULT 'not_started' CHECK (status IN ('not_started', 'waiting', 'running', 'completed', 'failed', 'blocked', 'skipped')),
+  attempt integer NOT NULL DEFAULT 1 CHECK (attempt > 0),
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (period_key, attempt)
+);
+
+CREATE TABLE IF NOT EXISTS marketing_pipeline_stages (
+  marketing_pipeline_stage_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  marketing_pipeline_run_id uuid NOT NULL REFERENCES marketing_pipeline_runs(marketing_pipeline_run_id) ON DELETE CASCADE,
+  stage_key text NOT NULL CHECK (stage_key IN (
+    'cmo_context',
+    'cmo_agent',
+    'content_context',
+    'head_of_content_agent',
+    'creative_context',
+    'creative_director_agent',
+    'preview_render',
+    'full_render_admin'
+  )),
+  position integer NOT NULL CHECK (position BETWEEN 1 AND 8),
+  status text NOT NULL DEFAULT 'not_started' CHECK (status IN ('not_started', 'waiting', 'running', 'completed', 'failed', 'blocked', 'skipped')),
+  attempt integer NOT NULL DEFAULT 1 CHECK (attempt > 0),
+  input_path text,
+  output_path text,
+  input_sha256 text CHECK (input_sha256 IS NULL OR input_sha256 ~ '^sha256:[a-f0-9]{64}$'),
+  output_sha256 text CHECK (output_sha256 IS NULL OR output_sha256 ~ '^sha256:[a-f0-9]{64}$'),
+  execution_kind text NOT NULL CHECK (execution_kind IN ('github_action', 'codex_agent', 'human_review')),
+  execution_reference text,
+  summary text NOT NULL DEFAULT '',
+  error_message text NOT NULL DEFAULT '',
+  log_excerpt text NOT NULL DEFAULT '',
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (marketing_pipeline_run_id, stage_key, attempt)
+);
+
+CREATE TABLE IF NOT EXISTS marketing_pipeline_events (
+  marketing_pipeline_event_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  marketing_pipeline_run_id uuid NOT NULL REFERENCES marketing_pipeline_runs(marketing_pipeline_run_id) ON DELETE CASCADE,
+  marketing_pipeline_stage_id uuid REFERENCES marketing_pipeline_stages(marketing_pipeline_stage_id) ON DELETE CASCADE,
+  event_type text NOT NULL,
+  message text NOT NULL DEFAULT '',
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS marketing_pipeline_runs_period_idx
+  ON marketing_pipeline_runs (period_key DESC, attempt DESC);
+
+CREATE INDEX IF NOT EXISTS marketing_pipeline_stages_run_position_idx
+  ON marketing_pipeline_stages (marketing_pipeline_run_id, position, attempt DESC);
+
+CREATE INDEX IF NOT EXISTS marketing_pipeline_events_run_created_idx
+  ON marketing_pipeline_events (marketing_pipeline_run_id, created_at DESC);

--- a/apps/api/src/modules/admin/admin.routes.ts
+++ b/apps/api/src/modules/admin/admin.routes.ts
@@ -4,6 +4,7 @@ import { authMiddleware } from '../../middlewares/auth-middleware.js';
 import { asyncHandler } from '../../lib/async-handler.js';
 import { validateMarketingR2AssetUrls } from '../../services/marketingR2AssetService.js';
 import { updateMarketingCampaignPostsBulk } from '../../services/marketingCampaignBulkUpdateService.js';
+import { listMarketingPipelineRuns } from '../../services/marketingPipelineService.js';
 import {
   exportAdminUserLogsCsv,
   getAdminMe,
@@ -73,9 +74,18 @@ const marketingCampaignBulkSaveSchema = z.object({
   })).min(1).max(100),
 });
 
+const marketingPipelineQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(24).default(12),
+});
+
 adminRouter.get('/me', getAdminMe);
 adminRouter.get('/users', getAdminUsers);
 adminRouter.get('/marketing/campaigns', getAdminMarketingCampaigns);
+adminRouter.get('/marketing/pipeline/runs', asyncHandler(async (req, res) => {
+  const query = marketingPipelineQuerySchema.parse(req.query);
+  const runs = await listMarketingPipelineRuns(query.limit);
+  res.json({ ok: true, runs });
+}));
 adminRouter.patch('/marketing/campaigns/:campaignCode/posts/:postCode', patchAdminMarketingPost);
 adminRouter.post('/marketing/campaigns/:campaignCode/posts/bulk-save', asyncHandler(async (req, res) => {
   const campaignCode = z.string().trim().min(1).max(120).parse(req.params.campaignCode);

--- a/apps/api/src/services/marketingPipelineService.ts
+++ b/apps/api/src/services/marketingPipelineService.ts
@@ -1,0 +1,141 @@
+import { pool } from '../db.js';
+
+export type MarketingPipelineStageStatus =
+  | 'not_started'
+  | 'waiting'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'blocked'
+  | 'skipped';
+
+export type MarketingPipelineStagePayload = {
+  stageKey: string;
+  position: number;
+  status: MarketingPipelineStageStatus;
+  attempt: number;
+  executionKind: 'github_action' | 'codex_agent' | 'human_review';
+  executionReference: string | null;
+  inputPath: string | null;
+  outputPath: string | null;
+  inputSha256: string | null;
+  outputSha256: string | null;
+  summary: string;
+  errorMessage: string;
+  logExcerpt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  updatedAt: string;
+};
+
+export type MarketingPipelineRunPayload = {
+  id: string;
+  periodKey: string;
+  branchName: string;
+  status: MarketingPipelineStageStatus;
+  attempt: number;
+  startedAt: string | null;
+  completedAt: string | null;
+  updatedAt: string;
+  stages: MarketingPipelineStagePayload[];
+};
+
+type RunRow = {
+  marketing_pipeline_run_id: string;
+  period_key: string;
+  branch_name: string;
+  status: MarketingPipelineStageStatus;
+  attempt: number;
+  started_at: Date | string | null;
+  completed_at: Date | string | null;
+  updated_at: Date | string;
+};
+
+type StageRow = {
+  marketing_pipeline_run_id: string;
+  stage_key: string;
+  position: number;
+  status: MarketingPipelineStageStatus;
+  attempt: number;
+  execution_kind: 'github_action' | 'codex_agent' | 'human_review';
+  execution_reference: string | null;
+  input_path: string | null;
+  output_path: string | null;
+  input_sha256: string | null;
+  output_sha256: string | null;
+  summary: string;
+  error_message: string;
+  log_excerpt: string;
+  started_at: Date | string | null;
+  completed_at: Date | string | null;
+  updated_at: Date | string;
+};
+
+export async function listMarketingPipelineRuns(limit = 12): Promise<MarketingPipelineRunPayload[]> {
+  const safeLimit = Math.max(1, Math.min(24, Math.trunc(limit)));
+  const runs = await pool.query<RunRow>(
+    `SELECT marketing_pipeline_run_id, period_key, branch_name, status, attempt,
+            started_at, completed_at, updated_at
+       FROM marketing_pipeline_runs
+      ORDER BY period_key DESC, attempt DESC
+      LIMIT $1`,
+    [safeLimit],
+  );
+
+  if (runs.rows.length === 0) return [];
+
+  const runIds = runs.rows.map((row) => row.marketing_pipeline_run_id);
+  const stages = await pool.query<StageRow>(
+    `SELECT marketing_pipeline_run_id, stage_key, position, status, attempt,
+            execution_kind, execution_reference, input_path, output_path,
+            input_sha256, output_sha256, summary, error_message, log_excerpt,
+            started_at, completed_at, updated_at
+       FROM marketing_pipeline_stages
+      WHERE marketing_pipeline_run_id = ANY($1::uuid[])
+      ORDER BY marketing_pipeline_run_id, position, attempt DESC`,
+    [runIds],
+  );
+
+  const stagesByRun = new Map<string, MarketingPipelineStagePayload[]>();
+  for (const row of stages.rows) {
+    const items = stagesByRun.get(row.marketing_pipeline_run_id) ?? [];
+    if (!items.some((item) => item.stageKey === row.stage_key)) {
+      items.push({
+        stageKey: row.stage_key,
+        position: row.position,
+        status: row.status,
+        attempt: row.attempt,
+        executionKind: row.execution_kind,
+        executionReference: row.execution_reference,
+        inputPath: row.input_path,
+        outputPath: row.output_path,
+        inputSha256: row.input_sha256,
+        outputSha256: row.output_sha256,
+        summary: row.summary,
+        errorMessage: row.error_message,
+        logExcerpt: row.log_excerpt,
+        startedAt: toIso(row.started_at),
+        completedAt: toIso(row.completed_at),
+        updatedAt: toIso(row.updated_at)!,
+      });
+      stagesByRun.set(row.marketing_pipeline_run_id, items);
+    }
+  }
+
+  return runs.rows.map((row) => ({
+    id: row.marketing_pipeline_run_id,
+    periodKey: row.period_key,
+    branchName: row.branch_name,
+    status: row.status,
+    attempt: row.attempt,
+    startedAt: toIso(row.started_at),
+    completedAt: toIso(row.completed_at),
+    updatedAt: toIso(row.updated_at)!,
+    stages: (stagesByRun.get(row.marketing_pipeline_run_id) ?? []).sort((a, b) => a.position - b.position),
+  }));
+}
+
+function toIso(value: Date | string | null): string | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}

--- a/apps/web/src/components/admin2/Admin2Shell.tsx
+++ b/apps/web/src/components/admin2/Admin2Shell.tsx
@@ -4,6 +4,7 @@ import { CoreEnginePage } from '../../pages/admin2/CoreEnginePage';
 import { UserOpsPage } from '../../pages/admin2/UserOpsPage';
 import { NotificationsPage } from '../../pages/admin2/NotificationsPage';
 import { MarketingPageV2 } from '../../pages/admin2/MarketingPageV2';
+import { MarketingPipelinePage } from '../../pages/admin2/MarketingPipelinePage';
 import { AiTaskgenPage } from '../../pages/admin2/AiTaskgenPage';
 import { AdvancedPage } from '../../pages/admin2/AdvancedPage';
 import { TaskgenUserPage } from '../../pages/admin/TaskgenUserPage';
@@ -15,6 +16,7 @@ const NAV_ITEMS = [
   { to: '/admin/user-ops', label: 'User Ops' },
   { to: '/admin/notifications', label: 'Notifications' },
   { to: '/admin/marketing', label: 'Marketing' },
+  { to: '/admin/marketing-pipeline', label: 'Marketing Pipeline' },
   { to: '/admin/ai-taskgen', label: 'AI TaskGen' },
   { to: '/admin/advanced', label: 'Advanced' },
 ];
@@ -73,6 +75,7 @@ export function Admin2Shell() {
             <Route path="user-ops" element={<UserOpsPage />} />
             <Route path="notifications" element={<NotificationsPage />} />
             <Route path="marketing" element={<MarketingPageV2 />} />
+            <Route path="marketing-pipeline" element={<MarketingPipelinePage />} />
             <Route path="ai-taskgen" element={<AiTaskgenPage />} />
             <Route path="advanced" element={<AdvancedPage />} />
             <Route path="users/:userId/taskgen" element={<TaskgenUserPage baseTaskgenPath="/admin/ai-taskgen" baseUserPath="/admin/users" />} />

--- a/apps/web/src/lib/marketingPipeline.ts
+++ b/apps/web/src/lib/marketingPipeline.ts
@@ -1,0 +1,49 @@
+import { apiAuthorizedFetch } from './api';
+
+export type MarketingPipelineStatus =
+  | 'not_started'
+  | 'waiting'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'blocked'
+  | 'skipped';
+
+export type MarketingPipelineStageRecord = {
+  stageKey: string;
+  position: number;
+  status: MarketingPipelineStatus;
+  attempt: number;
+  executionKind: 'github_action' | 'codex_agent' | 'human_review';
+  executionReference: string | null;
+  inputPath: string | null;
+  outputPath: string | null;
+  inputSha256: string | null;
+  outputSha256: string | null;
+  summary: string;
+  errorMessage: string;
+  logExcerpt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  updatedAt: string;
+};
+
+export type MarketingPipelineRunRecord = {
+  id: string;
+  periodKey: string;
+  branchName: string;
+  status: MarketingPipelineStatus;
+  attempt: number;
+  startedAt: string | null;
+  completedAt: string | null;
+  updatedAt: string;
+  stages: MarketingPipelineStageRecord[];
+};
+
+export async function fetchMarketingPipelineRuns(limit = 12) {
+  const response = await apiAuthorizedFetch(`/admin/marketing/pipeline/runs?limit=${encodeURIComponent(String(limit))}`, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) throw new Error(`Marketing pipeline request failed with HTTP ${response.status}`);
+  return response.json() as Promise<{ ok: boolean; runs: MarketingPipelineRunRecord[] }>;
+}

--- a/apps/web/src/pages/admin2/MarketingPipelinePage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPipelinePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ChevronDown, ChevronUp, RefreshCw } from '../../lib/lucide-react';
+import { ChevronDown, ChevronUp } from '../../lib/lucide-react';
 import {
   fetchMarketingPipelineRuns,
   type MarketingPipelineRunRecord,
@@ -76,7 +76,7 @@ export function MarketingPipelinePage() {
           {runs.length ? <select value={selectedRun?.id ?? ''} onChange={(event) => { setSelectedRunId(event.target.value); setExpandedStages(new Set()); }} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-sm">
             {runs.map((run) => <option key={run.id} value={run.id}>{run.periodKey} · attempt {run.attempt}</option>)}
           </select> : null}
-          <button className="admin2-btn admin2-btn--ghost inline-flex items-center gap-2" onClick={() => void loadRuns()} disabled={loading}><RefreshCw size={16}/>{loading ? 'Loading' : 'Refresh'}</button>
+          <button className="admin2-btn admin2-btn--ghost" onClick={() => void loadRuns()} disabled={loading}>{loading ? 'Loading' : 'Refresh'}</button>
         </div>
       </div>
       {error ? <p className="mt-4 rounded-xl border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">{error}</p> : null}
@@ -117,7 +117,7 @@ function StageRow({ stage, expanded, last, onToggle }: { stage: MarketingPipelin
     <button type="button" onClick={onToggle} disabled={!hasDetails} className="flex w-full items-center justify-between gap-4 rounded-xl px-3 py-4 text-left hover:bg-[color:var(--admin-hover)] disabled:cursor-default disabled:hover:bg-transparent">
       <div>
         <p className="font-semibold">{stageLabels[stage.stageKey] ?? stage.stageKey}</p>
-        <p className="mt-1 text-xs text-[color:var(--admin-muted)]">{stage.executionKind.replaceAll('_', ' ')} · attempt {stage.attempt}{stage.startedAt ? ` · ${formatDate(stage.startedAt)}` : ''}</p>
+        <p className="mt-1 text-xs text-[color:var(--admin-muted)]">{stage.executionKind.replace(/_/g, ' ')} · attempt {stage.attempt}{stage.startedAt ? ` · ${formatDate(stage.startedAt)}` : ''}</p>
       </div>
       <div className="flex items-center gap-3">
         <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${badgeClass(stage.status)}`}>{statusLabels[stage.status]}</span>

--- a/apps/web/src/pages/admin2/MarketingPipelinePage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPipelinePage.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp, RefreshCw } from '../../lib/lucide-react';
+import {
+  fetchMarketingPipelineRuns,
+  type MarketingPipelineRunRecord,
+  type MarketingPipelineStageRecord,
+  type MarketingPipelineStatus,
+} from '../../lib/marketingPipeline';
+
+const stageLabels: Record<string, string> = {
+  cmo_context: 'CMO context',
+  cmo_agent: 'CMO agent',
+  content_context: 'Head of Content context',
+  head_of_content_agent: 'Head of Content agent',
+  creative_context: 'Creative Director context',
+  creative_director_agent: 'Creative Director agent',
+  preview_render: 'Preview render',
+  full_render_admin: 'Full render and Admin import',
+};
+
+const statusLabels: Record<MarketingPipelineStatus, string> = {
+  not_started: 'Not started',
+  waiting: 'Waiting',
+  running: 'Running',
+  completed: 'Completed',
+  failed: 'Failed',
+  blocked: 'Blocked',
+  skipped: 'Skipped',
+};
+
+export function MarketingPipelinePage() {
+  const [runs, setRuns] = useState<MarketingPipelineRunRecord[]>([]);
+  const [selectedRunId, setSelectedRunId] = useState('');
+  const [expandedStages, setExpandedStages] = useState<Set<string>>(() => new Set());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedRun = useMemo(
+    () => runs.find((run) => run.id === selectedRunId) ?? runs[0] ?? null,
+    [runs, selectedRunId],
+  );
+
+  useEffect(() => { void loadRuns(); }, []);
+
+  async function loadRuns() {
+    setLoading(true);
+    try {
+      const result = await fetchMarketingPipelineRuns();
+      setRuns(result.runs);
+      setSelectedRunId((current) => current || result.runs[0]?.id || '');
+      setError(null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Unable to load marketing pipeline.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function toggleStage(stageKey: string) {
+    setExpandedStages((current) => {
+      const next = new Set(current);
+      next.has(stageKey) ? next.delete(stageKey) : next.add(stageKey);
+      return next;
+    });
+  }
+
+  return <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-5 pb-16">
+    <header className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--admin-muted)]">Marketing operations</p>
+          <h2 className="mt-1 text-2xl font-semibold">Automation pipeline</h2>
+          <p className="mt-2 max-w-2xl text-sm text-[color:var(--admin-muted)]">Stages, attempts, artifacts and concise failure details for each monthly marketing run.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {runs.length ? <select value={selectedRun?.id ?? ''} onChange={(event) => { setSelectedRunId(event.target.value); setExpandedStages(new Set()); }} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-sm">
+            {runs.map((run) => <option key={run.id} value={run.id}>{run.periodKey} · attempt {run.attempt}</option>)}
+          </select> : null}
+          <button className="admin2-btn admin2-btn--ghost inline-flex items-center gap-2" onClick={() => void loadRuns()} disabled={loading}><RefreshCw size={16}/>{loading ? 'Loading' : 'Refresh'}</button>
+        </div>
+      </div>
+      {error ? <p className="mt-4 rounded-xl border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">{error}</p> : null}
+    </header>
+
+    {loading ? <LoadingPanel/> : !selectedRun ? <EmptyPanel/> : <>
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Stat label="Period" value={selectedRun.periodKey}/>
+        <Stat label="Run status" value={statusLabels[selectedRun.status]}/>
+        <Stat label="Attempt" value={selectedRun.attempt}/>
+        <Stat label="Updated" value={formatDate(selectedRun.updatedAt)}/>
+      </section>
+
+      <section className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5">
+        <div className="mb-5">
+          <h3 className="font-semibold">{selectedRun.branchName}</h3>
+          <p className="mt-1 text-sm text-[color:var(--admin-muted)]">Expand a stage to inspect inputs, outputs, hashes and the concise error excerpt.</p>
+        </div>
+        <div className="space-y-0">
+          {selectedRun.stages.map((stage, index) => <StageRow
+            key={stage.stageKey}
+            stage={stage}
+            expanded={expandedStages.has(stage.stageKey)}
+            last={index === selectedRun.stages.length - 1}
+            onToggle={() => toggleStage(stage.stageKey)}
+          />)}
+        </div>
+      </section>
+    </>}
+  </div>;
+}
+
+function StageRow({ stage, expanded, last, onToggle }: { stage: MarketingPipelineStageRecord; expanded: boolean; last: boolean; onToggle: () => void }) {
+  const hasDetails = Boolean(stage.summary || stage.errorMessage || stage.logExcerpt || stage.inputPath || stage.outputPath || stage.executionReference);
+  return <div className="relative pl-10">
+    {!last ? <div className="absolute left-[11px] top-7 h-full w-px bg-[color:var(--admin-border)]"/> : null}
+    <span className={`absolute left-0 top-4 h-6 w-6 rounded-full border-4 border-[color:var(--admin-surface)] ${dotClass(stage.status)}`}/>
+    <button type="button" onClick={onToggle} disabled={!hasDetails} className="flex w-full items-center justify-between gap-4 rounded-xl px-3 py-4 text-left hover:bg-[color:var(--admin-hover)] disabled:cursor-default disabled:hover:bg-transparent">
+      <div>
+        <p className="font-semibold">{stageLabels[stage.stageKey] ?? stage.stageKey}</p>
+        <p className="mt-1 text-xs text-[color:var(--admin-muted)]">{stage.executionKind.replaceAll('_', ' ')} · attempt {stage.attempt}{stage.startedAt ? ` · ${formatDate(stage.startedAt)}` : ''}</p>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${badgeClass(stage.status)}`}>{statusLabels[stage.status]}</span>
+        {hasDetails ? expanded ? <ChevronUp size={17}/> : <ChevronDown size={17}/> : null}
+      </div>
+    </button>
+    {expanded ? <div className="mb-4 ml-3 space-y-3 rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-4 text-sm">
+      {stage.summary ? <Detail label="Summary" value={stage.summary}/> : null}
+      {stage.inputPath ? <Detail label="Input" value={stage.inputPath}/> : null}
+      {stage.outputPath ? <Detail label="Output" value={stage.outputPath}/> : null}
+      {stage.inputSha256 ? <Detail label="Input hash" value={stage.inputSha256}/> : null}
+      {stage.outputSha256 ? <Detail label="Output hash" value={stage.outputSha256}/> : null}
+      {stage.executionReference ? <Detail label="Execution" value={stage.executionReference}/> : null}
+      {stage.errorMessage ? <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-red-200"><p className="text-xs font-semibold uppercase tracking-wider">Error</p><p className="mt-1 whitespace-pre-wrap">{stage.errorMessage}</p></div> : null}
+      {stage.logExcerpt ? <div><p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">Log excerpt</p><pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap rounded-lg bg-black/30 p-3 text-xs">{stage.logExcerpt}</pre></div> : null}
+    </div> : null}
+  </div>;
+}
+
+function Detail({ label, value }: { label: string; value: string }) { return <div><p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">{label}</p><p className="mt-1 break-all">{value}</p></div>; }
+function Stat({ label, value }: { label: string; value: string | number }) { return <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4"><p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">{label}</p><p className="mt-2 text-lg font-semibold">{value}</p></div>; }
+function LoadingPanel() { return <div className="flex min-h-[320px] items-center justify-center rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)]"><p className="text-sm text-[color:var(--admin-muted)]">Loading pipeline runs…</p></div>; }
+function EmptyPanel() { return <div className="rounded-2xl border border-dashed border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-10 text-center"><h3 className="font-semibold">No marketing pipeline runs recorded yet</h3><p className="mx-auto mt-2 max-w-xl text-sm text-[color:var(--admin-muted)]">The next instrumentation PR will connect GitHub Actions and agent handoffs to this timeline. No status is inferred from partial files, so the Admin does not invent progress.</p></div>; }
+function formatDate(value: string) { return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value)); }
+function dotClass(status: MarketingPipelineStatus) { return status === 'completed' ? 'bg-emerald-400' : status === 'running' ? 'bg-blue-400 animate-pulse' : status === 'failed' ? 'bg-red-400' : status === 'blocked' ? 'bg-amber-400' : status === 'skipped' ? 'bg-slate-500' : 'bg-[color:var(--admin-border)]'; }
+function badgeClass(status: MarketingPipelineStatus) { return status === 'completed' ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300' : status === 'running' ? 'border-blue-500/40 bg-blue-500/10 text-blue-300' : status === 'failed' ? 'border-red-500/40 bg-red-500/10 text-red-300' : status === 'blocked' ? 'border-amber-500/40 bg-amber-500/10 text-amber-300' : 'border-[color:var(--admin-border)] text-[color:var(--admin-muted)]'; }


### PR DESCRIPTION
## Objetivo
Crear la primera base real de observabilidad del pipeline de marketing en Admin, sin inferir estados desde archivos parciales ni conectar todavía los workflows productivos.

## Incluye
- tablas Neon para runs, stages y eventos append-only;
- estados `not_started`, `waiting`, `running`, `completed`, `failed`, `blocked` y `skipped`;
- inputs, outputs, hashes, intentos, referencias de ejecución, resumen, error y extracto acotado de logs;
- endpoint admin read-only `GET /admin/marketing/pipeline/runs`;
- página vertical `Marketing Pipeline` en Admin;
- etapas desde CMO context hasta full render/Admin;
- detalles expandibles por etapa;
- estado vacío honesto hasta que la siguiente PR conecte Actions y agentes;
- plan de prueba aislada con período sintético `2099-01`, sin tocar agosto real;
- CI con typecheck de API/web y chequeo básico de la migración.

## Alcance deliberado
Esta PR no escribe estados desde GitHub Actions ni agentes todavía. Esa instrumentación será la siguiente PR. Tampoco modifica renderer, R2, campañas existentes ni publicación.

## Prueba segura
La documentación reserva `automation/marketing-cycle-2099-01` para pruebas determinísticas y prohíbe usar `2026-08` antes del shadow run real.