### PR TITLE
Remove reminder timers and add runtime diagnostics

### DIFF
--- a/apps/web/src/mobile/NativeReliabilityBridge.tsx
+++ b/apps/web/src/mobile/NativeReliabilityBridge.tsx
@@ -14,7 +14,6 @@ import { writeMobileDebug } from './mobileDebug';
 
 const NATIVE_SESSION_REFRESH_WINDOW_MS = 15 * 60 * 1000;
 const NATIVE_RELIABILITY_COOLDOWN_MS = 30_000;
-const REMINDER_SAVE_RECONCILE_DELAYS_MS = [750, 2_500];
 
 let maintenancePromise: Promise<void> | null = null;
 let lastMaintenanceStartedAt = 0;
@@ -30,10 +29,7 @@ export function shouldRefreshNativeSession(
   return expiresAt - now <= NATIVE_SESSION_REFRESH_WINDOW_MS;
 }
 
-async function runNativeReliabilityMaintenance(
-  reason: string,
-  options?: { force?: boolean },
-): Promise<void> {
+async function runNativeReliabilityMaintenance(reason: string): Promise<void> {
   if (!isNativeCapacitorPlatform() || shouldForceNativeWelcome()) {
     return;
   }
@@ -48,12 +44,7 @@ async function runNativeReliabilityMaintenance(
     return maintenancePromise;
   }
 
-  if (!options?.force && now - lastMaintenanceStartedAt < NATIVE_RELIABILITY_COOLDOWN_MS) {
-    writeMobileDebug('native-reliability:skipped-cooldown', {
-      reason,
-      elapsedMs: now - lastMaintenanceStartedAt,
-      at: now,
-    });
+  if (now - lastMaintenanceStartedAt < NATIVE_RELIABILITY_COOLDOWN_MS) {
     return;
   }
 
@@ -61,7 +52,6 @@ async function runNativeReliabilityMaintenance(
   maintenancePromise = (async () => {
     writeMobileDebug('native-reliability:start', {
       reason,
-      forced: options?.force === true,
       expiresAt: session.expiresAt,
       shouldRefresh: shouldRefreshNativeSession(session.expiresAt, now),
       at: now,
@@ -93,14 +83,9 @@ async function runNativeReliabilityMaintenance(
       }
 
       const reminder = await getDailyReminderSettings('notification');
-      await syncNativeDailyReminderNotification(reminder, {
-        requestPermissions: reason.startsWith('reminder-save'),
-      });
+      await syncNativeDailyReminderNotification(reminder);
       writeMobileDebug('native-reliability:reminder-resynced', {
         reason,
-        localTime: reminder?.local_time ?? reminder?.localTime ?? null,
-        status: reminder?.status ?? null,
-        enabled: reminder?.enabled ?? null,
         at: Date.now(),
       });
     } catch (error) {
@@ -121,11 +106,6 @@ async function runNativeReliabilityMaintenance(
   return maintenancePromise;
 }
 
-function isDailyReminderForm(target: EventTarget | null): target is HTMLFormElement {
-  return target instanceof HTMLFormElement
-    && target.classList.contains('reminder-scheduler-form');
-}
-
 export function NativeReliabilityBridge() {
   useEffect(() => {
     if (!isNativeCapacitorPlatform()) {
@@ -136,7 +116,6 @@ export function NativeReliabilityBridge() {
 
     const app = getCapacitorAppPlugin();
     let appStateHandle: Awaited<ReturnType<NonNullable<typeof app>['addListener']>> | null = null;
-    const reminderSaveTimeoutIds = new Set<number>();
 
     if (app) {
       void Promise.resolve(app.addListener('appStateChange', ({ isActive }) => {
@@ -151,37 +130,10 @@ export function NativeReliabilityBridge() {
     const handleOnline = () => {
       void runNativeReliabilityMaintenance('online');
     };
-
-    const handleReminderSubmit = (event: SubmitEvent) => {
-      if (!isDailyReminderForm(event.target)) {
-        return;
-      }
-
-      writeMobileDebug('native-reliability:reminder-save-detected', {
-        at: Date.now(),
-      });
-
-      for (const [index, delayMs] of REMINDER_SAVE_RECONCILE_DELAYS_MS.entries()) {
-        const timeoutId = window.setTimeout(() => {
-          reminderSaveTimeoutIds.delete(timeoutId);
-          void runNativeReliabilityMaintenance(`reminder-save-${index + 1}`, {
-            force: true,
-          });
-        }, delayMs);
-        reminderSaveTimeoutIds.add(timeoutId);
-      }
-    };
-
     window.addEventListener('online', handleOnline);
-    document.addEventListener('submit', handleReminderSubmit, true);
 
     return () => {
       window.removeEventListener('online', handleOnline);
-      document.removeEventListener('submit', handleReminderSubmit, true);
-      for (const timeoutId of reminderSaveTimeoutIds) {
-        window.clearTimeout(timeoutId);
-      }
-      reminderSaveTimeoutIds.clear();
       void appStateHandle?.remove();
     };
   }, []);

--- a/apps/web/src/mobile/NativeReliabilityBridge.tsx
+++ b/apps/web/src/mobile/NativeReliabilityBridge.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { getDailyReminderSettings } from '../lib/api';
 import {
   getCapacitorAppPlugin,
+  getCapacitorPlatform,
   isNativeCapacitorPlatform,
 } from './capacitor';
 import { syncNativeDailyReminderNotification } from './localNotifications';
@@ -14,6 +15,7 @@ import { writeMobileDebug } from './mobileDebug';
 
 const NATIVE_SESSION_REFRESH_WINDOW_MS = 15 * 60 * 1000;
 const NATIVE_RELIABILITY_COOLDOWN_MS = 30_000;
+const REMINDER_DIAGNOSTIC_BUILD = 'reminder-diagnostics-v1-2026-07-26';
 
 let maintenancePromise: Promise<void> | null = null;
 let lastMaintenanceStartedAt = 0;
@@ -106,16 +108,44 @@ async function runNativeReliabilityMaintenance(reason: string): Promise<void> {
   return maintenancePromise;
 }
 
+function isDailyReminderForm(target: EventTarget | null): target is HTMLFormElement {
+  return target instanceof HTMLFormElement
+    && target.classList.contains('reminder-scheduler-form');
+}
+
+function readReminderUiOutcome(): 'success' | 'error' | null {
+  const text = document.body?.innerText ?? '';
+  if (text.includes('Guardamos tus recordatorios.')) {
+    return 'success';
+  }
+  if (
+    text.includes('No pudimos guardar tus recordatorios.')
+    || text.includes('Necesitamos permiso para enviarte notificaciones')
+  ) {
+    return 'error';
+  }
+  return null;
+}
+
 export function NativeReliabilityBridge() {
   useEffect(() => {
     if (!isNativeCapacitorPlatform()) {
       return;
     }
 
+    writeMobileDebug('reminder-diagnostics:build', {
+      marker: REMINDER_DIAGNOSTIC_BUILD,
+      platform: getCapacitorPlatform(),
+      native: isNativeCapacitorPlatform(),
+      path: window.location.pathname,
+      at: Date.now(),
+    });
+
     void runNativeReliabilityMaintenance('mount');
 
     const app = getCapacitorAppPlugin();
     let appStateHandle: Awaited<ReturnType<NonNullable<typeof app>['addListener']>> | null = null;
+    let lastUiOutcome: 'success' | 'error' | null = null;
 
     if (app) {
       void Promise.resolve(app.addListener('appStateChange', ({ isActive }) => {
@@ -130,10 +160,73 @@ export function NativeReliabilityBridge() {
     const handleOnline = () => {
       void runNativeReliabilityMaintenance('online');
     };
+
+    const handleReminderSubmit = (event: SubmitEvent) => {
+      if (!isDailyReminderForm(event.target)) {
+        return;
+      }
+
+      lastUiOutcome = null;
+      writeMobileDebug('reminder-diagnostics:submit-captured', {
+        marker: REMINDER_DIAGNOSTIC_BUILD,
+        platform: getCapacitorPlatform(),
+        native: isNativeCapacitorPlatform(),
+        path: window.location.pathname,
+        submitterTag: event.submitter instanceof HTMLElement ? event.submitter.tagName : null,
+        at: Date.now(),
+      });
+    };
+
+    const handleWindowError = (event: ErrorEvent) => {
+      writeMobileDebug('reminder-diagnostics:window-error', {
+        marker: REMINDER_DIAGNOSTIC_BUILD,
+        message: event.message,
+        filename: event.filename || null,
+        line: event.lineno || null,
+        column: event.colno || null,
+        at: Date.now(),
+      });
+    };
+
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason;
+      writeMobileDebug('reminder-diagnostics:unhandled-rejection', {
+        marker: REMINDER_DIAGNOSTIC_BUILD,
+        error: reason instanceof Error ? reason.message : String(reason),
+        at: Date.now(),
+      });
+    };
+
+    const outcomeObserver = new MutationObserver(() => {
+      const outcome = readReminderUiOutcome();
+      if (!outcome || outcome === lastUiOutcome) {
+        return;
+      }
+      lastUiOutcome = outcome;
+      writeMobileDebug(`reminder-diagnostics:ui-${outcome}`, {
+        marker: REMINDER_DIAGNOSTIC_BUILD,
+        platform: getCapacitorPlatform(),
+        path: window.location.pathname,
+        at: Date.now(),
+      });
+    });
+
     window.addEventListener('online', handleOnline);
+    window.addEventListener('error', handleWindowError);
+    window.addEventListener('unhandledrejection', handleUnhandledRejection);
+    document.addEventListener('submit', handleReminderSubmit, true);
+    outcomeObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
 
     return () => {
       window.removeEventListener('online', handleOnline);
+      window.removeEventListener('error', handleWindowError);
+      window.removeEventListener('unhandledrejection', handleUnhandledRejection);
+      document.removeEventListener('submit', handleReminderSubmit, true);
+      outcomeObserver.disconnect();
       void appStateHandle?.remove();
     };
   }, []);


### PR DESCRIPTION
## Objetivo

Obtener evidencia exacta del flujo de guardado de recordatorios en un dispositivo real antes de aplicar otra corrección funcional.

## Qué cambia

- Elimina por completo el listener con temporizadores introducido por la PR #2343.
- Elimina las dos reconciliaciones diferidas que causaban `schedule()` y `getPending()` duplicados.
- Mantiene intacto el `handleSubmit` real y la programación existente.
- Añade instrumentación no invasiva en `NativeReliabilityBridge`.

## Logs nuevos

- `reminder-diagnostics:build`
  - confirma que el dispositivo ejecuta este bundle;
  - incluye marker, plataforma, native y ruta.
- `reminder-diagnostics:submit-captured`
  - confirma que el formulario real emitió submit.
- `reminder-diagnostics:ui-success`
  - confirma que el flujo terminó mostrando éxito.
- `reminder-diagnostics:ui-error`
  - confirma que terminó mostrando error.
- `reminder-diagnostics:window-error`
  - captura excepciones JS globales.
- `reminder-diagnostics:unhandled-rejection`
  - captura promesas rechazadas sin manejar.

Estos logs se complementan con los ya existentes:

- updates del backend;
- `mobile-reminder:sync-schedule-start`;
- `LocalNotifications schedule`;
- `LocalNotifications getPending`;
- `mobile-reminder:sync-scheduled`.

## Prueba necesaria

1. Mergear esta PR.
2. Bajar `main`, regenerar/sincronizar el bundle nativo e instalarlo.
3. Abrir Settings > Daily reminder.
4. Limpiar la consola.
5. Cambiar la hora una sola vez y guardar.
6. Copiar el log desde `reminder-diagnostics:submit-captured` hasta `ui-success`, `ui-error` o el último mensaje disponible.

## Importante

Esta PR es deliberadamente diagnóstica. No afirma corregir todavía la causa funcional. Su propósito es demostrar en qué punto exacto se corta el flujo real de iOS/Android y evitar otro parche basado en suposiciones.