### PR TITLE
Fix foreground delivery for native local reminders

### DIFF
--- a/apps/mobile/capacitor.config.ts
+++ b/apps/mobile/capacitor.config.ts
@@ -16,6 +16,7 @@ const config: CapacitorConfig = {
     LocalNotifications: {
       smallIcon: 'ic_stat_innerbloom',
       iconColor: '#A855F7',
+      presentationOptions: ['badge', 'sound', 'alert'],
     },
   },
 };


### PR DESCRIPTION
## Hallazgo confirmado

Innerbloom ya programa recordatorios locales con `@capacitor/local-notifications`, pero la configuración de Capacitor no declaraba `presentationOptions`.

En iOS, cuando una notificación local vence mientras la aplicación está abierta, el sistema consulta al delegate de `UNUserNotificationCenter` cómo presentarla. Sin opciones de presentación configuradas, la notificación puede ser recibida sin mostrar banner, sonido ni badge. Esto encaja con las pruebas hechas manteniendo Innerbloom abierta después de guardar el reminder.

## Corrección quirúrgica

- conserva notificaciones locales y el flujo compartido iOS/Android;
- no introduce APNs, FCM ni backend push;
- no modifica autenticación ni el plugin `InnerbloomAuthBrowser`;
- configura `LocalNotifications.presentationOptions` con `alert`, `sound` y `badge`;
- la configuración se aplica mediante el plugin oficial de Capacitor en ambas plataformas.

## Qué cubre

- iOS foreground: muestra banner/alerta y sonido cuando Innerbloom está abierta;
- iOS background/cerrada: mantiene el comportamiento normal del sistema;
- Android foreground/background: conserva el scheduling actual y permite presentación consistente según el sistema y el canal.

## Validación manual

Después de mergear:

1. bajar `main`;
2. desde `apps/mobile`, usar el Node habitual del proyecto y ejecutar `pnpm run sync:ios`;
3. abrir el scheme `App`, no `CapApp-SPM`;
4. instalar en el iPhone;
5. programar una hora 2–3 minutos futura;
6. dejar Innerbloom abierta y comprobar banner + sonido;
7. repetir con la aplicación en background;
8. repetir en Android después de `pnpm run sync:android`.

## Nota de investigación

El scheduling actual con `schedule.on = { hour, minute, second }` es una modalidad soportada oficialmente por Capacitor para iOS y Android y `getPending()` ya verifica que el ID `41001` quede registrado. Esta PR corrige el gap confirmado de presentación foreground. Si background sigue fallando en el dispositivo, los logs existentes (`sync-schedule-start`, `sync-scheduled`, `pendingIds`) permitirán distinguir programación de entrega.