### PR TITLE
Add Creative Director output for 2099-01

### DIFF
--- a/marketing/agent-outputs/2099-01/campaign.json
+++ b/marketing/agent-outputs/2099-01/campaign.json
@@ -1,0 +1,9134 @@
+{
+  "schema_version": "1.0",
+  "agent": "innerbloom_creative_director",
+  "period_key": "2099-01",
+  "generated_at": "2026-07-30T00:00:00Z",
+  "campaign": {
+    "campaign_code": "ib_209901",
+    "title": "Direction Through Real Weeks",
+    "objective": "new_users",
+    "status": "review",
+    "strategy_summary": "A 20-post Instagram sequence that moves from specific rigid-habit friction to source-backed adaptive mechanisms and transparent early-product invitations, while preserving three matched, attributable comparisons and distinct funnel reporting.",
+    "language": "English",
+    "platforms": [
+      "instagram"
+    ],
+    "formats": [
+      "static",
+      "carousel"
+    ],
+    "target_post_count": 20,
+    "timezone": "Europe/Madrid",
+    "publishing_start_date": "2099-01-01",
+    "publishing_end_date": "2099-01-31"
+  },
+  "campaign_execution_summary": {
+    "post_count": 20,
+    "format_counts": {
+      "static": 10,
+      "carousel": 10
+    },
+    "pillar_counts": {
+      "real_life_friction": 7,
+      "adaptive_mechanism": 6,
+      "return_without_shame": 4,
+      "early_adopter_loop": 3
+    },
+    "funnel_counts": {
+      "awareness": 9,
+      "consideration": 7,
+      "activation": 4
+    },
+    "asset_slot_count": 50,
+    "notes": [
+      "All posts remain subject to human review.",
+      "Experiment conclusions require the CMO-defined minimum evidence and verified instrumentation."
+    ]
+  },
+  "posts": [
+    {
+      "post_code": "post_001",
+      "sequence_number": 1,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-01T18:00:00+01:00",
+      "content_pillar": "real_life_friction",
+      "funnel_stage": "awareness",
+      "experiment_code": "pain_frame_intent",
+      "audience_tension": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+      "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+      "hook": "A messy Monday does not make your plan meaningless.",
+      "caption": "A messy Monday can expose the limits of a plan built for identical days. Innerbloom approaches habits as something that can adapt to real life while keeping direction. This is a product approach, not a promise of results. Learn how Innerbloom approaches adaptive habits.",
+      "cta": {
+        "label": "Learn how Innerbloom approaches adaptive habits",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "For the provisional audience, posts framing plans that fail on messy weeks will produce a higher landing_cta_clicked rate per attributable landing session than posts framing broken-streak pressure.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions for each message variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_001&ib_post=post_001",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_001",
+        "ib_post": "post_001"
+      },
+      "visible_copy_plan": {
+        "headline": "A messy Monday does not make your plan meaningless.",
+        "supporting_text": "Habits should adapt to real life rather than demand identical days"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate messy Monday as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_core_message_1"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "A messy Monday does not make your plan meaningless.",
+          "Habits should adapt to real life rather than demand identical days",
+          "Learn how Innerbloom approaches adaptive habits"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about messy Monday: A messy Monday does not make your plan meaningless.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_001_asset_01",
+          "post_code": "post_001",
+          "asset_kind": "static",
+          "semantic_purpose": "One-frame editorial statement about messy Monday.",
+          "product_evidence_requirement": "Habits should adapt to real life rather than demand identical days",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "One-frame editorial statement about messy Monday.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ]
+        }
+      ]
+    },
+    {
+      "post_code": "post_002",
+      "sequence_number": 2,
+      "platform": "instagram",
+      "format": "carousel",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-03T18:00:00+01:00",
+      "content_pillar": "adaptive_mechanism",
+      "funnel_stage": "consideration",
+      "experiment_code": "proof_format_intent",
+      "audience_tension": "Adaptive language can sound vague without a concrete mechanism.",
+      "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+      "hook": "Adaptive does not have to mean unstructured.",
+      "caption": "Task Intensity makes adaptive habits more concrete: effort may change while direction remains clear. Innerbloom's early product includes named mechanisms such as task intensity, recalibration, and visible progress. We are testing whether this explanation helps people explore, not claiming effectiveness. Learn how Innerbloom approaches adaptive habits.",
+      "cta": {
+        "label": "Learn how Innerbloom approaches adaptive habits",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "A carousel that connects a real-life problem to a verified product mechanism will produce a higher landing_cta_clicked rate per attributable landing session than a static post using the same mechanism and CTA.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions by format",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_002&ib_post=post_002",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_002",
+        "ib_post": "post_002"
+      },
+      "visible_copy_plan": {
+        "headline": "Adaptive does not have to mean unstructured.",
+        "supporting_text": "Adjusting intensity is different from abandoning direction"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate task intensity as one specific step in the campaign narrative.",
+        "proof_type": "hybrid",
+        "product_evidence": [
+          "cmo_supporting_message_2"
+        ],
+        "screenshot_requirement": "required",
+        "informational_hierarchy": [
+          "Adaptive does not have to mean unstructured.",
+          "Adjusting intensity is different from abandoning direction",
+          "Learn how Innerbloom approaches adaptive habits"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "dark",
+        "truthful_transformations": [
+          "Crop an existing source for legibility without altering its product state."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about task intensity: Adaptive does not have to mean unstructured.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_002_slide_01",
+          "post_code": "post_002",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Recognition slide for the task intensity narrative.",
+          "product_evidence_requirement": "Adjusting intensity is different from abandoning direction",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Recognition slide for the task intensity narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 1
+        },
+        {
+          "asset_code": "post_002_slide_02",
+          "post_code": "post_002",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Tension slide for the task intensity narrative.",
+          "product_evidence_requirement": "Adjusting intensity is different from abandoning direction",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Tension slide for the task intensity narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 2
+        },
+        {
+          "asset_code": "post_002_slide_03",
+          "post_code": "post_002",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Product approach slide for the task intensity narrative.",
+          "product_evidence_requirement": "Adjusting intensity is different from abandoning direction",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [
+            "campaign-ib20-mvp-post-003-innerbloom-mobile-dailyquest-dark-tasks-selection-png"
+          ],
+          "new_binary_may_be_required": false,
+          "alt_text": "Product approach slide for the task intensity narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 3
+        },
+        {
+          "asset_code": "post_002_slide_04",
+          "post_code": "post_002",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Invitation slide for the task intensity narrative.",
+          "product_evidence_requirement": "Adjusting intensity is different from abandoning direction",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Invitation slide for the task intensity narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 4
+        }
+      ],
+      "carousel": {
+        "slide_count": 4,
+        "narrative_arc": "Move from recognition of task intensity, through the audience tension and supported product approach, to an approved invitation.",
+        "slides": [
+          {
+            "slide_number": 1,
+            "narrative_role": "Recognition",
+            "visible_copy": {
+              "headline": "Adaptive does not have to mean unstructured.",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_002_slide_01",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 2,
+            "narrative_role": "Tension",
+            "visible_copy": {
+              "headline": "Adaptive language can sound vague without a concrete mechanism.",
+              "supporting_text": "Keep the idea focused on one real-life decision."
+            },
+            "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_002_slide_02",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 3,
+            "narrative_role": "Product approach",
+            "visible_copy": {
+              "headline": "Adjusting intensity is different from abandoning direction",
+              "supporting_text": "A product approach, not a promised result."
+            },
+            "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+            "visual_proof_requirement": "Use the verified Daily Quest task-selection source.",
+            "asset_code": "post_002_slide_03",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 4,
+            "narrative_role": "Invitation",
+            "visible_copy": {
+              "headline": "Learn how Innerbloom approaches adaptive habits",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_002_slide_04",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "post_code": "post_003",
+      "sequence_number": 3,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-04T18:00:00+01:00",
+      "content_pillar": "return_without_shame",
+      "funnel_stage": "awareness",
+      "experiment_code": "early_adopter_activation",
+      "audience_tension": "A disruption can feel like progress has been erased.",
+      "product_truth_anchor": "Returning is a skill worth designing for",
+      "hook": "Returning is part of the practice.",
+      "caption": "First Return reframes disruption as a moment to recalibrate rather than erase what came before. Innerbloom is designed around returning and visible progress without perfection pressure. The early version is available to explore without any promised outcome. Explore the early version.",
+      "cta": {
+        "label": "Explore the early version",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "An explicit early-adopter co-creation invitation will produce a higher auth_started rate per attributable landing session than a generic try-the-product invitation.",
+      "primary_metric": "auth_started events divided by attributable landing sessions for each CTA variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_003&ib_post=post_003",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_003",
+        "ib_post": "post_003"
+      },
+      "visible_copy_plan": {
+        "headline": "Returning is part of the practice.",
+        "supporting_text": "Returning is a skill worth designing for"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate first return as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_supporting_message_1"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Returning is part of the practice.",
+          "Returning is a skill worth designing for",
+          "Explore the early version"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about first return: Returning is part of the practice.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_003_asset_01",
+          "post_code": "post_003",
+          "asset_kind": "static",
+          "semantic_purpose": "One-frame editorial statement about first return.",
+          "product_evidence_requirement": "Returning is a skill worth designing for",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "One-frame editorial statement about first return.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ]
+        }
+      ]
+    },
+    {
+      "post_code": "post_004",
+      "sequence_number": 4,
+      "platform": "instagram",
+      "format": "carousel",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-06T18:00:00+01:00",
+      "content_pillar": "real_life_friction",
+      "funnel_stage": "awareness",
+      "experiment_code": "pain_frame_intent",
+      "audience_tension": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+      "product_truth_anchor": "Visible progress can matter without perfection pressure",
+      "hook": "One missed day is not the whole story.",
+      "caption": "A broken streak can expose the limits of a plan built for identical days. Innerbloom approaches habits as something that can adapt to real life while keeping direction. This is a product approach, not a promise of results. Learn how Innerbloom approaches adaptive habits.",
+      "cta": {
+        "label": "Learn how Innerbloom approaches adaptive habits",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "For the provisional audience, posts framing plans that fail on messy weeks will produce a higher landing_cta_clicked rate per attributable landing session than posts framing broken-streak pressure.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions for each message variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_004&ib_post=post_004",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_004",
+        "ib_post": "post_004"
+      },
+      "visible_copy_plan": {
+        "headline": "One missed day is not the whole story.",
+        "supporting_text": "Visible progress can matter without perfection pressure"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate broken streak as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_core_message_3"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "One missed day is not the whole story.",
+          "Visible progress can matter without perfection pressure",
+          "Learn how Innerbloom approaches adaptive habits"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about broken streak: One missed day is not the whole story.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_004_slide_01",
+          "post_code": "post_004",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Recognition slide for the broken streak narrative.",
+          "product_evidence_requirement": "Visible progress can matter without perfection pressure",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Recognition slide for the broken streak narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 1
+        },
+        {
+          "asset_code": "post_004_slide_02",
+          "post_code": "post_004",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Tension slide for the broken streak narrative.",
+          "product_evidence_requirement": "Visible progress can matter without perfection pressure",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Tension slide for the broken streak narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 2
+        },
+        {
+          "asset_code": "post_004_slide_03",
+          "post_code": "post_004",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Product approach slide for the broken streak narrative.",
+          "product_evidence_requirement": "Visible progress can matter without perfection pressure",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Product approach slide for the broken streak narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 3
+        },
+        {
+          "asset_code": "post_004_slide_04",
+          "post_code": "post_004",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Invitation slide for the broken streak narrative.",
+          "product_evidence_requirement": "Visible progress can matter without perfection pressure",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Invitation slide for the broken streak narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 4
+        }
+      ],
+      "carousel": {
+        "slide_count": 4,
+        "narrative_arc": "Move from recognition of broken streak, through the audience tension and supported product approach, to an approved invitation.",
+        "slides": [
+          {
+            "slide_number": 1,
+            "narrative_role": "Recognition",
+            "visible_copy": {
+              "headline": "One missed day is not the whole story.",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Visible progress can matter without perfection pressure",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_004_slide_01",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 2,
+            "narrative_role": "Tension",
+            "visible_copy": {
+              "headline": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+              "supporting_text": "Keep the idea focused on one real-life decision."
+            },
+            "product_truth_anchor": "Visible progress can matter without perfection pressure",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_004_slide_02",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 3,
+            "narrative_role": "Product approach",
+            "visible_copy": {
+              "headline": "Visible progress can matter without perfection pressure",
+              "supporting_text": "A product approach, not a promised result."
+            },
+            "product_truth_anchor": "Visible progress can matter without perfection pressure",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_004_slide_03",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 4,
+            "narrative_role": "Invitation",
+            "visible_copy": {
+              "headline": "Learn how Innerbloom approaches adaptive habits",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Visible progress can matter without perfection pressure",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_004_slide_04",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "post_code": "post_005",
+      "sequence_number": 5,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-07T18:00:00+01:00",
+      "content_pillar": "early_adopter_loop",
+      "funnel_stage": "activation",
+      "experiment_code": "early_adopter_activation",
+      "audience_tension": "An early product must earn exploration through clarity and honesty.",
+      "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+      "hook": "Rigid habit tools not working for you?",
+      "caption": "Transparent Invitation is an invitation for people who recognize the limits of rigid habit tools. Innerbloom is an early product, and feedback is welcome after real product exposure. The invitation does not imply established outcomes. Try the early version.",
+      "cta": {
+        "label": "Try the early version",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "An explicit early-adopter co-creation invitation will produce a higher auth_started rate per attributable landing session than a generic try-the-product invitation.",
+      "primary_metric": "auth_started events divided by attributable landing sessions for each CTA variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_005&ib_post=post_005",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_005",
+        "ib_post": "post_005"
+      },
+      "visible_copy_plan": {
+        "headline": "Rigid habit tools not working for you?",
+        "supporting_text": "The early product is open to feedback from people who experience this problem"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate transparent invitation as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_supporting_message_3"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Rigid habit tools not working for you?",
+          "The early product is open to feedback from people who experience this problem",
+          "Try the early version"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about transparent invitation: Rigid habit tools not working for you?",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_005_asset_01",
+          "post_code": "post_005",
+          "asset_kind": "static",
+          "semantic_purpose": "One-frame editorial statement about transparent invitation.",
+          "product_evidence_requirement": "The early product is open to feedback from people who experience this problem",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "One-frame editorial statement about transparent invitation.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ]
+        }
+      ]
+    },
+    {
+      "post_code": "post_006",
+      "sequence_number": 6,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-09T18:00:00+01:00",
+      "content_pillar": "adaptive_mechanism",
+      "funnel_stage": "consideration",
+      "experiment_code": "proof_format_intent",
+      "audience_tension": "Adaptive language can sound vague without a concrete mechanism.",
+      "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+      "hook": "Task intensity can change without losing direction.",
+      "caption": "Daily Quest Selection makes adaptive habits more concrete: effort may change while direction remains clear. Innerbloom's early product includes named mechanisms such as task intensity, recalibration, and visible progress. We are testing whether this explanation helps people explore, not claiming effectiveness. Explore the early version.",
+      "cta": {
+        "label": "Explore the early version",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "A carousel that connects a real-life problem to a verified product mechanism will produce a higher landing_cta_clicked rate per attributable landing session than a static post using the same mechanism and CTA.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions by format",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_006&ib_post=post_006",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_006",
+        "ib_post": "post_006"
+      },
+      "visible_copy_plan": {
+        "headline": "Task intensity can change without losing direction.",
+        "supporting_text": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate Daily Quest selection as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_proof_point_2"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Task intensity can change without losing direction.",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "Explore the early version"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about Daily Quest selection: Task intensity can change without losing direction.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_006_asset_01",
+          "post_code": "post_006",
+          "asset_kind": "static",
+          "semantic_purpose": "One-frame editorial statement about Daily Quest selection.",
+          "product_evidence_requirement": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "One-frame editorial statement about Daily Quest selection.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ]
+        }
+      ]
+    },
+    {
+      "post_code": "post_007",
+      "sequence_number": 7,
+      "platform": "instagram",
+      "format": "carousel",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-10T18:00:00+01:00",
+      "content_pillar": "real_life_friction",
+      "funnel_stage": "awareness",
+      "experiment_code": "pain_frame_intent",
+      "audience_tension": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+      "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+      "hook": "Your energy changed. Why should the plan pretend otherwise?",
+      "caption": "A energy change can expose the limits of a plan built for identical days. Innerbloom approaches habits as something that can adapt to real life while keeping direction. This is a product approach, not a promise of results. Learn how Innerbloom approaches adaptive habits.",
+      "cta": {
+        "label": "Learn how Innerbloom approaches adaptive habits",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "For the provisional audience, posts framing plans that fail on messy weeks will produce a higher landing_cta_clicked rate per attributable landing session than posts framing broken-streak pressure.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions for each message variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_007&ib_post=post_007",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_007",
+        "ib_post": "post_007"
+      },
+      "visible_copy_plan": {
+        "headline": "Your energy changed. Why should the plan pretend otherwise?",
+        "supporting_text": "Habits should adapt to real life rather than demand identical days"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate energy change as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_core_message_1"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Your energy changed. Why should the plan pretend otherwise?",
+          "Habits should adapt to real life rather than demand identical days",
+          "Learn how Innerbloom approaches adaptive habits"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about energy change: Your energy changed. Why should the plan pretend otherwise?",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_007_slide_01",
+          "post_code": "post_007",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Recognition slide for the energy change narrative.",
+          "product_evidence_requirement": "Habits should adapt to real life rather than demand identical days",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Recognition slide for the energy change narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 1
+        },
+        {
+          "asset_code": "post_007_slide_02",
+          "post_code": "post_007",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Tension slide for the energy change narrative.",
+          "product_evidence_requirement": "Habits should adapt to real life rather than demand identical days",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Tension slide for the energy change narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 2
+        },
+        {
+          "asset_code": "post_007_slide_03",
+          "post_code": "post_007",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Product approach slide for the energy change narrative.",
+          "product_evidence_requirement": "Habits should adapt to real life rather than demand identical days",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Product approach slide for the energy change narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 3
+        },
+        {
+          "asset_code": "post_007_slide_04",
+          "post_code": "post_007",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Invitation slide for the energy change narrative.",
+          "product_evidence_requirement": "Habits should adapt to real life rather than demand identical days",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Invitation slide for the energy change narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 4
+        }
+      ],
+      "carousel": {
+        "slide_count": 4,
+        "narrative_arc": "Move from recognition of energy change, through the audience tension and supported product approach, to an approved invitation.",
+        "slides": [
+          {
+            "slide_number": 1,
+            "narrative_role": "Recognition",
+            "visible_copy": {
+              "headline": "Your energy changed. Why should the plan pretend otherwise?",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_007_slide_01",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 2,
+            "narrative_role": "Tension",
+            "visible_copy": {
+              "headline": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+              "supporting_text": "Keep the idea focused on one real-life decision."
+            },
+            "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_007_slide_02",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 3,
+            "narrative_role": "Product approach",
+            "visible_copy": {
+              "headline": "Habits should adapt to real life rather than demand identical days",
+              "supporting_text": "A product approach, not a promised result."
+            },
+            "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_007_slide_03",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 4,
+            "narrative_role": "Invitation",
+            "visible_copy": {
+              "headline": "Learn how Innerbloom approaches adaptive habits",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_007_slide_04",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "post_code": "post_008",
+      "sequence_number": 8,
+      "platform": "instagram",
+      "format": "carousel",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-12T18:00:00+01:00",
+      "content_pillar": "return_without_shame",
+      "funnel_stage": "consideration",
+      "experiment_code": "early_adopter_activation",
+      "audience_tension": "A disruption can feel like progress has been erased.",
+      "product_truth_anchor": "Recalibration can preserve direction without pretending disruption did not happen",
+      "hook": "Recalibration is different from starting over.",
+      "caption": "Recalibrate Not Erase reframes disruption as a moment to recalibrate rather than erase what came before. Innerbloom is designed around returning and visible progress without perfection pressure. The early version is available to explore without any promised outcome. Explore the early version.",
+      "cta": {
+        "label": "Explore the early version",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "An explicit early-adopter co-creation invitation will produce a higher auth_started rate per attributable landing session than a generic try-the-product invitation.",
+      "primary_metric": "auth_started events divided by attributable landing sessions for each CTA variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_008&ib_post=post_008",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_008",
+        "ib_post": "post_008"
+      },
+      "visible_copy_plan": {
+        "headline": "Recalibration is different from starting over.",
+        "supporting_text": "Recalibration can preserve direction without pretending disruption did not happen"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate recalibrate not erase as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_core_message_2"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Recalibration is different from starting over.",
+          "Recalibration can preserve direction without pretending disruption did not happen",
+          "Explore the early version"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about recalibrate not erase: Recalibration is different from starting over.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_008_slide_01",
+          "post_code": "post_008",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Recognition slide for the recalibrate not erase narrative.",
+          "product_evidence_requirement": "Recalibration can preserve direction without pretending disruption did not happen",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Recognition slide for the recalibrate not erase narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 1
+        },
+        {
+          "asset_code": "post_008_slide_02",
+          "post_code": "post_008",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Tension slide for the recalibrate not erase narrative.",
+          "product_evidence_requirement": "Recalibration can preserve direction without pretending disruption did not happen",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Tension slide for the recalibrate not erase narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 2
+        },
+        {
+          "asset_code": "post_008_slide_03",
+          "post_code": "post_008",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Product approach slide for the recalibrate not erase narrative.",
+          "product_evidence_requirement": "Recalibration can preserve direction without pretending disruption did not happen",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Product approach slide for the recalibrate not erase narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 3
+        },
+        {
+          "asset_code": "post_008_slide_04",
+          "post_code": "post_008",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Invitation slide for the recalibrate not erase narrative.",
+          "product_evidence_requirement": "Recalibration can preserve direction without pretending disruption did not happen",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Invitation slide for the recalibrate not erase narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 4
+        }
+      ],
+      "carousel": {
+        "slide_count": 4,
+        "narrative_arc": "Move from recognition of recalibrate not erase, through the audience tension and supported product approach, to an approved invitation.",
+        "slides": [
+          {
+            "slide_number": 1,
+            "narrative_role": "Recognition",
+            "visible_copy": {
+              "headline": "Recalibration is different from starting over.",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Recalibration can preserve direction without pretending disruption did not happen",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_008_slide_01",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 2,
+            "narrative_role": "Tension",
+            "visible_copy": {
+              "headline": "A disruption can feel like progress has been erased.",
+              "supporting_text": "Keep the idea focused on one real-life decision."
+            },
+            "product_truth_anchor": "Recalibration can preserve direction without pretending disruption did not happen",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_008_slide_02",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 3,
+            "narrative_role": "Product approach",
+            "visible_copy": {
+              "headline": "Recalibration can preserve direction without pretending disruption did not happen",
+              "supporting_text": "A product approach, not a promised result."
+            },
+            "product_truth_anchor": "Recalibration can preserve direction without pretending disruption did not happen",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_008_slide_03",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 4,
+            "narrative_role": "Invitation",
+            "visible_copy": {
+              "headline": "Explore the early version",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Recalibration can preserve direction without pretending disruption did not happen",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_008_slide_04",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "post_code": "post_009",
+      "sequence_number": 9,
+      "platform": "instagram",
+      "format": "carousel",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-13T18:00:00+01:00",
+      "content_pillar": "adaptive_mechanism",
+      "funnel_stage": "consideration",
+      "experiment_code": "proof_format_intent",
+      "audience_tension": "Adaptive language can sound vague without a concrete mechanism.",
+      "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+      "hook": "A weekly review can keep direction visible.",
+      "caption": "Weekly Recalibration makes adaptive habits more concrete: effort may change while direction remains clear. Innerbloom's early product includes named mechanisms such as task intensity, recalibration, and visible progress. We are testing whether this explanation helps people explore, not claiming effectiveness. Learn how Innerbloom approaches adaptive habits.",
+      "cta": {
+        "label": "Learn how Innerbloom approaches adaptive habits",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "A carousel that connects a real-life problem to a verified product mechanism will produce a higher landing_cta_clicked rate per attributable landing session than a static post using the same mechanism and CTA.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions by format",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_009&ib_post=post_009",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_009",
+        "ib_post": "post_009"
+      },
+      "visible_copy_plan": {
+        "headline": "A weekly review can keep direction visible.",
+        "supporting_text": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate weekly recalibration as one specific step in the campaign narrative.",
+        "proof_type": "hybrid",
+        "product_evidence": [
+          "cmo_proof_point_2"
+        ],
+        "screenshot_requirement": "required",
+        "informational_hierarchy": [
+          "A weekly review can keep direction visible.",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "Learn how Innerbloom approaches adaptive habits"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "dark",
+        "truthful_transformations": [
+          "Crop an existing source for legibility without altering its product state."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about weekly recalibration: A weekly review can keep direction visible.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_009_slide_01",
+          "post_code": "post_009",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Recognition slide for the weekly recalibration narrative.",
+          "product_evidence_requirement": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Recognition slide for the weekly recalibration narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 1
+        },
+        {
+          "asset_code": "post_009_slide_02",
+          "post_code": "post_009",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Tension slide for the weekly recalibration narrative.",
+          "product_evidence_requirement": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Tension slide for the weekly recalibration narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 2
+        },
+        {
+          "asset_code": "post_009_slide_03",
+          "post_code": "post_009",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Product approach slide for the weekly recalibration narrative.",
+          "product_evidence_requirement": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [
+            "campaign-ib20-mvp-post-003-innerbloom-mobile-dailyquest-dark-tasks-selection-png"
+          ],
+          "new_binary_may_be_required": false,
+          "alt_text": "Product approach slide for the weekly recalibration narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 3
+        },
+        {
+          "asset_code": "post_009_slide_04",
+          "post_code": "post_009",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Invitation slide for the weekly recalibration narrative.",
+          "product_evidence_requirement": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Invitation slide for the weekly recalibration narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 4
+        }
+      ],
+      "carousel": {
+        "slide_count": 4,
+        "narrative_arc": "Move from recognition of weekly recalibration, through the audience tension and supported product approach, to an approved invitation.",
+        "slides": [
+          {
+            "slide_number": 1,
+            "narrative_role": "Recognition",
+            "visible_copy": {
+              "headline": "A weekly review can keep direction visible.",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_009_slide_01",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 2,
+            "narrative_role": "Tension",
+            "visible_copy": {
+              "headline": "Adaptive language can sound vague without a concrete mechanism.",
+              "supporting_text": "Keep the idea focused on one real-life decision."
+            },
+            "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_009_slide_02",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 3,
+            "narrative_role": "Product approach",
+            "visible_copy": {
+              "headline": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+              "supporting_text": "A product approach, not a promised result."
+            },
+            "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+            "visual_proof_requirement": "Use the verified Daily Quest task-selection source.",
+            "asset_code": "post_009_slide_03",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 4,
+            "narrative_role": "Invitation",
+            "visible_copy": {
+              "headline": "Learn how Innerbloom approaches adaptive habits",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_009_slide_04",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "post_code": "post_010",
+      "sequence_number": 10,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-15T18:00:00+01:00",
+      "content_pillar": "real_life_friction",
+      "funnel_stage": "awareness",
+      "experiment_code": "pain_frame_intent",
+      "audience_tension": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+      "product_truth_anchor": "real-life rhythm",
+      "hook": "Real weeks rarely match perfect calendars.",
+      "caption": "A calendar collision can expose the limits of a plan built for identical days. Innerbloom approaches habits as something that can adapt to real life while keeping direction. This is a product approach, not a promise of results. Learn how Innerbloom approaches adaptive habits.",
+      "cta": {
+        "label": "Learn how Innerbloom approaches adaptive habits",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "For the provisional audience, posts framing plans that fail on messy weeks will produce a higher landing_cta_clicked rate per attributable landing session than posts framing broken-streak pressure.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions for each message variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_010&ib_post=post_010",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_010",
+        "ib_post": "post_010"
+      },
+      "visible_copy_plan": {
+        "headline": "Real weeks rarely match perfect calendars.",
+        "supporting_text": "real-life rhythm"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate calendar collision as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "positioning_4"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Real weeks rarely match perfect calendars.",
+          "real-life rhythm",
+          "Learn how Innerbloom approaches adaptive habits"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about calendar collision: Real weeks rarely match perfect calendars.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_010_asset_01",
+          "post_code": "post_010",
+          "asset_kind": "static",
+          "semantic_purpose": "One-frame editorial statement about calendar collision.",
+          "product_evidence_requirement": "real-life rhythm",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "One-frame editorial statement about calendar collision.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ]
+        }
+      ]
+    },
+    {
+      "post_code": "post_011",
+      "sequence_number": 11,
+      "platform": "instagram",
+      "format": "carousel",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-16T18:00:00+01:00",
+      "content_pillar": "early_adopter_loop",
+      "funnel_stage": "activation",
+      "experiment_code": "early_adopter_activation",
+      "audience_tension": "An early product must earn exploration through clarity and honesty.",
+      "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+      "hook": "Try an early product. Then tell us what felt useful.",
+      "caption": "Co-Creation Invitation is an invitation for people who recognize the limits of rigid habit tools. Innerbloom is an early product, and feedback is welcome after real product exposure. The invitation does not imply established outcomes. Share feedback after exploring the dashboard.",
+      "cta": {
+        "label": "Share feedback after exploring the dashboard",
+        "intent": "Visit the tracked Innerbloom landing page to share feedback after product exposure",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "An explicit early-adopter co-creation invitation will produce a higher auth_started rate per attributable landing session than a generic try-the-product invitation.",
+      "primary_metric": "auth_started events divided by attributable landing sessions for each CTA variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_011&ib_post=post_011",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_011",
+        "ib_post": "post_011"
+      },
+      "visible_copy_plan": {
+        "headline": "Try an early product. Then tell us what felt useful.",
+        "supporting_text": "The early product is open to feedback from people who experience this problem"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate co-creation invitation as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_supporting_message_3"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Try an early product. Then tell us what felt useful.",
+          "The early product is open to feedback from people who experience this problem",
+          "Share feedback after exploring the dashboard"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about co-creation invitation: Try an early product. Then tell us what felt useful.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_011_slide_01",
+          "post_code": "post_011",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Recognition slide for the co-creation invitation narrative.",
+          "product_evidence_requirement": "The early product is open to feedback from people who experience this problem",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Recognition slide for the co-creation invitation narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 1
+        },
+        {
+          "asset_code": "post_011_slide_02",
+          "post_code": "post_011",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Tension slide for the co-creation invitation narrative.",
+          "product_evidence_requirement": "The early product is open to feedback from people who experience this problem",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Tension slide for the co-creation invitation narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 2
+        },
+        {
+          "asset_code": "post_011_slide_03",
+          "post_code": "post_011",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Product approach slide for the co-creation invitation narrative.",
+          "product_evidence_requirement": "The early product is open to feedback from people who experience this problem",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Product approach slide for the co-creation invitation narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 3
+        },
+        {
+          "asset_code": "post_011_slide_04",
+          "post_code": "post_011",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Invitation slide for the co-creation invitation narrative.",
+          "product_evidence_requirement": "The early product is open to feedback from people who experience this problem",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Invitation slide for the co-creation invitation narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 4
+        }
+      ],
+      "carousel": {
+        "slide_count": 4,
+        "narrative_arc": "Move from recognition of co-creation invitation, through the audience tension and supported product approach, to an approved invitation.",
+        "slides": [
+          {
+            "slide_number": 1,
+            "narrative_role": "Recognition",
+            "visible_copy": {
+              "headline": "Try an early product. Then tell us what felt useful.",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_011_slide_01",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 2,
+            "narrative_role": "Tension",
+            "visible_copy": {
+              "headline": "An early product must earn exploration through clarity and honesty.",
+              "supporting_text": "Keep the idea focused on one real-life decision."
+            },
+            "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_011_slide_02",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 3,
+            "narrative_role": "Product approach",
+            "visible_copy": {
+              "headline": "The early product is open to feedback from people who experience this problem",
+              "supporting_text": "A product approach, not a promised result."
+            },
+            "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_011_slide_03",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 4,
+            "narrative_role": "Invitation",
+            "visible_copy": {
+              "headline": "Share feedback after exploring the dashboard",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_011_slide_04",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "post_code": "post_012",
+      "sequence_number": 12,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-18T18:00:00+01:00",
+      "content_pillar": "adaptive_mechanism",
+      "funnel_stage": "consideration",
+      "experiment_code": "proof_format_intent",
+      "audience_tension": "Adaptive language can sound vague without a concrete mechanism.",
+      "product_truth_anchor": "Visible progress can matter without perfection pressure",
+      "hook": "Progress can stay visible without demanding perfection.",
+      "caption": "Visible Momentum makes adaptive habits more concrete: effort may change while direction remains clear. Innerbloom's early product includes named mechanisms such as task intensity, recalibration, and visible progress. We are testing whether this explanation helps people explore, not claiming effectiveness. Explore the early version.",
+      "cta": {
+        "label": "Explore the early version",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "A carousel that connects a real-life problem to a verified product mechanism will produce a higher landing_cta_clicked rate per attributable landing session than a static post using the same mechanism and CTA.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions by format",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_012&ib_post=post_012",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_012",
+        "ib_post": "post_012"
+      },
+      "visible_copy_plan": {
+        "headline": "Progress can stay visible without demanding perfection.",
+        "supporting_text": "Visible progress can matter without perfection pressure"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate visible momentum as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_core_message_3"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Progress can stay visible without demanding perfection.",
+          "Visible progress can matter without perfection pressure",
+          "Explore the early version"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about visible momentum: Progress can stay visible without demanding perfection.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_012_asset_01",
+          "post_code": "post_012",
+          "asset_kind": "static",
+          "semantic_purpose": "One-frame editorial statement about visible momentum.",
+          "product_evidence_requirement": "Visible progress can matter without perfection pressure",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "One-frame editorial statement about visible momentum.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ]
+        }
+      ]
+    },
+    {
+      "post_code": "post_013",
+      "sequence_number": 13,
+      "platform": "instagram",
+      "format": "carousel",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-19T18:00:00+01:00",
+      "content_pillar": "real_life_friction",
+      "funnel_stage": "awareness",
+      "experiment_code": "pain_frame_intent",
+      "audience_tension": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+      "product_truth_anchor": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+      "hook": "When the week bends, the habit plan can bend too.",
+      "caption": "A messy week comparison can expose the limits of a plan built for identical days. Innerbloom approaches habits as something that can adapt to real life while keeping direction. This is a product approach, not a promise of results. Learn how Innerbloom approaches adaptive habits.",
+      "cta": {
+        "label": "Learn how Innerbloom approaches adaptive habits",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "For the provisional audience, posts framing plans that fail on messy weeks will produce a higher landing_cta_clicked rate per attributable landing session than posts framing broken-streak pressure.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions for each message variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_013&ib_post=post_013",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_013",
+        "ib_post": "post_013"
+      },
+      "visible_copy_plan": {
+        "headline": "When the week bends, the habit plan can bend too.",
+        "supporting_text": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity."
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate messy week comparison as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "positioning_1"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "When the week bends, the habit plan can bend too.",
+          "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+          "Learn how Innerbloom approaches adaptive habits"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about messy week comparison: When the week bends, the habit plan can bend too.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_013_slide_01",
+          "post_code": "post_013",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Recognition slide for the messy week comparison narrative.",
+          "product_evidence_requirement": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Recognition slide for the messy week comparison narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 1
+        },
+        {
+          "asset_code": "post_013_slide_02",
+          "post_code": "post_013",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Tension slide for the messy week comparison narrative.",
+          "product_evidence_requirement": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Tension slide for the messy week comparison narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 2
+        },
+        {
+          "asset_code": "post_013_slide_03",
+          "post_code": "post_013",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Product approach slide for the messy week comparison narrative.",
+          "product_evidence_requirement": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Product approach slide for the messy week comparison narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 3
+        },
+        {
+          "asset_code": "post_013_slide_04",
+          "post_code": "post_013",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Invitation slide for the messy week comparison narrative.",
+          "product_evidence_requirement": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Invitation slide for the messy week comparison narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 4
+        }
+      ],
+      "carousel": {
+        "slide_count": 4,
+        "narrative_arc": "Move from recognition of messy week comparison, through the audience tension and supported product approach, to an approved invitation.",
+        "slides": [
+          {
+            "slide_number": 1,
+            "narrative_role": "Recognition",
+            "visible_copy": {
+              "headline": "When the week bends, the habit plan can bend too.",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_013_slide_01",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 2,
+            "narrative_role": "Tension",
+            "visible_copy": {
+              "headline": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+              "supporting_text": "Keep the idea focused on one real-life decision."
+            },
+            "product_truth_anchor": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_013_slide_02",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 3,
+            "narrative_role": "Product approach",
+            "visible_copy": {
+              "headline": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+              "supporting_text": "A product approach, not a promised result."
+            },
+            "product_truth_anchor": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_013_slide_03",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 4,
+            "narrative_role": "Invitation",
+            "visible_copy": {
+              "headline": "Learn how Innerbloom approaches adaptive habits",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_013_slide_04",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "post_code": "post_014",
+      "sequence_number": 14,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-21T18:00:00+01:00",
+      "content_pillar": "return_without_shame",
+      "funnel_stage": "awareness",
+      "experiment_code": "early_adopter_activation",
+      "audience_tension": "A disruption can feel like progress has been erased.",
+      "product_truth_anchor": "Returning is a skill worth designing for",
+      "hook": "You can return without calling everything a failure.",
+      "caption": "Gentler Restart reframes disruption as a moment to recalibrate rather than erase what came before. Innerbloom is designed around returning and visible progress without perfection pressure. The early version is available to explore without any promised outcome. Try the early version.",
+      "cta": {
+        "label": "Try the early version",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "An explicit early-adopter co-creation invitation will produce a higher auth_started rate per attributable landing session than a generic try-the-product invitation.",
+      "primary_metric": "auth_started events divided by attributable landing sessions for each CTA variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_014&ib_post=post_014",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_014",
+        "ib_post": "post_014"
+      },
+      "visible_copy_plan": {
+        "headline": "You can return without calling everything a failure.",
+        "supporting_text": "Returning is a skill worth designing for"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate gentler restart as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_supporting_message_1"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "You can return without calling everything a failure.",
+          "Returning is a skill worth designing for",
+          "Try the early version"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about gentler restart: You can return without calling everything a failure.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_014_asset_01",
+          "post_code": "post_014",
+          "asset_kind": "static",
+          "semantic_purpose": "One-frame editorial statement about gentler restart.",
+          "product_evidence_requirement": "Returning is a skill worth designing for",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "One-frame editorial statement about gentler restart.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ]
+        }
+      ]
+    },
+    {
+      "post_code": "post_015",
+      "sequence_number": 15,
+      "platform": "instagram",
+      "format": "carousel",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-22T18:00:00+01:00",
+      "content_pillar": "adaptive_mechanism",
+      "funnel_stage": "consideration",
+      "experiment_code": "proof_format_intent",
+      "audience_tension": "Adaptive language can sound vague without a concrete mechanism.",
+      "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+      "hook": "Visible progress can support the next adjustment.",
+      "caption": "Dashboard Progress makes adaptive habits more concrete: effort may change while direction remains clear. Innerbloom's early product includes named mechanisms such as task intensity, recalibration, and visible progress. We are testing whether this explanation helps people explore, not claiming effectiveness. Explore the early version.",
+      "cta": {
+        "label": "Explore the early version",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "A carousel that connects a real-life problem to a verified product mechanism will produce a higher landing_cta_clicked rate per attributable landing session than a static post using the same mechanism and CTA.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions by format",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_015&ib_post=post_015",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_015",
+        "ib_post": "post_015"
+      },
+      "visible_copy_plan": {
+        "headline": "Visible progress can support the next adjustment.",
+        "supporting_text": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate dashboard progress as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_proof_point_2"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Visible progress can support the next adjustment.",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "Explore the early version"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about dashboard progress: Visible progress can support the next adjustment.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_015_slide_01",
+          "post_code": "post_015",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Recognition slide for the dashboard progress narrative.",
+          "product_evidence_requirement": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Recognition slide for the dashboard progress narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 1
+        },
+        {
+          "asset_code": "post_015_slide_02",
+          "post_code": "post_015",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Tension slide for the dashboard progress narrative.",
+          "product_evidence_requirement": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Tension slide for the dashboard progress narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 2
+        },
+        {
+          "asset_code": "post_015_slide_03",
+          "post_code": "post_015",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Product approach slide for the dashboard progress narrative.",
+          "product_evidence_requirement": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Product approach slide for the dashboard progress narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 3
+        },
+        {
+          "asset_code": "post_015_slide_04",
+          "post_code": "post_015",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Invitation slide for the dashboard progress narrative.",
+          "product_evidence_requirement": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Invitation slide for the dashboard progress narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 4
+        }
+      ],
+      "carousel": {
+        "slide_count": 4,
+        "narrative_arc": "Move from recognition of dashboard progress, through the audience tension and supported product approach, to an approved invitation.",
+        "slides": [
+          {
+            "slide_number": 1,
+            "narrative_role": "Recognition",
+            "visible_copy": {
+              "headline": "Visible progress can support the next adjustment.",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_015_slide_01",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 2,
+            "narrative_role": "Tension",
+            "visible_copy": {
+              "headline": "Adaptive language can sound vague without a concrete mechanism.",
+              "supporting_text": "Keep the idea focused on one real-life decision."
+            },
+            "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_015_slide_02",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 3,
+            "narrative_role": "Product approach",
+            "visible_copy": {
+              "headline": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+              "supporting_text": "A product approach, not a promised result."
+            },
+            "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_015_slide_03",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 4,
+            "narrative_role": "Invitation",
+            "visible_copy": {
+              "headline": "Explore the early version",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_015_slide_04",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "post_code": "post_016",
+      "sequence_number": 16,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-24T18:00:00+01:00",
+      "content_pillar": "real_life_friction",
+      "funnel_stage": "awareness",
+      "experiment_code": "pain_frame_intent",
+      "audience_tension": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+      "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+      "hook": "The same effort every day is not the only structure.",
+      "caption": "A fixed effort can expose the limits of a plan built for identical days. Innerbloom approaches habits as something that can adapt to real life while keeping direction. This is a product approach, not a promise of results. Learn how Innerbloom approaches adaptive habits.",
+      "cta": {
+        "label": "Learn how Innerbloom approaches adaptive habits",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "For the provisional audience, posts framing plans that fail on messy weeks will produce a higher landing_cta_clicked rate per attributable landing session than posts framing broken-streak pressure.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions for each message variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_016&ib_post=post_016",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_016",
+        "ib_post": "post_016"
+      },
+      "visible_copy_plan": {
+        "headline": "The same effort every day is not the only structure.",
+        "supporting_text": "Adjusting intensity is different from abandoning direction"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate fixed effort as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "cmo_supporting_message_2"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "The same effort every day is not the only structure.",
+          "Adjusting intensity is different from abandoning direction",
+          "Learn how Innerbloom approaches adaptive habits"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about fixed effort: The same effort every day is not the only structure.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_016_asset_01",
+          "post_code": "post_016",
+          "asset_kind": "static",
+          "semantic_purpose": "One-frame editorial statement about fixed effort.",
+          "product_evidence_requirement": "Adjusting intensity is different from abandoning direction",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "One-frame editorial statement about fixed effort.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ]
+        }
+      ]
+    },
+    {
+      "post_code": "post_017",
+      "sequence_number": 17,
+      "platform": "instagram",
+      "format": "carousel",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-25T18:00:00+01:00",
+      "content_pillar": "early_adopter_loop",
+      "funnel_stage": "activation",
+      "experiment_code": "early_adopter_activation",
+      "audience_tension": "An early product must earn exploration through clarity and honesty.",
+      "product_truth_anchor": "early product, feedback welcome",
+      "hook": "Explore first. Share informed feedback second.",
+      "caption": "Feedback After Exposure is an invitation for people who recognize the limits of rigid habit tools. Innerbloom is an early product, and feedback is welcome after real product exposure. The invitation does not imply established outcomes. Share feedback after exploring the dashboard.",
+      "cta": {
+        "label": "Share feedback after exploring the dashboard",
+        "intent": "Visit the tracked Innerbloom landing page to share feedback after product exposure",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "An explicit early-adopter co-creation invitation will produce a higher auth_started rate per attributable landing session than a generic try-the-product invitation.",
+      "primary_metric": "auth_started events divided by attributable landing sessions for each CTA variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_017&ib_post=post_017",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_017",
+        "ib_post": "post_017"
+      },
+      "visible_copy_plan": {
+        "headline": "Explore first. Share informed feedback second.",
+        "supporting_text": "early product, feedback welcome"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate feedback after exposure as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "positioning_7"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Explore first. Share informed feedback second.",
+          "early product, feedback welcome",
+          "Share feedback after exploring the dashboard"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about feedback after exposure: Explore first. Share informed feedback second.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_017_slide_01",
+          "post_code": "post_017",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Recognition slide for the feedback after exposure narrative.",
+          "product_evidence_requirement": "early product, feedback welcome",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Recognition slide for the feedback after exposure narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 1
+        },
+        {
+          "asset_code": "post_017_slide_02",
+          "post_code": "post_017",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Tension slide for the feedback after exposure narrative.",
+          "product_evidence_requirement": "early product, feedback welcome",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Tension slide for the feedback after exposure narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 2
+        },
+        {
+          "asset_code": "post_017_slide_03",
+          "post_code": "post_017",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Product approach slide for the feedback after exposure narrative.",
+          "product_evidence_requirement": "early product, feedback welcome",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Product approach slide for the feedback after exposure narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 3
+        },
+        {
+          "asset_code": "post_017_slide_04",
+          "post_code": "post_017",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Invitation slide for the feedback after exposure narrative.",
+          "product_evidence_requirement": "early product, feedback welcome",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Invitation slide for the feedback after exposure narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 4
+        }
+      ],
+      "carousel": {
+        "slide_count": 4,
+        "narrative_arc": "Move from recognition of feedback after exposure, through the audience tension and supported product approach, to an approved invitation.",
+        "slides": [
+          {
+            "slide_number": 1,
+            "narrative_role": "Recognition",
+            "visible_copy": {
+              "headline": "Explore first. Share informed feedback second.",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "early product, feedback welcome",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_017_slide_01",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 2,
+            "narrative_role": "Tension",
+            "visible_copy": {
+              "headline": "An early product must earn exploration through clarity and honesty.",
+              "supporting_text": "Keep the idea focused on one real-life decision."
+            },
+            "product_truth_anchor": "early product, feedback welcome",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_017_slide_02",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 3,
+            "narrative_role": "Product approach",
+            "visible_copy": {
+              "headline": "early product, feedback welcome",
+              "supporting_text": "A product approach, not a promised result."
+            },
+            "product_truth_anchor": "early product, feedback welcome",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_017_slide_03",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 4,
+            "narrative_role": "Invitation",
+            "visible_copy": {
+              "headline": "Share feedback after exploring the dashboard",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "early product, feedback welcome",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_017_slide_04",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "post_code": "post_018",
+      "sequence_number": 18,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-27T18:00:00+01:00",
+      "content_pillar": "adaptive_mechanism",
+      "funnel_stage": "consideration",
+      "experiment_code": "proof_format_intent",
+      "audience_tension": "Adaptive language can sound vague without a concrete mechanism.",
+      "product_truth_anchor": "adaptive habits",
+      "hook": "A clear direction can include different intensities.",
+      "caption": "Adaptive Rhythm makes adaptive habits more concrete: effort may change while direction remains clear. Innerbloom's early product includes named mechanisms such as task intensity, recalibration, and visible progress. We are testing whether this explanation helps people explore, not claiming effectiveness. Try the early version.",
+      "cta": {
+        "label": "Try the early version",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "A carousel that connects a real-life problem to a verified product mechanism will produce a higher landing_cta_clicked rate per attributable landing session than a static post using the same mechanism and CTA.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions by format",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_018&ib_post=post_018",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_018",
+        "ib_post": "post_018"
+      },
+      "visible_copy_plan": {
+        "headline": "A clear direction can include different intensities.",
+        "supporting_text": "adaptive habits"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate adaptive rhythm as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "positioning_3"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "A clear direction can include different intensities.",
+          "adaptive habits",
+          "Try the early version"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about adaptive rhythm: A clear direction can include different intensities.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_018_asset_01",
+          "post_code": "post_018",
+          "asset_kind": "static",
+          "semantic_purpose": "One-frame editorial statement about adaptive rhythm.",
+          "product_evidence_requirement": "adaptive habits",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "One-frame editorial statement about adaptive rhythm.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ]
+        }
+      ]
+    },
+    {
+      "post_code": "post_019",
+      "sequence_number": 19,
+      "platform": "instagram",
+      "format": "carousel",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-29T18:00:00+01:00",
+      "content_pillar": "real_life_friction",
+      "funnel_stage": "awareness",
+      "experiment_code": "pain_frame_intent",
+      "audience_tension": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+      "product_truth_anchor": "visible progress without perfection pressure",
+      "hook": "A broken streak does not erase visible progress.",
+      "caption": "A broken streak pressure can expose the limits of a plan built for identical days. Innerbloom approaches habits as something that can adapt to real life while keeping direction. This is a product approach, not a promise of results. Learn how Innerbloom approaches adaptive habits.",
+      "cta": {
+        "label": "Learn how Innerbloom approaches adaptive habits",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "For the provisional audience, posts framing plans that fail on messy weeks will produce a higher landing_cta_clicked rate per attributable landing session than posts framing broken-streak pressure.",
+      "primary_metric": "landing_cta_clicked events divided by attributable landing sessions for each message variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_019&ib_post=post_019",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_019",
+        "ib_post": "post_019"
+      },
+      "visible_copy_plan": {
+        "headline": "A broken streak does not erase visible progress.",
+        "supporting_text": "visible progress without perfection pressure"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate broken streak pressure as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "positioning_6"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "A broken streak does not erase visible progress.",
+          "visible progress without perfection pressure",
+          "Learn how Innerbloom approaches adaptive habits"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about broken streak pressure: A broken streak does not erase visible progress.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_019_slide_01",
+          "post_code": "post_019",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Recognition slide for the broken streak pressure narrative.",
+          "product_evidence_requirement": "visible progress without perfection pressure",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Recognition slide for the broken streak pressure narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 1
+        },
+        {
+          "asset_code": "post_019_slide_02",
+          "post_code": "post_019",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Tension slide for the broken streak pressure narrative.",
+          "product_evidence_requirement": "visible progress without perfection pressure",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Tension slide for the broken streak pressure narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 2
+        },
+        {
+          "asset_code": "post_019_slide_03",
+          "post_code": "post_019",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Product approach slide for the broken streak pressure narrative.",
+          "product_evidence_requirement": "visible progress without perfection pressure",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Product approach slide for the broken streak pressure narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 3
+        },
+        {
+          "asset_code": "post_019_slide_04",
+          "post_code": "post_019",
+          "asset_kind": "carousel_slide",
+          "semantic_purpose": "Invitation slide for the broken streak pressure narrative.",
+          "product_evidence_requirement": "visible progress without perfection pressure",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "Invitation slide for the broken streak pressure narrative.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ],
+          "slide_number": 4
+        }
+      ],
+      "carousel": {
+        "slide_count": 4,
+        "narrative_arc": "Move from recognition of broken streak pressure, through the audience tension and supported product approach, to an approved invitation.",
+        "slides": [
+          {
+            "slide_number": 1,
+            "narrative_role": "Recognition",
+            "visible_copy": {
+              "headline": "A broken streak does not erase visible progress.",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "visible progress without perfection pressure",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_019_slide_01",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 2,
+            "narrative_role": "Tension",
+            "visible_copy": {
+              "headline": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+              "supporting_text": "Keep the idea focused on one real-life decision."
+            },
+            "product_truth_anchor": "visible progress without perfection pressure",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_019_slide_02",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 3,
+            "narrative_role": "Product approach",
+            "visible_copy": {
+              "headline": "visible progress without perfection pressure",
+              "supporting_text": "A product approach, not a promised result."
+            },
+            "product_truth_anchor": "visible progress without perfection pressure",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_019_slide_03",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          },
+          {
+            "slide_number": 4,
+            "narrative_role": "Invitation",
+            "visible_copy": {
+              "headline": "Learn how Innerbloom approaches adaptive habits",
+              "supporting_text": null
+            },
+            "product_truth_anchor": "visible progress without perfection pressure",
+            "visual_proof_requirement": "Use editorial explanation grounded in the cited truth; no invented interface.",
+            "asset_code": "post_019_slide_04",
+            "acceptance_criteria": [
+              "One clear idea is readable on mobile.",
+              "The slide advances the ordered narrative without unsupported claims."
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "post_code": "post_020",
+      "sequence_number": 20,
+      "platform": "instagram",
+      "format": "static",
+      "status": "needs_review",
+      "scheduled_at": "2099-01-31T18:00:00+01:00",
+      "content_pillar": "return_without_shame",
+      "funnel_stage": "activation",
+      "experiment_code": "early_adopter_activation",
+      "audience_tension": "A disruption can feel like progress has been erased.",
+      "product_truth_anchor": "recalibration instead of restart",
+      "hook": "Make the return a designed step, not a verdict.",
+      "caption": "Return Invitation reframes disruption as a moment to recalibrate rather than erase what came before. Innerbloom is designed around returning and visible progress without perfection pressure. The early version is available to explore without any promised outcome. Try the early version.",
+      "cta": {
+        "label": "Try the early version",
+        "intent": "Visit the tracked Innerbloom landing page to explore the stated adaptive-habit approach",
+        "destination": "https://innerbloomjourney.org/",
+        "truthfulness_note": "The CTA presents Innerbloom as an early product and does not promise an outcome."
+      },
+      "hypothesis": "An explicit early-adopter co-creation invitation will produce a higher auth_started rate per attributable landing session than a generic try-the-product invitation.",
+      "primary_metric": "auth_started events divided by attributable landing sessions for each CTA variant",
+      "tracking_url": "https://innerbloomjourney.org/?utm_source=instagram&utm_medium=social&utm_campaign=ib_209901&utm_content=post_020&ib_post=post_020",
+      "utm": {
+        "utm_source": "instagram",
+        "utm_medium": "social",
+        "utm_campaign": "ib_209901",
+        "utm_content": "post_020",
+        "ib_post": "post_020"
+      },
+      "visible_copy_plan": {
+        "headline": "Make the return a designed step, not a verdict.",
+        "supporting_text": "recalibration instead of restart"
+      },
+      "visual_strategy": {
+        "visual_goal": "Communicate return invitation as one specific step in the campaign narrative.",
+        "proof_type": "editorial",
+        "product_evidence": [
+          "positioning_5"
+        ],
+        "screenshot_requirement": "optional",
+        "informational_hierarchy": [
+          "Make the return a designed step, not a verdict.",
+          "recalibration instead of restart",
+          "Try the early version"
+        ],
+        "editorial_character": [
+          "calm",
+          "specific",
+          "non-judgmental"
+        ],
+        "preferred_mode": "either",
+        "truthful_transformations": [
+          "Use typographic emphasis without changing the meaning of the claim."
+        ],
+        "forbidden_uses": [
+          "Do not imply measured effectiveness or a universal result.",
+          "Do not invent product screens, states, or capabilities."
+        ],
+        "acceptance_criteria": [
+          "The central idea is understandable without the caption.",
+          "The evidence remains consistent with the cited approved truth.",
+          "The CTA is subordinate to the editorial idea."
+        ]
+      },
+      "accessibility": {
+        "alt_text": "Editorial visual about return invitation: Make the return a designed step, not a verdict.",
+        "readability_note": "Use short lines, high contrast, mobile-readable type, and non-color cues for every comparison."
+      },
+      "asset_slots": [
+        {
+          "asset_code": "post_020_asset_01",
+          "post_code": "post_020",
+          "asset_kind": "static",
+          "semantic_purpose": "One-frame editorial statement about return invitation.",
+          "product_evidence_requirement": "recalibration instead of restart",
+          "existing_sources_preferred": true,
+          "semantic_source_references": [],
+          "new_binary_may_be_required": true,
+          "alt_text": "One-frame editorial statement about return invitation.",
+          "acceptance_criteria": [
+            "Readable on a mobile viewport with high contrast.",
+            "Communicates the cited product truth without implying an outcome.",
+            "Does not rely on color alone."
+          ]
+        }
+      ]
+    }
+  ],
+  "image_generation": {
+    "jobs": [
+      {
+        "asset_code": "post_001_asset_01",
+        "post_code": "post_001",
+        "asset_kind": "static",
+        "batch_number": 1,
+        "generation_order": 1,
+        "platform": "instagram",
+        "format": "static",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "A messy Monday does not make your plan meaningless.",
+          "supporting_text": "Habits should adapt to real life rather than demand identical days"
+        },
+        "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dailyquest_dark_tasks_selection",
+            "kind": "product_screenshot",
+            "module": "tasks",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "One-frame editorial statement about messy Monday. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable split_device_right composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram static asset using the split_device_right layout. Preserve exact visible copy: {\"headline\":\"A messy Monday does not make your plan meaningless.\",\"supporting_text\":\"Habits should adapt to real life rather than demand identical days\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "A messy Monday does not make your plan meaningless.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Habits should adapt to real life rather than demand identical days"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_001_asset_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_001_asset_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "split_device_right",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered tasks product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dailyquest_dark_tasks_selection"
+          ],
+          "focal_instruction": "Keep mobile_dailyquest_dark_tasks_selection legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "One-frame editorial statement about messy Monday.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_002_slide_01",
+        "post_code": "post_002",
+        "asset_kind": "carousel_slide",
+        "slide_number": 1,
+        "batch_number": 1,
+        "generation_order": 2,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Adaptive does not have to mean unstructured.",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_achievements_dark_calibration_detail_10",
+            "kind": "product_screenshot",
+            "module": "growth_calibration",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Recognition slide for the task intensity narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable split_device_left composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the split_device_left layout. Preserve exact visible copy: {\"headline\":\"Adaptive does not have to mean unstructured.\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Adaptive does not have to mean unstructured.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Adjusting intensity is different from abandoning direction"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_002_slide_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_002_slide_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "split_device_left",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered growth_calibration product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_achievements_dark_calibration_detail_10"
+          ],
+          "focal_instruction": "Keep mobile_achievements_dark_calibration_detail_10 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Recognition slide for the task intensity narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_002_slide_02",
+        "post_code": "post_002",
+        "asset_kind": "carousel_slide",
+        "slide_number": 2,
+        "batch_number": 1,
+        "generation_order": 3,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Adaptive language can sound vague without a concrete mechanism.",
+          "supporting_text": "Keep the idea focused on one real-life decision."
+        },
+        "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_overview_streaks_04",
+            "kind": "product_screenshot",
+            "module": "dashboard",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Tension slide for the task intensity narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable cinematic_device_center composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the cinematic_device_center layout. Preserve exact visible copy: {\"headline\":\"Adaptive language can sound vague without a concrete mechanism.\",\"supporting_text\":\"Keep the idea focused on one real-life decision.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Adaptive language can sound vague without a concrete mechanism.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Adjusting intensity is different from abandoning direction"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_002_slide_02.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_002_slide_02.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "cinematic_device_center",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered dashboard product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_overview_streaks_04"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_overview_streaks_04 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Tension slide for the task intensity narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_002_slide_03",
+        "post_code": "post_002",
+        "asset_kind": "carousel_slide",
+        "slide_number": 3,
+        "batch_number": 1,
+        "generation_order": 4,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Adjusting intensity is different from abandoning direction",
+          "supporting_text": "A product approach, not a promised result."
+        },
+        "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_overview_top_01",
+            "kind": "product_screenshot",
+            "module": "dashboard",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Product approach slide for the task intensity narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable device_diagonal_crop composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the device_diagonal_crop layout. Preserve exact visible copy: {\"headline\":\"Adjusting intensity is different from abandoning direction\",\"supporting_text\":\"A product approach, not a promised result.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Adjusting intensity is different from abandoning direction",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Adjusting intensity is different from abandoning direction"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_002_slide_03.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_002_slide_03.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "device_diagonal_crop",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "diagonal_soft",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered dashboard product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_overview_top_01"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_overview_top_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Product approach slide for the task intensity narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_002_slide_04",
+        "post_code": "post_002",
+        "asset_kind": "carousel_slide",
+        "slide_number": 4,
+        "batch_number": 1,
+        "generation_order": 5,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Learn how Innerbloom approaches adaptive habits",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_tasks_dark_list_05",
+            "kind": "product_screenshot",
+            "module": "tasks",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Invitation slide for the task intensity narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_type_monument composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the editorial_type_monument layout. Preserve exact visible copy: {\"headline\":\"Learn how Innerbloom approaches adaptive habits\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Learn how Innerbloom approaches adaptive habits",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Adjusting intensity is different from abandoning direction"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_002_slide_04.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_002_slide_04.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_type_monument",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered tasks product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_tasks_dark_list_05"
+          ],
+          "focal_instruction": "Keep mobile_tasks_dark_list_05 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Invitation slide for the task intensity narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_003_asset_01",
+        "post_code": "post_003",
+        "asset_kind": "static",
+        "batch_number": 1,
+        "generation_order": 6,
+        "platform": "instagram",
+        "format": "static",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Returning is part of the practice.",
+          "supporting_text": "Returning is a skill worth designing for"
+        },
+        "product_truth_anchor": "Returning is a skill worth designing for",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_task_detail_dark_activity_streaks_07",
+            "kind": "product_screenshot",
+            "module": "task_detail",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "One-frame editorial statement about first return. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_signal_line composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram static asset using the editorial_signal_line layout. Preserve exact visible copy: {\"headline\":\"Returning is part of the practice.\",\"supporting_text\":\"Returning is a skill worth designing for\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Returning is part of the practice.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Returning is a skill worth designing for"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_003_asset_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_003_asset_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_signal_line",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered task_detail product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_task_detail_dark_activity_streaks_07"
+          ],
+          "focal_instruction": "Keep mobile_task_detail_dark_activity_streaks_07 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "One-frame editorial statement about first return.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_004_slide_01",
+        "post_code": "post_004",
+        "asset_kind": "carousel_slide",
+        "slide_number": 1,
+        "batch_number": 1,
+        "generation_order": 7,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "One missed day is not the whole story.",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Visible progress can matter without perfection pressure",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_task_detail_dark_habit_score_06",
+            "kind": "product_screenshot",
+            "module": "task_detail",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Recognition slide for the broken streak narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_numbered_steps composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the editorial_numbered_steps layout. Preserve exact visible copy: {\"headline\":\"One missed day is not the whole story.\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "One missed day is not the whole story.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Visible progress can matter without perfection pressure"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_004_slide_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_004_slide_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_numbered_steps",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered task_detail product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_task_detail_dark_habit_score_06"
+          ],
+          "focal_instruction": "Keep mobile_task_detail_dark_habit_score_06 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Recognition slide for the broken streak narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_004_slide_02",
+        "post_code": "post_004",
+        "asset_kind": "carousel_slide",
+        "slide_number": 2,
+        "batch_number": 1,
+        "generation_order": 8,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+          "supporting_text": "Keep the idea focused on one real-life decision."
+        },
+        "product_truth_anchor": "Visible progress can matter without perfection pressure",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_settings_dark_rhythm_selector_15",
+            "kind": "product_screenshot",
+            "module": "rhythm_selection",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Tension slide for the broken streak narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_chapter_cover composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the carousel_chapter_cover layout. Preserve exact visible copy: {\"headline\":\"Rigid plans feel mismatched when schedules, stress, or energy change.\",\"supporting_text\":\"Keep the idea focused on one real-life decision.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Rigid plans feel mismatched when schedules, stress, or energy change.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Visible progress can matter without perfection pressure"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_004_slide_02.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_004_slide_02.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_chapter_cover",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered rhythm_selection product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_settings_dark_rhythm_selector_15"
+          ],
+          "focal_instruction": "Keep mobile_settings_dark_rhythm_selector_15 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Tension slide for the broken streak narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_004_slide_03",
+        "post_code": "post_004",
+        "asset_kind": "carousel_slide",
+        "slide_number": 3,
+        "batch_number": 1,
+        "generation_order": 9,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Visible progress can matter without perfection pressure",
+          "supporting_text": "A product approach, not a promised result."
+        },
+        "product_truth_anchor": "Visible progress can matter without perfection pressure",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dailyquest_dark_feedback_summary",
+            "kind": "product_screenshot",
+            "module": "brand_or_product_support",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Product approach slide for the broken streak narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_proof_focus composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the carousel_proof_focus layout. Preserve exact visible copy: {\"headline\":\"Visible progress can matter without perfection pressure\",\"supporting_text\":\"A product approach, not a promised result.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Visible progress can matter without perfection pressure",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Visible progress can matter without perfection pressure"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_004_slide_03.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_004_slide_03.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_proof_focus",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered brand_or_product_support product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dailyquest_dark_feedback_summary"
+          ],
+          "focal_instruction": "Keep mobile_dailyquest_dark_feedback_summary legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Product approach slide for the broken streak narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_004_slide_04",
+        "post_code": "post_004",
+        "asset_kind": "carousel_slide",
+        "slide_number": 4,
+        "batch_number": 1,
+        "generation_order": 10,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Learn how Innerbloom approaches adaptive habits",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Visible progress can matter without perfection pressure",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_energy_balance_02",
+            "kind": "product_screenshot",
+            "module": "balance",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Invitation slide for the broken streak narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_transition composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the carousel_transition layout. Preserve exact visible copy: {\"headline\":\"Learn how Innerbloom approaches adaptive habits\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Learn how Innerbloom approaches adaptive habits",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Visible progress can matter without perfection pressure"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_004_slide_04.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_004_slide_04.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_transition",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered balance product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_energy_balance_02"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_energy_balance_02 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Invitation slide for the broken streak narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_005_asset_01",
+        "post_code": "post_005",
+        "asset_kind": "static",
+        "batch_number": 2,
+        "generation_order": 11,
+        "platform": "instagram",
+        "format": "static",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Rigid habit tools not working for you?",
+          "supporting_text": "The early product is open to feedback from people who experience this problem"
+        },
+        "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+        "funnel_stage": "activation",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_overview_list_03",
+            "kind": "product_screenshot",
+            "module": "dashboard",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "One-frame editorial statement about transparent invitation. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_cta_close composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram static asset using the carousel_cta_close layout. Preserve exact visible copy: {\"headline\":\"Rigid habit tools not working for you?\",\"supporting_text\":\"The early product is open to feedback from people who experience this problem\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Rigid habit tools not working for you?",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "The early product is open to feedback from people who experience this problem"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_005_asset_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_005_asset_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_cta_close",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered dashboard product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_overview_list_03"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_overview_list_03 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "One-frame editorial statement about transparent invitation.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_006_asset_01",
+        "post_code": "post_006",
+        "asset_kind": "static",
+        "batch_number": 2,
+        "generation_order": 12,
+        "platform": "instagram",
+        "format": "static",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Task intensity can change without losing direction.",
+          "supporting_text": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+        },
+        "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_achievements_dark_wrapped_hub_01",
+            "kind": "product_screenshot",
+            "module": "achievements",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "One-frame editorial statement about Daily Quest selection. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable storefront_feature_stage composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram static asset using the storefront_feature_stage layout. Preserve exact visible copy: {\"headline\":\"Task intensity can change without losing direction.\",\"supporting_text\":\"Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Task intensity can change without losing direction.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_006_asset_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_006_asset_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "storefront_feature_stage",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered achievements product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_achievements_dark_wrapped_hub_01"
+          ],
+          "focal_instruction": "Keep mobile_achievements_dark_wrapped_hub_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "One-frame editorial statement about Daily Quest selection.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_007_slide_01",
+        "post_code": "post_007",
+        "asset_kind": "carousel_slide",
+        "slide_number": 1,
+        "batch_number": 2,
+        "generation_order": 13,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Your energy changed. Why should the plan pretend otherwise?",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_emotion_chart_dark_overview_01",
+            "kind": "product_screenshot",
+            "module": "emotion_chart",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Recognition slide for the energy change narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable storefront_dark_monolith composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the storefront_dark_monolith layout. Preserve exact visible copy: {\"headline\":\"Your energy changed. Why should the plan pretend otherwise?\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Your energy changed. Why should the plan pretend otherwise?",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Habits should adapt to real life rather than demand identical days"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_007_slide_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_007_slide_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "storefront_dark_monolith",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered emotion_chart product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_emotion_chart_dark_overview_01"
+          ],
+          "focal_instruction": "Keep mobile_emotion_chart_dark_overview_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Recognition slide for the energy change narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_007_slide_02",
+        "post_code": "post_007",
+        "asset_kind": "carousel_slide",
+        "slide_number": 2,
+        "batch_number": 2,
+        "generation_order": 14,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+          "supporting_text": "Keep the idea focused on one real-life decision."
+        },
+        "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_new_task_ai_category_dark_08",
+            "kind": "product_screenshot",
+            "module": "tasks",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Tension slide for the energy change narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable storefront_edge_editorial composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the storefront_edge_editorial layout. Preserve exact visible copy: {\"headline\":\"Rigid plans feel mismatched when schedules, stress, or energy change.\",\"supporting_text\":\"Keep the idea focused on one real-life decision.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Rigid plans feel mismatched when schedules, stress, or energy change.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Habits should adapt to real life rather than demand identical days"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_007_slide_02.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_007_slide_02.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "storefront_edge_editorial",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered tasks product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_new_task_ai_category_dark_08"
+          ],
+          "focal_instruction": "Keep mobile_new_task_ai_category_dark_08 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Tension slide for the energy change narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_007_slide_03",
+        "post_code": "post_007",
+        "asset_kind": "carousel_slide",
+        "slide_number": 3,
+        "batch_number": 2,
+        "generation_order": 15,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Habits should adapt to real life rather than demand identical days",
+          "supporting_text": "A product approach, not a promised result."
+        },
+        "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_task_light_01",
+            "kind": "product_screenshot",
+            "module": "tasks",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          },
+          {
+            "asset_key": "scene_frosted_glass_mist_01",
+            "kind": "scene_plate",
+            "module": "editorial_scene",
+            "mode": "light",
+            "surface": "photographic_background",
+            "status": "approved_current",
+            "composition_profile": "material_editorial_v1",
+            "composition_slots": {
+              "copy_zone": "left",
+              "product_zone": "lower_right",
+              "scene_crop": "center",
+              "readability_veil": "left_soft",
+              "device_grounding": "leaning"
+            },
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          }
+        ],
+        "visual_concept": "Product approach slide for the energy change narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_material_scene composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the editorial_material_scene layout. Preserve exact visible copy: {\"headline\":\"Habits should adapt to real life rather than demand identical days\",\"supporting_text\":\"A product approach, not a promised result.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Habits should adapt to real life rather than demand identical days",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Habits should adapt to real life rather than demand identical days"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_007_slide_03.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_007_slide_03.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_material_scene",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "three_quarter_resting",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered tasks product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_task_light_01"
+          ],
+          "focal_instruction": "Keep mobile_task_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": true,
+            "asset_key": "scene_frosted_glass_mist_01",
+            "role": "registered_editorial_scene_plate"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Product approach slide for the energy change narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ],
+          "art_direction": {
+            "profile": "material_editorial_v1",
+            "scene_asset_key": "scene_frosted_glass_mist_01",
+            "scene_crop": "center",
+            "copy_zone": "left",
+            "product_zone": "lower_right",
+            "readability_veil": "left_soft",
+            "device_grounding": "resting",
+            "device_angle_deg": 6,
+            "headline_emphasis": null
+          }
+        }
+      },
+      {
+        "asset_code": "post_007_slide_04",
+        "post_code": "post_007",
+        "asset_kind": "carousel_slide",
+        "slide_number": 4,
+        "batch_number": 2,
+        "generation_order": 16,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Learn how Innerbloom approaches adaptive habits",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Habits should adapt to real life rather than demand identical days",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_task_detail_light_01",
+            "kind": "product_screenshot",
+            "module": "task_detail",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Invitation slide for the energy change narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable split_device_right composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the split_device_right layout. Preserve exact visible copy: {\"headline\":\"Learn how Innerbloom approaches adaptive habits\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Learn how Innerbloom approaches adaptive habits",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Habits should adapt to real life rather than demand identical days"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_007_slide_04.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_007_slide_04.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "split_device_right",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered task_detail product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_task_detail_light_01"
+          ],
+          "focal_instruction": "Keep mobile_task_detail_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Invitation slide for the energy change narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_008_slide_01",
+        "post_code": "post_008",
+        "asset_kind": "carousel_slide",
+        "slide_number": 1,
+        "batch_number": 2,
+        "generation_order": 17,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Recalibration is different from starting over.",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Recalibration can preserve direction without pretending disruption did not happen",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_light_01",
+            "kind": "product_screenshot",
+            "module": "dashboard",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Recognition slide for the recalibrate not erase narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable split_device_left composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the split_device_left layout. Preserve exact visible copy: {\"headline\":\"Recalibration is different from starting over.\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Recalibration is different from starting over.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Recalibration can preserve direction without pretending disruption did not happen"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_008_slide_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_008_slide_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "split_device_left",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered dashboard product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_light_01"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Recognition slide for the recalibrate not erase narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_008_slide_02",
+        "post_code": "post_008",
+        "asset_kind": "carousel_slide",
+        "slide_number": 2,
+        "batch_number": 2,
+        "generation_order": 18,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "A disruption can feel like progress has been erased.",
+          "supporting_text": "Keep the idea focused on one real-life decision."
+        },
+        "product_truth_anchor": "Recalibration can preserve direction without pretending disruption did not happen",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dquest_light_01",
+            "kind": "product_screenshot",
+            "module": "daily_quest",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Tension slide for the recalibrate not erase narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable cinematic_device_center composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the cinematic_device_center layout. Preserve exact visible copy: {\"headline\":\"A disruption can feel like progress has been erased.\",\"supporting_text\":\"Keep the idea focused on one real-life decision.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "A disruption can feel like progress has been erased.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Recalibration can preserve direction without pretending disruption did not happen"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_008_slide_02.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_008_slide_02.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "cinematic_device_center",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered daily_quest product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dquest_light_01"
+          ],
+          "focal_instruction": "Keep mobile_dquest_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Tension slide for the recalibrate not erase narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_008_slide_03",
+        "post_code": "post_008",
+        "asset_kind": "carousel_slide",
+        "slide_number": 3,
+        "batch_number": 2,
+        "generation_order": 19,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Recalibration can preserve direction without pretending disruption did not happen",
+          "supporting_text": "A product approach, not a promised result."
+        },
+        "product_truth_anchor": "Recalibration can preserve direction without pretending disruption did not happen",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_rhythm_light_01",
+            "kind": "product_screenshot",
+            "module": "brand_or_product_support",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Product approach slide for the recalibrate not erase narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable device_diagonal_crop composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the device_diagonal_crop layout. Preserve exact visible copy: {\"headline\":\"Recalibration can preserve direction without pretending disruption did not happen\",\"supporting_text\":\"A product approach, not a promised result.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Recalibration can preserve direction without pretending disruption did not happen",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Recalibration can preserve direction without pretending disruption did not happen"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_008_slide_03.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_008_slide_03.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "device_diagonal_crop",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "diagonal_soft",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered brand_or_product_support product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_rhythm_light_01"
+          ],
+          "focal_instruction": "Keep mobile_rhythm_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Product approach slide for the recalibrate not erase narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_008_slide_04",
+        "post_code": "post_008",
+        "asset_kind": "carousel_slide",
+        "slide_number": 4,
+        "batch_number": 2,
+        "generation_order": 20,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Explore the early version",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Recalibration can preserve direction without pretending disruption did not happen",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_achievements_card_light_01",
+            "kind": "product_screenshot",
+            "module": "brand_or_product_support",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Invitation slide for the recalibrate not erase narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_type_monument composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the editorial_type_monument layout. Preserve exact visible copy: {\"headline\":\"Explore the early version\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Explore the early version",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Recalibration can preserve direction without pretending disruption did not happen"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_008_slide_04.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_008_slide_04.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_type_monument",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered brand_or_product_support product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_achievements_card_light_01"
+          ],
+          "focal_instruction": "Keep mobile_achievements_card_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Invitation slide for the recalibrate not erase narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_009_slide_01",
+        "post_code": "post_009",
+        "asset_kind": "carousel_slide",
+        "slide_number": 1,
+        "batch_number": 3,
+        "generation_order": 21,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "A weekly review can keep direction visible.",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dailyquest_dark_tasks_selection",
+            "kind": "product_screenshot",
+            "module": "tasks",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Recognition slide for the weekly recalibration narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_signal_line composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the editorial_signal_line layout. Preserve exact visible copy: {\"headline\":\"A weekly review can keep direction visible.\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "A weekly review can keep direction visible.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_009_slide_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_009_slide_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_signal_line",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered tasks product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dailyquest_dark_tasks_selection"
+          ],
+          "focal_instruction": "Keep mobile_dailyquest_dark_tasks_selection legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Recognition slide for the weekly recalibration narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_009_slide_02",
+        "post_code": "post_009",
+        "asset_kind": "carousel_slide",
+        "slide_number": 2,
+        "batch_number": 3,
+        "generation_order": 22,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Adaptive language can sound vague without a concrete mechanism.",
+          "supporting_text": "Keep the idea focused on one real-life decision."
+        },
+        "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_achievements_dark_calibration_detail_10",
+            "kind": "product_screenshot",
+            "module": "growth_calibration",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Tension slide for the weekly recalibration narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_numbered_steps composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the editorial_numbered_steps layout. Preserve exact visible copy: {\"headline\":\"Adaptive language can sound vague without a concrete mechanism.\",\"supporting_text\":\"Keep the idea focused on one real-life decision.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Adaptive language can sound vague without a concrete mechanism.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_009_slide_02.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_009_slide_02.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_numbered_steps",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered growth_calibration product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_achievements_dark_calibration_detail_10"
+          ],
+          "focal_instruction": "Keep mobile_achievements_dark_calibration_detail_10 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Tension slide for the weekly recalibration narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_009_slide_03",
+        "post_code": "post_009",
+        "asset_kind": "carousel_slide",
+        "slide_number": 3,
+        "batch_number": 3,
+        "generation_order": 23,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "supporting_text": "A product approach, not a promised result."
+        },
+        "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_overview_streaks_04",
+            "kind": "product_screenshot",
+            "module": "dashboard",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Product approach slide for the weekly recalibration narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_chapter_cover composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the carousel_chapter_cover layout. Preserve exact visible copy: {\"headline\":\"Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum\",\"supporting_text\":\"A product approach, not a promised result.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_009_slide_03.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_009_slide_03.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_chapter_cover",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered dashboard product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_overview_streaks_04"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_overview_streaks_04 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Product approach slide for the weekly recalibration narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_009_slide_04",
+        "post_code": "post_009",
+        "asset_kind": "carousel_slide",
+        "slide_number": 4,
+        "batch_number": 3,
+        "generation_order": 24,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Learn how Innerbloom approaches adaptive habits",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_overview_top_01",
+            "kind": "product_screenshot",
+            "module": "dashboard",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Invitation slide for the weekly recalibration narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_proof_focus composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the carousel_proof_focus layout. Preserve exact visible copy: {\"headline\":\"Learn how Innerbloom approaches adaptive habits\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Learn how Innerbloom approaches adaptive habits",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_009_slide_04.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_009_slide_04.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_proof_focus",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered dashboard product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_overview_top_01"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_overview_top_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Invitation slide for the weekly recalibration narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_010_asset_01",
+        "post_code": "post_010",
+        "asset_kind": "static",
+        "batch_number": 3,
+        "generation_order": 25,
+        "platform": "instagram",
+        "format": "static",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Real weeks rarely match perfect calendars.",
+          "supporting_text": "real-life rhythm"
+        },
+        "product_truth_anchor": "real-life rhythm",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_tasks_dark_list_05",
+            "kind": "product_screenshot",
+            "module": "tasks",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "One-frame editorial statement about calendar collision. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_transition composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram static asset using the carousel_transition layout. Preserve exact visible copy: {\"headline\":\"Real weeks rarely match perfect calendars.\",\"supporting_text\":\"real-life rhythm\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Real weeks rarely match perfect calendars.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "real-life rhythm"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_010_asset_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_010_asset_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_transition",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered tasks product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_tasks_dark_list_05"
+          ],
+          "focal_instruction": "Keep mobile_tasks_dark_list_05 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "One-frame editorial statement about calendar collision.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_011_slide_01",
+        "post_code": "post_011",
+        "asset_kind": "carousel_slide",
+        "slide_number": 1,
+        "batch_number": 3,
+        "generation_order": 26,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Try an early product. Then tell us what felt useful.",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+        "funnel_stage": "activation",
+        "source_assets": [
+          {
+            "asset_key": "mobile_task_detail_dark_activity_streaks_07",
+            "kind": "product_screenshot",
+            "module": "task_detail",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Recognition slide for the co-creation invitation narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_cta_close composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the carousel_cta_close layout. Preserve exact visible copy: {\"headline\":\"Try an early product. Then tell us what felt useful.\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Try an early product. Then tell us what felt useful.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "The early product is open to feedback from people who experience this problem"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_011_slide_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_011_slide_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_cta_close",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered task_detail product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_task_detail_dark_activity_streaks_07"
+          ],
+          "focal_instruction": "Keep mobile_task_detail_dark_activity_streaks_07 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Recognition slide for the co-creation invitation narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_011_slide_02",
+        "post_code": "post_011",
+        "asset_kind": "carousel_slide",
+        "slide_number": 2,
+        "batch_number": 3,
+        "generation_order": 27,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "An early product must earn exploration through clarity and honesty.",
+          "supporting_text": "Keep the idea focused on one real-life decision."
+        },
+        "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+        "funnel_stage": "activation",
+        "source_assets": [
+          {
+            "asset_key": "mobile_task_detail_dark_habit_score_06",
+            "kind": "product_screenshot",
+            "module": "task_detail",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Tension slide for the co-creation invitation narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable storefront_feature_stage composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the storefront_feature_stage layout. Preserve exact visible copy: {\"headline\":\"An early product must earn exploration through clarity and honesty.\",\"supporting_text\":\"Keep the idea focused on one real-life decision.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "An early product must earn exploration through clarity and honesty.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "The early product is open to feedback from people who experience this problem"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_011_slide_02.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_011_slide_02.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "storefront_feature_stage",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered task_detail product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_task_detail_dark_habit_score_06"
+          ],
+          "focal_instruction": "Keep mobile_task_detail_dark_habit_score_06 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Tension slide for the co-creation invitation narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_011_slide_03",
+        "post_code": "post_011",
+        "asset_kind": "carousel_slide",
+        "slide_number": 3,
+        "batch_number": 3,
+        "generation_order": 28,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "The early product is open to feedback from people who experience this problem",
+          "supporting_text": "A product approach, not a promised result."
+        },
+        "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+        "funnel_stage": "activation",
+        "source_assets": [
+          {
+            "asset_key": "mobile_settings_dark_rhythm_selector_15",
+            "kind": "product_screenshot",
+            "module": "rhythm_selection",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Product approach slide for the co-creation invitation narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable storefront_dark_monolith composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the storefront_dark_monolith layout. Preserve exact visible copy: {\"headline\":\"The early product is open to feedback from people who experience this problem\",\"supporting_text\":\"A product approach, not a promised result.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "The early product is open to feedback from people who experience this problem",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "The early product is open to feedback from people who experience this problem"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_011_slide_03.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_011_slide_03.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "storefront_dark_monolith",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered rhythm_selection product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_settings_dark_rhythm_selector_15"
+          ],
+          "focal_instruction": "Keep mobile_settings_dark_rhythm_selector_15 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Product approach slide for the co-creation invitation narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_011_slide_04",
+        "post_code": "post_011",
+        "asset_kind": "carousel_slide",
+        "slide_number": 4,
+        "batch_number": 3,
+        "generation_order": 29,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Share feedback after exploring the dashboard",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "The early product is open to feedback from people who experience this problem",
+        "funnel_stage": "activation",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dailyquest_dark_feedback_summary",
+            "kind": "product_screenshot",
+            "module": "brand_or_product_support",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Invitation slide for the co-creation invitation narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable storefront_edge_editorial composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the storefront_edge_editorial layout. Preserve exact visible copy: {\"headline\":\"Share feedback after exploring the dashboard\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Share feedback after exploring the dashboard",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "The early product is open to feedback from people who experience this problem"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_011_slide_04.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_011_slide_04.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "storefront_edge_editorial",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered brand_or_product_support product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dailyquest_dark_feedback_summary"
+          ],
+          "focal_instruction": "Keep mobile_dailyquest_dark_feedback_summary legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Invitation slide for the co-creation invitation narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_012_asset_01",
+        "post_code": "post_012",
+        "asset_kind": "static",
+        "batch_number": 3,
+        "generation_order": 30,
+        "platform": "instagram",
+        "format": "static",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Progress can stay visible without demanding perfection.",
+          "supporting_text": "Visible progress can matter without perfection pressure"
+        },
+        "product_truth_anchor": "Visible progress can matter without perfection pressure",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_energy_balance_02",
+            "kind": "product_screenshot",
+            "module": "balance",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          },
+          {
+            "asset_key": "scene_aubergine_pedestal_01",
+            "kind": "scene_plate",
+            "module": "editorial_scene",
+            "mode": "dark",
+            "surface": "photographic_background",
+            "status": "approved_current",
+            "composition_profile": "material_editorial_v1",
+            "composition_slots": {
+              "copy_zone": "right",
+              "product_zone": "lower_left",
+              "scene_crop": "center",
+              "readability_veil": "right_dark",
+              "device_grounding": "resting"
+            },
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          }
+        ],
+        "visual_concept": "One-frame editorial statement about visible momentum. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_material_scene composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram static asset using the editorial_material_scene layout. Preserve exact visible copy: {\"headline\":\"Progress can stay visible without demanding perfection.\",\"supporting_text\":\"Visible progress can matter without perfection pressure\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Progress can stay visible without demanding perfection.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Visible progress can matter without perfection pressure"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_012_asset_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_012_asset_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_material_scene",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "three_quarter_resting",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered balance product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_energy_balance_02"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_energy_balance_02 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": true,
+            "asset_key": "scene_aubergine_pedestal_01",
+            "role": "registered_editorial_scene_plate"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "One-frame editorial statement about visible momentum.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ],
+          "art_direction": {
+            "profile": "material_editorial_v1",
+            "scene_asset_key": "scene_aubergine_pedestal_01",
+            "scene_crop": "center",
+            "copy_zone": "left",
+            "product_zone": "lower_right",
+            "readability_veil": "right_dark",
+            "device_grounding": "resting",
+            "device_angle_deg": 6,
+            "headline_emphasis": null
+          }
+        }
+      },
+      {
+        "asset_code": "post_013_slide_01",
+        "post_code": "post_013",
+        "asset_kind": "carousel_slide",
+        "slide_number": 1,
+        "batch_number": 4,
+        "generation_order": 31,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "When the week bends, the habit plan can bend too.",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_overview_list_03",
+            "kind": "product_screenshot",
+            "module": "dashboard",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Recognition slide for the messy week comparison narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable split_device_right composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the split_device_right layout. Preserve exact visible copy: {\"headline\":\"When the week bends, the habit plan can bend too.\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "When the week bends, the habit plan can bend too.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity."
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_013_slide_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_013_slide_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "split_device_right",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered dashboard product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_overview_list_03"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_overview_list_03 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Recognition slide for the messy week comparison narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_013_slide_02",
+        "post_code": "post_013",
+        "asset_kind": "carousel_slide",
+        "slide_number": 2,
+        "batch_number": 4,
+        "generation_order": 32,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+          "supporting_text": "Keep the idea focused on one real-life decision."
+        },
+        "product_truth_anchor": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_achievements_dark_wrapped_hub_01",
+            "kind": "product_screenshot",
+            "module": "achievements",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Tension slide for the messy week comparison narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable split_device_left composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the split_device_left layout. Preserve exact visible copy: {\"headline\":\"Rigid plans feel mismatched when schedules, stress, or energy change.\",\"supporting_text\":\"Keep the idea focused on one real-life decision.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Rigid plans feel mismatched when schedules, stress, or energy change.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity."
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_013_slide_02.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_013_slide_02.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "split_device_left",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered achievements product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_achievements_dark_wrapped_hub_01"
+          ],
+          "focal_instruction": "Keep mobile_achievements_dark_wrapped_hub_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Tension slide for the messy week comparison narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_013_slide_03",
+        "post_code": "post_013",
+        "asset_kind": "carousel_slide",
+        "slide_number": 3,
+        "batch_number": 4,
+        "generation_order": 33,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+          "supporting_text": "A product approach, not a promised result."
+        },
+        "product_truth_anchor": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_emotion_chart_dark_overview_01",
+            "kind": "product_screenshot",
+            "module": "emotion_chart",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Product approach slide for the messy week comparison narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable cinematic_device_center composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the cinematic_device_center layout. Preserve exact visible copy: {\"headline\":\"Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.\",\"supporting_text\":\"A product approach, not a promised result.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity."
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_013_slide_03.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_013_slide_03.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "cinematic_device_center",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered emotion_chart product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_emotion_chart_dark_overview_01"
+          ],
+          "focal_instruction": "Keep mobile_emotion_chart_dark_overview_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Product approach slide for the messy week comparison narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_013_slide_04",
+        "post_code": "post_013",
+        "asset_kind": "carousel_slide",
+        "slide_number": 4,
+        "batch_number": 4,
+        "generation_order": 34,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Learn how Innerbloom approaches adaptive habits",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity.",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_new_task_ai_category_dark_08",
+            "kind": "product_screenshot",
+            "module": "tasks",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Invitation slide for the messy week comparison narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable device_diagonal_crop composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the device_diagonal_crop layout. Preserve exact visible copy: {\"headline\":\"Learn how Innerbloom approaches adaptive habits\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Learn how Innerbloom approaches adaptive habits",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Innerbloom helps people build sustainable habits that adapt to real life instead of forcing rigid streaks or perfect-day productivity."
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_013_slide_04.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_013_slide_04.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "device_diagonal_crop",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "diagonal_soft",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered tasks product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_new_task_ai_category_dark_08"
+          ],
+          "focal_instruction": "Keep mobile_new_task_ai_category_dark_08 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Invitation slide for the messy week comparison narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_014_asset_01",
+        "post_code": "post_014",
+        "asset_kind": "static",
+        "batch_number": 4,
+        "generation_order": 35,
+        "platform": "instagram",
+        "format": "static",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "You can return without calling everything a failure.",
+          "supporting_text": "Returning is a skill worth designing for"
+        },
+        "product_truth_anchor": "Returning is a skill worth designing for",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_task_light_01",
+            "kind": "product_screenshot",
+            "module": "tasks",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "One-frame editorial statement about gentler restart. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_type_monument composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram static asset using the editorial_type_monument layout. Preserve exact visible copy: {\"headline\":\"You can return without calling everything a failure.\",\"supporting_text\":\"Returning is a skill worth designing for\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "You can return without calling everything a failure.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Returning is a skill worth designing for"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_014_asset_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_014_asset_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_type_monument",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered tasks product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_task_light_01"
+          ],
+          "focal_instruction": "Keep mobile_task_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "One-frame editorial statement about gentler restart.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_015_slide_01",
+        "post_code": "post_015",
+        "asset_kind": "carousel_slide",
+        "slide_number": 1,
+        "batch_number": 4,
+        "generation_order": 36,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Visible progress can support the next adjustment.",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_task_detail_light_01",
+            "kind": "product_screenshot",
+            "module": "task_detail",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Recognition slide for the dashboard progress narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_signal_line composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the editorial_signal_line layout. Preserve exact visible copy: {\"headline\":\"Visible progress can support the next adjustment.\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Visible progress can support the next adjustment.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_015_slide_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_015_slide_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_signal_line",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered task_detail product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_task_detail_light_01"
+          ],
+          "focal_instruction": "Keep mobile_task_detail_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Recognition slide for the dashboard progress narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_015_slide_02",
+        "post_code": "post_015",
+        "asset_kind": "carousel_slide",
+        "slide_number": 2,
+        "batch_number": 4,
+        "generation_order": 37,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Adaptive language can sound vague without a concrete mechanism.",
+          "supporting_text": "Keep the idea focused on one real-life decision."
+        },
+        "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_light_01",
+            "kind": "product_screenshot",
+            "module": "dashboard",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Tension slide for the dashboard progress narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_numbered_steps composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the editorial_numbered_steps layout. Preserve exact visible copy: {\"headline\":\"Adaptive language can sound vague without a concrete mechanism.\",\"supporting_text\":\"Keep the idea focused on one real-life decision.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Adaptive language can sound vague without a concrete mechanism.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_015_slide_02.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_015_slide_02.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_numbered_steps",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered dashboard product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_light_01"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Tension slide for the dashboard progress narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_015_slide_03",
+        "post_code": "post_015",
+        "asset_kind": "carousel_slide",
+        "slide_number": 3,
+        "batch_number": 4,
+        "generation_order": 38,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "supporting_text": "A product approach, not a promised result."
+        },
+        "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dquest_light_01",
+            "kind": "product_screenshot",
+            "module": "daily_quest",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Product approach slide for the dashboard progress narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_chapter_cover composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the carousel_chapter_cover layout. Preserve exact visible copy: {\"headline\":\"Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum\",\"supporting_text\":\"A product approach, not a promised result.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_015_slide_03.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_015_slide_03.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_chapter_cover",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered daily_quest product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dquest_light_01"
+          ],
+          "focal_instruction": "Keep mobile_dquest_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Product approach slide for the dashboard progress narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_015_slide_04",
+        "post_code": "post_015",
+        "asset_kind": "carousel_slide",
+        "slide_number": 4,
+        "batch_number": 4,
+        "generation_order": 39,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Explore the early version",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_rhythm_light_01",
+            "kind": "product_screenshot",
+            "module": "brand_or_product_support",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Invitation slide for the dashboard progress narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_proof_focus composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the carousel_proof_focus layout. Preserve exact visible copy: {\"headline\":\"Explore the early version\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Explore the early version",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Use only product mechanisms named in the canonical context: adaptive rhythm, weekly recalibration, dashboard progress, task intensity, visible momentum"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_015_slide_04.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_015_slide_04.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_proof_focus",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered brand_or_product_support product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_rhythm_light_01"
+          ],
+          "focal_instruction": "Keep mobile_rhythm_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Invitation slide for the dashboard progress narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_016_asset_01",
+        "post_code": "post_016",
+        "asset_kind": "static",
+        "batch_number": 4,
+        "generation_order": 40,
+        "platform": "instagram",
+        "format": "static",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "The same effort every day is not the only structure.",
+          "supporting_text": "Adjusting intensity is different from abandoning direction"
+        },
+        "product_truth_anchor": "Adjusting intensity is different from abandoning direction",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_achievements_card_light_01",
+            "kind": "product_screenshot",
+            "module": "brand_or_product_support",
+            "mode": "light",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "One-frame editorial statement about fixed effort. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_transition composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram static asset using the carousel_transition layout. Preserve exact visible copy: {\"headline\":\"The same effort every day is not the only structure.\",\"supporting_text\":\"Adjusting intensity is different from abandoning direction\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "The same effort every day is not the only structure.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "Adjusting intensity is different from abandoning direction"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_016_asset_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_016_asset_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_transition",
+          "mode": "light",
+          "palette": "light",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm light-mode square with exact editorial copy in a dedicated safe zone and the registered brand_or_product_support product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_achievements_card_light_01"
+          ],
+          "focal_instruction": "Keep mobile_achievements_card_light_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "One-frame editorial statement about fixed effort.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_017_slide_01",
+        "post_code": "post_017",
+        "asset_kind": "carousel_slide",
+        "slide_number": 1,
+        "batch_number": 5,
+        "generation_order": 41,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Explore first. Share informed feedback second.",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "early product, feedback welcome",
+        "funnel_stage": "activation",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dailyquest_dark_tasks_selection",
+            "kind": "product_screenshot",
+            "module": "tasks",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Recognition slide for the feedback after exposure narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable carousel_cta_close composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the carousel_cta_close layout. Preserve exact visible copy: {\"headline\":\"Explore first. Share informed feedback second.\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Explore first. Share informed feedback second.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "early product, feedback welcome"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_017_slide_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_017_slide_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "proof_sequence",
+          "layout_variant": "carousel_cta_close",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered tasks product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dailyquest_dark_tasks_selection"
+          ],
+          "focal_instruction": "Keep mobile_dailyquest_dark_tasks_selection legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Recognition slide for the feedback after exposure narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_017_slide_02",
+        "post_code": "post_017",
+        "asset_kind": "carousel_slide",
+        "slide_number": 2,
+        "batch_number": 5,
+        "generation_order": 42,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "An early product must earn exploration through clarity and honesty.",
+          "supporting_text": "Keep the idea focused on one real-life decision."
+        },
+        "product_truth_anchor": "early product, feedback welcome",
+        "funnel_stage": "activation",
+        "source_assets": [
+          {
+            "asset_key": "mobile_achievements_dark_calibration_detail_10",
+            "kind": "product_screenshot",
+            "module": "growth_calibration",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Tension slide for the feedback after exposure narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable storefront_feature_stage composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the storefront_feature_stage layout. Preserve exact visible copy: {\"headline\":\"An early product must earn exploration through clarity and honesty.\",\"supporting_text\":\"Keep the idea focused on one real-life decision.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "An early product must earn exploration through clarity and honesty.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "early product, feedback welcome"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_017_slide_02.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_017_slide_02.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "storefront_feature_stage",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered growth_calibration product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_achievements_dark_calibration_detail_10"
+          ],
+          "focal_instruction": "Keep mobile_achievements_dark_calibration_detail_10 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Tension slide for the feedback after exposure narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_017_slide_03",
+        "post_code": "post_017",
+        "asset_kind": "carousel_slide",
+        "slide_number": 3,
+        "batch_number": 5,
+        "generation_order": 43,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "early product, feedback welcome",
+          "supporting_text": "A product approach, not a promised result."
+        },
+        "product_truth_anchor": "early product, feedback welcome",
+        "funnel_stage": "activation",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_overview_streaks_04",
+            "kind": "product_screenshot",
+            "module": "dashboard",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Product approach slide for the feedback after exposure narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable storefront_dark_monolith composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the storefront_dark_monolith layout. Preserve exact visible copy: {\"headline\":\"early product, feedback welcome\",\"supporting_text\":\"A product approach, not a promised result.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "early product, feedback welcome",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "early product, feedback welcome"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_017_slide_03.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_017_slide_03.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "storefront_dark_monolith",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered dashboard product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_overview_streaks_04"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_overview_streaks_04 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Product approach slide for the feedback after exposure narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_017_slide_04",
+        "post_code": "post_017",
+        "asset_kind": "carousel_slide",
+        "slide_number": 4,
+        "batch_number": 5,
+        "generation_order": 44,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Share feedback after exploring the dashboard",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "early product, feedback welcome",
+        "funnel_stage": "activation",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_overview_top_01",
+            "kind": "product_screenshot",
+            "module": "dashboard",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Invitation slide for the feedback after exposure narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable storefront_edge_editorial composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the storefront_edge_editorial layout. Preserve exact visible copy: {\"headline\":\"Share feedback after exploring the dashboard\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Share feedback after exploring the dashboard",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "early product, feedback welcome"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_017_slide_04.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_017_slide_04.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "storefront_edge_editorial",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered dashboard product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_overview_top_01"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_overview_top_01 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Invitation slide for the feedback after exposure narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_018_asset_01",
+        "post_code": "post_018",
+        "asset_kind": "static",
+        "batch_number": 5,
+        "generation_order": 45,
+        "platform": "instagram",
+        "format": "static",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "A clear direction can include different intensities.",
+          "supporting_text": "adaptive habits"
+        },
+        "product_truth_anchor": "adaptive habits",
+        "funnel_stage": "consideration",
+        "source_assets": [
+          {
+            "asset_key": "mobile_tasks_dark_list_05",
+            "kind": "product_screenshot",
+            "module": "tasks",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          },
+          {
+            "asset_key": "scene_aubergine_pedestal_01",
+            "kind": "scene_plate",
+            "module": "editorial_scene",
+            "mode": "dark",
+            "surface": "photographic_background",
+            "status": "approved_current",
+            "composition_profile": "material_editorial_v1",
+            "composition_slots": {
+              "copy_zone": "right",
+              "product_zone": "lower_left",
+              "scene_crop": "center",
+              "readability_veil": "right_dark",
+              "device_grounding": "resting"
+            },
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          }
+        ],
+        "visual_concept": "One-frame editorial statement about adaptive rhythm. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_material_scene composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram static asset using the editorial_material_scene layout. Preserve exact visible copy: {\"headline\":\"A clear direction can include different intensities.\",\"supporting_text\":\"adaptive habits\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "A clear direction can include different intensities.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "adaptive habits"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_018_asset_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_018_asset_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_material_scene",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "three_quarter_resting",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered tasks product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_tasks_dark_list_05"
+          ],
+          "focal_instruction": "Keep mobile_tasks_dark_list_05 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": true,
+            "asset_key": "scene_aubergine_pedestal_01",
+            "role": "registered_editorial_scene_plate"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "One-frame editorial statement about adaptive rhythm.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ],
+          "art_direction": {
+            "profile": "material_editorial_v1",
+            "scene_asset_key": "scene_aubergine_pedestal_01",
+            "scene_crop": "center",
+            "copy_zone": "left",
+            "product_zone": "lower_right",
+            "readability_veil": "right_dark",
+            "device_grounding": "resting",
+            "device_angle_deg": 6,
+            "headline_emphasis": null
+          }
+        }
+      },
+      {
+        "asset_code": "post_019_slide_01",
+        "post_code": "post_019",
+        "asset_kind": "carousel_slide",
+        "slide_number": 1,
+        "batch_number": 5,
+        "generation_order": 46,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "A broken streak does not erase visible progress.",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "visible progress without perfection pressure",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_task_detail_dark_activity_streaks_07",
+            "kind": "product_screenshot",
+            "module": "task_detail",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Recognition slide for the broken streak pressure narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable split_device_right composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the split_device_right layout. Preserve exact visible copy: {\"headline\":\"A broken streak does not erase visible progress.\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "A broken streak does not erase visible progress.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "visible progress without perfection pressure"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_019_slide_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_019_slide_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "split_device_right",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered task_detail product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_task_detail_dark_activity_streaks_07"
+          ],
+          "focal_instruction": "Keep mobile_task_detail_dark_activity_streaks_07 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Recognition slide for the broken streak pressure narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_019_slide_02",
+        "post_code": "post_019",
+        "asset_kind": "carousel_slide",
+        "slide_number": 2,
+        "batch_number": 5,
+        "generation_order": 47,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Rigid plans feel mismatched when schedules, stress, or energy change.",
+          "supporting_text": "Keep the idea focused on one real-life decision."
+        },
+        "product_truth_anchor": "visible progress without perfection pressure",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_task_detail_dark_habit_score_06",
+            "kind": "product_screenshot",
+            "module": "task_detail",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Tension slide for the broken streak pressure narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable split_device_left composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the split_device_left layout. Preserve exact visible copy: {\"headline\":\"Rigid plans feel mismatched when schedules, stress, or energy change.\",\"supporting_text\":\"Keep the idea focused on one real-life decision.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Rigid plans feel mismatched when schedules, stress, or energy change.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "visible progress without perfection pressure"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_019_slide_02.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_019_slide_02.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "split_device_left",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered task_detail product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_task_detail_dark_habit_score_06"
+          ],
+          "focal_instruction": "Keep mobile_task_detail_dark_habit_score_06 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Tension slide for the broken streak pressure narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_019_slide_03",
+        "post_code": "post_019",
+        "asset_kind": "carousel_slide",
+        "slide_number": 3,
+        "batch_number": 5,
+        "generation_order": 48,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "visible progress without perfection pressure",
+          "supporting_text": "A product approach, not a promised result."
+        },
+        "product_truth_anchor": "visible progress without perfection pressure",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_settings_dark_rhythm_selector_15",
+            "kind": "product_screenshot",
+            "module": "rhythm_selection",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Product approach slide for the broken streak pressure narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable cinematic_device_center composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the cinematic_device_center layout. Preserve exact visible copy: {\"headline\":\"visible progress without perfection pressure\",\"supporting_text\":\"A product approach, not a promised result.\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "visible progress without perfection pressure",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "visible progress without perfection pressure"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_019_slide_03.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_019_slide_03.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "cinematic_device_center",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered rhythm_selection product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_settings_dark_rhythm_selector_15"
+          ],
+          "focal_instruction": "Keep mobile_settings_dark_rhythm_selector_15 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Product approach slide for the broken streak pressure narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_019_slide_04",
+        "post_code": "post_019",
+        "asset_kind": "carousel_slide",
+        "slide_number": 4,
+        "batch_number": 5,
+        "generation_order": 49,
+        "platform": "instagram",
+        "format": "carousel",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Learn how Innerbloom approaches adaptive habits",
+          "supporting_text": null
+        },
+        "product_truth_anchor": "visible progress without perfection pressure",
+        "funnel_stage": "awareness",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dailyquest_dark_feedback_summary",
+            "kind": "product_screenshot",
+            "module": "brand_or_product_support",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "Invitation slide for the broken streak pressure narrative. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable device_diagonal_crop composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram carousel asset using the device_diagonal_crop layout. Preserve exact visible copy: {\"headline\":\"Learn how Innerbloom approaches adaptive habits\",\"supporting_text\":null}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Learn how Innerbloom approaches adaptive habits",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "visible progress without perfection pressure"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_019_slide_04.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_019_slide_04.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "product_hero_scene",
+          "layout_variant": "device_diagonal_crop",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "diagonal_soft",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered brand_or_product_support product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dailyquest_dark_feedback_summary"
+          ],
+          "focal_instruction": "Keep mobile_dailyquest_dark_feedback_summary legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "Invitation slide for the broken streak pressure narrative.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      },
+      {
+        "asset_code": "post_020_asset_01",
+        "post_code": "post_020",
+        "asset_kind": "static",
+        "batch_number": 5,
+        "generation_order": 50,
+        "platform": "instagram",
+        "format": "static",
+        "canvas": {
+          "width": 1080,
+          "height": 1080,
+          "aspect_ratio": "1:1",
+          "safe_area": "Keep essential copy, product evidence, and logo inside the central 940x940 safe area."
+        },
+        "visible_copy": {
+          "headline": "Make the return a designed step, not a verdict.",
+          "supporting_text": "recalibration instead of restart"
+        },
+        "product_truth_anchor": "recalibration instead of restart",
+        "funnel_stage": "activation",
+        "source_assets": [
+          {
+            "asset_key": "mobile_dashboard_dark_energy_balance_02",
+            "kind": "product_screenshot",
+            "module": "balance",
+            "mode": "dark",
+            "surface": "mobile",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets",
+              "crop_or_reframe"
+            ]
+          },
+          {
+            "asset_key": "brand_logo_full",
+            "kind": "brand_logo",
+            "module": "brand_logo",
+            "mode": "neutral",
+            "surface": "brand",
+            "status": "approved_current",
+            "composition_profile": null,
+            "composition_slots": null,
+            "allowed_operations": [
+              "reuse_existing_asset",
+              "compose_existing_assets"
+            ]
+          }
+        ],
+        "visual_concept": "One-frame editorial statement about return invitation. Calm, evidence-led Innerbloom editorial composition.",
+        "composition_spec": {
+          "layout": "Executable editorial_type_monument composition with separated copy and product zones.",
+          "hierarchy": "Exact headline first, registered product evidence second, supporting text third, canonical logo quiet.",
+          "screenshot_treatment": "Contain the exact registered screen without modifying UI labels, values, or state.",
+          "brand_treatment": "Calm, premium Innerbloom identity using only the registered logo.",
+          "mobile_readability_priority": "All editorial copy remains legible at Instagram feed-preview size."
+        },
+        "generation_prompt": "Render a finished 1080x1080 Instagram static asset using the editorial_type_monument layout. Preserve exact visible copy: {\"headline\":\"Make the return a designed step, not a verdict.\",\"supporting_text\":\"recalibration instead of restart\"}. Use only the supplied registered product screen and registered logo. Do not invent UI, claims, metrics, testimonials, or outcomes.",
+        "negative_prompt": "Reject fake UI, changed product states, invented metrics, recreated logos, illegible text, overlapping copy and devices, generic SaaS styling, medical claims, guarantees, and unsupported outcomes.",
+        "must_show": [
+          "Make the return a designed step, not a verdict.",
+          "registered Innerbloom product evidence",
+          "canonical Innerbloom lockup"
+        ],
+        "must_preserve": [
+          "exact visible copy",
+          "registered source UI without modification",
+          "recalibration instead of restart"
+        ],
+        "must_avoid": [
+          "invented UI or data",
+          "unsupported outcome claims",
+          "copy-product overlap"
+        ],
+        "acceptance_criteria": [
+          "Readable on a mobile viewport with high contrast.",
+          "Communicates the cited product truth without implying an outcome.",
+          "Does not rely on color alone.",
+          "Use only registered source assets and preserve their metadata.",
+          "Keep the exact visible copy unchanged."
+        ],
+        "expected_output": {
+          "filename": "post_020_asset_01.png",
+          "local_staging_path": "marketing/agent-outputs/2099-01/generated-assets/post_020_asset_01.png",
+          "mime_type": "image/png",
+          "width": 1080,
+          "height": 1080
+        },
+        "creative_direction": {
+          "status": "ready_for_render",
+          "visual_family": "editorial_statement",
+          "layout_variant": "editorial_type_monument",
+          "mode": "dark",
+          "palette": "dark",
+          "device_presentation": "front",
+          "wordmark_treatment": "canonical_innerbloom_lockup",
+          "composition_intent": "Build a calm dark-mode square with exact editorial copy in a dedicated safe zone and the registered balance product screen as unaltered evidence. Keep the logo quiet and preserve a clear reading order.",
+          "selected_asset_keys": [
+            "mobile_dashboard_dark_energy_balance_02"
+          ],
+          "focal_instruction": "Keep mobile_dashboard_dark_energy_balance_02 legible and unmodified; make the exact headline the first reading point and the product evidence the second.",
+          "supporting_visual": {
+            "required": false,
+            "asset_key": null,
+            "role": "none"
+          },
+          "supporting_treatment": "none",
+          "screen_fit": "contain",
+          "feature_callout": "One-frame editorial statement about return invitation.",
+          "acceptance_criteria": [
+            "The exact visible copy is legible inside the 940x940 safe area.",
+            "The canonical registered Innerbloom lockup is visible but subordinate.",
+            "The selected registered product screen is preserved without invented UI, metrics, or state changes.",
+            "Copy and product evidence occupy distinct, non-overlapping zones.",
+            "The composition does not imply effectiveness, guaranteed outcomes, or product capabilities beyond the stated anchor."
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation

- Convert the validated `creative-context.json` for period `2099-01` into a renderer-ready `campaign.json` that the render workflow can consume. 
- Produce one exact renderer job per draft `asset_slot`, preserve all immutable editorial fields and product-truth anchors, and use only registered assets and executable layouts. 
- Keep the campaign and posts in review states and avoid running renderer/upload/import workflows.

### Description

- Add the generated file `marketing/agent-outputs/2099-01/campaign.json` containing campaign metadata, the preserved `posts` array, and an `image_generation.jobs` array with 50 renderer-ready jobs. 
- Each job includes canonical `expected_output` (1080x1080 PNG, staged path), copied `source_assets` from the registry, exact `visible_copy`, and a complete `creative_direction` with `layout_variant` set to a declared `renderer_layout`. 
- Jobs use only registered `approved_current` assets and supported layouts across 15 executable layouts and ~20 distinct registered assets, with safe-area and acceptance criteria included. 
- PR metadata prepared targeting branch `automation/marketing-cycle-2099-01` and the generated output written under `marketing/agent-outputs/2099-01/`.

### Testing

- Validated input schema with `npx tsx apps/api/scripts/validate-marketing-agent-json.ts --schema=prompts/marketing/agent-system/schemas/creative-director-input-v1.schema.json --input=marketing/agent-inputs/2099-01/creative-context.json`, which passed. 
- Validated output schema with `npx tsx apps/api/scripts/validate-marketing-agent-json.ts --schema=prompts/marketing/agent-system/schemas/creative-director-output-v1.schema.json --input=marketing/agent-outputs/2099-01/campaign.json`, which passed. 
- Ran renderer rules check with `node scripts/marketing/validate-creative-direction-v3.mjs marketing/agent-outputs/2099-01/campaign.json`, which passed. 
- Ran preservation validator with `npx tsx apps/api/scripts/validate-creative-director-preservation.ts --draft=marketing/agent-outputs/2099-01/campaign-draft.json --campaign=marketing/agent-outputs/2099-01/campaign.json --context=marketing/agent-inputs/2099-01/creative-context.json`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b563973208332ba8c02655d7f70ad)