### PR TITLE
Fix iOS refresh to reuse the Clerk browser session

### DIFF
--- a/apps/mobile/ios/App/App/InnerbloomAuthBrowserPlugin.swift
+++ b/apps/mobile/ios/App/App/InnerbloomAuthBrowserPlugin.swift
@@ -30,7 +30,19 @@ public class InnerbloomAuthBrowserPlugin: CAPPlugin, CAPBridgedPlugin, ASWebAuth
         }
 
         let callbackScheme = call.getString("callbackScheme") ?? "innerbloom"
-        let prefersEphemeralSession = call.getBool("prefersEphemeralWebBrowserSession", false)
+        let requestedEphemeralSession = call.getBool("prefersEphemeralWebBrowserSession", false)
+        let authMode = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == "mode" })?
+            .value
+        let prefersEphemeralSession = authMode == "refresh" ? false : requestedEphemeralSession
+
+        NSLog(
+            "[mobile-auth][ios] opening auth session mode=%@ requestedEphemeral=%@ effectiveEphemeral=%@",
+            authMode ?? "unknown",
+            requestedEphemeralSession.description,
+            prefersEphemeralSession.description
+        )
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -42,15 +54,22 @@ public class InnerbloomAuthBrowserPlugin: CAPPlugin, CAPBridgedPlugin, ASWebAuth
                 self.activeSession = nil
 
                 if let callbackURL {
+                    NSLog("[mobile-auth][ios] auth callback received mode=%@", authMode ?? "unknown")
                     pendingCall?.resolve(["url": callbackURL.absoluteString])
                     return
                 }
 
                 if let authError = error as? ASWebAuthenticationSessionError, authError.code == .canceledLogin {
+                    NSLog("[mobile-auth][ios] auth session cancelled mode=%@", authMode ?? "unknown")
                     pendingCall?.reject("Authentication session was cancelled", "AUTH_CANCELLED", authError)
                     return
                 }
 
+                NSLog(
+                    "[mobile-auth][ios] auth session failed mode=%@ error=%@",
+                    authMode ?? "unknown",
+                    error?.localizedDescription ?? "unknown"
+                )
                 pendingCall?.reject(error?.localizedDescription ?? "Authentication session failed", "AUTH_FAILED", error)
             }
 


### PR DESCRIPTION
## Problema confirmado

La renovación nativa de sesión usa el mismo `InnerbloomAuthBrowser` que login, sign-up y logout. Desde JavaScript se solicita una sesión efímera para todos los modos. En iOS eso se traducía directamente en `ASWebAuthenticationSession.prefersEphemeralWebBrowserSession = true`, incluso para `mode=refresh`.

Como consecuencia, el refresh descartaba la sesión web persistida de Clerk y podía mostrar nuevamente Restore your session, Google, email o passkey.

## Corrección quirúrgica

- conserva el plugin único y su contrato actual;
- no agrega Clerk SDK nativo;
- no modifica callbacks, rutas, logout, Android ni el componente web compartido;
- el plugin iOS inspecciona `mode` en la URL;
- únicamente para `mode=refresh`, fuerza `prefersEphemeralWebBrowserSession = false` para permitir que Clerk reutilice la sesión web existente;
- login, sign-up y logout siguen respetando el valor efímero solicitado por la capa compartida;
- agrega logs nativos visibles en Xcode con modo, valor solicitado, valor efectivo, callback, cancelación y error.

## Logs esperados en Xcode

Durante refresh:

```text
[mobile-auth][ios] opening auth session mode=refresh requestedEphemeral=true effectiveEphemeral=false
[mobile-auth][ios] auth callback received mode=refresh
```

Durante login/sign-up/logout, `effectiveEphemeral` continúa siguiendo el valor solicitado.

## Validación manual

1. Instalar la build desde esta rama en un iPhone real.
2. Iniciar sesión normalmente.
3. Dejar la aplicación en background hasta que el JWT entre en la ventana de refresh.
4. Volver a abrirla.
5. Confirmar en Xcode los dos logs de refresh.
6. Confirmar que no solicita Google, email ni passkey y vuelve automáticamente a la app.
7. Probar logout y segundo login para confirmar que el comportamiento fresco sigue intacto.

## Alcance

Esta PR corrige el principal gap iOS sin cambiar la arquitectura Capacitor. No elimina todavía la superficie breve de `ASWebAuthenticationSession`; evalúa primero si la sesión Clerk persistente permite que el refresh sea automático, que es el cambio menos invasivo posible.