### PR TITLE
Fix shared Drive asset inspection

### DIFF
--- a/apps/api/src/modules/admin/admin.routes.ts
+++ b/apps/api/src/modules/admin/admin.routes.ts
@@ -5,7 +5,7 @@ import { asyncHandler } from '../../lib/async-handler.js';
 import { validateMarketingR2AssetUrls } from '../../services/marketingR2AssetService.js';
 import { updateMarketingCampaignPostsBulk } from '../../services/marketingCampaignBulkUpdateService.js';
 import { listMarketingPipelineRuns } from '../../services/marketingPipelineService.js';
-import { listDriveFolderImages } from '../../services/marketingGoogleDriveService.js';
+import { listDriveFolderImages, MarketingDriveError } from '../../services/marketingGoogleDriveService.js';
 import { HttpError } from '../../lib/http-error.js';
 import {
   exportAdminUserLogsCsv,
@@ -93,11 +93,14 @@ adminRouter.post('/marketing/supplied-assets/inspect', asyncHandler(async (req, 
     assets = await listDriveFolderImages(folderId);
   } catch (error) {
     const reason = error instanceof Error ? error.message : 'Unknown Google Drive error';
+    const detail = error instanceof MarketingDriveError ? { googleStatus: error.status, googleReason: error.reason, folderId } : { folderId };
+    console.error('Supplied marketing Drive inspection failed', { ...detail, error: reason });
     const configured = !reason.includes('not configured');
     throw new HttpError(
       configured ? 502 : 503,
       configured ? 'marketing_drive_unavailable' : 'marketing_drive_not_configured',
-      configured ? 'Unable to list this Google Drive folder. Confirm the folder is shared with the Innerbloom marketing service account.' : reason,
+      configured ? reason : reason,
+      detail,
     );
   }
   res.json({ ok: true, assets });

--- a/apps/api/src/services/marketingGoogleDriveService.ts
+++ b/apps/api/src/services/marketingGoogleDriveService.ts
@@ -14,6 +14,17 @@ export type DriveFile = {
   thumbnailLink?: string;
 };
 
+export class MarketingDriveError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number | null = null,
+    public readonly reason: string | null = null,
+  ) {
+    super(message);
+    this.name = 'MarketingDriveError';
+  }
+}
+
 export function assertMarketingDriveConfigured() {
   const rawJson = String(process.env.GOOGLE_SERVICE_ACCOUNT_JSON ?? '').trim();
   const legacyBase64 = String(process.env.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64 ?? '').trim();
@@ -33,6 +44,8 @@ export async function listDriveFolderImages(folderId: string): Promise<DriveFile
       fields: 'nextPageToken,files(id,name,mimeType,webViewLink,thumbnailLink)',
       orderBy: 'name_natural',
       pageSize: '100',
+      corpora: 'allDrives',
+      spaces: 'drive',
       supportsAllDrives: 'true',
       includeItemsFromAllDrives: 'true',
     });
@@ -40,12 +53,28 @@ export async function listDriveFolderImages(folderId: string): Promise<DriveFile
     const response = await fetch(`https://www.googleapis.com/drive/v3/files?${params}`, {
       headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(30_000),
     });
-    if (!response.ok) throw new Error(`Google Drive folder listing failed (HTTP ${response.status})`);
+    if (!response.ok) {
+      const detail = await safeGoogleError(response);
+      throw new MarketingDriveError(
+        `Google Drive rejected the folder listing (HTTP ${response.status})${detail.message ? `: ${detail.message}` : ''}`,
+        response.status,
+        detail.reason,
+      );
+    }
     const payload = await response.json() as { files?: DriveFile[]; nextPageToken?: string };
     files.push(...(payload.files ?? []));
     pageToken = payload.nextPageToken ?? '';
   } while (pageToken);
   return files;
+}
+
+async function safeGoogleError(response: Response) {
+  try {
+    const body = await response.json() as { error?: { message?: string; errors?: Array<{ reason?: string }> } };
+    return { message: body.error?.message?.slice(0, 500) ?? null, reason: body.error?.errors?.[0]?.reason?.slice(0, 120) ?? null };
+  } catch {
+    return { message: null, reason: null };
+  }
 }
 
 const DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive';
@@ -161,7 +190,8 @@ async function getAccessToken() {
   });
 
   if (!response.ok) {
-    throw new Error(`Google OAuth token request failed (HTTP ${response.status})`);
+    const detail = await safeGoogleError(response);
+    throw new MarketingDriveError(`Google OAuth token request failed (HTTP ${response.status})${detail.message ? `: ${detail.message}` : ''}`, response.status, detail.reason);
   }
 
   const payload = (await response.json()) as { access_token?: string };

--- a/apps/api/src/services/marketingGoogleDriveService.ts
+++ b/apps/api/src/services/marketingGoogleDriveService.ts
@@ -70,7 +70,7 @@ export async function listDriveFolderImages(folderId: string): Promise<DriveFile
 
 async function safeGoogleError(response: Response) {
   try {
-    const body = await response.json() as { error?: { message?: string; errors?: Array<{ reason?: string }> } };
+    const body = await response.json() as { error?: { message?: string; errors?: { reason?: string }[] } };
     return { message: body.error?.message?.slice(0, 500) ?? null, reason: body.error?.errors?.[0]?.reason?.slice(0, 120) ?? null };
   } catch {
     return { message: null, reason: null };


### PR DESCRIPTION
Corrige el listado de bases visuales desde Google Drive.

- La consulta usa `corpora=allDrives` y `spaces=drive`, de acuerdo con Drive API, para incluir carpetas compartidas.
- Cuando Google falla, el API guarda en Railway el status y motivo seguro de Google y lo devuelve al Admin; deja de colapsar todo en un 502 sin información.
- El Admin enseña esa causa concreta.

No modifica secretos ni solicita cambios manuales en Railway.