### PR TITLE
Fix native local reminder permission and scheduling reliability

### DIFF
--- a/apps/web/src/mobile/localNotifications.ts
+++ b/apps/web/src/mobile/localNotifications.ts
@@ -276,14 +276,22 @@ export async function syncNativeDailyReminderNotification(
       return;
     }
 
-    const permissions = options?.requestPermissions
-      ? await ensureNativeDailyReminderNotificationPermissions()
-      : await plugin.checkPermissions().then((result) => ({ granted: result.display === 'granted' }));
+    const existingPermission = await plugin.checkPermissions();
+    const shouldRequestPermission =
+      options?.requestPermissions === true ||
+      existingPermission.display === 'prompt' ||
+      existingPermission.display === 'prompt-with-rationale';
+    const permissions = shouldRequestPermission
+      ? await ensureNativeDailyReminderNotificationPermissions({ requestExactAlarm: true })
+      : { granted: existingPermission.display === 'granted' };
 
     if (!permissions.granted) {
-      logNativeReminder('sync-permission-denied', { requestPermissions: options?.requestPermissions === true });
-      await cancelNativeDailyReminderNotification();
-      if (options?.requestPermissions) {
+      logNativeReminder('sync-permission-unavailable', {
+        display: existingPermission.display,
+        requestPermissions: shouldRequestPermission,
+        preservedExistingSchedule: true,
+      });
+      if (options?.requestPermissions || shouldRequestPermission) {
         throw new Error(tNotification('dailyQuest.mobile.permissionRequired'));
       }
       return;
@@ -319,7 +327,6 @@ export async function syncNativeDailyReminderNotification(
       channel: reminder?.channel ?? null,
     });
 
-    await cancelNativeDailyReminderNotification();
     await plugin.schedule({
       notifications: [
         {
@@ -344,11 +351,17 @@ export async function syncNativeDailyReminderNotification(
       logNativeReminder('sync-pending-check-failed', { error: error instanceof Error ? error.message : String(error) });
       return null;
     });
+    const pendingIds = pending?.notifications?.map((notification) => notification.id).filter(Boolean) ?? null;
+    const isConfirmedPending = pendingIds?.includes(DAILY_REMINDER_NOTIFICATION_ID) ?? false;
     logNativeReminder('sync-scheduled', {
       id: DAILY_REMINDER_NOTIFICATION_ID,
       pendingCount: pending?.notifications?.length ?? null,
-      pendingIds: pending?.notifications?.map((notification) => notification.id).filter(Boolean) ?? null,
+      pendingIds,
+      confirmed: isConfirmedPending,
     });
+    if (pending && !isConfirmedPending) {
+      throw new Error(tNotification('dailyQuest.mobile.permissionRequired'));
+    }
   } finally {
     isReminderSyncInProgress = false;
   }


### PR DESCRIPTION
## Causa confirmada

En iOS, `LocalNotifications.checkPermissions()` devolvía `display: prompt`. El flujo de sincronización se ejecutaba con `requestPermissions: false`, interpretaba el permiso como denegado y cancelaba la notificación local `41001`. El backend quedaba activo, pero el sistema operativo no tenía ninguna notificación programada.

La misma condición puede ocurrir en Android 13+ o en una instalación nueva, por lo que la corrección se aplica a la capa compartida de Capacitor.

## Corrección

- cuando el permiso está en `prompt` o `prompt-with-rationale`, solicita autorización nativa automáticamente;
- solicita también la configuración de alarma exacta cuando la plataforma la expone;
- no cancela una programación existente durante una comprobación pasiva sin permisos;
- programa/reemplaza directamente la notificación con el mismo ID, evitando el intervalo destructivo de cancelar antes de programar;
- verifica con `getPending()` que `41001` realmente quedó registrada;
- añade logs con estado de permiso, preservación y confirmación del pending schedule;
- devuelve un error visible si el usuario rechaza el permiso o si el sistema no confirma la programación.

## Plataformas

- iOS: corrige el caso observado con `display: prompt`.
- Android: previene el mismo fallo en Android 13+ y conserva la revisión de exact alarms.

## Validación manual después de bajar la PR

1. Instalar la build en un dispositivo limpio o restablecer permisos de Innerbloom.
2. Elegir `Notification`, una hora 2–3 minutos futura y guardar.
3. Aceptar el diálogo nativo.
4. Confirmar en Xcode/Logcat:
   - `permission-check`;
   - `permission-request` con `granted`;
   - `sync-schedule-start`;
   - `sync-scheduled` con `confirmed: true` y `pendingIds: [41001]`.
5. Cerrar completamente la app y verificar la entrega.
6. Repetir en Android 13+.

## Alcance

No modifica backend, base de datos, email reminders, OAuth, logout ni rutas de navegación.