### PR TITLE
Package supplied Story campaigns for Railway Admin import

### DIFF
--- a/apps/api/scripts/copy-taskgen-assets.mjs
+++ b/apps/api/scripts/copy-taskgen-assets.mjs
@@ -12,6 +12,8 @@ const snapshotSampleSource = path.resolve(scriptDir, '../db-snapshot.sample.json
 const snapshotSampleDest = path.resolve(distDir, 'db-snapshot.sample.json'); // #REMOVE_ME_DEBUG_BYPASS
 const fixturesSource = path.resolve(scriptDir, '../fixtures'); // #REMOVE_ME_DEBUG_BYPASS
 const fixturesDest = path.resolve(distDir, 'fixtures'); // #REMOVE_ME_DEBUG_BYPASS
+const suppliedCampaignsSource = path.resolve(scriptDir, '../../../marketing/supplied-campaigns');
+const suppliedCampaignsDest = path.resolve(scriptDir, '../dist/marketing/supplied-campaigns');
 
 if (!existsSync(taskgenSource)) {
   throw new Error(`Task generation CLI not found at ${taskgenSource}`);
@@ -31,4 +33,11 @@ if (existsSync(snapshotSampleSource)) {
 if (existsSync(fixturesSource)) {
   rmSync(fixturesDest, { recursive: true, force: true }); // #REMOVE_ME_DEBUG_BYPASS
   cpSync(fixturesSource, fixturesDest, { recursive: true }); // #REMOVE_ME_DEBUG_BYPASS
+}
+// Supplied Story configurations are created at repository level by Codex Cloud.
+// Copy them into the API build output so Railway can import them at runtime.
+rmSync(suppliedCampaignsDest, { recursive: true, force: true });
+if (existsSync(suppliedCampaignsSource)) {
+  mkdirSync(path.dirname(suppliedCampaignsDest), { recursive: true });
+  cpSync(suppliedCampaignsSource, suppliedCampaignsDest, { recursive: true });
 }

--- a/apps/api/src/services/marketingSuppliedStoryCampaignImportService.ts
+++ b/apps/api/src/services/marketingSuppliedStoryCampaignImportService.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { pool } from '../db.js';
 
 type SuppliedStory = {
@@ -170,7 +171,10 @@ export async function importSuppliedStoryCampaign(
 }
 
 async function findSuppliedCampaignDirectory(): Promise<string | null> {
+  const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
   const candidates = [
+    // Production build: copied by copy-taskgen-assets.mjs into apps/api/dist.
+    path.resolve(moduleDirectory, '..', 'marketing', 'supplied-campaigns'),
     path.resolve(process.cwd(), 'marketing', 'supplied-campaigns'),
     path.resolve(process.cwd(), '..', '..', 'marketing', 'supplied-campaigns'),
   ];


### PR DESCRIPTION
## Root cause
PR #2369 imported supplied campaign JSONs at runtime, but Railway may run the compiled API without the repository-level `marketing/` directory available. The Admin request therefore had no campaign file to discover.

## Change
- Copy `marketing/supplied-campaigns/` into `apps/api/dist/marketing/` during the API build.
- Resolve that packaged directory first at runtime, before fallbacks for local development.

## Result
After merge and a successful Railway API deploy, refreshing Admin Marketing will import `ib_202608_stories` into the production database and show it in the campaign selector.

## Validation
- `npm --workspace apps/api run lint`
- `npm --workspace apps/api run typecheck`
- `npm --workspace apps/api run build`
- Confirmed the built artifact contains `apps/api/dist/marketing/supplied-campaigns/ib_202608_stories/campaign.json`.