### PR TITLE
Clarify supplied Drive inspection failures

### DIFF
--- a/Docs/marketing/automated-marketing-system.md
+++ b/Docs/marketing/automated-marketing-system.md
@@ -39,6 +39,8 @@ For mini campaigns built from already-created visual bases, Admin Marketing acce
 
 The PR workflow stages the Drive bases and canonical logo, renders a deterministic Story preview and runs the Story quality gate. Once merged, it imports the Story campaign into Admin as `needs_review`, using the Drive source reference; it does not upload to R2. Admin review remains the human publication gate: after the final asset is uploaded and approved there, its public R2 URL is validated and the Metricool CSV is enabled. Metricool rows map `story` to Instagram `STORY` (static and carousel remain `POST`; reel is `REEL`).
 
+The running API must have `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64` (or `GOOGLE_SERVICE_ACCOUNT_JSON`) configured in Railway. The service account must be shared on the selected Drive folder. If either requirement is missing, Admin reports that concrete configuration error instead of a generic 500 response.
+
 ## 3. Current production flow
 
 ```mermaid

--- a/apps/api/src/modules/admin/admin.routes.ts
+++ b/apps/api/src/modules/admin/admin.routes.ts
@@ -6,6 +6,7 @@ import { validateMarketingR2AssetUrls } from '../../services/marketingR2AssetSer
 import { updateMarketingCampaignPostsBulk } from '../../services/marketingCampaignBulkUpdateService.js';
 import { listMarketingPipelineRuns } from '../../services/marketingPipelineService.js';
 import { listDriveFolderImages } from '../../services/marketingGoogleDriveService.js';
+import { HttpError } from '../../lib/http-error.js';
 import {
   exportAdminUserLogsCsv,
   getAdminMe,
@@ -87,7 +88,18 @@ adminRouter.get('/product-notification-preferences', getAdminProductNotification
 adminRouter.get('/marketing/campaigns', getAdminMarketingCampaigns);
 adminRouter.post('/marketing/supplied-assets/inspect', asyncHandler(async (req, res) => {
   const { folderId } = suppliedAssetFolderSchema.parse(req.body ?? {});
-  const assets = await listDriveFolderImages(folderId);
+  let assets;
+  try {
+    assets = await listDriveFolderImages(folderId);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : 'Unknown Google Drive error';
+    const configured = !reason.includes('not configured');
+    throw new HttpError(
+      configured ? 502 : 503,
+      configured ? 'marketing_drive_unavailable' : 'marketing_drive_not_configured',
+      configured ? 'Unable to list this Google Drive folder. Confirm the folder is shared with the Innerbloom marketing service account.' : reason,
+    );
+  }
   res.json({ ok: true, assets });
 }));
 adminRouter.get('/marketing/pipeline/runs', asyncHandler(async (req, res) => {

--- a/apps/api/src/services/marketingGoogleDriveService.ts
+++ b/apps/api/src/services/marketingGoogleDriveService.ts
@@ -14,6 +14,14 @@ export type DriveFile = {
   thumbnailLink?: string;
 };
 
+export function assertMarketingDriveConfigured() {
+  const rawJson = String(process.env.GOOGLE_SERVICE_ACCOUNT_JSON ?? '').trim();
+  const legacyBase64 = String(process.env.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 ?? '').trim();
+  if (!rawJson && !legacyBase64) {
+    throw new Error('Marketing Drive is not configured on this API service. Set GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 (or GOOGLE_SERVICE_ACCOUNT_JSON) in Railway, then redeploy.');
+  }
+}
+
 /** Lists only direct image children.  Folder traversal is deliberately not recursive. */
 export async function listDriveFolderImages(folderId: string): Promise<DriveFile[]> {
   const token = await getAccessToken();
@@ -119,9 +127,7 @@ export async function uploadDriveImage(input: {
 async function getAccessToken() {
   const rawJson = String(process.env.GOOGLE_SERVICE_ACCOUNT_JSON ?? '').trim();
   const legacyBase64 = String(process.env.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 ?? '').trim();
-  if (!rawJson && !legacyBase64) {
-    throw new Error('GOOGLE_SERVICE_ACCOUNT_JSON is required for the Drive staging step.');
-  }
+  assertMarketingDriveConfigured();
 
   let serviceAccount: ServiceAccount;
   try {

--- a/apps/web/src/pages/admin2/MarketingPageV2.tsx
+++ b/apps/web/src/pages/admin2/MarketingPageV2.tsx
@@ -199,7 +199,10 @@ export function MarketingPageV2() {
     setInspectingAssets(true); setError(null); setTaskCopied(false);
     try {
       const response = await apiAuthorizedFetch('/admin/marketing/supplied-assets/inspect', { method: 'POST', headers: { Accept: 'application/json', 'Content-Type': 'application/json' }, body: JSON.stringify({ folderId }) });
-      if (!response.ok) throw new Error(`Unable to inspect Drive folder (HTTP ${response.status}).`);
+      if (!response.ok) {
+        const body = await response.json().catch(() => null) as { message?: string } | null;
+        throw new Error(body?.message || `Unable to inspect Drive folder (HTTP ${response.status}).`);
+      }
       const body = await response.json() as { assets: SuppliedDriveAsset[] };
       setSuppliedAssets(body.assets); setMessage(`${body.assets.length} image base${body.assets.length === 1 ? '' : 's'} found. Ready to copy the Codex task.`);
     } catch (cause) { setError(cause instanceof Error ? cause.message : 'Unable to inspect Drive folder.'); } finally { setInspectingAssets(false); }


### PR DESCRIPTION
Corrige el fallo de `Inspect images`.

El endpoint nuevo de Drive ahora distingue dos casos:
- API de Railway sin `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64` / `GOOGLE_SERVICE_ACCOUNT_JSON`: responde 503 y dice exactamente qué variable configurar y que hay que redeployar.
- Cuenta configurada pero Drive no lista la carpeta: responde 502 y pide verificar que el folder esté compartido con la cuenta de servicio.

El Admin muestra el mensaje concreto que devuelve la API, en lugar del genérico “Unable to inspect Drive folder (HTTP 500)”.

Validación: `git diff --check` pasó.