### PR TITLE
Force cross-platform reminder resync after settings save

### DIFF
--- a/apps/web/src/mobile/NativeReliabilityBridge.tsx
+++ b/apps/web/src/mobile/NativeReliabilityBridge.tsx
@@ -14,6 +14,7 @@ import { writeMobileDebug } from './mobileDebug';
 
 const NATIVE_SESSION_REFRESH_WINDOW_MS = 15 * 60 * 1000;
 const NATIVE_RELIABILITY_COOLDOWN_MS = 30_000;
+const REMINDER_SAVE_RECONCILE_DELAYS_MS = [750, 2_500];
 
 let maintenancePromise: Promise<void> | null = null;
 let lastMaintenanceStartedAt = 0;
@@ -29,7 +30,10 @@ export function shouldRefreshNativeSession(
   return expiresAt - now <= NATIVE_SESSION_REFRESH_WINDOW_MS;
 }
 
-async function runNativeReliabilityMaintenance(reason: string): Promise<void> {
+async function runNativeReliabilityMaintenance(
+  reason: string,
+  options?: { force?: boolean },
+): Promise<void> {
   if (!isNativeCapacitorPlatform() || shouldForceNativeWelcome()) {
     return;
   }
@@ -44,7 +48,12 @@ async function runNativeReliabilityMaintenance(reason: string): Promise<void> {
     return maintenancePromise;
   }
 
-  if (now - lastMaintenanceStartedAt < NATIVE_RELIABILITY_COOLDOWN_MS) {
+  if (!options?.force && now - lastMaintenanceStartedAt < NATIVE_RELIABILITY_COOLDOWN_MS) {
+    writeMobileDebug('native-reliability:skipped-cooldown', {
+      reason,
+      elapsedMs: now - lastMaintenanceStartedAt,
+      at: now,
+    });
     return;
   }
 
@@ -52,6 +61,7 @@ async function runNativeReliabilityMaintenance(reason: string): Promise<void> {
   maintenancePromise = (async () => {
     writeMobileDebug('native-reliability:start', {
       reason,
+      forced: options?.force === true,
       expiresAt: session.expiresAt,
       shouldRefresh: shouldRefreshNativeSession(session.expiresAt, now),
       at: now,
@@ -83,9 +93,14 @@ async function runNativeReliabilityMaintenance(reason: string): Promise<void> {
       }
 
       const reminder = await getDailyReminderSettings('notification');
-      await syncNativeDailyReminderNotification(reminder);
+      await syncNativeDailyReminderNotification(reminder, {
+        requestPermissions: reason.startsWith('reminder-save'),
+      });
       writeMobileDebug('native-reliability:reminder-resynced', {
         reason,
+        localTime: reminder?.local_time ?? reminder?.localTime ?? null,
+        status: reminder?.status ?? null,
+        enabled: reminder?.enabled ?? null,
         at: Date.now(),
       });
     } catch (error) {
@@ -106,6 +121,11 @@ async function runNativeReliabilityMaintenance(reason: string): Promise<void> {
   return maintenancePromise;
 }
 
+function isDailyReminderForm(target: EventTarget | null): target is HTMLFormElement {
+  return target instanceof HTMLFormElement
+    && target.classList.contains('reminder-scheduler-form');
+}
+
 export function NativeReliabilityBridge() {
   useEffect(() => {
     if (!isNativeCapacitorPlatform()) {
@@ -116,6 +136,7 @@ export function NativeReliabilityBridge() {
 
     const app = getCapacitorAppPlugin();
     let appStateHandle: Awaited<ReturnType<NonNullable<typeof app>['addListener']>> | null = null;
+    const reminderSaveTimeoutIds = new Set<number>();
 
     if (app) {
       void Promise.resolve(app.addListener('appStateChange', ({ isActive }) => {
@@ -130,10 +151,37 @@ export function NativeReliabilityBridge() {
     const handleOnline = () => {
       void runNativeReliabilityMaintenance('online');
     };
+
+    const handleReminderSubmit = (event: SubmitEvent) => {
+      if (!isDailyReminderForm(event.target)) {
+        return;
+      }
+
+      writeMobileDebug('native-reliability:reminder-save-detected', {
+        at: Date.now(),
+      });
+
+      for (const [index, delayMs] of REMINDER_SAVE_RECONCILE_DELAYS_MS.entries()) {
+        const timeoutId = window.setTimeout(() => {
+          reminderSaveTimeoutIds.delete(timeoutId);
+          void runNativeReliabilityMaintenance(`reminder-save-${index + 1}`, {
+            force: true,
+          });
+        }, delayMs);
+        reminderSaveTimeoutIds.add(timeoutId);
+      }
+    };
+
     window.addEventListener('online', handleOnline);
+    document.addEventListener('submit', handleReminderSubmit, true);
 
     return () => {
       window.removeEventListener('online', handleOnline);
+      document.removeEventListener('submit', handleReminderSubmit, true);
+      for (const timeoutId of reminderSaveTimeoutIds) {
+        window.clearTimeout(timeoutId);
+      }
+      reminderSaveTimeoutIds.clear();
       void appStateHandle?.remove();
     };
   }, []);


### PR DESCRIPTION
## Problema confirmado por logs

La sincronización al abrir la app programaba correctamente la notificación local y `getPending()` confirmaba el ID `41001`. Sin embargo, al cambiar el horario desde Settings, el backend actualizaba la nueva hora pero no siempre se ejecutaba una reconciliación local posterior.

El puente de confiabilidad tenía un cooldown global de 30 segundos. Cuando la app acababa de sincronizar al montar y el usuario cambiaba el horario inmediatamente después, una nueva reconciliación podía quedar bloqueada por ese cooldown.

## Solución

- Detecta cada submit real del formulario `.reminder-scheduler-form` en la app nativa.
- Ejecuta dos reconciliaciones posteriores al guardado, a 750 ms y 2.5 s, para cubrir la finalización del backend.
- Estas reconciliaciones son forzadas y no quedan bloqueadas por el cooldown de 30 segundos.
- Vuelve a leer `channel=notification` desde el backend y usa la misma función compartida `syncNativeDailyReminderNotification()` para programar y verificar la notificación local.
- Solicita permisos durante el guardado cuando corresponda.
- Aplica por igual a iOS y Android porque usa la capa compartida de Capacitor.
- Mantiene el cooldown para mount, foreground y online, evitando llamadas repetitivas normales.
- Añade logs explícitos para detectar submit, cooldown omitido, hora recuperada y resultado de reconciliación.

## Logs esperados después de guardar

- `native-reliability:reminder-save-detected`
- `native-reliability:start` con `forced: true`
- `mobile-reminder:sync-schedule-start`
- `LocalNotifications schedule`
- `LocalNotifications getPending`
- `mobile-reminder:sync-scheduled` con `confirmed: true`
- `native-reliability:reminder-resynced` con la nueva `localTime`

## Validación manual

1. Abrir la app y esperar la sincronización inicial.
2. Cambiar el horario de Notification dentro de los siguientes 30 segundos.
3. Guardar.
4. Confirmar que `getPending()` devuelve `41001` con la nueva hora.
5. Repetir en iOS y Android.

## Alcance

No modifica backend, email reminders, autenticación, logout ni navegación.