### PR TITLE
Make native reminder scheduling authoritative and repeatable

### DIFF
--- a/apps/web/src/components/dashboard-v3/ReminderSchedulerDialog.tsx
+++ b/apps/web/src/components/dashboard-v3/ReminderSchedulerDialog.tsx
@@ -13,6 +13,8 @@ import { createPortal } from "react-dom";
 import type { RefObject } from "react";
 import { DailyReminderSettings } from "../settings/DailyReminderSettings";
 import { usePostLoginLanguage } from "../../i18n/postLoginLanguage";
+import { isNativeCapacitorPlatform } from "../../mobile/capacitor";
+import { sendNativeDailyReminderTestNotification } from "../../mobile/localNotifications";
 
 export type ReminderSchedulerDialogHandle = {
   open: () => void;
@@ -25,6 +27,8 @@ interface ReminderSchedulerDialogProps {
   onScheduled?: (metadata: { wasFirstScheduleCompletion: boolean }) => void | Promise<void>;
 }
 
+type TestNotificationStatus = "idle" | "sending" | "scheduled" | "error";
+
 export const ReminderSchedulerDialog = forwardRef<
   ReminderSchedulerDialogHandle,
   ReminderSchedulerDialogProps
@@ -33,11 +37,13 @@ export const ReminderSchedulerDialog = forwardRef<
   const [isOpen, setIsOpen] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
   const [portalNode, setPortalNode] = useState<Element | null>(null);
+  const [testNotificationStatus, setTestNotificationStatus] = useState<TestNotificationStatus>("idle");
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const titleId = useMemo(
     () => `reminder-dialog-${Math.random().toString(36).slice(2, 8)}`,
     [],
   );
+  const isNativeApp = isNativeCapacitorPlatform();
 
   const open = useCallback(() => {
     if (!enabled) {
@@ -48,12 +54,28 @@ export const ReminderSchedulerDialog = forwardRef<
 
   const close = useCallback(() => {
     setIsOpen(false);
+    setTestNotificationStatus("idle");
     if (returnFocusRef?.current) {
       requestAnimationFrame(() => {
         returnFocusRef.current?.focus({ preventScroll: true });
       });
     }
   }, [returnFocusRef]);
+
+  const handleTestNotification = useCallback(async () => {
+    if (!isNativeApp || testNotificationStatus === "sending") {
+      return;
+    }
+
+    setTestNotificationStatus("sending");
+    try {
+      await sendNativeDailyReminderTestNotification();
+      setTestNotificationStatus("scheduled");
+    } catch (error) {
+      console.error("Failed to schedule native test notification", error);
+      setTestNotificationStatus("error");
+    }
+  }, [isNativeApp, testNotificationStatus]);
 
   useImperativeHandle(ref, () => ({ open, close }), [open, close]);
 
@@ -167,6 +189,31 @@ export const ReminderSchedulerDialog = forwardRef<
                   response.wasFirstScheduleCompletion === true;
                 void onScheduled?.({ wasFirstScheduleCompletion });
               }} />
+
+              {isNativeApp ? (
+                <div className="mt-5 border-t border-white/10 pt-5">
+                  <button
+                    type="button"
+                    onClick={() => void handleTestNotification()}
+                    disabled={testNotificationStatus === "sending"}
+                    className="w-full rounded-full border border-violet-400/70 bg-violet-500/10 px-5 py-3 text-sm font-semibold text-violet-200 transition hover:bg-violet-500/20 disabled:cursor-wait disabled:opacity-60"
+                  >
+                    {testNotificationStatus === "sending"
+                      ? "Scheduling test…"
+                      : "Test notification in 10 seconds"}
+                  </button>
+                  {testNotificationStatus === "scheduled" ? (
+                    <p className="mt-2 text-center text-xs text-emerald-300">
+                      Test scheduled. You can repeat it as many times as needed.
+                    </p>
+                  ) : null}
+                  {testNotificationStatus === "error" ? (
+                    <p className="mt-2 text-center text-xs text-rose-300">
+                      The test could not be scheduled. Check the native logs.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           </motion.div>
         </motion.div>

--- a/apps/web/src/mobile/NativeReliabilityBridge.tsx
+++ b/apps/web/src/mobile/NativeReliabilityBridge.tsx
@@ -5,7 +5,10 @@ import {
   getCapacitorPlatform,
   isNativeCapacitorPlatform,
 } from './capacitor';
-import { syncNativeDailyReminderNotification } from './localNotifications';
+import {
+  clearNativeReminderDeliveryState,
+  syncNativeDailyReminderNotification,
+} from './localNotifications';
 import {
   ensureFreshMobileAuthSession,
   getMobileAuthSession,
@@ -15,10 +18,12 @@ import { writeMobileDebug } from './mobileDebug';
 
 const NATIVE_SESSION_REFRESH_WINDOW_MS = 15 * 60 * 1000;
 const NATIVE_RELIABILITY_COOLDOWN_MS = 30_000;
-const REMINDER_DIAGNOSTIC_BUILD = 'reminder-post-save-resync-v2-2026-07-27';
+const REMINDER_SAVE_PROTECTION_MS = 90_000;
+const REMINDER_DIAGNOSTIC_BUILD = 'reminder-authoritative-scheduler-v3-2026-07-28';
 
 let maintenancePromise: Promise<void> | null = null;
 let lastMaintenanceStartedAt = 0;
+let lastReminderSubmitAt = 0;
 
 export function shouldRefreshNativeSession(
   expiresAt: number | null | undefined,
@@ -29,6 +34,15 @@ export function shouldRefreshNativeSession(
   }
 
   return expiresAt - now <= NATIVE_SESSION_REFRESH_WINDOW_MS;
+}
+
+function isDailyReminderForm(target: EventTarget | null): target is HTMLFormElement {
+  return target instanceof HTMLFormElement
+    && target.classList.contains('reminder-scheduler-form');
+}
+
+function isReminderSaveProtected(now = Date.now()): boolean {
+  return lastReminderSubmitAt > 0 && now - lastReminderSubmitAt < REMINDER_SAVE_PROTECTION_MS;
 }
 
 async function runNativeReliabilityMaintenance(
@@ -63,6 +77,7 @@ async function runNativeReliabilityMaintenance(
       forced: options?.force === true,
       expiresAt: session.expiresAt,
       shouldRefresh: shouldRefreshNativeSession(session.expiresAt, now),
+      reminderSaveProtected: isReminderSaveProtected(now),
       at: now,
     });
 
@@ -83,6 +98,16 @@ async function runNativeReliabilityMaintenance(
         error: error instanceof Error ? error.message : String(error),
         at: Date.now(),
       });
+    }
+
+    if (isReminderSaveProtected()) {
+      writeMobileDebug('native-reliability:reminder-resync-skipped-after-submit', {
+        reason,
+        protectionMs: REMINDER_SAVE_PROTECTION_MS,
+        elapsedSinceSubmitMs: Date.now() - lastReminderSubmitAt,
+        at: Date.now(),
+      });
+      return;
     }
 
     try {
@@ -106,7 +131,18 @@ async function runNativeReliabilityMaintenance(
         timezone: reminder?.timezone ?? reminder?.timeZone ?? reminder?.time_zone ?? null,
         at: Date.now(),
       });
-      await syncNativeDailyReminderNotification(reminder);
+
+      if (isReminderSaveProtected()) {
+        writeMobileDebug('native-reliability:reminder-resync-discarded-after-fetch', {
+          reason,
+          localTime: reminder?.local_time ?? reminder?.localTime ?? null,
+          elapsedSinceSubmitMs: Date.now() - lastReminderSubmitAt,
+          at: Date.now(),
+        });
+        return;
+      }
+
+      await syncNativeDailyReminderNotification(reminder, { source: 'lifecycle' });
       writeMobileDebug('native-reliability:reminder-resynced', {
         reason,
         forced: options?.force === true,
@@ -132,25 +168,6 @@ async function runNativeReliabilityMaintenance(
   return maintenancePromise;
 }
 
-function isDailyReminderForm(target: EventTarget | null): target is HTMLFormElement {
-  return target instanceof HTMLFormElement
-    && target.classList.contains('reminder-scheduler-form');
-}
-
-function readReminderUiOutcome(): 'success' | 'error' | null {
-  const text = document.body?.innerText ?? '';
-  if (text.includes('Guardamos tus recordatorios.')) {
-    return 'success';
-  }
-  if (
-    text.includes('No pudimos guardar tus recordatorios.')
-    || text.includes('Necesitamos permiso para enviarte notificaciones')
-  ) {
-    return 'error';
-  }
-  return null;
-}
-
 export function NativeReliabilityBridge() {
   useEffect(() => {
     if (!isNativeCapacitorPlatform()) {
@@ -165,16 +182,16 @@ export function NativeReliabilityBridge() {
       at: Date.now(),
     });
 
+    void clearNativeReminderDeliveryState('bridge-mount');
     void runNativeReliabilityMaintenance('mount');
 
     const app = getCapacitorAppPlugin();
     let appStateHandle: Awaited<ReturnType<NonNullable<typeof app>['addListener']>> | null = null;
-    let lastUiOutcome: 'success' | 'error' | null = null;
-    let reminderSubmitPending = false;
 
     if (app) {
       void Promise.resolve(app.addListener('appStateChange', ({ isActive }) => {
         if (isActive) {
+          void clearNativeReminderDeliveryState('app-active');
           void runNativeReliabilityMaintenance('app-active');
         }
       })).then((handle) => {
@@ -191,15 +208,15 @@ export function NativeReliabilityBridge() {
         return;
       }
 
-      reminderSubmitPending = true;
-      lastUiOutcome = null;
+      lastReminderSubmitAt = Date.now();
       writeMobileDebug('reminder-diagnostics:submit-captured', {
         marker: REMINDER_DIAGNOSTIC_BUILD,
         platform: getCapacitorPlatform(),
         native: isNativeCapacitorPlatform(),
         path: window.location.pathname,
         submitterTag: event.submitter instanceof HTMLElement ? event.submitter.tagName : null,
-        at: Date.now(),
+        protectionMs: REMINDER_SAVE_PROTECTION_MS,
+        at: lastReminderSubmitAt,
       });
     };
 
@@ -223,50 +240,16 @@ export function NativeReliabilityBridge() {
       });
     };
 
-    const outcomeObserver = new MutationObserver(() => {
-      const outcome = readReminderUiOutcome();
-      if (!outcome || outcome === lastUiOutcome) {
-        return;
-      }
-      lastUiOutcome = outcome;
-      writeMobileDebug(`reminder-diagnostics:ui-${outcome}`, {
-        marker: REMINDER_DIAGNOSTIC_BUILD,
-        platform: getCapacitorPlatform(),
-        path: window.location.pathname,
-        submitPending: reminderSubmitPending,
-        at: Date.now(),
-      });
-
-      if (outcome === 'success' && reminderSubmitPending) {
-        reminderSubmitPending = false;
-        writeMobileDebug('reminder-diagnostics:post-save-resync-start', {
-          marker: REMINDER_DIAGNOSTIC_BUILD,
-          platform: getCapacitorPlatform(),
-          path: window.location.pathname,
-          at: Date.now(),
-        });
-        void runNativeReliabilityMaintenance('reminder-save-success', { force: true });
-      } else if (outcome === 'error') {
-        reminderSubmitPending = false;
-      }
-    });
-
     window.addEventListener('online', handleOnline);
     window.addEventListener('error', handleWindowError);
     window.addEventListener('unhandledrejection', handleUnhandledRejection);
     document.addEventListener('submit', handleReminderSubmit, true);
-    outcomeObserver.observe(document.body, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    });
 
     return () => {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('error', handleWindowError);
       window.removeEventListener('unhandledrejection', handleUnhandledRejection);
       document.removeEventListener('submit', handleReminderSubmit, true);
-      outcomeObserver.disconnect();
       void appStateHandle?.remove();
     };
   }, []);

--- a/apps/web/src/mobile/localNotifications.ts
+++ b/apps/web/src/mobile/localNotifications.ts
@@ -14,6 +14,7 @@ import { writeMobileDebug } from './mobileDebug';
 const DAILY_REMINDER_NOTIFICATION_CHANNEL_ID = 'daily-quest-reminders';
 const DEFAULT_NOTIFICATION_SOUND = 'default';
 const IOS_INTERRUPTION_LEVEL = 'timeSensitive';
+const USER_SAVE_LIFECYCLE_PROTECTION_MS = 90_000;
 
 export const DAILY_REMINDER_NOTIFICATION_ID = 41001;
 export const DAILY_REMINDER_TEST_NOTIFICATION_ID = 41999;
@@ -24,8 +25,18 @@ type DailyReminderNotificationPermissionResult = {
   exactAlarm?: 'prompt' | 'prompt-with-rationale' | 'granted' | 'denied' | null;
 };
 
+type ReminderSyncSource = 'user-save' | 'lifecycle';
+
+type ReminderSyncOptions = {
+  requestPermissions?: boolean;
+  source?: ReminderSyncSource;
+};
+
 const ONBOARDING_LANGUAGE_STORAGE_KEY = 'innerbloom.onboarding.language';
 let isReminderSyncInProgress = false;
+let isUserSaveSyncInProgress = false;
+let lastUserSaveSyncStartedAt = 0;
+let reminderOperationQueue: Promise<void> = Promise.resolve();
 
 function withNativeDeliveryOptions<T extends Record<string, unknown>>(
   notification: T,
@@ -83,6 +94,32 @@ function isReminderEnabled(reminder: DailyReminderSettingsResponse | null | unde
   if (!reminder) return false;
   if (typeof reminder.enabled === 'boolean') return reminder.enabled;
   return reminder.status === 'active';
+}
+
+function enqueueReminderOperation(operation: () => Promise<void>): Promise<void> {
+  const next = reminderOperationQueue.then(operation, operation);
+  reminderOperationQueue = next.catch(() => undefined);
+  return next;
+}
+
+function isLifecycleSyncProtected(now = Date.now()): boolean {
+  return isUserSaveSyncInProgress || now - lastUserSaveSyncStartedAt < USER_SAVE_LIFECYCLE_PROTECTION_MS;
+}
+
+function describePendingReminder(
+  notifications: Array<Record<string, unknown>> | null | undefined,
+  id: number,
+): Record<string, unknown> | null {
+  const matching = notifications?.find((notification) => notification.id === id);
+  if (!matching) return null;
+
+  const schedule = matching.schedule;
+  return {
+    id: matching.id ?? null,
+    title: matching.title ?? null,
+    schedule: typeof schedule === 'object' && schedule !== null ? schedule : null,
+    extra: typeof matching.extra === 'object' && matching.extra !== null ? matching.extra : null,
+  };
 }
 
 async function readAndroidExactAlarmPermission(
@@ -157,7 +194,7 @@ export async function cancelNativeDailyReminderNotification(): Promise<void> {
   if (!isNativeCapacitorPlatform()) return;
 
   if (isReminderSyncInProgress || typeof window === 'undefined') {
-    await performNativeDailyReminderCancellation();
+    await enqueueReminderOperation(performNativeDailyReminderCancellation);
     return;
   }
 
@@ -167,7 +204,7 @@ export async function cancelNativeDailyReminderNotification(): Promise<void> {
       logNativeReminder('cancel-skipped-for-logout');
       return;
     }
-    void performNativeDailyReminderCancellation().catch((error) => {
+    void enqueueReminderOperation(performNativeDailyReminderCancellation).catch((error) => {
       logNativeReminder('cancel-failed', {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -194,6 +231,24 @@ async function ensureAndroidReminderChannel(): Promise<void> {
   });
 }
 
+export async function clearNativeReminderDeliveryState(reason: string): Promise<void> {
+  if (!isNativeCapacitorPlatform()) return;
+  const plugin = getCapacitorLocalNotificationsPlugin();
+  if (!plugin) return;
+
+  const deliveredPlugin = plugin as typeof plugin & {
+    removeAllDeliveredNotifications?: () => Promise<void>;
+  };
+
+  await deliveredPlugin.removeAllDeliveredNotifications?.().catch((error) => {
+    logNativeReminder('delivered-clear-failed', {
+      reason,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+  logNativeReminder('delivered-cleared', { reason });
+}
+
 export async function sendNativeDailyReminderTestNotification(): Promise<void> {
   if (!isNativeCapacitorPlatform()) {
     logNativeReminder('test-skip-not-native');
@@ -212,142 +267,183 @@ export async function sendNativeDailyReminderTestNotification(): Promise<void> {
     throw new Error(tNotification('dailyQuest.mobile.permissionRequired'));
   }
 
-  await ensureAndroidReminderChannel();
-  await plugin.cancel({ notifications: [{ id: DAILY_REMINDER_TEST_NOTIFICATION_ID }] });
-  await plugin.schedule({
-    notifications: [withNativeDeliveryOptions({
-      id: DAILY_REMINDER_TEST_NOTIFICATION_ID,
-      title: tNotification('dailyQuest.mobile.testNotification.title'),
-      body: tNotification('dailyQuest.mobile.testNotification.body'),
-      channelId: DAILY_REMINDER_NOTIFICATION_CHANNEL_ID,
-      schedule: {
-        at: new Date(Date.now() + 10_000),
-        allowWhileIdle: true,
-      },
-      extra: {
-        targetPath: DAILY_REMINDER_NOTIFICATION_TARGET_PATH,
-        kind: 'daily-reminder-test',
-      },
-    })],
-  });
+  await enqueueReminderOperation(async () => {
+    await ensureAndroidReminderChannel();
+    await plugin.cancel({ notifications: [{ id: DAILY_REMINDER_TEST_NOTIFICATION_ID }] });
+    await plugin.schedule({
+      notifications: [withNativeDeliveryOptions({
+        id: DAILY_REMINDER_TEST_NOTIFICATION_ID,
+        title: tNotification('dailyQuest.mobile.testNotification.title'),
+        body: tNotification('dailyQuest.mobile.testNotification.body'),
+        badge: 1,
+        channelId: DAILY_REMINDER_NOTIFICATION_CHANNEL_ID,
+        schedule: {
+          at: new Date(Date.now() + 10_000),
+          allowWhileIdle: true,
+        },
+        extra: {
+          targetPath: DAILY_REMINDER_NOTIFICATION_TARGET_PATH,
+          kind: 'daily-reminder-test',
+        },
+      })],
+    });
 
-  const pending = await plugin.getPending?.().catch(() => null);
-  logNativeReminder('test-scheduled', {
-    id: DAILY_REMINDER_TEST_NOTIFICATION_ID,
-    sound: DEFAULT_NOTIFICATION_SOUND,
-    interruptionLevel: getCapacitorPlatform() === 'ios' ? IOS_INTERRUPTION_LEVEL : null,
-    vibration: getCapacitorPlatform() === 'android',
-    pendingIds: pending?.notifications?.map((notification) => notification.id).filter(Boolean) ?? null,
+    const pending = await plugin.getPending?.().catch(() => null);
+    logNativeReminder('test-scheduled', {
+      id: DAILY_REMINDER_TEST_NOTIFICATION_ID,
+      sound: DEFAULT_NOTIFICATION_SOUND,
+      badge: 1,
+      interruptionLevel: getCapacitorPlatform() === 'ios' ? IOS_INTERRUPTION_LEVEL : null,
+      vibration: getCapacitorPlatform() === 'android',
+      pendingIds: pending?.notifications?.map((notification) => notification.id).filter(Boolean) ?? null,
+      pendingNotification: describePendingReminder(pending?.notifications, DAILY_REMINDER_TEST_NOTIFICATION_ID),
+    });
   });
 }
 
 export async function syncNativeDailyReminderNotification(
   reminder: DailyReminderSettingsResponse | null | undefined,
-  options?: { requestPermissions?: boolean },
+  options?: ReminderSyncOptions,
 ): Promise<void> {
   if (!isNativeCapacitorPlatform()) {
     logNativeReminder('sync-skip-not-native');
     return;
   }
 
-  const plugin = getCapacitorLocalNotificationsPlugin();
-  if (!plugin) {
-    logNativeReminder('sync-plugin-missing');
+  const source = options?.source ?? 'lifecycle';
+  if (source === 'lifecycle' && isLifecycleSyncProtected()) {
+    logNativeReminder('sync-lifecycle-skipped-after-user-save', {
+      protectionMs: USER_SAVE_LIFECYCLE_PROTECTION_MS,
+      userSaveInProgress: isUserSaveSyncInProgress,
+      elapsedSinceUserSaveMs: Date.now() - lastUserSaveSyncStartedAt,
+    });
     return;
   }
 
-  isReminderSyncInProgress = true;
+  if (source === 'user-save') {
+    isUserSaveSyncInProgress = true;
+    lastUserSaveSyncStartedAt = Date.now();
+  }
+
   try {
-    if (!isReminderEnabled(reminder)) {
-      logNativeReminder('sync-reminder-disabled', {
-        status: reminder?.status ?? null,
-        enabled: reminder?.enabled ?? null,
-      });
-      await performNativeDailyReminderCancellation();
-      return;
-    }
-
-    const existingPermission = await plugin.checkPermissions();
-    const shouldRequestPermission =
-      options?.requestPermissions === true ||
-      existingPermission.display === 'prompt' ||
-      existingPermission.display === 'prompt-with-rationale';
-    const permissions = shouldRequestPermission
-      ? await ensureNativeDailyReminderNotificationPermissions({ requestExactAlarm: true })
-      : { granted: existingPermission.display === 'granted' };
-
-    if (!permissions.granted) {
-      logNativeReminder('sync-permission-unavailable', {
-        display: existingPermission.display,
-        requestPermissions: shouldRequestPermission,
-      });
-      if (options?.requestPermissions || shouldRequestPermission) {
-        throw new Error(tNotification('dailyQuest.mobile.permissionRequired'));
+    await enqueueReminderOperation(async () => {
+      const plugin = getCapacitorLocalNotificationsPlugin();
+      if (!plugin) {
+        logNativeReminder('sync-plugin-missing');
+        return;
       }
-      return;
-    }
 
-    const { hour, minute, second } = normalizeLocalTimeParts(
-      reminder?.local_time ?? reminder?.localTime ?? '09:00:00',
-    );
+      isReminderSyncInProgress = true;
+      try {
+        if (!isReminderEnabled(reminder)) {
+          logNativeReminder('sync-reminder-disabled', {
+            source,
+            status: reminder?.status ?? null,
+            enabled: reminder?.enabled ?? null,
+          });
+          await performNativeDailyReminderCancellation();
+          return;
+        }
 
-    await ensureAndroidReminderChannel();
+        const existingPermission = await plugin.checkPermissions();
+        const shouldRequestPermission =
+          options?.requestPermissions === true ||
+          existingPermission.display === 'prompt' ||
+          existingPermission.display === 'prompt-with-rationale';
+        const permissions = shouldRequestPermission
+          ? await ensureNativeDailyReminderNotificationPermissions({ requestExactAlarm: true })
+          : { granted: existingPermission.display === 'granted' };
 
-    logNativeReminder('sync-replace-start', {
-      id: DAILY_REMINDER_NOTIFICATION_ID,
-      hour,
-      minute,
-      second,
-      platform: getCapacitorPlatform(),
-      sound: DEFAULT_NOTIFICATION_SOUND,
-      interruptionLevel: getCapacitorPlatform() === 'ios' ? IOS_INTERRUPTION_LEVEL : null,
-      vibration: getCapacitorPlatform() === 'android',
+        if (!permissions.granted) {
+          logNativeReminder('sync-permission-unavailable', {
+            source,
+            display: existingPermission.display,
+            requestPermissions: shouldRequestPermission,
+          });
+          if (options?.requestPermissions || shouldRequestPermission) {
+            throw new Error(tNotification('dailyQuest.mobile.permissionRequired'));
+          }
+          return;
+        }
+
+        const { hour, minute, second } = normalizeLocalTimeParts(
+          reminder?.local_time ?? reminder?.localTime ?? '09:00:00',
+        );
+
+        await ensureAndroidReminderChannel();
+
+        logNativeReminder('sync-replace-start', {
+          source,
+          id: DAILY_REMINDER_NOTIFICATION_ID,
+          hour,
+          minute,
+          second,
+          platform: getCapacitorPlatform(),
+          sound: DEFAULT_NOTIFICATION_SOUND,
+          badge: 1,
+          interruptionLevel: getCapacitorPlatform() === 'ios' ? IOS_INTERRUPTION_LEVEL : null,
+          vibration: getCapacitorPlatform() === 'android',
+        });
+
+        await plugin.cancel({ notifications: [{ id: DAILY_REMINDER_NOTIFICATION_ID }] });
+        logNativeReminder('sync-previous-cancelled', { source, id: DAILY_REMINDER_NOTIFICATION_ID });
+
+        await plugin.schedule({
+          notifications: [withNativeDeliveryOptions({
+            id: DAILY_REMINDER_NOTIFICATION_ID,
+            title: tNotification('dailyQuest.mobile.notification.title'),
+            body: tNotification('dailyQuest.mobile.notification.body'),
+            badge: 1,
+            channelId: DAILY_REMINDER_NOTIFICATION_CHANNEL_ID,
+            smallIcon: 'ic_stat_innerbloom',
+            iconColor: '#A855F7',
+            schedule: {
+              on: { hour, minute, second },
+              allowWhileIdle: true,
+            },
+            extra: {
+              targetPath: DAILY_REMINDER_NOTIFICATION_TARGET_PATH,
+              kind: 'daily-reminder',
+            },
+          })],
+        });
+
+        const pending = await plugin.getPending?.().catch((error) => {
+          logNativeReminder('sync-pending-check-failed', {
+            source,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        });
+        const pendingIds = pending?.notifications?.map((notification) => notification.id).filter(Boolean) ?? null;
+        const confirmed = pendingIds?.includes(DAILY_REMINDER_NOTIFICATION_ID) ?? false;
+        const pendingNotification = describePendingReminder(
+          pending?.notifications,
+          DAILY_REMINDER_NOTIFICATION_ID,
+        );
+        logNativeReminder('sync-scheduled', {
+          source,
+          id: DAILY_REMINDER_NOTIFICATION_ID,
+          hour,
+          minute,
+          second,
+          sound: DEFAULT_NOTIFICATION_SOUND,
+          badge: 1,
+          interruptionLevel: getCapacitorPlatform() === 'ios' ? IOS_INTERRUPTION_LEVEL : null,
+          pendingIds,
+          pendingNotification,
+          confirmed,
+        });
+        if (pending && !confirmed) {
+          throw new Error(tNotification('dailyQuest.mobile.permissionRequired'));
+        }
+      } finally {
+        isReminderSyncInProgress = false;
+      }
     });
-
-    await plugin.cancel({ notifications: [{ id: DAILY_REMINDER_NOTIFICATION_ID }] });
-    logNativeReminder('sync-previous-cancelled', { id: DAILY_REMINDER_NOTIFICATION_ID });
-
-    await plugin.schedule({
-      notifications: [withNativeDeliveryOptions({
-        id: DAILY_REMINDER_NOTIFICATION_ID,
-        title: tNotification('dailyQuest.mobile.notification.title'),
-        body: tNotification('dailyQuest.mobile.notification.body'),
-        channelId: DAILY_REMINDER_NOTIFICATION_CHANNEL_ID,
-        smallIcon: 'ic_stat_innerbloom',
-        iconColor: '#A855F7',
-        schedule: {
-          on: { hour, minute, second },
-          allowWhileIdle: true,
-        },
-        extra: {
-          targetPath: DAILY_REMINDER_NOTIFICATION_TARGET_PATH,
-          kind: 'daily-reminder',
-        },
-      })],
-    });
-
-    const pending = await plugin.getPending?.().catch((error) => {
-      logNativeReminder('sync-pending-check-failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return null;
-    });
-    const pendingIds = pending?.notifications?.map((notification) => notification.id).filter(Boolean) ?? null;
-    const confirmed = pendingIds?.includes(DAILY_REMINDER_NOTIFICATION_ID) ?? false;
-    logNativeReminder('sync-scheduled', {
-      id: DAILY_REMINDER_NOTIFICATION_ID,
-      hour,
-      minute,
-      second,
-      sound: DEFAULT_NOTIFICATION_SOUND,
-      interruptionLevel: getCapacitorPlatform() === 'ios' ? IOS_INTERRUPTION_LEVEL : null,
-      pendingIds,
-      confirmed,
-    });
-    if (pending && !confirmed) {
-      throw new Error(tNotification('dailyQuest.mobile.permissionRequired'));
-    }
   } finally {
-    isReminderSyncInProgress = false;
+    if (source === 'user-save') {
+      isUserSaveSyncInProgress = false;
+    }
   }
 }


### PR DESCRIPTION
## Objetivo

Corregir el comportamiento observado en iOS donde el horario recién guardado podía ser reemplazado por una resincronización posterior, y dejar una base local reutilizable para futuras notificaciones móviles.

La sesión/autenticación queda completamente fuera de esta PR.

## Análisis realizado

Se revisaron conjuntamente:

- el submit y guardado backend en `DailyReminderSettings`;
- el scheduler local de Capacitor;
- el bridge de mantenimiento en mount/app-active/online;
- el job backend de correo y su regla `last_sent_at`;
- el listener de notificaciones locales;
- la API oficial de `@capacitor/local-notifications` para pending/delivered notifications y badge.

El límite de una entrega por día existe únicamente en el job de **email**. Las notificaciones locales no consultan `last_sent_at`, el estado del Daily Quest ni si ya hubo una entrega ese día.

El riesgo real era que el submit programaba el horario nuevo y, después, el observer post-save volvía a hacer GET al backend y reprogramaba el mismo ID `41001`. Además mount/app-active/online podían competir con un guardado reciente.

## Cambios

1. Elimina completamente el observer que buscaba texto de éxito en la UI y ejecutaba una segunda resincronización post-save.
2. Mantiene el guardado backend existente y la programación directa que ya ocurre dentro del submit.
3. Mantiene la recuperación desde backend en mount/app-active/online, pero la bloquea durante 90 segundos después de un submit para que no sobrescriba el horario recién guardado.
4. Vuelve a comprobar la protección después del GET: una respuesta iniciada antes del submit también se descarta si terminó después.
5. Serializa operaciones locales de cancelación/programación para que dos escrituras sobre el mismo ID no se intercalen.
6. Amplía los logs de `getPending()` para incluir el trigger efectivo, no solo el ID.
7. Añade una prueba local independiente con ID `41999`, programada a 10 segundos y repetible ilimitadamente desde el diálogo de recordatorios.
8. Añade `badge: 1` tanto al recordatorio diario como a la prueba.
9. Limpia notificaciones entregadas/badge cuando la app vuelve a primer plano.
10. No modifica el job de correo, `last_sent_at`, timezone, Neon, Clerk ni la renovación de sesión.

## IDs reservados

- `41001`: Daily Quest diario.
- `41999`: prueba local manual.

La prueba cancela solo su propio ID antes de volver a programarse y no modifica el Daily Quest diario.

## Logs esperados

Al guardar:

```text
reminder-diagnostics:submit-captured
mobile-reminder:sync-replace-start
mobile-reminder:sync-previous-cancelled
mobile-reminder:sync-scheduled {
  pendingNotification: { schedule: ... },
  confirmed: true
}
```

Si app-active/online intenta resincronizar cerca del guardado:

```text
native-reliability:reminder-resync-skipped-after-submit
```

o, si el GET ya estaba en curso:

```text
native-reliability:reminder-resync-discarded-after-fetch
```

Para la prueba independiente:

```text
mobile-reminder:test-start
mobile-reminder:test-scheduled {
  id: 41999,
  pendingNotification: ...
}
```

## Validación manual después del merge

Primero mergear también la PR #2350 para restaurar la firma iOS.

```bash
cd /Users/ramirofernandezdeullivarri/Developer/innerbloomv3
git pull
nvm use 24
pnpm install --no-frozen-lockfile
cd apps/mobile
pnpm run sync:ios
```

Después en Xcode:

1. Product → Clean Build Folder.
2. Ejecutar scheme `App` en el iPhone.
3. Abrir el diálogo de recordatorios.
4. Pulsar `Test notification in 10 seconds` varias veces, dejando que cada prueba se entregue antes de repetir.
5. Guardar un horario 5–10 minutos futuro.
6. Confirmar en logs que `pendingNotification.schedule` contiene exactamente la hora nueva.
7. Dejar la aplicación en background/bloquear el teléfono.
8. Abrir la notificación y comprobar que el badge se limpia al volver la app a primer plano.

## Validación de entorno

No pude ejecutar Vite/Xcode desde este entorno. La PR está limitada a tres archivos web y no toca archivos nativos de firma.