### PR TITLE
Fix Marketing pipeline runtime and move it into Marketing

### DIFF
--- a/.github/workflows/marketing-pipeline-admin-contract.yml
+++ b/.github/workflows/marketing-pipeline-admin-contract.yml
@@ -8,6 +8,7 @@ on:
       - 'apps/api/src/modules/admin/admin.routes.ts'
       - 'apps/web/src/lib/marketingPipeline.ts'
       - 'apps/web/src/pages/admin2/MarketingPipelinePage.tsx'
+      - 'apps/web/src/pages/admin2/MarketingOperationsPage.tsx'
       - 'apps/web/src/components/admin2/Admin2Shell.tsx'
       - 'Docs/marketing/manual-action-test-plan.md'
       - '.github/workflows/marketing-pipeline-admin-contract.yml'
@@ -40,14 +41,23 @@ jobs:
           --skipLibCheck
           src/lib/marketingPipeline.ts
           src/pages/admin2/MarketingPipelinePage.tsx
-      - name: Verify Admin route registration
+          src/pages/admin2/MarketingOperationsPage.tsx
+      - name: Verify Marketing tab registration
         shell: bash
         run: |
           set -euo pipefail
           shell_file=apps/web/src/components/admin2/Admin2Shell.tsx
-          grep -F "import { MarketingPipelinePage }" "$shell_file"
-          grep -F "{ to: '/admin/marketing-pipeline', label: 'Marketing Pipeline' }" "$shell_file"
-          grep -F 'path="marketing-pipeline" element={<MarketingPipelinePage />}' "$shell_file"
+          operations_file=apps/web/src/pages/admin2/MarketingOperationsPage.tsx
+          grep -F "import { MarketingOperationsPage }" "$shell_file"
+          grep -F 'path="marketing" element={<MarketingOperationsPage />}' "$shell_file"
+          ! grep -F "{ to: '/admin/marketing-pipeline', label: 'Marketing Pipeline' }" "$shell_file"
+          grep -F "<TabButton active={section === 'pipeline'}" "$operations_file"
+          grep -F '<MarketingPipelinePanel/>' "$operations_file"
+      - name: Validate missing-table fallback
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -F "cause.code === '42P01'" apps/api/src/services/marketingPipelineService.ts
       - name: Validate migration contract
         shell: bash
         run: |

--- a/apps/api/src/services/marketingPipelineService.ts
+++ b/apps/api/src/services/marketingPipelineService.ts
@@ -73,66 +73,76 @@ type StageRow = {
 
 export async function listMarketingPipelineRuns(limit = 12): Promise<MarketingPipelineRunPayload[]> {
   const safeLimit = Math.max(1, Math.min(24, Math.trunc(limit)));
-  const runs = await pool.query<RunRow>(
-    `SELECT marketing_pipeline_run_id, period_key, branch_name, status, attempt,
-            started_at, completed_at, updated_at
-       FROM marketing_pipeline_runs
-      ORDER BY period_key DESC, attempt DESC
-      LIMIT $1`,
-    [safeLimit],
-  );
 
-  if (runs.rows.length === 0) return [];
+  try {
+    const runs = await pool.query<RunRow>(
+      `SELECT marketing_pipeline_run_id, period_key, branch_name, status, attempt,
+              started_at, completed_at, updated_at
+         FROM marketing_pipeline_runs
+        ORDER BY period_key DESC, attempt DESC
+        LIMIT $1`,
+      [safeLimit],
+    );
 
-  const runIds = runs.rows.map((row) => row.marketing_pipeline_run_id);
-  const stages = await pool.query<StageRow>(
-    `SELECT marketing_pipeline_run_id, stage_key, position, status, attempt,
-            execution_kind, execution_reference, input_path, output_path,
-            input_sha256, output_sha256, summary, error_message, log_excerpt,
-            started_at, completed_at, updated_at
-       FROM marketing_pipeline_stages
-      WHERE marketing_pipeline_run_id = ANY($1::uuid[])
-      ORDER BY marketing_pipeline_run_id, position, attempt DESC`,
-    [runIds],
-  );
+    if (runs.rows.length === 0) return [];
 
-  const stagesByRun = new Map<string, MarketingPipelineStagePayload[]>();
-  for (const row of stages.rows) {
-    const items = stagesByRun.get(row.marketing_pipeline_run_id) ?? [];
-    if (!items.some((item) => item.stageKey === row.stage_key)) {
-      items.push({
-        stageKey: row.stage_key,
-        position: row.position,
-        status: row.status,
-        attempt: row.attempt,
-        executionKind: row.execution_kind,
-        executionReference: row.execution_reference,
-        inputPath: row.input_path,
-        outputPath: row.output_path,
-        inputSha256: row.input_sha256,
-        outputSha256: row.output_sha256,
-        summary: row.summary,
-        errorMessage: row.error_message,
-        logExcerpt: row.log_excerpt,
-        startedAt: toIso(row.started_at),
-        completedAt: toIso(row.completed_at),
-        updatedAt: toIso(row.updated_at)!,
-      });
-      stagesByRun.set(row.marketing_pipeline_run_id, items);
+    const runIds = runs.rows.map((row) => row.marketing_pipeline_run_id);
+    const stages = await pool.query<StageRow>(
+      `SELECT marketing_pipeline_run_id, stage_key, position, status, attempt,
+              execution_kind, execution_reference, input_path, output_path,
+              input_sha256, output_sha256, summary, error_message, log_excerpt,
+              started_at, completed_at, updated_at
+         FROM marketing_pipeline_stages
+        WHERE marketing_pipeline_run_id = ANY($1::uuid[])
+        ORDER BY marketing_pipeline_run_id, position, attempt DESC`,
+      [runIds],
+    );
+
+    const stagesByRun = new Map<string, MarketingPipelineStagePayload[]>();
+    for (const row of stages.rows) {
+      const items = stagesByRun.get(row.marketing_pipeline_run_id) ?? [];
+      if (!items.some((item) => item.stageKey === row.stage_key)) {
+        items.push({
+          stageKey: row.stage_key,
+          position: row.position,
+          status: row.status,
+          attempt: row.attempt,
+          executionKind: row.execution_kind,
+          executionReference: row.execution_reference,
+          inputPath: row.input_path,
+          outputPath: row.output_path,
+          inputSha256: row.input_sha256,
+          outputSha256: row.output_sha256,
+          summary: row.summary,
+          errorMessage: row.error_message,
+          logExcerpt: row.log_excerpt,
+          startedAt: toIso(row.started_at),
+          completedAt: toIso(row.completed_at),
+          updatedAt: toIso(row.updated_at)!,
+        });
+        stagesByRun.set(row.marketing_pipeline_run_id, items);
+      }
     }
-  }
 
-  return runs.rows.map((row) => ({
-    id: row.marketing_pipeline_run_id,
-    periodKey: row.period_key,
-    branchName: row.branch_name,
-    status: row.status,
-    attempt: row.attempt,
-    startedAt: toIso(row.started_at),
-    completedAt: toIso(row.completed_at),
-    updatedAt: toIso(row.updated_at)!,
-    stages: (stagesByRun.get(row.marketing_pipeline_run_id) ?? []).sort((a, b) => a.position - b.position),
-  }));
+    return runs.rows.map((row) => ({
+      id: row.marketing_pipeline_run_id,
+      periodKey: row.period_key,
+      branchName: row.branch_name,
+      status: row.status,
+      attempt: row.attempt,
+      startedAt: toIso(row.started_at),
+      completedAt: toIso(row.completed_at),
+      updatedAt: toIso(row.updated_at)!,
+      stages: (stagesByRun.get(row.marketing_pipeline_run_id) ?? []).sort((a, b) => a.position - b.position),
+    }));
+  } catch (cause) {
+    if (isUndefinedTableError(cause)) return [];
+    throw cause;
+  }
+}
+
+function isUndefinedTableError(cause: unknown): boolean {
+  return typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === '42P01';
 }
 
 function toIso(value: Date | string | null): string | null {

--- a/apps/web/src/components/admin2/Admin2Shell.tsx
+++ b/apps/web/src/components/admin2/Admin2Shell.tsx
@@ -3,8 +3,7 @@ import { OverviewPage } from '../../pages/admin2/OverviewPage';
 import { CoreEnginePage } from '../../pages/admin2/CoreEnginePage';
 import { UserOpsPage } from '../../pages/admin2/UserOpsPage';
 import { NotificationsPage } from '../../pages/admin2/NotificationsPage';
-import { MarketingPageV2 } from '../../pages/admin2/MarketingPageV2';
-import { MarketingPipelinePage } from '../../pages/admin2/MarketingPipelinePage';
+import { MarketingOperationsPage } from '../../pages/admin2/MarketingOperationsPage';
 import { AiTaskgenPage } from '../../pages/admin2/AiTaskgenPage';
 import { AdvancedPage } from '../../pages/admin2/AdvancedPage';
 import { TaskgenUserPage } from '../../pages/admin/TaskgenUserPage';
@@ -16,7 +15,6 @@ const NAV_ITEMS = [
   { to: '/admin/user-ops', label: 'User Ops' },
   { to: '/admin/notifications', label: 'Notifications' },
   { to: '/admin/marketing', label: 'Marketing' },
-  { to: '/admin/marketing-pipeline', label: 'Marketing Pipeline' },
   { to: '/admin/ai-taskgen', label: 'AI TaskGen' },
   { to: '/admin/advanced', label: 'Advanced' },
 ];
@@ -74,8 +72,8 @@ export function Admin2Shell() {
             <Route path="core-engine" element={<CoreEnginePage />} />
             <Route path="user-ops" element={<UserOpsPage />} />
             <Route path="notifications" element={<NotificationsPage />} />
-            <Route path="marketing" element={<MarketingPageV2 />} />
-            <Route path="marketing-pipeline" element={<MarketingPipelinePage />} />
+            <Route path="marketing" element={<MarketingOperationsPage />} />
+            <Route path="marketing-pipeline" element={<Navigate to="../marketing" replace />} />
             <Route path="ai-taskgen" element={<AiTaskgenPage />} />
             <Route path="advanced" element={<AdvancedPage />} />
             <Route path="users/:userId/taskgen" element={<TaskgenUserPage baseTaskgenPath="/admin/ai-taskgen" baseUserPath="/admin/users" />} />

--- a/apps/web/src/pages/admin2/MarketingOperationsPage.tsx
+++ b/apps/web/src/pages/admin2/MarketingOperationsPage.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { MarketingPageV2 } from './MarketingPageV2';
+import { MarketingPipelinePanel } from './MarketingPipelinePage';
+
+type MarketingSection = 'campaigns' | 'pipeline';
+
+export function MarketingOperationsPage() {
+  const [section, setSection] = useState<MarketingSection>('campaigns');
+
+  return <div className="mx-auto flex w-full max-w-[1500px] flex-col gap-5 pb-16">
+    <header className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] px-5 pt-5">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--admin-muted)]">Marketing operations</p>
+        <h2 className="mt-1 text-2xl font-semibold">Marketing</h2>
+        <p className="mt-2 text-sm text-[color:var(--admin-muted)]">Review campaigns or inspect the automation workflow that produces them.</p>
+      </div>
+      <div className="mt-5 flex gap-2 border-b border-[color:var(--admin-border)]">
+        <TabButton active={section === 'campaigns'} onClick={() => setSection('campaigns')}>Campaigns</TabButton>
+        <TabButton active={section === 'pipeline'} onClick={() => setSection('pipeline')}>Pipeline</TabButton>
+      </div>
+    </header>
+
+    {section === 'campaigns' ? <MarketingPageV2/> : <MarketingPipelinePanel/>}
+  </div>;
+}
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: string }) {
+  return <button type="button" onClick={onClick} className={`border-b-2 px-4 py-3 text-sm font-semibold ${active ? 'border-[color:var(--admin-accent)] text-[color:var(--admin-text)]' : 'border-transparent text-[color:var(--admin-muted)]'}`}>{children}</button>;
+}

--- a/apps/web/src/pages/admin2/MarketingPipelinePage.tsx
+++ b/apps/web/src/pages/admin2/MarketingPipelinePage.tsx
@@ -8,27 +8,31 @@ import {
 } from '../../lib/marketingPipeline';
 
 const stageLabels: Record<string, string> = {
-  cmo_context: 'CMO context',
-  cmo_agent: 'CMO agent',
-  content_context: 'Head of Content context',
-  head_of_content_agent: 'Head of Content agent',
-  creative_context: 'Creative Director context',
-  creative_director_agent: 'Creative Director agent',
-  preview_render: 'Preview render',
-  full_render_admin: 'Full render and Admin import',
+  cmo_context: 'Generate CMO context',
+  cmo_agent: 'Run CMO agent',
+  content_context: 'Generate Head of Content context',
+  head_of_content_agent: 'Run Head of Content agent',
+  creative_context: 'Generate Creative Director context',
+  creative_director_agent: 'Run Creative Director agent',
+  preview_render: 'Render preview campaign',
+  full_render_admin: 'Render full campaign and import to Admin',
 };
 
 const statusLabels: Record<MarketingPipelineStatus, string> = {
   not_started: 'Not started',
   waiting: 'Waiting',
-  running: 'Running',
-  completed: 'Completed',
+  running: 'In progress',
+  completed: 'Succeeded',
   failed: 'Failed',
   blocked: 'Blocked',
   skipped: 'Skipped',
 };
 
 export function MarketingPipelinePage() {
+  return <div className="mx-auto w-full max-w-[1500px] pb-16"><MarketingPipelinePanel /></div>;
+}
+
+export function MarketingPipelinePanel() {
   const [runs, setRuns] = useState<MarketingPipelineRunRecord[]>([]);
   const [selectedRunId, setSelectedRunId] = useState('');
   const [expandedStages, setExpandedStages] = useState<Set<string>>(() => new Set());
@@ -64,83 +68,87 @@ export function MarketingPipelinePage() {
     });
   }
 
-  return <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-5 pb-16">
-    <header className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--admin-muted)]">Marketing operations</p>
-          <h2 className="mt-1 text-2xl font-semibold">Automation pipeline</h2>
-          <p className="mt-2 max-w-2xl text-sm text-[color:var(--admin-muted)]">Stages, attempts, artifacts and concise failure details for each monthly marketing run.</p>
-        </div>
-        <div className="flex items-center gap-2">
-          {runs.length ? <select value={selectedRun?.id ?? ''} onChange={(event) => { setSelectedRunId(event.target.value); setExpandedStages(new Set()); }} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-sm">
-            {runs.map((run) => <option key={run.id} value={run.id}>{run.periodKey} · attempt {run.attempt}</option>)}
-          </select> : null}
-          <button className="admin2-btn admin2-btn--ghost" onClick={() => void loadRuns()} disabled={loading}>{loading ? 'Loading' : 'Refresh'}</button>
-        </div>
+  if (loading) return <LoadingPanel/>;
+
+  return <section className="overflow-hidden rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)]">
+    <div className="flex flex-wrap items-center justify-between gap-4 border-b border-[color:var(--admin-border)] px-5 py-4">
+      <div>
+        <h3 className="text-lg font-semibold">Marketing workflow runs</h3>
+        <p className="mt-1 text-sm text-[color:var(--admin-muted)]">A GitHub Actions-style view of each deterministic Action and agent handoff.</p>
       </div>
-      {error ? <p className="mt-4 rounded-xl border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">{error}</p> : null}
-    </header>
+      <div className="flex items-center gap-2">
+        {runs.length ? <select value={selectedRun?.id ?? ''} onChange={(event) => { setSelectedRunId(event.target.value); setExpandedStages(new Set()); }} className="rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-3 py-2 text-sm">
+          {runs.map((run) => <option key={run.id} value={run.id}>{run.periodKey} · attempt {run.attempt}</option>)}
+        </select> : null}
+        <button className="admin2-btn admin2-btn--ghost" onClick={() => void loadRuns()}>Refresh</button>
+      </div>
+    </div>
 
-    {loading ? <LoadingPanel/> : !selectedRun ? <EmptyPanel/> : <>
-      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <Stat label="Period" value={selectedRun.periodKey}/>
-        <Stat label="Run status" value={statusLabels[selectedRun.status]}/>
-        <Stat label="Attempt" value={selectedRun.attempt}/>
-        <Stat label="Updated" value={formatDate(selectedRun.updatedAt)}/>
-      </section>
+    {error ? <p className="m-4 rounded-xl border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">{error}</p> : null}
 
-      <section className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-5">
-        <div className="mb-5">
-          <h3 className="font-semibold">{selectedRun.branchName}</h3>
-          <p className="mt-1 text-sm text-[color:var(--admin-muted)]">Expand a stage to inspect inputs, outputs, hashes and the concise error excerpt.</p>
+    {!selectedRun ? <EmptyPanel/> : <>
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] px-5 py-4">
+        <div>
+          <div className="flex items-center gap-2"><StatusIcon status={selectedRun.status}/><p className="font-semibold">{selectedRun.periodKey} marketing cycle</p></div>
+          <p className="mt-1 text-xs text-[color:var(--admin-muted)]">{selectedRun.branchName} · attempt {selectedRun.attempt}</p>
         </div>
-        <div className="space-y-0">
-          {selectedRun.stages.map((stage, index) => <StageRow
-            key={stage.stageKey}
-            stage={stage}
-            expanded={expandedStages.has(stage.stageKey)}
-            last={index === selectedRun.stages.length - 1}
-            onToggle={() => toggleStage(stage.stageKey)}
-          />)}
-        </div>
-      </section>
+        <div className="text-right"><p className="text-sm font-semibold">{statusLabels[selectedRun.status]}</p><p className="mt-1 text-xs text-[color:var(--admin-muted)]">Updated {formatDate(selectedRun.updatedAt)}</p></div>
+      </div>
+
+      <div className="divide-y divide-[color:var(--admin-border)]">
+        {selectedRun.stages.map((stage) => <StageRow
+          key={stage.stageKey}
+          stage={stage}
+          expanded={expandedStages.has(stage.stageKey)}
+          onToggle={() => toggleStage(stage.stageKey)}
+        />)}
+      </div>
     </>}
-  </div>;
+  </section>;
 }
 
-function StageRow({ stage, expanded, last, onToggle }: { stage: MarketingPipelineStageRecord; expanded: boolean; last: boolean; onToggle: () => void }) {
+function StageRow({ stage, expanded, onToggle }: { stage: MarketingPipelineStageRecord; expanded: boolean; onToggle: () => void }) {
   const hasDetails = Boolean(stage.summary || stage.errorMessage || stage.logExcerpt || stage.inputPath || stage.outputPath || stage.executionReference);
-  return <div className="relative pl-10">
-    {!last ? <div className="absolute left-[11px] top-7 h-full w-px bg-[color:var(--admin-border)]"/> : null}
-    <span className={`absolute left-0 top-4 h-6 w-6 rounded-full border-4 border-[color:var(--admin-surface)] ${dotClass(stage.status)}`}/>
-    <button type="button" onClick={onToggle} disabled={!hasDetails} className="flex w-full items-center justify-between gap-4 rounded-xl px-3 py-4 text-left hover:bg-[color:var(--admin-hover)] disabled:cursor-default disabled:hover:bg-transparent">
-      <div>
-        <p className="font-semibold">{stageLabels[stage.stageKey] ?? stage.stageKey}</p>
-        <p className="mt-1 text-xs text-[color:var(--admin-muted)]">{stage.executionKind.replace(/_/g, ' ')} · attempt {stage.attempt}{stage.startedAt ? ` · ${formatDate(stage.startedAt)}` : ''}</p>
+  return <div>
+    <button type="button" onClick={onToggle} disabled={!hasDetails} className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left hover:bg-[color:var(--admin-hover)] disabled:cursor-default disabled:hover:bg-transparent">
+      <div className="flex min-w-0 items-center gap-3">
+        <StatusIcon status={stage.status}/>
+        <div className="min-w-0">
+          <p className="truncate font-semibold">{stageLabels[stage.stageKey] ?? stage.stageKey}</p>
+          <p className="mt-1 truncate text-xs text-[color:var(--admin-muted)]">{stage.executionKind.replace(/_/g, ' ')} · attempt {stage.attempt}{stage.startedAt ? ` · ${formatDate(stage.startedAt)}` : ''}</p>
+        </div>
       </div>
-      <div className="flex items-center gap-3">
+      <div className="flex shrink-0 items-center gap-4">
+        <span className="text-sm text-[color:var(--admin-muted)]">{durationLabel(stage)}</span>
         <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${badgeClass(stage.status)}`}>{statusLabels[stage.status]}</span>
         {hasDetails ? expanded ? <ChevronUp size={17}/> : <ChevronDown size={17}/> : null}
       </div>
     </button>
-    {expanded ? <div className="mb-4 ml-3 space-y-3 rounded-xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface-muted)] p-4 text-sm">
-      {stage.summary ? <Detail label="Summary" value={stage.summary}/> : null}
-      {stage.inputPath ? <Detail label="Input" value={stage.inputPath}/> : null}
-      {stage.outputPath ? <Detail label="Output" value={stage.outputPath}/> : null}
-      {stage.inputSha256 ? <Detail label="Input hash" value={stage.inputSha256}/> : null}
-      {stage.outputSha256 ? <Detail label="Output hash" value={stage.outputSha256}/> : null}
-      {stage.executionReference ? <Detail label="Execution" value={stage.executionReference}/> : null}
-      {stage.errorMessage ? <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-red-200"><p className="text-xs font-semibold uppercase tracking-wider">Error</p><p className="mt-1 whitespace-pre-wrap">{stage.errorMessage}</p></div> : null}
-      {stage.logExcerpt ? <div><p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">Log excerpt</p><pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap rounded-lg bg-black/30 p-3 text-xs">{stage.logExcerpt}</pre></div> : null}
+
+    {expanded ? <div className="border-t border-[color:var(--admin-border)] bg-[#090d14] px-5 py-4 text-sm">
+      <div className="grid gap-3 md:grid-cols-2">
+        {stage.summary ? <Detail label="Result" value={stage.summary}/> : null}
+        {stage.inputPath ? <Detail label="Input" value={stage.inputPath}/> : null}
+        {stage.outputPath ? <Detail label="Output" value={stage.outputPath}/> : null}
+        {stage.executionReference ? <Detail label="Execution" value={stage.executionReference}/> : null}
+        {stage.inputSha256 ? <Detail label="Input hash" value={stage.inputSha256}/> : null}
+        {stage.outputSha256 ? <Detail label="Output hash" value={stage.outputSha256}/> : null}
+      </div>
+      {stage.errorMessage ? <div className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-red-200"><p className="text-xs font-semibold uppercase tracking-wider">Error</p><p className="mt-1 whitespace-pre-wrap">{stage.errorMessage}</p></div> : null}
+      {stage.logExcerpt ? <div className="mt-4"><p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">Logs</p><pre className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap rounded-lg border border-white/10 bg-black p-4 font-mono text-xs leading-5 text-slate-200">{stage.logExcerpt}</pre></div> : null}
     </div> : null}
   </div>;
 }
 
-function Detail({ label, value }: { label: string; value: string }) { return <div><p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">{label}</p><p className="mt-1 break-all">{value}</p></div>; }
-function Stat({ label, value }: { label: string; value: string | number }) { return <div className="rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-4"><p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">{label}</p><p className="mt-2 text-lg font-semibold">{value}</p></div>; }
+function StatusIcon({ status }: { status: MarketingPipelineStatus }) {
+  const symbol = status === 'completed' ? '✓' : status === 'failed' ? '×' : status === 'running' ? '●' : status === 'blocked' ? '!' : status === 'skipped' ? '−' : '○';
+  return <span className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs font-bold ${iconClass(status)}`}>{symbol}</span>;
+}
+
+function Detail({ label, value }: { label: string; value: string }) { return <div><p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--admin-muted)]">{label}</p><p className="mt-1 break-all font-mono text-xs text-slate-200">{value}</p></div>; }
 function LoadingPanel() { return <div className="flex min-h-[320px] items-center justify-center rounded-2xl border border-[color:var(--admin-border)] bg-[color:var(--admin-surface)]"><p className="text-sm text-[color:var(--admin-muted)]">Loading pipeline runs…</p></div>; }
-function EmptyPanel() { return <div className="rounded-2xl border border-dashed border-[color:var(--admin-border)] bg-[color:var(--admin-surface)] p-10 text-center"><h3 className="font-semibold">No marketing pipeline runs recorded yet</h3><p className="mx-auto mt-2 max-w-xl text-sm text-[color:var(--admin-muted)]">The next instrumentation PR will connect GitHub Actions and agent handoffs to this timeline. No status is inferred from partial files, so the Admin does not invent progress.</p></div>; }
+function EmptyPanel() { return <div className="p-10 text-center"><h3 className="font-semibold">No workflow runs recorded yet</h3><p className="mx-auto mt-2 max-w-xl text-sm text-[color:var(--admin-muted)]">The timeline is ready. The next instrumentation change will write each Action and agent result here; until then this view stays empty rather than inventing status.</p></div>; }
 function formatDate(value: string) { return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value)); }
-function dotClass(status: MarketingPipelineStatus) { return status === 'completed' ? 'bg-emerald-400' : status === 'running' ? 'bg-blue-400 animate-pulse' : status === 'failed' ? 'bg-red-400' : status === 'blocked' ? 'bg-amber-400' : status === 'skipped' ? 'bg-slate-500' : 'bg-[color:var(--admin-border)]'; }
+function durationLabel(stage: MarketingPipelineStageRecord) { if (!stage.startedAt) return '—'; const end = stage.completedAt ? new Date(stage.completedAt).getTime() : Date.now(); const seconds = Math.max(0, Math.round((end - new Date(stage.startedAt).getTime()) / 1000)); return seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m ${seconds % 60}s`; }
+function iconClass(status: MarketingPipelineStatus) { return status === 'completed' ? 'border-emerald-500 bg-emerald-500 text-black' : status === 'running' ? 'border-blue-400 bg-blue-400/20 text-blue-300 animate-pulse' : status === 'failed' ? 'border-red-500 bg-red-500 text-black' : status === 'blocked' ? 'border-amber-400 bg-amber-400/20 text-amber-300' : 'border-slate-500 text-slate-400'; }
 function badgeClass(status: MarketingPipelineStatus) { return status === 'completed' ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300' : status === 'running' ? 'border-blue-500/40 bg-blue-500/10 text-blue-300' : status === 'failed' ? 'border-red-500/40 bg-red-500/10 text-red-300' : status === 'blocked' ? 'border-amber-500/40 bg-amber-500/10 text-amber-300' : 'border-[color:var(--admin-border)] text-[color:var(--admin-muted)]'; }


### PR DESCRIPTION
## Objetivo
Corregir el HTTP 500 del pipeline en producción y alinear la experiencia visual con GitHub Actions.

## Cambios
- el endpoint devuelve `runs: []` cuando la migración de observabilidad todavía no fue aplicada (`Postgres 42P01`) en lugar de responder 500;
- Pipeline pasa a ser una tab dentro de Marketing;
- se elimina el ítem separado `Marketing Pipeline` del menú lateral;
- la URL anterior redirige a Marketing para no romper bookmarks;
- nueva vista estilo GitHub Actions con run seleccionado, etapas, iconos de estado, duración, intentos y paneles desplegables;
- los detalles muestran input, output, hashes, referencia de ejecución, error y logs monoespaciados;
- CI valida la tab embebida y el fallback de tablas faltantes.

## Nota
Esta PR corrige la lectura y la presentación. Los Actions y agentes todavía deben instrumentarse para escribir runs y stages reales en estas tablas.