### PR TITLE
Fix monthly achievement integrity and grid detail

### DIFF
--- a/apps/api/src/routes/dailyQuest.ts
+++ b/apps/api/src/routes/dailyQuest.ts
@@ -14,6 +14,7 @@ import {
   type SubmitDailyQuestLogger,
 } from '../services/dailyQuestService.js';
 import { markOnboardingProgressStep } from '../services/onboardingProgressService.js';
+import { runMonthlyMaintenanceWatchdog } from '../services/monthlyMaintenanceWatchdog.js';
 
 const router = Router();
 
@@ -124,6 +125,19 @@ router.post(
 
     try {
       const result = await submitDailyQuest(user.id, payload, { requestId: reqId, log });
+
+      // The first Daily Quest submitted in a new month is the user-facing fallback
+      // for a missed cron/watchdog interval. Awaiting this idempotent check means
+      // a closed month is settled before Logros and Wrapped are rendered again.
+      try {
+        await runMonthlyMaintenanceWatchdog(new Date());
+      } catch (error) {
+        log('warn', 'Monthly maintenance check failed after daily quest submit', {
+          userId: user.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
       await markOnboardingProgressStep(user.id, 'first_daily_quest_completed', {
         source: { trigger: 'daily_quest_submit' },
       });

--- a/apps/web/src/pages/labs/mobile-premium/variants/PremiumRewardsSection.tsx
+++ b/apps/web/src/pages/labs/mobile-premium/variants/PremiumRewardsSection.tsx
@@ -276,8 +276,7 @@ export function PremiumRewardsSection({
     { enabled: Boolean(backendUserId) },
   );
   const previewRewards = onboardingPreview && localSnapshot ? buildLocalPreviewRewards(localSnapshot) : EMPTY_REWARDS_HISTORY;
-  const rewards = localRewards ?? data ?? (onboardingPreview ? previewRewards : FALLBACK_REWARDS_HISTORY);
-  const hasRealRewards = Boolean(localRewards ?? data) || onboardingPreview;
+  const rewards = localRewards ?? data ?? (onboardingPreview ? previewRewards : EMPTY_REWARDS_HISTORY);
   const groups = normalizeRewardGroups(rewards.habitAchievements.achievedByPillar);
   const activeGroup = groups.find((group) => group.pillar.code === activePillar) ?? groups[0];
   const habits = activeGroup?.habits ?? [];
@@ -286,12 +285,8 @@ export function PremiumRewardsSection({
   const currentPendingReview = pendingReviewItems[pendingDecisionIndex] ?? pendingReviewItems[0] ?? null;
   const safeActiveIndex = Math.min(Math.max(activeIndex, 0), Math.max(habits.length - 1, 0));
   const growth = rewards.growthCalibration;
-  const weeklyItems = rewards.weeklyWrapups.length
-    ? rewards.weeklyWrapups.slice(0, 2)
-    : hasRealRewards
-      ? []
-      : FALLBACK_REWARDS_HISTORY.weeklyWrapups.slice(0, 2);
-  const monthly = rewards.monthlyWrapups[0] ?? (hasRealRewards ? null : FALLBACK_REWARDS_HISTORY.monthlyWrapups[0]);
+  const weeklyItems = rewards.weeklyWrapups.slice(0, 2);
+  const monthly = rewards.monthlyWrapups[0] ?? null;
 
   useEffect(() => {
     const initialIndex = Math.min(1, Math.max(0, habits.length - 1));
@@ -751,8 +746,8 @@ function AllAchievementsGrid({
 function AchievementGridOverlay({ backendUserId, habit, maintainPending, onClose, onToggleMaintained, reducedMotion, showBack }: { backendUserId: string | null; habit: HabitAchievementShelfItem; maintainPending: boolean; onClose: () => void; onToggleMaintained: (habit: HabitAchievementShelfItem, enabled: boolean) => Promise<void>; reducedMotion: boolean; showBack: boolean }) {
   const achieved = isHabitAchieved(habit);
   return renderStoryPortal(
-    <motion.div animate={{ opacity: 1 }} className="fixed inset-0 z-[9999] flex h-[100dvh] items-center justify-center overflow-hidden bg-black/70 px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] pt-[calc(env(safe-area-inset-top)+1rem)]" data-mp-achievement-overlay="grid-card" exit={{ opacity: 0 }} initial={{ opacity: 0 }} onClick={onClose} transition={{ duration: reducedMotion ? 0.1 : 0.24 }}>
-      <motion.div className="relative h-[min(76dvh,31rem)] min-h-[21rem] w-full max-w-[23rem] [perspective:1100px]" layoutId={`mp-achievement-${habit.id}`} onClick={(event) => { event.stopPropagation(); onClose(); }} transition={reducedMotion ? { duration: 0.1 } : { type: 'spring', stiffness: 250, damping: 28 }}>
+    <motion.div animate={{ opacity: 1 }} className="fixed inset-0 z-[9999] flex h-[100dvh] items-center justify-center overflow-hidden bg-black/92 px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] pt-[calc(env(safe-area-inset-top)+1rem)] backdrop-blur-sm" data-mp-achievement-overlay="grid-card" exit={{ opacity: 0 }} initial={{ opacity: 0 }} onClick={onClose} transition={{ duration: reducedMotion ? 0.1 : 0.24 }}>
+      <motion.div className="relative h-[min(76dvh,31rem)] min-h-[21rem] w-full max-w-[23rem] [perspective:1100px]" layoutId={`mp-achievement-${habit.id}`} onClick={(event) => event.stopPropagation()} transition={reducedMotion ? { duration: 0.1 } : { type: 'spring', stiffness: 250, damping: 28 }}>
         <motion.div animate={{ rotateY: showBack || reducedMotion ? 180 : 0 }} className="relative h-full w-full [transform-style:preserve-3d]" data-mp-achievement-flip={showBack ? 'back' : 'front'} transition={reducedMotion ? { duration: 0 } : { duration: 0.58, ease: [0.2, 0.82, 0.2, 1] }}>
           <div className={`absolute inset-0 rounded-[1.55rem] border bg-[color:var(--mp-surface)] p-5 text-center [backface-visibility:hidden] ${achieved ? 'border-violet-300/65' : 'border-amber-300/55 opacity-70 grayscale'}`}>
             <AchievementFrontFace habit={habit} isActive onShareAchievement={() => undefined} />
@@ -5439,15 +5434,24 @@ function resolveMonthlyHabitProgress(
       return !rowPeriod || rowPeriod === currentPeriod || rowPeriod === rewards.growthCalibration.latestPeriodLabel?.slice(0, 7);
     });
   const periodWindow = buildMonthlyPeriodWindow(currentPeriod);
-  const unlockedHabits = rows
-    .filter((row) => clampMonthlyScore(row.completionRatePct) >= 100)
-    .sort((a, b) => a.taskTitle.localeCompare(b.taskTitle, 'es', { sensitivity: 'base' }))
+  const unlockedHabits = rewards.habitAchievements.achievedByPillar
+    .flatMap((group) =>
+      group.habits.map((habit) => ({
+        habit,
+        pillar: group.pillar.name ?? group.pillar.code ?? 'Tarea',
+      })),
+    )
+    .filter(({ habit }) =>
+      (habit.status === 'maintained' || habit.status === 'stored') &&
+      habit.achievedAt?.slice(0, 7) === currentPeriod,
+    )
+    .sort((a, b) => a.habit.taskName.localeCompare(b.habit.taskName, 'es', { sensitivity: 'base' }))
     .slice(0, 2)
-    .map((row) => ({
-      label: row.pillar ?? 'Tarea',
-      monthLabel: formatMonthFromPeriod(row.evaluationMonthLabel) ?? formatMonthFromPeriod(currentPeriod) ?? 'Mes',
+    .map(({ habit, pillar }) => ({
+      label: pillar,
+      monthLabel: formatMonthFromPeriod(currentPeriod) ?? 'Mes',
       percent: 100,
-      title: row.taskTitle,
+      title: habit.taskName,
     }));
   const nearHabits = rows
     .filter((row) => {


### PR DESCRIPTION
Corrige cuatro fallos conectados:

- La vista premium deja de mostrar datos demo cuando los datos reales aún no cargaron o fallan.
- El Monthly Wrapped sólo anuncia logros con ciclo real `maintained` o `stored` logrados en ese período; un 100% de calibración ya no se interpreta como logro desbloqueado.
- Un Daily Quest ejecuta la comprobación idempotente de mantenimiento mensual, cubriendo un cron/watchdog perdido al inicio del mes.
- El detalle de la grilla usa una capa opaca y ya no se cierra al tocar la tarjeta, para poder ver e interactuar con el mismo contenido de desarrollo que el carrusel.

Verificación estática realizada sobre los cambios. Falta ejecutar la suite completa en el checkout/CI.