### PR TITLE
Restore iOS signing after time-sensitive entitlement

### DIFF
--- a/apps/mobile/ios/App/App/App.entitlements
+++ b/apps/mobile/ios/App/App/App.entitlements
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>com.apple.developer.usernotifications.time-sensitive</key>
-	<true/>
-</dict>
-</plist>

--- a/apps/mobile/ios/debug.xcconfig
+++ b/apps/mobile/ios/debug.xcconfig
@@ -1,2 +1,1 @@
 CAPACITOR_DEBUG = true
-CODE_SIGN_ENTITLEMENTS = App/App.entitlements


### PR DESCRIPTION
## Qué corrige

La PR anterior añadió manualmente el entitlement `com.apple.developer.usernotifications.time-sensitive`, pero el provisioning profile de `org.innerbloom.app` no lo incluye. Eso bloquea completamente la firma y evita ejecutar la app en el iPhone.

Esta PR:

- elimina `App.entitlements`;
- elimina `CODE_SIGN_ENTITLEMENTS = App/App.entitlements` de `ios/debug.xcconfig`;
- restaura la firma automática existente;
- no toca backend, horarios, Clerk ni el scheduler local.

## Resultado esperado

Después del merge, Xcode deja de exigir un provisioning profile con el entitlement time-sensitive y vuelve a poder firmar el target con el perfil actual.

## Pasos después del merge

```bash
cd /Users/ramirofernandezdeullivarri/Developer/innerbloomv3
git pull
cd apps/mobile
nvm use 24
pnpm run sync:ios
```

Luego en Xcode:

1. Product → Clean Build Folder
2. Signing & Capabilities → Try Again si todavía muestra el error anterior
3. Play con el iPhone conectado

No hace falta agregar ninguna capability manualmente en Xcode para aplicar esta corrección.