### PR TITLE
Use onboarding2 task design in landing Step 1

### DIFF
--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -6599,8 +6599,8 @@
   animation: v3-task-selected 3.2s ease-in-out infinite;
 }
 
-.landing.landing--v3-conversion[data-theme-mode="dark"] .v3-quickstart-tasks-preview .space-y-3 > :nth-child(4) .quickstart-task-row,
-.landing.landing--v3-conversion[data-theme-mode="dark"] .v3-quickstart-tasks-preview .space-y-3 > :nth-child(4) .quickstart-task-row__back {
+.landing.landing--v3-conversion[data-theme-mode="dark"] .v3-quickstart-tasks-preview .quickstart-premium-card > div > :nth-child(4) .quickstart-task-row,
+.landing.landing--v3-conversion[data-theme-mode="dark"] .v3-quickstart-tasks-preview .quickstart-premium-card > div > :nth-child(4) .quickstart-task-row__back {
   border-color: rgba(139, 92, 246, 0.12) !important;
   background: rgba(18, 18, 23, 0.82) !important;
   box-shadow: 0 16px 34px rgba(0, 0, 0, 0.16) !important;

--- a/apps/web/src/pages/Landing.css
+++ b/apps/web/src/pages/Landing.css
@@ -6185,6 +6185,7 @@
 
 .landing.landing--v3-conversion .v3-quickstart-tasks-preview {
   position: relative;
+  background: transparent;
   opacity: 0;
   transform: translateY(26px) scale(0.98);
   animation: v3-quickstart-tasks-cycle 8.4s cubic-bezier(0.22, 1, 0.36, 1) infinite;
@@ -6435,13 +6436,13 @@
   text-transform: uppercase;
 }
 
-.landing.landing--v3-conversion .v3-quickstart-tasks-preview .space-y-3 {
+.landing.landing--v3-conversion .v3-quickstart-tasks-preview .quickstart-premium-card > div {
   display: grid;
   gap: 9px;
   padding-top: 40px;
 }
 
-.landing.landing--v3-conversion .v3-quickstart-tasks-preview .space-y-3 > * {
+.landing.landing--v3-conversion .v3-quickstart-tasks-preview .quickstart-premium-card > div > * {
   opacity: 0;
   transform: translateX(74px);
   animation: v3-quickstart-task-rise 8.4s cubic-bezier(0.22, 1, 0.36, 1) infinite;
@@ -6449,7 +6450,7 @@
 }
 
 .landing.landing--v3-conversion .v3-quickstart-tasks-preview .quickstart-task-row {
-  grid-template-columns: 32px minmax(0, 1fr) 34px !important;
+  grid-template-columns: 32px minmax(0, 1fr) 64px !important;
   gap: 8px !important;
   padding-inline: 12px !important;
   overflow: hidden;
@@ -6501,19 +6502,19 @@
   animation: v3-quickstart-task-title 8.4s cubic-bezier(0.22, 1, 0.36, 1) infinite;
 }
 
-.landing.landing--v3-conversion .v3-quickstart-tasks-preview .space-y-3 > :nth-child(1) {
+.landing.landing--v3-conversion .v3-quickstart-tasks-preview .quickstart-premium-card > div > :nth-child(1) {
   animation-delay: 0.08s;
 }
 
-.landing.landing--v3-conversion .v3-quickstart-tasks-preview .space-y-3 > :nth-child(2) {
+.landing.landing--v3-conversion .v3-quickstart-tasks-preview .quickstart-premium-card > div > :nth-child(2) {
   animation-delay: 0.24s;
 }
 
-.landing.landing--v3-conversion .v3-quickstart-tasks-preview .space-y-3 > :nth-child(3) {
+.landing.landing--v3-conversion .v3-quickstart-tasks-preview .quickstart-premium-card > div > :nth-child(3) {
   animation-delay: 0.4s;
 }
 
-.landing.landing--v3-conversion .v3-quickstart-tasks-preview .space-y-3 > :nth-child(4) {
+.landing.landing--v3-conversion .v3-quickstart-tasks-preview .quickstart-premium-card > div > :nth-child(4) {
   animation-delay: 0.56s;
 }
 
@@ -6530,6 +6531,20 @@
   border-color: rgba(139, 92, 246, 0.12) !important;
   background: rgba(18, 18, 23, 0.82) !important;
   color: rgba(255, 248, 236, 0.94) !important;
+}
+
+.landing.landing--v3-conversion .v3-method-quickstart__scene .quickstart-task-row--foundation.quickstart-task-row--selected {
+  border-color: rgba(167, 139, 250, 0.58) !important;
+  background: linear-gradient(90deg, rgba(105, 74, 165, 0.42), rgba(18, 18, 23, 0.82) 72%) !important;
+  box-shadow:
+    inset 3px 0 0 #9f7aea,
+    0 16px 34px rgba(0, 0, 0, 0.16) !important;
+}
+
+.landing.landing--v3-conversion .v3-quickstart-tasks-preview .quickstart-quantity {
+  min-width: 3.75rem;
+  transform: scale(0.86);
+  transform-origin: right center;
 }
 
 .landing.landing--v3-conversion .v3-method-quickstart__scene .quickstart-task-row__back {
@@ -6580,7 +6595,7 @@
   color: #a879ff !important;
 }
 
-.landing.landing--v3-conversion .v3-quickstart-tasks-preview .space-y-3 > :nth-child(1) .quickstart-task-row {
+.landing.landing--v3-conversion .v3-quickstart-tasks-preview .quickstart-premium-card > div > :nth-child(1) .quickstart-task-row {
   animation: v3-task-selected 3.2s ease-in-out infinite;
 }
 
@@ -6720,6 +6735,14 @@
   background: rgba(255, 255, 255, 0.46) !important;
   box-shadow: 0 16px 34px rgba(75, 62, 91, 0.1) !important;
   color: rgba(23, 19, 34, 0.9) !important;
+}
+
+.landing.landing--v3-conversion[data-theme-mode="light"] .v3-method-quickstart__scene .quickstart-task-row--foundation.quickstart-task-row--selected {
+  border-color: rgba(139, 92, 246, 0.42) !important;
+  background: linear-gradient(90deg, rgba(196, 181, 253, 0.48), rgba(255, 255, 255, 0.46) 72%) !important;
+  box-shadow:
+    inset 3px 0 0 #8b5cf6,
+    0 16px 34px rgba(75, 62, 91, 0.1) !important;
 }
 
 .landing.landing--v3-conversion[data-theme-mode="light"] .v3-method-quickstart__scene .quickstart-task-row__back {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -581,7 +581,7 @@ export function LandingV3MethodVisual({
             </p>
             <LandingV3RhythmPickerPreview language={language} />
           </div>
-          <div className="v3-quickstart-tasks-preview">
+          <div className="v3-quickstart-tasks-preview onboarding2-premium-root">
             <p className="v3-quickstart-phase-title v3-quickstart-phase-title--tasks">
               {language === "es" ? "Customizá tus tareas" : "Customize your tasks"}
             </p>
@@ -590,10 +590,11 @@ export function LandingV3MethodVisual({
               pillar="Body"
               tasks={tasks}
               selectedIds={tasks.slice(0, 3).map((task) => task.id)}
-              inputValues={{ "Body-ENERGIA": animatedMinutes, "Body-SUENO": "7" }}
+              inputValues={{ "Body-ENERGIA": animatedMinutes, "Body-NUTRICION": "3", "Body-SUENO": "7" }}
               minimum={1}
               gameMode="FLOW"
               balancedBonusActive={false}
+              variant="onboarding2"
               onToggleTask={() => undefined}
               onInputChange={() => undefined}
               onBack={() => undefined}


### PR DESCRIPTION
## Qué cambia

- Actualiza la fase animada **“Customizá tus tareas”** del Step 1 para usar la variante visual real `onboarding2`.
- Conserva la animación anterior de **“Elegí tu ritmo”** y el resto de los steps sin cambios.
- Añade valores de ejemplo completos para energía, nutrición y sueño.
- Ajusta únicamente el scope CSS del preview para mostrar correctamente los controles de cantidad, estados seleccionados y cards foundations tanto en dark como en light mode.

## Rutas afectadas

El renderer modificado es el compartido por las landings de conversión publicadas en `/` y `/v2`.

La ruta `/v3` continúa usando su timeline legacy y actualmente no contiene esta animación de selección de tareas; no se alteró el resto de su estructura.

## Motivo

La landing reutilizaba `QuickStartTasksStep`, pero omitía `variant="onboarding2"`, por lo que mostraba el frontal anterior aunque el onboarding real ya tuviera el diseño nuevo.

## Validación

- Diff revisado contra `main`: solo `Landing.tsx` y `Landing.css`.
- Selectores de animación actualizados para la estructura vigente del componente.
- Sin cambios en el onboarding ni en el dashboard reales.
- CI de la PR pendiente.